### PR TITLE
Feat/prsd 403 add tests

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/ManageLocalAuthorityUsersController.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/ManageLocalAuthorityUsersController.kt
@@ -46,6 +46,10 @@ class ManageLocalAuthorityUsersController(
                 page - 1,
             )
 
+        if (pagedUserList.totalPages < page) {
+            return "redirect:/local-authority/{localAuthorityId}/manage-users"
+        }
+
         model.addAttribute("localAuthority", currentUserLocalAuthority.name)
         model.addAttribute("userList", pagedUserList)
         model.addAttribute("totalPages", pagedUserList.totalPages)

--- a/src/main/resources/data-local.sql
+++ b/src/main/resources/data-local.sql
@@ -40,4 +40,6 @@ VALUES ('urn:fdc:gov.uk:2022:KLMNO', true, 1, '10/07/24', '10/07/24'),
 
 INSERT INTO local_authority_invitation (invited_email, inviting_authority_id, token)
 VALUES ('invited.user@example.com', 1, gen_random_uuid()),
+       ('user.invited@example.com', 1, gen_random_uuid()),
+       ('further.user@example.com', 1, gen_random_uuid()),
        ('another.user@example.com', 1, gen_random_uuid());

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/controllers/ManageLocalAuthorityUsersControllerTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/controllers/ManageLocalAuthorityUsersControllerTests.kt
@@ -47,7 +47,7 @@ class ManageLocalAuthorityUsersControllerTests(
         whenever(localAuthorityDataService.getLocalAuthorityForUser("user"))
             .thenReturn(localAuthority)
         whenever(localAuthorityDataService.getPaginatedUsersAndInvitations(localAuthority, 0))
-            .thenReturn(PageImpl(listOf(), PageRequest.of(0, 10), 0))
+            .thenReturn(PageImpl(listOf(), PageRequest.of(0, 10), 1))
 
         mvc
             .get("/local-authority/123/manage-users")

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/IntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/IntegrationTest.kt
@@ -16,7 +16,6 @@ import uk.gov.communities.prsdb.webapp.clients.OSPlacesClient
 import uk.gov.communities.prsdb.webapp.config.NotifyConfig
 import uk.gov.communities.prsdb.webapp.config.OSPlacesConfig
 import uk.gov.service.notify.NotificationClient
-import java.security.Principal
 
 @Import(TestcontainersConfiguration::class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
@@ -37,9 +36,6 @@ abstract class IntegrationTest {
 
     @MockBean
     lateinit var osPlacesClient: OSPlacesClient
-
-    @MockBean
-    lateinit var principal: Principal
 
     @SpyBean
     lateinit var clientRegistrationRepository: ClientRegistrationRepository

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/ManageLAUsersTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/ManageLAUsersTests.kt
@@ -4,7 +4,6 @@ import com.microsoft.playwright.Page
 import com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat
 import kotlin.test.Test
 
-// @ActiveProfiles("local-no-auth")
 class ManageLAUsersTests : IntegrationTest() {
     val localAuthorityId = 1
 

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/ManageLAUsersTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/ManageLAUsersTests.kt
@@ -1,20 +1,48 @@
 package uk.gov.communities.prsdb.webapp.integration
 
-import org.junit.jupiter.api.BeforeEach
-import org.mockito.kotlin.whenever
+import com.microsoft.playwright.Page
+import com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat
+import kotlin.test.Test
 
+// @ActiveProfiles("local-no-auth")
 class ManageLAUsersTests : IntegrationTest() {
-    @BeforeEach
-    fun setup() {
-        whenever(principal.name).thenReturn("Test user")
+    val localAuthorityId = 1
+
+    @Test
+    fun `manageLAUsers page renders`(page: Page) {
+        page.navigate("http://localhost:$port/local-authority/$localAuthorityId/manage-users")
+        assertThat(page.locator("h1")).containsText("Manage Betelgeuse's users")
     }
 
-// TODO: Add tests when OneLogin mockking is working
+    @Test
+    fun `table of users renders`(page: Page) {
+        page.navigate("http://localhost:$port/local-authority/$localAuthorityId/manage-users")
+        assertThat(page.locator("table")).containsText("Username")
+        assertThat(page.locator("table")).containsText("Access level")
+        assertThat(page.locator("table")).containsText("Account status")
+        assertThat(page.locator("table")).containsText("Arthur Dent")
+        assertThat(page.locator("table")).containsText("Basic")
+        assertThat(page.locator("table")).containsText("ACTIVE")
+        assertThat(page.locator("table")).containsText("Admin")
+    }
 
-/*    @Test
-    fun `manageLAUsers page renders`(page: Page) {
-        page.navigate("http://localhost:$port/manage-users")
-        assertThat(page.getByRole(AriaRole.HEADING)).containsText("Manage")
-        assertThat(page.getByRole(AriaRole.HEADING)).containsText("'s users'")
-    }*/
+    @Test
+    fun `buttons render`(page: Page) {
+        page.navigate("http://localhost:$port/local-authority/$localAuthorityId/manage-users")
+        assertThat(page.locator("button").getByText("Invite another user")).isVisible()
+        assertThat(page.locator("button").getByText("Return to dashboard")).isVisible()
+    }
+
+    @Test
+    fun `pagination component renders with more than 10 table entries`(page: Page) {
+        page.navigate("http://localhost:$port/local-authority/$localAuthorityId/manage-users")
+        assertThat(page.locator("nav.govuk-pagination")).isVisible()
+        assertThat(page.locator("nav.govuk-pagination")).containsText("Next")
+        assertThat(page.locator("li.govuk-pagination__item--current")).containsText("1")
+
+        page.navigate("http://localhost:$port/local-authority/$localAuthorityId/manage-users?page=2")
+        assertThat(page.locator("nav.govuk-pagination")).isVisible()
+        assertThat(page.locator("nav.govuk-pagination")).containsText("Previous")
+        assertThat(page.locator("li.govuk-pagination__item--current")).containsText("2")
+    }
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/LocalAuthorityDataServiceTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/LocalAuthorityDataServiceTests.kt
@@ -5,7 +5,6 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.InjectMocks
 import org.mockito.Mock
-import org.mockito.Mockito
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.whenever
 import org.springframework.data.domain.PageImpl
@@ -86,8 +85,9 @@ class LocalAuthorityDataServiceTests {
 
     @Test
     fun `getUserList returns LocalAuthorityUserDataModels from the LocalAuthorityUserOrInvitationRepository`() {
+        // Arrange
         val localAuthority = createLocalAuthority(123)
-        val expectedPageRequest =
+        val pageRequest =
             PageRequest.of(
                 1,
                 10,
@@ -96,18 +96,85 @@ class LocalAuthorityDataServiceTests {
         val user1 = LocalAuthorityUserOrInvitation(1, "local_authority_user", "User 1", true, localAuthority)
         val user2 = LocalAuthorityUserOrInvitation(2, "local_authority_user", "User 2", false, localAuthority)
         val invitation = LocalAuthorityUserOrInvitation(3, "local_authority_invitation", "invite@test.com", false, localAuthority)
-        Mockito
-            .`when`(localAuthorityUserOrInvitationRepository.findByLocalAuthority(localAuthority, expectedPageRequest))
-            .thenReturn(PageImpl(listOf(user1, user2, invitation), expectedPageRequest, 3))
-
-        val userList = localAuthorityDataService.getPaginatedUsersAndInvitations(localAuthority, 1)
-
+        whenever(localAuthorityUserOrInvitationRepository.findByLocalAuthority(localAuthority, pageRequest))
+            .thenReturn(PageImpl(listOf(user1, user2, invitation), pageRequest, 3))
         val expectedLaUserList =
             listOf(
                 LocalAuthorityUserDataModel("User 1", true, false),
                 LocalAuthorityUserDataModel("User 2", false, false),
                 LocalAuthorityUserDataModel("invite@test.com", false, true),
             )
+
+        // Act
+        val userList = localAuthorityDataService.getPaginatedUsersAndInvitations(localAuthority, 1)
+
+        // Assert
         Assertions.assertIterableEquals(expectedLaUserList, userList)
+    }
+
+    @Test
+    fun `Returns all users if there are fewer users in the database than MAX_ENTRIES_IN_TABLE_PAGE`() {
+        // Arrange
+        val localAuthority = createLocalAuthority(123)
+        val pageRequest =
+            PageRequest.of(
+                1,
+                10,
+                Sort.by(Sort.Order.desc("entityType"), Sort.Order.asc("name")),
+            )
+        val user1 = LocalAuthorityUserOrInvitation(1, "local_authority_user", "User 1", true, localAuthority)
+        val user2 = LocalAuthorityUserOrInvitation(2, "local_authority_user", "User 2", false, localAuthority)
+        val invitation = LocalAuthorityUserOrInvitation(3, "local_authority_invitation", "invite@test.com", false, localAuthority)
+        whenever(localAuthorityUserOrInvitationRepository.findByLocalAuthority(localAuthority, pageRequest))
+            .thenReturn(PageImpl(listOf(user1, user2, invitation), pageRequest, 3))
+
+        // Act
+        val userList = localAuthorityDataService.getPaginatedUsersAndInvitations(localAuthority, 1)
+
+        // Assert
+        Assertions.assertEquals(3, userList.content.size)
+    }
+
+    @Test
+    fun `Returns the requested page of users if there are more users in the database than MAX_ENTRIES_IN_TABLE_PAGE`() {
+        // Arrange
+        val localAuthority = createLocalAuthority(123)
+        val usersFromRepository = mutableListOf<LocalAuthorityUserOrInvitation>()
+        for (i in 1..20) {
+            usersFromRepository.add(LocalAuthorityUserOrInvitation(i.toLong(), "local_authority_user", "User $i", false, localAuthority))
+        }
+        val pageRequest1 =
+            PageRequest.of(
+                1,
+                10,
+                Sort.by(Sort.Order.desc("entityType"), Sort.Order.asc("name")),
+            )
+        val pageRequest2 =
+            PageRequest.of(
+                2,
+                10,
+                Sort.by(Sort.Order.desc("entityType"), Sort.Order.asc("name")),
+            )
+        whenever(localAuthorityUserOrInvitationRepository.findByLocalAuthority(localAuthority, pageRequest1))
+            .thenReturn(PageImpl(usersFromRepository.subList(0, 10).toList(), pageRequest1, 3))
+        whenever(localAuthorityUserOrInvitationRepository.findByLocalAuthority(localAuthority, pageRequest2))
+            .thenReturn(PageImpl(usersFromRepository.subList(10, 20).toList(), pageRequest2, 3))
+
+        val expectedUserListPage1 = mutableListOf<LocalAuthorityUserDataModel>()
+        val expectedUserListPage2 = mutableListOf<LocalAuthorityUserDataModel>()
+        for (i in 1..10) {
+            expectedUserListPage1.add(LocalAuthorityUserDataModel("User $i", false, false))
+        }
+        for (i in 11..20) {
+            expectedUserListPage2.add(LocalAuthorityUserDataModel("User $i", false, false))
+        }
+
+        // Act
+        val userListPage1 = localAuthorityDataService.getPaginatedUsersAndInvitations(localAuthority, 1)
+        val userListPage2 = localAuthorityDataService.getPaginatedUsersAndInvitations(localAuthority, 2)
+
+        // Assert
+        Assertions.assertIterableEquals(expectedUserListPage1, userListPage1)
+        Assertions.assertIterableEquals(expectedUserListPage2, userListPage2)
     }
 }


### PR DESCRIPTION
I'm expecting this to be the last PR for PRSD-403, it includes

- Pagination: redirect to the first page in the table if the user requests a page that doesn't exist (i.e. page 3 where there are only 2)
- Backend pagination tests
- Frontend playwright tests for Manage LA Users
    - I haven't looked for pending users in the table because they may not show on the first page if many more active users get added!
    - I added a couple more pending users to the database so we have enough to need pagination
    - This checks that the Previous, Next and current page links appear correctly for pagination