### PR TITLE
PRSD-364: Move email template models

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/ExampleEmailSendingController.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/ExampleEmailSendingController.kt
@@ -7,8 +7,8 @@ import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PostMapping
 import uk.gov.communities.prsdb.webapp.constants.SERVICE_NAME
 import uk.gov.communities.prsdb.webapp.exceptions.TransientEmailSentException
+import uk.gov.communities.prsdb.webapp.models.viewModels.ExampleEmail
 import uk.gov.communities.prsdb.webapp.services.EmailNotificationService
-import uk.gov.communities.prsdb.webapp.viewmodel.ExampleEmail
 
 // TODO PRSD-404: Remove this controller once there is another way to reach the EmailNotificationService
 // This controller is an example controller to demo our integration with notify and should be removed once

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/EmailTemplateModel.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/EmailTemplateModel.kt
@@ -1,4 +1,4 @@
-package uk.gov.communities.prsdb.webapp.viewmodel
+package uk.gov.communities.prsdb.webapp.models.viewModels
 
 interface EmailTemplateModel {
     val templateId: EmailTemplateId

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/ExampleEmail.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/ExampleEmail.kt
@@ -1,4 +1,4 @@
-package uk.gov.communities.prsdb.webapp.viewmodel
+package uk.gov.communities.prsdb.webapp.models.viewModels
 
 data class ExampleEmail(
     var firstName: String,

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/EmailNotificationService.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/EmailNotificationService.kt
@@ -1,6 +1,6 @@
 package uk.gov.communities.prsdb.webapp.services
 
-import uk.gov.communities.prsdb.webapp.viewmodel.EmailTemplateModel
+import uk.gov.communities.prsdb.webapp.models.viewModels.EmailTemplateModel
 
 interface EmailNotificationService<EmailModel : EmailTemplateModel> {
     fun sendEmail(

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/NotifyEmailNotificationService.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/NotifyEmailNotificationService.kt
@@ -6,7 +6,7 @@ import kotlinx.serialization.json.Json
 import org.springframework.stereotype.Service
 import uk.gov.communities.prsdb.webapp.exceptions.PersistentEmailSendException
 import uk.gov.communities.prsdb.webapp.exceptions.TransientEmailSentException
-import uk.gov.communities.prsdb.webapp.viewmodel.EmailTemplateModel
+import uk.gov.communities.prsdb.webapp.models.viewModels.EmailTemplateModel
 import uk.gov.service.notify.NotificationClient
 import uk.gov.service.notify.NotificationClientException
 

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/EmailTemplateModelsTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/EmailTemplateModelsTests.kt
@@ -1,9 +1,8 @@
-package uk.gov.communities.prsdb.webapp.viewmodels
+package uk.gov.communities.prsdb.webapp.models.viewModels
+
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.MethodSource
-import uk.gov.communities.prsdb.webapp.viewmodel.EmailTemplateModel
-import uk.gov.communities.prsdb.webapp.viewmodel.ExampleEmail
 
 class EmailTemplateModelsTests {
     companion object {

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/notify/NotifyEmailTemplateTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/notify/NotifyEmailTemplateTests.kt
@@ -11,7 +11,7 @@ import org.junit.jupiter.params.provider.MethodSource
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import uk.gov.communities.prsdb.webapp.config.NotifyConfig
-import uk.gov.communities.prsdb.webapp.viewmodel.EmailTemplateId
+import uk.gov.communities.prsdb.webapp.models.viewModels.EmailTemplateId
 import uk.gov.service.notify.NotificationClient
 import uk.gov.service.notify.Template
 import uk.gov.service.notify.TemplateList

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/NotifyEmailNotificationServiceTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/NotifyEmailNotificationServiceTests.kt
@@ -12,8 +12,8 @@ import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito
 import uk.gov.communities.prsdb.webapp.exceptions.PersistentEmailSendException
 import uk.gov.communities.prsdb.webapp.exceptions.TransientEmailSentException
-import uk.gov.communities.prsdb.webapp.viewmodel.EmailTemplateId
-import uk.gov.communities.prsdb.webapp.viewmodel.EmailTemplateModel
+import uk.gov.communities.prsdb.webapp.models.viewModels.EmailTemplateId
+import uk.gov.communities.prsdb.webapp.models.viewModels.EmailTemplateModel
 import uk.gov.service.notify.NotificationClient
 import uk.gov.service.notify.NotificationClientException
 


### PR DESCRIPTION
Moving the email template view models to the models folder as discussed.