### PR TITLE
PRSD-NONE: Prevents error on hot reload from re-seeding data

### DIFF
--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -28,6 +28,7 @@ spring:
     init:
       mode: always
       platform: local
+      continue-on-error: true
 
   data:
     redis:


### PR DESCRIPTION
Updates hibernate config when running locally to avoid crash from incorrectly re-seeding the database when hot-reloading