### PR TITLE
PRSD-364: Stub calls to notify for local

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/ExampleEmailSendingController.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/ExampleEmailSendingController.kt
@@ -7,8 +7,8 @@ import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PostMapping
 import uk.gov.communities.prsdb.webapp.constants.SERVICE_NAME
 import uk.gov.communities.prsdb.webapp.exceptions.TransientEmailSentException
+import uk.gov.communities.prsdb.webapp.models.viewModels.ExampleEmail
 import uk.gov.communities.prsdb.webapp.services.EmailNotificationService
-import uk.gov.communities.prsdb.webapp.viewmodel.ExampleEmail
 
 // TODO PRSD-404: Remove this controller once there is another way to reach the EmailNotificationService
 // This controller is an example controller to demo our integration with notify and should be removed once

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/exceptions/PersistentEmailSendException.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/exceptions/PersistentEmailSendException.kt
@@ -1,6 +1,6 @@
 package uk.gov.communities.prsdb.webapp.exceptions
 
-class PersistentEmailSendException(
-    message: String,
-    cause: Throwable,
-) : PrsdbWebException(message, cause)
+class PersistentEmailSendException : PrsdbWebException {
+    constructor(message: String, cause: Throwable) : super(message, cause)
+    constructor(message: String) : super(message)
+}

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/exceptions/TransientEmailSentException.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/exceptions/TransientEmailSentException.kt
@@ -1,6 +1,6 @@
 package uk.gov.communities.prsdb.webapp.exceptions
 
