### PR TITLE
PRSD-364: Add block comment to notify tests

### DIFF
--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/notify/NotifyEmailTemplateTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/notify/NotifyEmailTemplateTests.kt
@@ -16,6 +16,18 @@ import uk.gov.service.notify.NotificationClient
 import uk.gov.service.notify.Template
 import uk.gov.service.notify.TemplateList
 
+/*
+ * These tests verify that the templates we have in this code base match the templates stored in notify. This means
+ * they need to query notify to retrieve the templates to compare. That requires the notify api key to be available
+ * for these tests to be able to run.
+ *
+ * By default, these tests are disabled so that they don't fail when you don't have an environment variable set. To
+ * run them locally, get the notify api key and set the appropriate environment variable on the gradle run
+ * configuration. Under no circumstances should you commit the api key or configuration containing the api in git.
+ * There is a prepared run configuration called "notify-template-tests.run.xml" that runs these tests - if you want
+ * this ask your team lead where it can be found.
+ */
+
 @EnabledIf("canFetchNotifyTemplates")
 @SpringBootTest(classes = [NotifyConfig::class])
 class NotifyEmailTemplateTests {


### PR DESCRIPTION
Not sure if this is necessary or not (or if this file is the right place) but I wanted to include an explanation for if someone noticed that a chunk of tests are disabled when they run them locally. 

Also, we should (before PRSD-404) add the appropriate environment variable to the test runner so that the PR tests fail if someone hasn't set this up correctly.

Let me know what you think.