### PR TITLE
PRSD-362: Run OS Places stub without having API key

### DIFF
--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -107,3 +107,4 @@ spring:
 
 os-places:
   base-url: http://localhost:8080
+  api-key: fake-key


### PR DESCRIPTION
Uses fake API key for stubbed OS Places calls