-class TransientEmailSentException(
-    message: String,
-    cause: Throwable,
-) : PrsdbWebException(message, cause)
+class TransientEmailSentException : PrsdbWebException {
+    constructor(message: String, cause: Throwable) : super(message, cause)
+    constructor(message: String) : super(message)
+}

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/local/services/EmailNotificationStubService.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/local/services/EmailNotificationStubService.kt
@@ -1,0 +1,46 @@
+package uk.gov.communities.prsdb.webapp.local.services
+
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.annotation.Primary
+import org.springframework.context.annotation.Profile
+import org.springframework.stereotype.Service
+import uk.gov.communities.prsdb.webapp.exceptions.PersistentEmailSendException
+import uk.gov.communities.prsdb.webapp.exceptions.TransientEmailSentException
+import uk.gov.communities.prsdb.webapp.models.viewModels.EmailTemplateModel
+import uk.gov.communities.prsdb.webapp.services.EmailNotificationService
+
+@Service
+@Profile("local & !use-notify")
+@Primary
+class EmailNotificationStubService<EmailModel : EmailTemplateModel> : EmailNotificationService<EmailModel> {
+    @Value("\${local.emails.transientExceptionAddress}")
+    var transientExceptionRecipient: String? = null
+
+    @Value("\${local.emails.persistentExceptionAddress}")
+    var persistentExceptionRecipient: String? = null
+
+    override fun sendEmail(
+        recipientAddress: String,
+        email: EmailModel,
+    ) {
+        if (recipientAddress == persistentExceptionRecipient) {
+            throw PersistentEmailSendException("Emails sent to $persistentExceptionRecipient always persistently fail")
+        }
+        if (recipientAddress == transientExceptionRecipient) {
+            throw TransientEmailSentException("Emails sent to $transientExceptionRecipient always transiently fail")
+        }
+
+        val consoleString =
+            """
+            ***************
+            STUB EMAIL SENT
+            ***************
+            
+            Email sent to:   $recipientAddress
+            Template used:   ${email.templateId.name}
+            Personalisation: ${email.toHashMap()}
+            """.trimIndent()
+
+        println(consoleString)
+    }
+}

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/EmailTemplateModel.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/EmailTemplateModel.kt
@@ -1,4 +1,4 @@
-package uk.gov.communities.prsdb.webapp.viewmodel
+package uk.gov.communities.prsdb.webapp.models.viewModels
 
 interface EmailTemplateModel {
     val templateId: EmailTemplateId

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/ExampleEmail.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/ExampleEmail.kt
@@ -1,4 +1,4 @@
-package uk.gov.communities.prsdb.webapp.viewmodel
+package uk.gov.communities.prsdb.webapp.models.viewModels
 
 data class ExampleEmail(
     var firstName: String,

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/EmailNotificationService.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/EmailNotificationService.kt
@@ -1,6 +1,6 @@
 package uk.gov.communities.prsdb.webapp.services
 
-import uk.gov.communities.prsdb.webapp.viewmodel.EmailTemplateModel
+import uk.gov.communities.prsdb.webapp.models.viewModels.EmailTemplateModel
 
 interface EmailNotificationService<EmailModel : EmailTemplateModel> {
     fun sendEmail(

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/NotifyEmailNotificationService.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/NotifyEmailNotificationService.kt
@@ -6,7 +6,7 @@ import kotlinx.serialization.json.Json
 import org.springframework.stereotype.Service
 import uk.gov.communities.prsdb.webapp.exceptions.PersistentEmailSendException
 import uk.gov.communities.prsdb.webapp.exceptions.TransientEmailSentException
-import uk.gov.communities.prsdb.webapp.viewmodel.EmailTemplateModel
+import uk.gov.communities.prsdb.webapp.models.viewModels.EmailTemplateModel
 import uk.gov.service.notify.NotificationClient
 import uk.gov.service.notify.NotificationClientException
 

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -60,3 +60,8 @@ notify:
 server:
   error:
     path: /error
+
+local:
+  emails:
+    transientExceptionAddress: transient@example.com
+    persistentExceptionAddress: persistent@example.com

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/EmailTemplateModelsTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/EmailTemplateModelsTests.kt
@@ -1,9 +1,8 @@
-package uk.gov.communities.prsdb.webapp.viewmodels
+package uk.gov.communities.prsdb.webapp.models.viewModels
+
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.MethodSource
-import uk.gov.communities.prsdb.webapp.viewmodel.EmailTemplateModel
-import uk.gov.communities.prsdb.webapp.viewmodel.ExampleEmail
 
 class EmailTemplateModelsTests {
     companion object {

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/notify/NotifyEmailTemplateTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/notify/NotifyEmailTemplateTests.kt
@@ -11,7 +11,7 @@ import org.junit.jupiter.params.provider.MethodSource
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import uk.gov.communities.prsdb.webapp.config.NotifyConfig
-import uk.gov.communities.prsdb.webapp.viewmodel.EmailTemplateId
+import uk.gov.communities.prsdb.webapp.models.viewModels.EmailTemplateId
 import uk.gov.service.notify.NotificationClient
 import uk.gov.service.notify.Template
 import uk.gov.service.notify.TemplateList

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/NotifyEmailNotificationServiceTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/NotifyEmailNotificationServiceTests.kt
@@ -12,8 +12,8 @@ import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito
 import uk.gov.communities.prsdb.webapp.exceptions.PersistentEmailSendException
 import uk.gov.communities.prsdb.webapp.exceptions.TransientEmailSentException
-import uk.gov.communities.prsdb.webapp.viewmodel.EmailTemplateId
-import uk.gov.communities.prsdb.webapp.viewmodel.EmailTemplateModel
+import uk.gov.communities.prsdb.webapp.models.viewModels.EmailTemplateId
+import uk.gov.communities.prsdb.webapp.models.viewModels.EmailTemplateModel
 import uk.gov.service.notify.NotificationClient
 import uk.gov.service.notify.NotificationClientException
 


### PR DESCRIPTION
Added a stubbed email sending service. I've annotated with the profile "!use-notify" even though "use-notify" doesn't currently exist as it lets you easily connect to notify for real during local development by adding that profile to your build configuration. I've also created some email addressed to simulate the two exception types that can be thrown by the notify email service.