### PR TITLE
PRSD-NONE: Replace  with whenever

### DIFF
--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/clients/OSPlacesClientTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/clients/OSPlacesClientTests.kt
@@ -6,7 +6,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.mock
-import org.mockito.Mockito.`when`
+import org.mockito.kotlin.whenever
 import uk.gov.communities.prsdb.webapp.exceptions.RateLimitExceededException
 import java.net.http.HttpClient
 import java.net.http.HttpResponse
@@ -26,7 +26,7 @@ class OSPlacesClientTests {
     fun `OSPlacesClient returns the response body when the response's status code is 200`() {
         val expectedResponseBody = "body"
 
-        `when`(
+        whenever(
             mockHttpClient.send(any(), any<HttpResponse.BodyHandler<String>>()),
         ).thenReturn(MockHttpResponse(body = expectedResponseBody))
 
@@ -36,7 +36,7 @@ class OSPlacesClientTests {
 
     @Test
     fun `OSPlacesClient throws a RateLimitExceededException when the response's status code is 429`() {
-        `when`(mockHttpClient.send(any(), any<HttpResponse.BodyHandler<String>>())).thenReturn(MockHttpResponse(429))
+        whenever(mockHttpClient.send(any(), any<HttpResponse.BodyHandler<String>>())).thenReturn(MockHttpResponse(429))
 
         assertThrows<RateLimitExceededException> { osPlacesClient.searchByPostcode("") }
     }
@@ -46,7 +46,7 @@ class OSPlacesClientTests {
         val expectedErrorBody = "{'error':{'message':'example error message','statuscode':'400'}}"
         val expectedErrorMessage = "Error 400: example error message"
 
-        `when`(mockHttpClient.send(any(), any<HttpResponse.BodyHandler<String>>())).thenReturn(
+        whenever(mockHttpClient.send(any(), any<HttpResponse.BodyHandler<String>>())).thenReturn(
             MockHttpResponse(
                 400,
                 expectedErrorBody,
@@ -62,7 +62,7 @@ class OSPlacesClientTests {
         val unexpectedErrorBody = "wrong error format"
         val expectedErrorMessage = "Error 400: wrong error format"
 
-        `when`(mockHttpClient.send(any(), any<HttpResponse.BodyHandler<String>>())).thenReturn(
+        whenever(mockHttpClient.send(any(), any<HttpResponse.BodyHandler<String>>())).thenReturn(
             MockHttpResponse(
                 400,
                 unexpectedErrorBody,

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/controllers/ManageLocalAuthorityUsersControllerTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/controllers/ManageLocalAuthorityUsersControllerTests.kt
@@ -1,6 +1,6 @@
 package uk.gov.communities.prsdb.webapp.controllers
 
-import org.mockito.Mockito
+import org.mockito.kotlin.whenever
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
 import org.springframework.security.test.context.support.WithMockUser
@@ -37,8 +37,7 @@ class ManageLocalAuthorityUsersControllerTests(
         val localAuthority = LocalAuthority()
         ReflectionTestUtils.setField(localAuthority, "id", 123)
         ReflectionTestUtils.setField(localAuthority, "name", "Test Local Authority")
-        Mockito
-            .`when`(localAuthorityDataService.getLocalAuthorityForUser("user"))
+        whenever(localAuthorityDataService.getLocalAuthorityForUser("user"))
             .thenReturn(localAuthority)
 
         mvc

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/ManageLAUsersTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/ManageLAUsersTests.kt
@@ -1,12 +1,12 @@
 package uk.gov.communities.prsdb.webapp.integration
 
 import org.junit.jupiter.api.BeforeEach
-import org.mockito.Mockito
+import org.mockito.kotlin.whenever
 
 class ManageLAUsersTests : IntegrationTest() {
     @BeforeEach
     fun setup() {
-        Mockito.`when`(principal.name).thenReturn("Test user")
+        whenever(principal.name).thenReturn("Test user")
     }
 
 // TODO: Add tests when OneLogin mockking is working

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/LocalAuthorityDataServiceTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/LocalAuthorityDataServiceTests.kt
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.mockito.Mockito
+import org.mockito.kotlin.whenever
 import org.springframework.test.util.ReflectionTestUtils
 import uk.gov.communities.prsdb.webapp.database.entity.LocalAuthority
 import uk.gov.communities.prsdb.webapp.database.entity.LocalAuthorityUser
@@ -56,8 +57,7 @@ class LocalAuthorityDataServiceTests {
         val baseUser2 = createOneLoginUser("Test user 2")
         val localAuthorityUser1 = createLocalAuthorityUser(baseUser1, true, localAuthorityTest)
         val localAuthorityUser2 = createLocalAuthorityUser(baseUser2, false, localAuthorityTest)
-        Mockito
-            .`when`(localAuthorityUsersRepository.findByLocalAuthority(localAuthorityTest))
+        whenever(localAuthorityUsersRepository.findByLocalAuthority(localAuthorityTest))
             .thenReturn(listOf(localAuthorityUser1, localAuthorityUser2))
 
         // Act
@@ -77,8 +77,7 @@ class LocalAuthorityDataServiceTests {
         val localAuthority = createLocalAuthority(123)
         val baseUser = createOneLoginUser("Test user 1")
         val localAuthorityUser = createLocalAuthorityUser(baseUser, false, localAuthority)
-        Mockito
-            .`when`(localAuthorityUsersRepository.findByBaseUser_Id("test-user-1"))
+        whenever(localAuthorityUsersRepository.findByBaseUser_Id("test-user-1"))
             .thenReturn(localAuthorityUser)
 
         // Act
@@ -91,8 +90,7 @@ class LocalAuthorityDataServiceTests {
     @Test
     fun `getLocalAuthorityForUser returns null if user is not in a local authority`() {
         // Arrange
-        Mockito
-            .`when`(localAuthorityUsersRepository.findByBaseUser_Id("test-user-1"))
+        whenever(localAuthorityUsersRepository.findByBaseUser_Id("test-user-1"))
             .thenReturn(null)
 
         // Act, Assert

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/LocalAuthorityInvitationServiceTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/LocalAuthorityInvitationServiceTests.kt
@@ -6,7 +6,7 @@ import org.junit.jupiter.api.Test
 import org.mockito.ArgumentCaptor.captor
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.verify
-import org.mockito.Mockito.`when`
+import org.mockito.kotlin.whenever
 import uk.gov.communities.prsdb.webapp.database.entity.LocalAuthority
 import uk.gov.communities.prsdb.webapp.database.entity.LocalAuthorityInvitation
 import uk.gov.communities.prsdb.webapp.database.repository.LocalAuthorityInvitationRepository
@@ -40,7 +40,7 @@ class LocalAuthorityInvitationServiceTests {
         val testUuid = UUID.randomUUID()
         val testEmail = "test@example.com"
         val testAuthority = LocalAuthority()
-        `when`(mockLaInviteRepository.findByToken(testUuid)).thenReturn(LocalAuthorityInvitation(testUuid, testEmail, testAuthority))
+        whenever(mockLaInviteRepository.findByToken(testUuid)).thenReturn(LocalAuthorityInvitation(testUuid, testEmail, testAuthority))
 
         val authority = inviteService.getAuthorityForToken(testUuid.toString())
 

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/NotifyEmailNotificationServiceTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/NotifyEmailNotificationServiceTests.kt
@@ -10,6 +10,7 @@ import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.MethodSource
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito
+import org.mockito.kotlin.whenever
 import uk.gov.communities.prsdb.webapp.exceptions.PersistentEmailSendException
 import uk.gov.communities.prsdb.webapp.exceptions.TransientEmailSentException
 import uk.gov.communities.prsdb.webapp.models.viewModels.EmailTemplateId
@@ -61,7 +62,7 @@ class NotifyEmailNotificationServiceTests {
         var innerException = NotificationClientException(errorMessage)
         Mockito
             .doThrow(innerException)
-            .`when`(notifyClient)
+            .whenever(notifyClient)
             .sendEmail(any(), any(), any(), any())
 
         var thrownException = assertThrows<PersistentEmailSendException> { emailNotificationService.sendEmail("", TestEmailTemplate()) }
@@ -76,7 +77,7 @@ class NotifyEmailNotificationServiceTests {
         var innerException = NotificationClientException(error)
         Mockito
             .doThrow(innerException)
-            .`when`(notifyClient)
+            .whenever(notifyClient)
             .sendEmail(any(), any(), any(), any())
 
         var thrownException = assertThrows<TransientEmailSentException> { emailNotificationService.sendEmail("", TestEmailTemplate()) }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/OSPlacesAddressLookupServiceTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/OSPlacesAddressLookupServiceTests.kt
@@ -7,7 +7,7 @@ import org.junit.jupiter.api.assertThrows
 import org.mockito.ArgumentMatchers.anyString
 import org.mockito.Mockito.doAnswer
 import org.mockito.Mockito.mock
-import org.mockito.Mockito.`when`
+import org.mockito.kotlin.whenever
 import uk.gov.communities.prsdb.webapp.clients.OSPlacesClient
 import uk.gov.communities.prsdb.webapp.models.dataModels.AddressDataModel
 import kotlin.test.assertEquals
@@ -37,7 +37,7 @@ class OSPlacesAddressLookupServiceTests {
                 AddressDataModel("PO1, Example Road, EG", "EG", poBoxNumber = "PO1"),
             )
 
-        `when`(
+        whenever(
             mockOSPlacesClient.searchByPostcode(anyString()),
         ).thenReturn(addressesJSON)
 
@@ -48,7 +48,7 @@ class OSPlacesAddressLookupServiceTests {
 
     @Test
     fun `searchByPostcode throws a HTTP error if the API call fails`() {
-        doAnswer { throw HttpException() }.`when`(mockOSPlacesClient).searchByPostcode(anyString())
+        doAnswer { throw HttpException() }.whenever(mockOSPlacesClient).searchByPostcode(anyString())
 
         assertThrows<HttpException> { addressLookupService.searchByPostcode("EG") }
     }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/RegistrationNumberServiceTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/RegistrationNumberServiceTests.kt
@@ -8,7 +8,7 @@ import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.times
 import org.mockito.Mockito.verify
-import org.mockito.Mockito.`when`
+import org.mockito.kotlin.whenever
 import uk.gov.communities.prsdb.webapp.constants.enums.RegistrationNumberType
 import uk.gov.communities.prsdb.webapp.database.entity.RegistrationNumber
 import uk.gov.communities.prsdb.webapp.database.repository.RegistrationNumberRepository
@@ -25,7 +25,7 @@ class RegistrationNumberServiceTests {
 
     @Test
     fun `createRegistrationNumber creates a registration number for the given entity type`() {
-        `when`(mockRegNumRepository.existsByNumber(any(Long::class.java))).thenReturn(false)
+        whenever(mockRegNumRepository.existsByNumber(any(Long::class.java))).thenReturn(false)
 
         regNumService.createRegistrationNumber(RegistrationNumberType.LANDLORD)
 
@@ -36,7 +36,7 @@ class RegistrationNumberServiceTests {
 
     @Test
     fun `createRegistrationNumber creates a unique registration number`() {
-        `when`(mockRegNumRepository.existsByNumber(any(Long::class.java))).thenReturn(true, false)
+        whenever(mockRegNumRepository.existsByNumber(any(Long::class.java))).thenReturn(true, false)
 
         regNumService.createRegistrationNumber(RegistrationNumberType.LANDLORD)
 

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/UserRolesServiceTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/UserRolesServiceTests.kt
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.mockito.Mockito
+import org.mockito.kotlin.whenever
 import org.springframework.test.util.ReflectionTestUtils
 import uk.gov.communities.prsdb.webapp.database.entity.LandlordUser
 import uk.gov.communities.prsdb.webapp.database.entity.LocalAuthorityUser
@@ -36,8 +37,7 @@ class UserRolesServiceTests {
         val baseUser = createOneLoginUser("Test User 1")
         val user = LandlordUser()
         ReflectionTestUtils.setField(user, "baseUser", baseUser)
-        Mockito
-            .`when`(landlordRepository.findByBaseUser_Id("test-user-1"))
+        whenever(landlordRepository.findByBaseUser_Id("test-user-1"))
             .thenReturn(user)
 
         // Act
@@ -55,8 +55,7 @@ class UserRolesServiceTests {
         val user = LocalAuthorityUser()
         ReflectionTestUtils.setField(user, "baseUser", baseUser)
         ReflectionTestUtils.setField(user, "isManager", true)
-        Mockito
-            .`when`(localAuthorityUserRepository.findByBaseUser_Id("test-user-1"))
+        whenever(localAuthorityUserRepository.findByBaseUser_Id("test-user-1"))
             .thenReturn(user)
 
         // Act
@@ -75,8 +74,7 @@ class UserRolesServiceTests {
         val user = LocalAuthorityUser()
         ReflectionTestUtils.setField(user, "baseUser", baseUser)
         ReflectionTestUtils.setField(user, "isManager", false)
-        Mockito
-            .`when`(localAuthorityUserRepository.findByBaseUser_Id("test-user-1"))
+        whenever(localAuthorityUserRepository.findByBaseUser_Id("test-user-1"))
             .thenReturn(user)
 
         // Act


### PR DESCRIPTION
Added `mockito.kotlin` in a previous PR, this just removes the very ugly `` `when` `` from the tests and replaces it with the much easier to read `whenever`.