### PR TITLE
PRSD-452: One Login Logout

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/config/CustomSecurityConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/config/CustomSecurityConfig.kt
@@ -10,14 +10,19 @@ import org.springframework.security.core.GrantedAuthority
 import org.springframework.security.core.authority.SimpleGrantedAuthority
 import org.springframework.security.oauth2.client.oidc.userinfo.OidcUserRequest
 import org.springframework.security.oauth2.client.oidc.userinfo.OidcUserService
+import org.springframework.security.oauth2.client.oidc.web.logout.OidcClientInitiatedLogoutSuccessHandler
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserService
 import org.springframework.security.oauth2.core.oidc.user.DefaultOidcUser
 import org.springframework.security.oauth2.core.oidc.user.OidcUser
 import org.springframework.security.web.SecurityFilterChain
+import org.springframework.security.web.authentication.logout.LogoutSuccessHandler
 import uk.gov.communities.prsdb.webapp.services.UserRolesService
 
 @Configuration
-class CustomSecurityConfig {
+class CustomSecurityConfig(
+    val clientRegistrationRepository: ClientRegistrationRepository,
+) {
     @Bean
     fun filterChain(http: HttpSecurity): SecurityFilterChain {
         http
@@ -26,6 +31,8 @@ class CustomSecurityConfig {
                     .requestMatchers("/")
                     .permitAll()
                     .requestMatchers("/register-as-a-landlord")
+                    .permitAll()
+                    .requestMatchers("/signout")
                     .permitAll()
                     .requestMatchers("/assets/**")
                     .permitAll()
@@ -40,7 +47,9 @@ class CustomSecurityConfig {
                     .anyRequest()
                     .authenticated()
             }.oauth2Login(Customizer.withDefaults())
-            .csrf { requests ->
+            .logout { logout ->
+                logout.logoutSuccessHandler(oidcLogoutSuccessHandler())
+            }.csrf { requests ->
                 requests.ignoringRequestMatchers("/one-login-local/**")
             }
 
@@ -65,6 +74,12 @@ class CustomSecurityConfig {
             }
             DefaultOidcUser(mappedAuthorities, oidcUser.idToken, oidcUser.userInfo)
         }
+    }
+
+    private fun oidcLogoutSuccessHandler(): LogoutSuccessHandler {
+        val oidcLogoutSuccessHandler = OidcClientInitiatedLogoutSuccessHandler(clientRegistrationRepository)
+        oidcLogoutSuccessHandler.setPostLogoutRedirectUri("{baseUrl}/signout")
+        return oidcLogoutSuccessHandler
     }
 }
 

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/config/CustomSecurityConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/config/CustomSecurityConfig.kt
@@ -79,6 +79,7 @@ class CustomSecurityConfig(
     private fun oidcLogoutSuccessHandler(): LogoutSuccessHandler {
         val oidcLogoutSuccessHandler = OidcClientInitiatedLogoutSuccessHandler(clientRegistrationRepository)
         oidcLogoutSuccessHandler.setPostLogoutRedirectUri("{baseUrl}/signout")
+        oidcLogoutSuccessHandler.setDefaultTargetUrl("/signout")
         return oidcLogoutSuccessHandler
     }
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/SignOutController.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/SignOutController.kt
@@ -6,6 +6,9 @@ import org.springframework.web.bind.annotation.GetMapping
 
 @Controller
 class SignOutController {
+    @GetMapping("/confirm-sign-out")
+    fun confirmSignOut(model: Model): String = "exampleConfirmSignOut"
+
     @GetMapping("/signout")
     fun signOut(model: Model): String {
         model.addAttribute("title", "signOut.title")

--- a/src/main/resources/data-local.sql
+++ b/src/main/resources/data-local.sql
@@ -4,25 +4,36 @@ VALUES ('urn:fdc:gov.uk:2022:ABCDE', 'Bob T Builder', 'bobthebuilder@gmail.com',
        ('urn:fdc:gov.uk:2022:KLMNO', 'Ford Prefect', 'Ford.Prefect@hotmail.com', '10/07/24', '10/07/24'),
        ('urn:fdc:gov.uk:2022:UVWXY', 'Mock User', 'test@example.com', '10/14/24', '10/14/24'),
        ('urn:fdc:gov.uk:2022:PQRST', 'Arthur Dent', 'Arthur.Dent@hotmail.com', '10/09/24', '10/09/24'),
-       ('urn:fdc:gov.uk:2022:07lXHJeQwE0k5PZO7w_PQF425vT8T7e63MrvyPYNSoI', 'Jasmin Conterio', 'jasmin.conterio@softwire.com', '10/07/24', '10/07/24'),
-       ('urn:fdc:gov.uk:2022:mGHDySEVfCsvfvc6lVWf6Qt9Dv0ZxPQWKoEzcjnBlUo','PRSDB Landlord', 'Team-PRSDB+landlord@softwire.com','10/15/24','10/15/24'),
-       ('urn:fdc:gov.uk:2022:n93slCXHsxJ9rU6-AFM0jFIctYQjYf0KN9YVuJT-cao','PRSDB LA Admin', 'Team-PRSDB+laadmin@softwire.com','10/15/24','10/15/24'),
-       ('urn:fdc:gov.uk:2022:cgVX2oJWKHMwzm8Gzx25CSoVXixVS0rw32Sar4Om8vQ','PRSDB La User', 'Team-PRSDB+lauser@softwire.com', '10/15/24', '10/15/24');
+       ('urn:fdc:gov.uk:2022:07lXHJeQwE0k5PZO7w_PQF425vT8T7e63MrvyPYNSoI', 'Jasmin Conterio',
+        'jasmin.conterio@softwire.com', '10/07/24', '10/07/24'),
+       ('urn:fdc:gov.uk:2022:mwfvbb5GgiDh0acjz9EDDQ7zwskWZzUSnWfavL70f6s', 'Isobel Ibironke',
+        'isobel.ibironke@softwire.com', '10/02/24', '10/02/24'),
+       ('urn:fdc:gov.uk:2022:mGHDySEVfCsvfvc6lVWf6Qt9Dv0ZxPQWKoEzcjnBlUo', 'PRSDB Landlord',
+        'Team-PRSDB+landlord@softwire.com', '10/15/24', '10/15/24'),
+       ('urn:fdc:gov.uk:2022:n93slCXHsxJ9rU6-AFM0jFIctYQjYf0KN9YVuJT-cao', 'PRSDB LA Admin',
+        'Team-PRSDB+laadmin@softwire.com', '10/15/24', '10/15/24'),
+       ('urn:fdc:gov.uk:2022:cgVX2oJWKHMwzm8Gzx25CSoVXixVS0rw32Sar4Om8vQ', 'PRSDB La User',
+        'Team-PRSDB+lauser@softwire.com', '10/15/24', '10/15/24');
 
 INSERT INTO landlord_user (subject_identifier, phone_number, date_of_birth, created_date, last_modified_date)
 VALUES ('urn:fdc:gov.uk:2022:ABCDE', '07712345678', '01/01/00', '09/13/24', '09/13/24'),
        ('urn:fdc:gov.uk:2022:FGHIJ', '07811111111', '11/23/98', '09/13/24', '09/13/24'),
        ('urn:fdc:gov.uk:2022:UVWXY', '01406946277', '06/16/84', '10/14/24', '10/14/24'),
-       ('urn:fdc:gov.uk:2022:07lXHJeQwE0k5PZO7w_PQF425vT8T7e63MrvyPYNSoI', '01223456789','02/01/00','10/09/24', '10/09/24'),
-       ('urn:fdc:gov.uk:2022:mGHDySEVfCsvfvc6lVWf6Qt9Dv0ZxPQWKoEzcjnBlUo','01223456789','03/05/00','10/15/24', '10/09/24');
+       ('urn:fdc:gov.uk:2022:07lXHJeQwE0k5PZO7w_PQF425vT8T7e63MrvyPYNSoI', '01223456789', '02/01/00', '10/09/24',
+        '10/09/24'),
+       ('urn:fdc:gov.uk:2022:mwfvbb5GgiDh0acjz9EDDQ7zwskWZzUSnWfavL70f6s', '01223456789', '02/01/00', '10/02/24',
+        '10/02/24'),
+       ('urn:fdc:gov.uk:2022:mGHDySEVfCsvfvc6lVWf6Qt9Dv0ZxPQWKoEzcjnBlUo', '01223456789', '03/05/00', '10/15/24',
+        '10/09/24');
 
 INSERT INTO local_authority (name, created_date, last_modified_date)
-VALUES ('Betelgeuse','09/13/24', '09/13/24');
+VALUES ('Betelgeuse', '09/13/24', '09/13/24');
 
 INSERT INTO local_authority_user (subject_identifier, is_manager, local_authority_id, created_date, last_modified_date)
-VALUES ('urn:fdc:gov.uk:2022:KLMNO',true, 1,'10/07/24', '10/07/24'),
+VALUES ('urn:fdc:gov.uk:2022:KLMNO', true, 1, '10/07/24', '10/07/24'),
        ('urn:fdc:gov.uk:2022:UVWXY', true, 1, '10/14/24', '10/14/24'),
-       ('urn:fdc:gov.uk:2022:PQRST',false, 1,'10/09/24', '10/09/24'),
-       ('urn:fdc:gov.uk:2022:07lXHJeQwE0k5PZO7w_PQF425vT8T7e63MrvyPYNSoI',true,1,'10/09/24', '10/09/24'),
-       ('urn:fdc:gov.uk:2022:n93slCXHsxJ9rU6-AFM0jFIctYQjYf0KN9YVuJT-cao',true,1,'10/15/24','10/15/24'),
-       ('urn:fdc:gov.uk:2022:cgVX2oJWKHMwzm8Gzx25CSoVXixVS0rw32Sar4Om8vQ',false,1,'10/15/24','10/15/24');
+       ('urn:fdc:gov.uk:2022:PQRST', false, 1, '10/09/24', '10/09/24'),
+       ('urn:fdc:gov.uk:2022:07lXHJeQwE0k5PZO7w_PQF425vT8T7e63MrvyPYNSoI', true, 1, '10/09/24', '10/09/24'),
+       ('urn:fdc:gov.uk:2022:mwfvbb5GgiDh0acjz9EDDQ7zwskWZzUSnWfavL70f6s', true, 1, '10/02/24', '10/02/24'),
+       ('urn:fdc:gov.uk:2022:n93slCXHsxJ9rU6-AFM0jFIctYQjYf0KN9YVuJT-cao', true, 1, '10/15/24', '10/15/24'),
+       ('urn:fdc:gov.uk:2022:cgVX2oJWKHMwzm8Gzx25CSoVXixVS0rw32Sar4Om8vQ', false, 1, '10/15/24', '10/15/24');

--- a/src/main/resources/templates/exampleConfirmSignOut.html
+++ b/src/main/resources/templates/exampleConfirmSignOut.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html th:replace="~{fragments/layout :: layout('Confirm Log Out', ~{::main})}">
+<main class="govuk-main-wrapper" id="main-content">
+    <form method="post" th:action="@{/logout}">
+        <h1 class="govuk-heading-l">
+            Are you sure you want to log out?
+        </h1>
+        <button type="submit" class="govuk-button" data-module="govuk-button">
+            Log Out
+        </button>
+    </form>
+</main>
+</html>

--- a/src/main/resources/templates/fragments/header/authenticatedHeader.html
+++ b/src/main/resources/templates/fragments/header/authenticatedHeader.html
@@ -96,7 +96,7 @@
                         </a>
                     </li>
                     <li class="one-login-header__nav__list-item">
-                        <a class="one-login-header__nav__link" th:href="@{/signout}" th:text="#{oneLoginHeader.logout}">
+                        <a class="one-login-header__nav__link" th:href="@{/logout}" th:text="#{oneLoginHeader.logout}">
                             oneLoginHeader.logout
                         </a>
                     </li>

--- a/src/main/resources/templates/fragments/header/authenticatedHeader.html
+++ b/src/main/resources/templates/fragments/header/authenticatedHeader.html
@@ -96,7 +96,8 @@
                         </a>
                     </li>
                     <li class="one-login-header__nav__list-item">
-                        <a class="one-login-header__nav__link" th:href="@{/logout}" th:text="#{oneLoginHeader.logout}">
+                        <a class="one-login-header__nav__link" th:href="@{/confirm-sign-out}"
+                           th:text="#{oneLoginHeader.logout}">
                             oneLoginHeader.logout
                         </a>
                     </li>


### PR DESCRIPTION
### Features
- Creates a `/confirm-sign-out` endpoint with a submit button that logs the user out of OneLogin
- Points the OneLogin header's 'Sign Out' link to `/confirm-sign-out`
- Sets the post OneLogin logout redirect URL to `/signout`

Confirm Sign Out Page:
![image](https://github.com/user-attachments/assets/859bd48f-ec90-4c49-b922-42ebdfbeecc7)

### Notes
- Integration tests are required to check that the logout functionality works, but the configuration required for integration tests has not been done yet