### PR TITLE
Feat/prsd 358 create frontend page

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/ManageLocalAuthorityUsersController.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/ManageLocalAuthorityUsersController.kt
@@ -37,9 +37,7 @@ class ManageLocalAuthorityUsersController(
         model.addAttribute("title", "Manage Local Authority Users")
         model.addAttribute("serviceName", SERVICE_NAME)
         model.addAttribute("userList", users)
-        model.addAttribute("tableColumn1Heading", "Username")
-        model.addAttribute("tableColumn2Heading", "Access level")
-        model.addAttribute("tableColumn3Heading", "Account status")
+        model.addAttribute("tableColumnHeadings", listOf("Username", "Access level", "Account status", ""))
 
         return "manageLAUsers"
     }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/ManageLocalAuthorityUsersController.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/ManageLocalAuthorityUsersController.kt
@@ -24,6 +24,7 @@ class ManageLocalAuthorityUsersController(
         val currentUserLocalAuthority = localAuthorityDataService.getLocalAuthorityForUser(principal.name)!!
 
         val activeUsers = localAuthorityDataService.getLocalAuthorityUsersForLocalAuthority(currentUserLocalAuthority)
+        // TODO: Get these from LocalAuthorityUserInvitation with userName=email, isManager=false and isPending=true
         val pendingUsers =
             listOf(
                 LocalAuthorityUserDataModel("Invited user 1", isManager = false, isPending = true),

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/ManageLocalAuthorityUsersController.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/ManageLocalAuthorityUsersController.kt
@@ -1,5 +1,7 @@
 package uk.gov.communities.prsdb.webapp.controllers
 
+import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.context.MessageSource
 import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.stereotype.Controller
 import org.springframework.ui.Model
@@ -9,12 +11,14 @@ import uk.gov.communities.prsdb.webapp.constants.SERVICE_NAME
 import uk.gov.communities.prsdb.webapp.models.dataModels.LocalAuthorityUserDataModel
 import uk.gov.communities.prsdb.webapp.services.LocalAuthorityDataService
 import java.security.Principal
+import java.util.Locale
 
 @PreAuthorize("hasRole('LA_ADMIN')")
 @Controller
 @RequestMapping("/manage-users")
 class ManageLocalAuthorityUsersController(
     val localAuthorityDataService: LocalAuthorityDataService,
+    @Qualifier("messageSource") private val messageSource: MessageSource,
 ) {
     @GetMapping
     fun index(
@@ -33,11 +37,24 @@ class ManageLocalAuthorityUsersController(
 
         val users = activeUsers + pendingUsers
 
-        model.addAttribute("contentHeader", "Manage ${currentUserLocalAuthority?.name}'s users")
-        model.addAttribute("title", "Manage Local Authority Users")
+        model.addAttribute(
+            "contentHeader",
+            messageSource.getMessage("manageLAUsers.contentHeader.part1", null, Locale("en")) +
+                " " + currentUserLocalAuthority.name +
+                messageSource.getMessage("manageLAUsers.contentHeader.part2", null, Locale("en")),
+        )
+        model.addAttribute("title", messageSource.getMessage("manageLAUsers.title", null, Locale("en")))
         model.addAttribute("serviceName", SERVICE_NAME)
         model.addAttribute("userList", users)
-        model.addAttribute("tableColumnHeadings", listOf("Username", "Access level", "Account status", ""))
+        model.addAttribute(
+            "tableColumnHeadings",
+            listOf(
+                messageSource.getMessage("manageLAUsers.table.column1Heading", null, Locale("en")),
+                messageSource.getMessage("manageLAUsers.table.column2Heading", null, Locale("en")),
+                messageSource.getMessage("manageLAUsers.table.column3Heading", null, Locale("en")),
+                "",
+            ),
+        )
 
         return "manageLAUsers"
     }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/ManageLocalAuthorityUsersController.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/ManageLocalAuthorityUsersController.kt
@@ -1,13 +1,12 @@
 package uk.gov.communities.prsdb.webapp.controllers
 
-import kotlinx.serialization.encodeToString
-import kotlinx.serialization.json.Json
 import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.stereotype.Controller
 import org.springframework.ui.Model
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import uk.gov.communities.prsdb.webapp.constants.SERVICE_NAME
+import uk.gov.communities.prsdb.webapp.models.dataModels.LocalAuthorityUserDataModel
 import uk.gov.communities.prsdb.webapp.services.LocalAuthorityDataService
 import java.security.Principal
 
@@ -24,13 +23,22 @@ class ManageLocalAuthorityUsersController(
     ): String {
         val currentUserLocalAuthority = localAuthorityDataService.getLocalAuthorityForUser(principal.name)!!
 
-        val users = localAuthorityDataService.getLocalAuthorityUsersForLocalAuthority(currentUserLocalAuthority)
-        val usersJson = Json.encodeToString(users)
-        model.addAttribute("usersJson", usersJson)
+        val activeUsers = localAuthorityDataService.getLocalAuthorityUsersForLocalAuthority(currentUserLocalAuthority)
+        val pendingUsers =
+            listOf(
+                LocalAuthorityUserDataModel("Invited user 1", isManager = false, isPending = true),
+                LocalAuthorityUserDataModel("Invited user 2", isManager = false, isPending = true),
+            )
 
-        model.addAttribute("contentHeader", "Manage Local Authority Users")
+        val users = activeUsers + pendingUsers
+
+        model.addAttribute("contentHeader", "Manage ${currentUserLocalAuthority?.name}'s users")
         model.addAttribute("title", "Manage Local Authority Users")
         model.addAttribute("serviceName", SERVICE_NAME)
+        model.addAttribute("userList", users)
+        model.addAttribute("tableColumn1Heading", "Username")
+        model.addAttribute("tableColumn2Heading", "Access level")
+        model.addAttribute("tableColumn3Heading", "Account status")
 
         return "manageLAUsers"
     }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/RegisterLandlordController.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/RegisterLandlordController.kt
@@ -1,17 +1,23 @@
 package uk.gov.communities.prsdb.webapp.controllers
 
+import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.context.MessageSource
 import org.springframework.stereotype.Controller
 import org.springframework.ui.Model
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import uk.gov.communities.prsdb.webapp.constants.SERVICE_NAME
+import java.util.Locale
 
 @Controller
 @RequestMapping("/register-as-a-landlord")
-class RegisterLandlordController {
+class RegisterLandlordController(
+    @Qualifier("messageSource")
+    private val messageSource: MessageSource,
+) {
     @GetMapping
     fun index(model: Model): String {
-        model.addAttribute("title", "Register as a Landlord")
+        model.addAttribute("title", messageSource.getMessage("registerAsALandlord.title", null, Locale("en")))
         model.addAttribute("serviceName", SERVICE_NAME)
         return "registerAsALandlord"
     }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/database/entity/LocalAuthority.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/database/entity/LocalAuthority.kt
@@ -10,7 +10,7 @@ import jakarta.persistence.Id
 class LocalAuthority : ModifiableAuditableEntity() {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    val id: Int? = null
+    private val id: Int? = null
 
     @Column(nullable = false)
     lateinit var name: String

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/database/entity/LocalAuthority.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/database/entity/LocalAuthority.kt
@@ -10,7 +10,7 @@ import jakarta.persistence.Id
 class LocalAuthority : ModifiableAuditableEntity() {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private val id: Int? = null
+    val id: Int? = null
 
     @Column(nullable = false)
     lateinit var name: String

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/dataModels/LocalAuthorityUserDataModel.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/dataModels/LocalAuthorityUserDataModel.kt
@@ -6,4 +6,5 @@ import kotlinx.serialization.Serializable
 data class LocalAuthorityUserDataModel(
     val userName: String,
     val isManager: Boolean,
+    val isPending: Boolean = false,
 )

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -1,3 +1,5 @@
+registerAsALandlord.title=Register as a Landlord
+
 registerAsALandlord.heading=Private Rented Sector Database
 registerAsALandlord.intro=This service holds information about private landlords and their rented properties. Private landlords in England are legally required to use this service.
 
@@ -49,3 +51,12 @@ registerAsALandlord.byEmail.paragraph.one.afterLink=.
 registerAsALandlord.byEmail.paragraph.two.beforeLink=You can email the completed form to
 registerAsALandlord.byEmail.paragraph.two.link=landlordregistration@uk.gov.uk
 registerAsALandlord.byEmail.paragraph.two.afterLink=.
+
+manageLAUsers.title=Manage Local Authority Users
+manageLAUsers.primaryButtonText=Invite another user
+manageLAUsers.secondaryButtonText=Return to dashboard
+manageLAUsers.table.column1Heading=Username
+manageLAUsers.table.column2Heading=Access level
+manageLAUsers.table.column3Heading=Account status
+manageLAUsers.contentHeader.part1=Manage
+manageLAUsers.contentHeader.part2='s users

--- a/src/main/resources/templates/demoStart.html
+++ b/src/main/resources/templates/demoStart.html
@@ -6,6 +6,6 @@
         <span>Example Landlord Registration Number: </span>
         <span th:text="${landlordRegNum}">Example Landlord Registration Number</span>
     </p>
-    <div th:replace="~{fragments/startButton :: startButton( href, buttonText )utton( ${startButtonHref}, ${startButtonText} )}"></div>
+    <div th:replace="~{fragments/startButton :: startButton( ${startButtonHref}, ${startButtonText} )}"></div>
 </main>
 </html>

--- a/src/main/resources/templates/demoStart.html
+++ b/src/main/resources/templates/demoStart.html
@@ -6,6 +6,6 @@
         <span>Example Landlord Registration Number: </span>
         <span th:text="${landlordRegNum}">Example Landlord Registration Number</span>
     </p>
-    <div th:replace="~{fragments/startButton :: button( ${startButtonHref}, ${startButtonText} )}"></div>
+    <div th:replace="~{fragments/startButton :: startButton( href, buttonText )utton( ${startButtonHref}, ${startButtonText} )}"></div>
 </main>
 </html>

--- a/src/main/resources/templates/fragments/fullWidthLayout.html
+++ b/src/main/resources/templates/fragments/fullWidthLayout.html
@@ -1,0 +1,7 @@
+<div th:fragment="fullWidthLayout(content)">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-full">
+            <div th:replace="${content}"></div>
+        </div>
+    </div>
+</div>

--- a/src/main/resources/templates/fragments/primaryButton.html
+++ b/src/main/resources/templates/fragments/primaryButton.html
@@ -1,0 +1,6 @@
+<button th:fragment="primaryButton(buttonText)"
+        type="submit"
+        class="govuk-button"
+        data-module="govuk-button"
+        th:text="${buttonText}">
+</button>

--- a/src/main/resources/templates/fragments/primaryButton.html
+++ b/src/main/resources/templates/fragments/primaryButton.html
@@ -2,5 +2,5 @@
         type="submit"
         class="govuk-button"
         data-module="govuk-button"
-        th:text="${buttonText}">
+        th:text="${buttonText}">Next
 </button>

--- a/src/main/resources/templates/fragments/secondaryButton.html
+++ b/src/main/resources/templates/fragments/secondaryButton.html
@@ -1,0 +1,6 @@
+<button th:fragment="secondaryButton(buttonText)"
+        type="submit"
+        class="govuk-button govuk-button--secondary"
+        data-module="govuk-button"
+        th:text="${buttonText}">
+</button>

--- a/src/main/resources/templates/fragments/secondaryButton.html
+++ b/src/main/resources/templates/fragments/secondaryButton.html
@@ -2,5 +2,5 @@
         type="submit"
         class="govuk-button govuk-button--secondary"
         data-module="govuk-button"
-        th:text="${buttonText}">
+        th:text="${buttonText}">Previous
 </button>

--- a/src/main/resources/templates/fragments/startButton.html
+++ b/src/main/resources/templates/fragments/startButton.html
@@ -1,4 +1,4 @@
-<a th:fragment="button( href, buttonText )" href="#" th:href="${href}" role="button" draggable="false"
+<a th:fragment="startButton( href, buttonText )" href="#" th:href="${href}" role="button" draggable="false"
    class="govuk-button govuk-button--start"
    data-module="govuk-button">
     <span th:text="${buttonText}">Start now</span>

--- a/src/main/resources/templates/fragments/tables/table.html
+++ b/src/main/resources/templates/fragments/tables/table.html
@@ -1,0 +1,9 @@
+<table th:fragment="table(theadFields, tbodyFragment)" class="govuk-table">
+    <thead class="govuk-table__head">
+        <tr class="govuk-table__row">
+            <th scope="col" class="govuk-table__header" th:each="heading: ${theadFields}" th:text="${heading}"></th>
+        </tr>
+    </thead>
+    <tbody th:replace="${tbodyFragment}">
+    </tbody>
+</table>

--- a/src/main/resources/templates/fragments/tables/tableBodyLAUser.html
+++ b/src/main/resources/templates/fragments/tables/tableBodyLAUser.html
@@ -1,0 +1,12 @@
+<tbody th:fragment="tableBody(userList)" class="govuk-table__body">
+    <tr class="govuk_table__row" th:each="user: ${userList}">
+        <td class="govuk-table__cell" th:text="${user.userName}"></td>
+        <td class="govuk-table__cell" th:text="${user.manager ? 'Admin' : 'Basic'}"></td>
+        <td class="govuk-table__cell" >
+            <span class="govuk-tag" th:classappend="${user.pending ? 'govuk-tag--blue' : 'govuk-tag--green'}">
+            <strong th:text="${user.pending ? 'PENDING' : 'ACTIVE'}"></strong>
+            </span>
+        </td>
+        <td class="govuk-table__cell"><a href="#" class="govuk-link" th:text="Change"></a></td>
+    </tr>
+</tbody>

--- a/src/main/resources/templates/manageLAUsers.html
+++ b/src/main/resources/templates/manageLAUsers.html
@@ -16,8 +16,8 @@
     </div>
     <div th:replace="~{fragments/twoThirdsLayout :: twoThirdsLayout(~{::#action-buttons})}">
       <div class="govuk-button-group" id="action-buttons">
-        <button th:replace="~{fragments/primaryButton :: primaryButton('Invite another user')}"></button>
-        <button th:replace="~{fragments/secondaryButton :: secondaryButton('Return to dashboard')}"></button>
+        <button th:replace="~{fragments/primaryButton :: primaryButton(#{manageLAUsers.primaryButtonText})}"></button>
+        <button th:replace="~{fragments/secondaryButton :: secondaryButton(#{manageLAUsers.secondaryButtonText})}"></button>
       </div>
     </div>
   </section>

--- a/src/main/resources/templates/manageLAUsers.html
+++ b/src/main/resources/templates/manageLAUsers.html
@@ -1,7 +1,34 @@
 <!DOCTYPE html>
 <html th:replace="~{fragments/layout :: layout(${title}, ${serviceName}, ~{::main})}">
 <main class="govuk-main-wrapper" id="main-content">
-  <h1 class="govuk-heading-xl" th:text="${contentHeader}">Default page template</h1>
-  <p th:text="${usersJson}"></p>
+  <div id="page-content">
+    <header>
+      <h1 class="govuk-heading-l" th:text="${contentHeader}">Default page template</h1>
+    </header>
+    <section>
+      <table class="govuk-table">
+        <thead class="govuk-table__head">
+            <tr class="govuk-table__row">
+              <th scope="col" class="govuk-table__header" th:text="${tableColumn1Heading}"></th>
+              <th scope="col" class="govuk-table__header" th:text="${tableColumn2Heading}"></th>
+              <th scope="col" class="govuk-table__header" th:text="${tableColumn3Heading}"></th>
+              <th scope="col" class="govuk-table__header"></th>
+            </tr>
+        </thead>
+        <tbody class="govuk-table__body">
+          <tr class="govuk_table__row" th:each="user: ${userList}">
+            <td class="govuk-table__cell" th:text="${user.userName}"></td>
+            <td class="govuk-table__cell" th:text="${user.manager ? 'Admin' : 'Basic'}"></td>
+            <td class="govuk-table__cell" >
+              <span class="govuk-tag" th:classappend="${user.pending ? 'govuk-tag--blue' : 'govuk-tag--green'}">
+                <strong th:text="${user.pending ? 'PENDING' : 'ACTIVE'}"></strong>
+              </span>
+            </td>
+            <td class="govuk-table__cell"><a href="#" class="govuk-link" th:text="Change"></a></td>
+          </tr>
+        </tbody>
+      </table>
+    </section>
+  </div>
 </main>
 </html>

--- a/src/main/resources/templates/manageLAUsers.html
+++ b/src/main/resources/templates/manageLAUsers.html
@@ -8,28 +8,11 @@
   </div>
   <section>
     <div th:replace="~{fragments/fullWidthLayout :: fullWidthLayout(~{::#LA-users-table})}">
-      <table id="LA-users-table" class="govuk-table">
-        <thead class="govuk-table__head">
-            <tr class="govuk-table__row">
-              <th scope="col" class="govuk-table__header" th:text="${tableColumn1Heading}"></th>
-              <th scope="col" class="govuk-table__header" th:text="${tableColumn2Heading}"></th>
-              <th scope="col" class="govuk-table__header" th:text="${tableColumn3Heading}"></th>
-              <th scope="col" class="govuk-table__header"></th>
-            </tr>
-        </thead>
-        <tbody class="govuk-table__body">
-          <tr class="govuk_table__row" th:each="user: ${userList}">
-            <td class="govuk-table__cell" th:text="${user.userName}"></td>
-            <td class="govuk-table__cell" th:text="${user.manager ? 'Admin' : 'Basic'}"></td>
-            <td class="govuk-table__cell" >
-              <span class="govuk-tag" th:classappend="${user.pending ? 'govuk-tag--blue' : 'govuk-tag--green'}">
-                <strong th:text="${user.pending ? 'PENDING' : 'ACTIVE'}"></strong>
-              </span>
-            </td>
-            <td class="govuk-table__cell"><a href="#" class="govuk-link" th:text="Change"></a></td>
-          </tr>
-        </tbody>
-      </table>
+      <div id="LA-users-table">
+        <table th:replace="~{fragments/tables/table :: table(${tableColumnHeadings},
+        ~{fragments/tables/tableBodyLAUser :: tableBody(${userList})})}">
+        </table>
+      </div>
     </div>
     <div th:replace="~{fragments/twoThirdsLayout :: twoThirdsLayout(~{::#action-buttons})}">
       <div class="govuk-button-group" id="action-buttons">

--- a/src/main/resources/templates/manageLAUsers.html
+++ b/src/main/resources/templates/manageLAUsers.html
@@ -1,12 +1,14 @@
 <!DOCTYPE html>
 <html th:replace="~{fragments/layout :: layout(${title}, ${serviceName}, ~{::main})}">
 <main class="govuk-main-wrapper" id="main-content">
-  <div id="page-content">
-    <header>
-      <h1 class="govuk-heading-l" th:text="${contentHeader}">Default page template</h1>
+  <div th:replace="~{fragments/twoThirdsLayout :: twoThirdsLayout(~{::#header})}">
+    <header id="header">
+      <h1 class="govuk-heading-l" th:text="${contentHeader}"></h1>
     </header>
-    <section>
-      <table class="govuk-table">
+  </div>
+  <section>
+    <div th:replace="~{fragments/fullWidthLayout :: fullWidthLayout(~{::#LA-users-table})}">
+      <table id="LA-users-table" class="govuk-table">
         <thead class="govuk-table__head">
             <tr class="govuk-table__row">
               <th scope="col" class="govuk-table__header" th:text="${tableColumn1Heading}"></th>
@@ -28,7 +30,13 @@
           </tr>
         </tbody>
       </table>
-    </section>
-  </div>
+    </div>
+    <div th:replace="~{fragments/twoThirdsLayout :: twoThirdsLayout(~{::#action-buttons})}">
+      <div class="govuk-button-group" id="action-buttons">
+        <button th:replace="~{fragments/primaryButton :: primaryButton('Invite another user')}"></button>
+        <button th:replace="~{fragments/secondaryButton :: secondaryButton('Return to dashboard')}"></button>
+      </div>
+    </div>
+  </section>
 </main>
 </html>

--- a/src/main/resources/templates/registerAsALandlord.html
+++ b/src/main/resources/templates/registerAsALandlord.html
@@ -38,7 +38,7 @@
                 <p class="govuk-body" th:text="#{registerAsALandlord.access.paragraph}">
                     registerAsALandlord.access.paragraph
                 </p>
-                <a th:replace="~{fragments/startButton :: button( '/registration', 'Start Now' )}"></a>
+                <a th:replace="~{fragments/startButton :: startButton( '/registration', 'Start Now' )}"></a>
             </section>
             <section>
                 <h2 class="govuk-heading-m" th:text="#{registerAsALandlord.responsibility.heading}">

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/controllers/ManageLocalAuthorityUsersControllerTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/controllers/ManageLocalAuthorityUsersControllerTests.kt
@@ -36,6 +36,7 @@ class ManageLocalAuthorityUsersControllerTests(
     fun `ManageLocalAuthorityUsersController returns 200 for authorized user`() {
         val localAuthority = LocalAuthority()
         ReflectionTestUtils.setField(localAuthority, "id", 123)
+        ReflectionTestUtils.setField(localAuthority, "name", "Test Local Authority")
         Mockito
             .`when`(localAuthorityDataService.getLocalAuthorityForUser("user"))
             .thenReturn(localAuthority)

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/IntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/IntegrationTest.kt
@@ -15,6 +15,7 @@ import uk.gov.communities.prsdb.webapp.TestcontainersConfiguration
 import uk.gov.communities.prsdb.webapp.config.NotifyConfig
 import uk.gov.communities.prsdb.webapp.config.OneLoginConfig
 import uk.gov.service.notify.NotificationClient
+import java.security.Principal
 
 @Import(TestcontainersConfiguration::class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
@@ -44,4 +45,7 @@ abstract class IntegrationTest {
 
     @MockBean
     lateinit var securityFilterChain: SecurityFilterChain
+
+    @MockBean
+    lateinit var principal: Principal
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/ManageLAUsersTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/ManageLAUsersTests.kt
@@ -1,0 +1,20 @@
+package uk.gov.communities.prsdb.webapp.integration
+
+import org.junit.jupiter.api.BeforeEach
+import org.mockito.Mockito
+
+class ManageLAUsersTests : IntegrationTest() {
+    @BeforeEach
+    fun setup() {
+        Mockito.`when`(principal.name).thenReturn("Test user")
+    }
+
+// TODO: Add tests when OneLogin mockking is working
+
+/*    @Test
+    fun `manageLAUsers page renders`(page: Page) {
+        page.navigate("http://localhost:$port/manage-users")
+        assertThat(page.getByRole(AriaRole.HEADING)).containsText("Manage")
+        assertThat(page.getByRole(AriaRole.HEADING)).containsText("'s users'")
+    }*/
+}


### PR DESCRIPTION
First pass at the frontend page.

This version:

- Gets the active LA users for the current users's LA from the database
- Takes hardcoded pending LA users (this will come from the database in a later branch)
- Shows these as a table (this will be paginated in a later branch)
- Does not include the common components of the One Login banner, the "Beta - this is a new service" message or breadcrumbs (these will be in later tickets)

![image](https://github.com/user-attachments/assets/7ca5bd17-66f3-497f-b5a9-d85003308824)
