### PR TITLE
Feat/PRSD-364 integrate with notify

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,7 @@ out/
 
 ### Secrets ###
 *.pem
+*.env
 
 ### Node ###
 /node_modules

--- a/.run/local.run.xml
+++ b/.run/local.run.xml
@@ -1,8 +1,14 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="local" type="SpringBootApplicationConfigurationType" factoryName="Spring Boot">
     <option name="ACTIVE_PROFILES" value="local" />
+    <option name="envFilePaths">
+      <option value="$PROJECT_DIR$/.env" />
+    </option>
     <option name="FRAME_DEACTIVATION_UPDATE_POLICY" value="UpdateClassesAndResources" />
     <module name="prsdb-webapp.main" />
+    <selectedOptions>
+      <option name="environmentVariables" />
+    </selectedOptions>
     <option name="SPRING_BOOT_MAIN_CLASS" value="uk.gov.communities.prsdb.webapp.PrsdbWebappApplication" />
     <method v="2">
       <option name="RunConfigurationTask" enabled="true" run_configuration_name="npm build" run_configuration_type="js.build_tools.npm" />

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -54,6 +54,9 @@ dependencies {
     // Templating
     implementation("org.springframework.boot:spring-boot-starter-thymeleaf")
 
+    // External service clients
+    implementation("uk.gov.service.notify:notifications-java-client:5.2.1-RELEASE")
+
     // Development
     developmentOnly("org.springframework.boot:spring-boot-devtools")
 

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/config/NotifyConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/config/NotifyConfig.kt
@@ -1,0 +1,15 @@
+package uk.gov.communities.prsdb.webapp.config
+
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import uk.gov.service.notify.NotificationClient
+
+@Configuration
+class NotifyConfig {
+    @Value("\${notify.api-key}")
+    lateinit var apiKey: String
+
+    @Bean
+    fun notificationClient(): NotificationClient = NotificationClient(apiKey)
+}

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/ExampleEmailSendingController.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/ExampleEmailSendingController.kt
@@ -1,0 +1,38 @@
+package uk.gov.communities.prsdb.webapp.controllers
+
+import org.springframework.http.MediaType
+import org.springframework.stereotype.Controller
+import org.springframework.ui.Model
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PostMapping
+import uk.gov.communities.prsdb.webapp.constants.SERVICE_NAME
+import uk.gov.communities.prsdb.webapp.services.EmailNotificationService
+import uk.gov.communities.prsdb.webapp.viewmodel.TestEmail
+
+@Controller
+class ExampleEmailSendingController(
+    var emailSender: EmailNotificationService,
+) {
+    @GetMapping("/send-test-email")
+    fun testEmailPage(model: Model): String {
+        model.addAttribute("title", "Send an email")
+        model.addAttribute("serviceName", SERVICE_NAME)
+        return "sendTestEmail"
+    }
+
+    class Submission(
+        val emailAddress: String,
+    )
+
+    @PostMapping("/send-test-email", consumes = [MediaType.APPLICATION_FORM_URLENCODED_VALUE])
+    fun sendEmail(
+        model: Model,
+        body: Submission,
+    ): String {
+        emailSender.sendTestEmail(body.emailAddress, TestEmail("Lucky Recipient"))
+        model.addAttribute("contentHeader", "Your have sent a test email to ${body.emailAddress}")
+        model.addAttribute("title", "Email sent")
+        model.addAttribute("serviceName", SERVICE_NAME)
+        return "index"
+    }
+}

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/ExampleEmailSendingController.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/ExampleEmailSendingController.kt
@@ -11,7 +11,7 @@ import uk.gov.communities.prsdb.webapp.viewmodel.TestEmail
 
 @Controller
 class ExampleEmailSendingController(
-    var emailSender: EmailNotificationService,
+    var emailSender: EmailNotificationService<TestEmail>,
 ) {
     @GetMapping("/send-test-email")
     fun testEmailPage(model: Model): String {
@@ -29,7 +29,7 @@ class ExampleEmailSendingController(
         model: Model,
         body: Submission,
     ): String {
-        emailSender.sendTestEmail(body.emailAddress, TestEmail("Lucky Recipient"))
+        emailSender.sendEmail(body.emailAddress, TestEmail("Lucky Recipient"))
         model.addAttribute("contentHeader", "Your have sent a test email to ${body.emailAddress}")
         model.addAttribute("title", "Email sent")
         model.addAttribute("serviceName", SERVICE_NAME)

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/ExampleEmailSendingController.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/ExampleEmailSendingController.kt
@@ -9,6 +9,9 @@ import uk.gov.communities.prsdb.webapp.constants.SERVICE_NAME
 import uk.gov.communities.prsdb.webapp.services.EmailNotificationService
 import uk.gov.communities.prsdb.webapp.viewmodel.TestEmail
 
+// TODO PRSD-404: Remove this controller once there is another way to reach the EmailNotificationService
+// This controller is an example controller to demo our integration with notify and should be removed once
+// there is an integration that belongs to an intended releasable feature.
 @Controller
 class ExampleEmailSendingController(
     var emailSender: EmailNotificationService<TestEmail>,

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/EmailNotificationService.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/EmailNotificationService.kt
@@ -1,10 +1,10 @@
 package uk.gov.communities.prsdb.webapp.services
 
-import uk.gov.communities.prsdb.webapp.viewmodel.EmailTemplate
+import uk.gov.communities.prsdb.webapp.viewmodel.EmailTemplateModel
 
-interface EmailNotificationService<Template : EmailTemplate> {
+interface EmailNotificationService<EmailModel : EmailTemplateModel> {
     fun sendEmail(
         recipientAddress: String,
-        email: Template,
+        email: EmailModel,
     )
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/EmailNotificationService.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/EmailNotificationService.kt
@@ -1,0 +1,10 @@
+package uk.gov.communities.prsdb.webapp.services
+
+import uk.gov.communities.prsdb.webapp.viewmodel.TestEmail
+
+interface EmailNotificationService {
+    fun sendTestEmail(
+        recipientAddress: String,
+        testEmail: TestEmail,
+    )
+}

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/EmailNotificationService.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/EmailNotificationService.kt
@@ -1,10 +1,10 @@
 package uk.gov.communities.prsdb.webapp.services
 
-import uk.gov.communities.prsdb.webapp.viewmodel.TestEmail
+import uk.gov.communities.prsdb.webapp.viewmodel.EmailTemplate
 
-interface EmailNotificationService {
-    fun sendTestEmail(
+interface EmailNotificationService<Template : EmailTemplate> {
+    fun sendEmail(
         recipientAddress: String,
-        testEmail: TestEmail,
+        email: Template,
     )
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/NotifyEmailNotificationService.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/NotifyEmailNotificationService.kt
@@ -1,18 +1,18 @@
 package uk.gov.communities.prsdb.webapp.services
 
 import org.springframework.stereotype.Service
-import uk.gov.communities.prsdb.webapp.viewmodel.EmailTemplate
+import uk.gov.communities.prsdb.webapp.viewmodel.EmailTemplateModel
 import uk.gov.service.notify.NotificationClient
 
 @Service
-class NotifyEmailNotificationService<Template : EmailTemplate>(
+class NotifyEmailNotificationService<EmailModel : EmailTemplateModel>(
     var notificationClient: NotificationClient,
-) : EmailNotificationService<Template> {
+) : EmailNotificationService<EmailModel> {
     override fun sendEmail(
         recipientAddress: String,
-        email: Template,
+        email: EmailModel,
     ) {
-        val emailParameters = email.asHashMap()
+        val emailParameters = email.toHashMap()
         notificationClient.sendEmail(email.templateId, recipientAddress, emailParameters, null)
     }
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/NotifyEmailNotificationService.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/NotifyEmailNotificationService.kt
@@ -1,18 +1,18 @@
 package uk.gov.communities.prsdb.webapp.services
 
 import org.springframework.stereotype.Service
-import uk.gov.communities.prsdb.webapp.viewmodel.TestEmail
+import uk.gov.communities.prsdb.webapp.viewmodel.EmailTemplate
 import uk.gov.service.notify.NotificationClient
 
 @Service
-class NotifyEmailNotificationService(
+class NotifyEmailNotificationService<Template : EmailTemplate>(
     var notificationClient: NotificationClient,
-) : EmailNotificationService {
-    override fun sendTestEmail(
+) : EmailNotificationService<Template> {
+    override fun sendEmail(
         recipientAddress: String,
-        testEmail: TestEmail,
+        email: Template,
     ) {
-        val emailParameters = testEmail.asHashMap()
-        notificationClient.sendEmail(testEmail.templateId, recipientAddress, emailParameters, null)
+        val emailParameters = email.asHashMap()
+        notificationClient.sendEmail(email.templateId, recipientAddress, emailParameters, null)
     }
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/NotifyEmailNotificationService.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/NotifyEmailNotificationService.kt
@@ -1,0 +1,18 @@
+package uk.gov.communities.prsdb.webapp.services
+
+import org.springframework.stereotype.Service
+import uk.gov.communities.prsdb.webapp.viewmodel.TestEmail
+import uk.gov.service.notify.NotificationClient
+
+@Service
+class NotifyEmailNotificationService(
+    var notificationClient: NotificationClient,
+) : EmailNotificationService {
+    override fun sendTestEmail(
+        recipientAddress: String,
+        testEmail: TestEmail,
+    ) {
+        val emailParameters = testEmail.asHashMap()
+        notificationClient.sendEmail(testEmail.templateId, recipientAddress, emailParameters, null)
+    }
+}

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/viewmodel/EmailTemplate.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/viewmodel/EmailTemplate.kt
@@ -1,0 +1,7 @@
+package uk.gov.communities.prsdb.webapp.viewmodel
+
+interface EmailTemplate {
+    val templateId: String
+
+    fun asHashMap(): HashMap<String, String>
+}

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/viewmodel/EmailTemplateModel.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/viewmodel/EmailTemplateModel.kt
@@ -1,7 +1,7 @@
 package uk.gov.communities.prsdb.webapp.viewmodel
 
-interface EmailTemplate {
+interface EmailTemplateModel {
     val templateId: String
 
-    fun asHashMap(): HashMap<String, String>
+    fun toHashMap(): HashMap<String, String>
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/viewmodel/TestEmail.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/viewmodel/TestEmail.kt
@@ -2,10 +2,10 @@ package uk.gov.communities.prsdb.webapp.viewmodel
 
 data class TestEmail(
     var firstName: String,
-) {
+) : EmailTemplate {
     private val firstNameName = "first name"
 
-    val templateId = "71551da6-f616-45c7-a4e0-23d6a8434561"
+    override val templateId = "71551da6-f616-45c7-a4e0-23d6a8434561"
 
-    fun asHashMap(): HashMap<String, String> = hashMapOf(firstNameName to firstName)
+    override fun asHashMap(): HashMap<String, String> = hashMapOf(firstNameName to firstName)
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/viewmodel/TestEmail.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/viewmodel/TestEmail.kt
@@ -1,0 +1,11 @@
+package uk.gov.communities.prsdb.webapp.viewmodel
+
+data class TestEmail(
+    var firstName: String,
+) {
+    private val firstNameName = "first name"
+
+    val templateId = "71551da6-f616-45c7-a4e0-23d6a8434561"
+
+    fun asHashMap(): HashMap<String, String> = hashMapOf(firstNameName to firstName)
+}

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/viewmodel/TestEmail.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/viewmodel/TestEmail.kt
@@ -2,10 +2,10 @@ package uk.gov.communities.prsdb.webapp.viewmodel
 
 data class TestEmail(
     var firstName: String,
-) : EmailTemplate {
-    private val firstNameName = "first name"
+) : EmailTemplateModel {
+    private val firstNameKey = "first name"
 
     override val templateId = "71551da6-f616-45c7-a4e0-23d6a8434561"
 
-    override fun asHashMap(): HashMap<String, String> = hashMapOf(firstNameName to firstName)
+    override fun toHashMap(): HashMap<String, String> = hashMapOf(firstNameKey to firstName)
 }

--- a/src/main/resources/templates/sendTestEmail.html
+++ b/src/main/resources/templates/sendTestEmail.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html th:replace="~{fragments/layout :: layout(${title}, ${serviceName}, ~{::main})}">
+<main class="govuk-main-wrapper" id="main-content">
+    <h1 class="govuk-heading-xl">Send a test email using notify</h1>
+    <form class="form" method="post" th:action="@{/send-test-email}">
+        <div class="govuk-form-group">
+            <h1 class="govuk-label-wrapper">
+                <label class="govuk-label govuk-label--l" for="email-address">
+                    Choose a recipient
+                </label>
+            </h1>
+            <input class="govuk-input" id="email-address" name="emailAddress" type="text">
+        </div>
+        <div>
+            <button type="submit" class="govuk-button" data-module="govuk-button">
+                Submit
+            </button>
+        </div>
+    </form>
+</main>
+</html>

--- a/src/main/resources/templates/sendTestEmail.html
+++ b/src/main/resources/templates/sendTestEmail.html
@@ -1,3 +1,6 @@
+<!--/* TODO PRSD-404: Remove this template once there is another way to reach the EmailNotificationService
+ This template is for an example page to demo our integration with notify and should be removed once
+ there is an integration that belongs to an intended releasable feature. */-->
 <!DOCTYPE html>
 <html th:replace="~{fragments/layout :: layout(${title}, ${serviceName}, ~{::main})}">
 <main class="govuk-main-wrapper" id="main-content">

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/PrsdbWebappApplicationTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/PrsdbWebappApplicationTests.kt
@@ -8,7 +8,9 @@ import org.springframework.security.oauth2.client.endpoint.DefaultAuthorizationC
 import org.springframework.security.oauth2.client.registration.ClientRegistration
 import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository
 import org.springframework.security.oauth2.jwt.JwtDecoderFactory
+import uk.gov.communities.prsdb.webapp.config.NotifyConfig
 import uk.gov.communities.prsdb.webapp.config.OneLoginConfig
+import uk.gov.service.notify.NotificationClient
 
 @Import(TestcontainersConfiguration::class)
 @SpringBootTest
@@ -28,4 +30,10 @@ class PrsdbWebappApplicationTests {
 
     @MockBean
     lateinit var oneLoginConfig: OneLoginConfig
+
+    @MockBean
+    lateinit var notifyConfig: NotifyConfig
+
+    @MockBean
+    lateinit var notificationClient: NotificationClient
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/IntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/IntegrationTest.kt
@@ -12,7 +12,9 @@ import org.springframework.security.oauth2.jwt.JwtDecoderFactory
 import org.springframework.security.web.SecurityFilterChain
 import org.springframework.test.context.ActiveProfiles
 import uk.gov.communities.prsdb.webapp.TestcontainersConfiguration
+import uk.gov.communities.prsdb.webapp.config.NotifyConfig
 import uk.gov.communities.prsdb.webapp.config.OneLoginConfig
+import uk.gov.service.notify.NotificationClient
 
 @Import(TestcontainersConfiguration::class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
@@ -33,6 +35,12 @@ abstract class IntegrationTest {
 
     @MockBean
     lateinit var oneLoginConfig: OneLoginConfig
+
+    @MockBean
+    lateinit var notifyConfig: NotifyConfig
+
+    @MockBean
+    lateinit var notificationClient: NotificationClient
 
     @MockBean
     lateinit var securityFilterChain: SecurityFilterChain

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/NotifyEmailNotificationServiceTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/NotifyEmailNotificationServiceTests.kt
@@ -17,7 +17,7 @@ class NotifyEmailNotificationServiceTests {
     }
 
     // This test currently tests that the test email hash map matches the corresponding template
-    // TODO: When bringing templates into source control, test each template creates a hash map that matches the Notify template
+    // TODO PRSD-364: When bringing templates into source control, test each template creates a hash map that matches the Notify template
     @Test
     fun `sendTestEmail sends a matching email using the notification client`() {
         // Arrange

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/NotifyEmailNotificationServiceTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/NotifyEmailNotificationServiceTests.kt
@@ -1,0 +1,37 @@
+package uk.gov.communities.prsdb.webapp.services
+
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.Mockito
+import uk.gov.communities.prsdb.webapp.viewmodel.TestEmail
+import uk.gov.service.notify.NotificationClient
+
+class NotifyEmailNotificationServiceTests {
+    private lateinit var notifyClient: NotificationClient
+    private lateinit var emailNotificationService: NotifyEmailNotificationService
+
+    @BeforeEach
+    fun setup() {
+        notifyClient = Mockito.mock(NotificationClient::class.java)
+        emailNotificationService = NotifyEmailNotificationService(notifyClient)
+    }
+
+    // This test currently tests that the test email hash map matches the corresponding template
+    // TODO: When bringing templates into source control, test each template creates a hash map that matches the Notify template
+    @Test
+    fun `sendTestEmail sends a matching email using the notification client`() {
+        // Arrange
+        val email = TestEmail("Recipient")
+        val recipientEmail = "an email address"
+
+        // Act
+        emailNotificationService.sendTestEmail(recipientEmail, email)
+
+        // Assert
+        Mockito
+            .verify(
+                notifyClient,
+                Mockito.times(1),
+            ).sendEmail(email.templateId, recipientEmail, hashMapOf("first name" to email.firstName), null)
+    }
+}

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/NotifyEmailNotificationServiceTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/NotifyEmailNotificationServiceTests.kt
@@ -8,7 +8,7 @@ import uk.gov.service.notify.NotificationClient
 
 class NotifyEmailNotificationServiceTests {
     private lateinit var notifyClient: NotificationClient
-    private lateinit var emailNotificationService: NotifyEmailNotificationService
+    private lateinit var emailNotificationService: NotifyEmailNotificationService<TestEmail>
 
     @BeforeEach
     fun setup() {
@@ -25,7 +25,7 @@ class NotifyEmailNotificationServiceTests {
         val recipientEmail = "an email address"
 
         // Act
-        emailNotificationService.sendTestEmail(recipientEmail, email)
+        emailNotificationService.sendEmail(recipientEmail, email)
 
         // Assert
         Mockito


### PR DESCRIPTION
Initial pull request for integrating with notify. This adds:
* Configuration to use a .env file for secrets in the code (I'll make a usable one available separately)
* A type-parameterised email sending service
* An email template for the test email in notify already
* A page at '/send-test-email' that allows you to send a test email to a specified email address.
* A single very simple test for the email sending service

Worth noting:
* I've not added any controller tests as the controller is only to demo notify integration and won't be used by the time we reach release 1. Let me know if you disagree.* 
* I've deliberately made the template for the email page as simple as possible, not trying to avoid repitition, for the same reason.
* I've left a TODO in the tests file mentioning the need for tests integrating with Notify to explain a slight gap currently left in the testing. Let me know if we should follow a particular convention here.
* I've not covered any of the error handling we talked about - I'll catch up with you and then add unhappy paths. As it is any errors will just result in reaching the "Sorry there's a problem" page. 
* The NotifyEmailNotificationService<TestEmail> appears to Just Work (tm) with dependency injection without any additional boilerplate.

Edit: Also, I've not checked with other branches where we're planning to put viewmodels in the file structure - very happy to move them to match on merge.