### PR TITLE
PRSD-404: add success page, link from manage users page, add Page Object style e2e tests

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/ManageLocalAuthorityUsersController.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/ManageLocalAuthorityUsersController.kt
@@ -46,7 +46,7 @@ class ManageLocalAuthorityUsersController(
                 page - 1,
             )
 
-        model.addAttribute("localAuthority", currentUserLocalAuthority.name)
+        model.addAttribute("localAuthority", currentUserLocalAuthority)
         model.addAttribute("userList", pagedUserList)
         model.addAttribute("totalPages", pagedUserList.totalPages)
         model.addAttribute("currentPage", page)

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/ManageLocalAuthorityUsersController.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/ManageLocalAuthorityUsersController.kt
@@ -93,9 +93,7 @@ class ManageLocalAuthorityUsersController(
                 LocalAuthorityInvitationEmail(currentAuthority, invitationLinkAddress),
             )
 
-            // TODO PRSD-404 Create a more permanent success template, rather than (ab)using "index" here
-            redirectAttributes.addFlashAttribute("contentHeader", "You have sent a test email to ${emailModel.email}")
-            redirectAttributes.addFlashAttribute("title", "Email sent")
+            redirectAttributes.addFlashAttribute("invitedEmailAddress", emailModel.email)
             return "redirect:invite-new-user/success"
         } catch (retryException: TransientEmailSentException) {
             bindingResult.reject("addLAUser.error.retryable")
@@ -104,7 +102,15 @@ class ManageLocalAuthorityUsersController(
     }
 
     @GetMapping("/invite-new-user/success")
-    fun successInvitedNewUser() = "index"
+    fun successInvitedNewUser(
+        @PathVariable localAuthorityId: Int,
+        principal: Principal,
+        model: Model,
+    ): String {
+        val currentAuthority = getCurrentUsersLocalAuthorityAndCheckAuthorisation(principal, localAuthorityId)
+        model.addAttribute("localAuthority", currentAuthority)
+        return "inviteLAUserSuccess"
+    }
 
     private fun getCurrentUsersLocalAuthorityAndCheckAuthorisation(
         principal: Principal,

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/database/entity/LocalAuthority.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/database/entity/LocalAuthority.kt
@@ -7,12 +7,17 @@ import jakarta.persistence.GenerationType
 import jakarta.persistence.Id
 
 @Entity
-class LocalAuthority : ModifiableAuditableEntity() {
+class LocalAuthority() : ModifiableAuditableEntity() {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    val id: Int? = null
+    var id: Int? = null
 
     @Column(nullable = false)
     lateinit var name: String
         private set
+
+    constructor(id: Int, name: String) : this() {
+        this.id = id
+        this.name = name
+    }
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/database/entity/LocalAuthority.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/database/entity/LocalAuthority.kt
@@ -7,17 +7,16 @@ import jakarta.persistence.GenerationType
 import jakarta.persistence.Id
 
 @Entity
-class LocalAuthority() : ModifiableAuditableEntity() {
+class LocalAuthority(
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    var id: Int? = null
-
+    val id: Int? = null,
+) : ModifiableAuditableEntity() {
     @Column(nullable = false)
     lateinit var name: String
         private set
 
-    constructor(id: Int, name: String) : this() {
-        this.id = id
+    constructor(id: Int, name: String) : this(id) {
         this.name = name
     }
 }

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -1,5 +1,7 @@
 serviceName=Private Rented Sector Database
 
+common.confirmationPage.whatHappensNext=What happens next
+
 oneLoginHeader.logout=Sign Out
 
 signOut.title=You have signed out
@@ -100,8 +102,6 @@ addLAUser.paragraph.one=Once you send an invite this person can register an acco
 addLAUser.paragraph.two=They can view and edit information related to:
 addLAUser.paragraph.two.bullet.one=landlords in the local area
 addLAUser.paragraph.two.bullet.two=properties in the local area
-
-# {0} = the council email address domain (i.e. council.co.uk)
 addLAUser.form.primaryEmailLabel=Enter their email address
 addLAUser.form.confirmEmailLabel=Confirm email address
 addLAUser.form.submitButton=Submit
@@ -111,6 +111,14 @@ addLAUser.error.notAnEmail=Enter an email address in the correct format
 addLAUser.error.noConfirmation=You must enter and confirm your email address
 addLAUser.error.confirmationDoesNotMatch=Both email address should match
 addLAUser.error.retryable=Please try again
+
+addLAUserSuccess.title=User invited
+addLAUserSuccess.banner.title=User invited
+addLAUserSuccess.banner.body=You''ve sent {0,,invitedEmailAddress} an invitation to the database
+addLAUserSuccess.whatHappensNext.paragraph.one=They'll receive a link in their email to register on the database.
+addLAUserSuccess.whatHappensNext.paragraph.two=Once they''ve registered, they can view property and landlord records that fall under {0}''s local area.
+addLAUserSuccess.inviteAnother=Invite another user
+addLAUserSuccess.returnToDashboard=Return to dashboard
 
 registerAHome=Register a home to rent
 registerAHome.navLink.one=Service Link 1

--- a/src/main/resources/templates/fragments/confirmationPageBanner.html
+++ b/src/main/resources/templates/fragments/confirmationPageBanner.html
@@ -1,0 +1,8 @@
+<div th:fragment="confirmationPageBanner(title, body)" class="govuk-panel govuk-panel--confirmation">
+    <h1 class="govuk-panel__title" th:text="${title}">
+        title
+    </h1>
+    <div class="govuk-panel__body" th:insert="${body}">
+        Body text that goes in the banner
+    </div>
+</div>

--- a/src/main/resources/templates/fragments/primaryButtonLink.html
+++ b/src/main/resources/templates/fragments/primaryButtonLink.html
@@ -1,0 +1,10 @@
+<a th:fragment="primaryButtonLink(href, text)"
+   th:href="${href}"
+   role="button"
+   draggable="false"
+   class="govuk-button"
+   data-module="govuk-button"
+   th:text="${text}"
+>
+    primaryButtonLink text
+</a>

--- a/src/main/resources/templates/fragments/secondaryButtonLink.html
+++ b/src/main/resources/templates/fragments/secondaryButtonLink.html
@@ -1,0 +1,10 @@
+<a th:fragment="secondaryButtonLink(href, text)"
+   th:href="${href}"
+   role="button"
+   draggable="false"
+   class="govuk-button govuk-button--secondary"
+   data-module="govuk-button"
+   th:text="${text}"
+>
+    secondaryButtonLink text
+</a>

--- a/src/main/resources/templates/inviteLAUserSuccess.html
+++ b/src/main/resources/templates/inviteLAUserSuccess.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html th:replace="~{fragments/layout :: layout(#{addLAUserSuccess.title}, ~{::main}, false)}">
+<main class="govuk-main-wrapper" id="main-content">
+    <div id="page-contents" th:replace="~{fragments/twoThirdsLayout :: twoThirdsLayout(~{::#page-contents/content()})}">
+        <div id="confirmation-banner" th:replace="~{fragments/confirmationPageBanner :: confirmationPageBanner(#{addLAUserSuccess.banner.title}, ~{::#confirmation-banner/content()})}">
+            <span th:text="#{addLAUserSuccess.banner.body(${invitedEmailAddress})}" th:remove="tag">addLAUserSuccess.banner.body</span>
+        </div>
+        <h2 class="govuk-heading-m" th:text="#{common.confirmationPage.whatHappensNext}">common.whatHappensNext</h2>
+        <p class="govuk-body" th:text="#{addLAUserSuccess.whatHappensNext.paragraph.one}">
+            addLAUserSuccess.whatHappensNext.para1
+        </p>
+        <p class="govuk-body" th:text="#{addLAUserSuccess.whatHappensNext.paragraph.two(${localAuthority.name})}">
+            addLAUserSuccess.whatHappensNext.para2
+        </p>
+        <div class="govuk-button-group">
+            <a th:replace="~{fragments/primaryButtonLink :: primaryButtonLink(@{/local-authority/{id}/invite-new-user(id=${localAuthority.id})}, #{addLAUserSuccess.inviteAnother})}">
+                addLAUserSuccess.inviteAnother
+            </a>
+            <a th:replace="~{fragments/secondaryButtonLink :: secondaryButtonLink('#', #{addLAUserSuccess.returnToDashboard})}">
+                addLAUserSuccess.returnToDashboard
+            </a>
+        </div>
+    </div>
+</main>
+</html>

--- a/src/main/resources/templates/manageLAUsers.html
+++ b/src/main/resources/templates/manageLAUsers.html
@@ -3,7 +3,7 @@
 <main class="govuk-main-wrapper" id="main-content">
     <div id="page-contents" th:replace="~{fragments/twoThirdsLayout :: twoThirdsLayout(~{::#page-contents/content()})}">
         <header id="header">
-            <h1 class="govuk-heading-l" th:text="#{manageLAUsers.contentHeader(${localAuthority})}">
+            <h1 class="govuk-heading-l" th:text="#{manageLAUsers.contentHeader(${localAuthority.name})}">
                 manageLAUsers.contentHeader
             </h1>
         </header>
@@ -31,7 +31,9 @@
                 </nav>
             </div>
             <div class="govuk-button-group" id="action-buttons">
-                <button th:replace="~{fragments/primaryButton :: primaryButton(#{manageLAUsers.inviteAnotherUserButtonText})}"></button>
+                <a th:replace="~{fragments/primaryButtonLink :: primaryButtonLink(@{/local-authority/{id}/invite-new-user(id=${localAuthority.id})}, #{manageLAUsers.inviteAnotherUserButtonText})}">
+                    manageLAUsers.inviteAnotherUserButtonText
+                </a>
                 <button th:replace="~{fragments/secondaryButton :: secondaryButton(#{manageLAUsers.returnToDashboardButton})}"></button>
             </div>
         </section>

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/controllers/ControllerTest.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/controllers/ControllerTest.kt
@@ -10,9 +10,6 @@ import org.springframework.test.web.servlet.setup.DefaultMockMvcBuilder
 import org.springframework.test.web.servlet.setup.MockMvcBuilders
 import org.springframework.web.context.WebApplicationContext
 import uk.gov.communities.prsdb.webapp.config.CustomSecurityConfig
-import uk.gov.communities.prsdb.webapp.models.viewModels.EmailTemplateModel
-import uk.gov.communities.prsdb.webapp.services.EmailNotificationService
-import uk.gov.communities.prsdb.webapp.services.LocalAuthorityInvitationService
 import uk.gov.communities.prsdb.webapp.services.UserRolesService
 
 @Import(CustomSecurityConfig::class)
@@ -35,10 +32,4 @@ abstract class ControllerTest(
 
     @MockBean
     lateinit var userRolesService: UserRolesService
-
-    @MockBean
-    lateinit var anyEmailNotificationService: EmailNotificationService<EmailTemplateModel>
-
-    @MockBean
-    lateinit var localAuthorityInvitationService: LocalAuthorityInvitationService
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/controllers/ManageLocalAuthorityUsersControllerTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/controllers/ManageLocalAuthorityUsersControllerTests.kt
@@ -1,23 +1,37 @@
 package uk.gov.communities.prsdb.webapp.controllers
 
+import org.mockito.kotlin.any
 import org.mockito.kotlin.whenever
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
 import org.springframework.boot.test.mock.mockito.MockBean
 import org.springframework.data.domain.PageImpl
 import org.springframework.data.domain.PageRequest
+import org.springframework.http.MediaType
 import org.springframework.security.test.context.support.WithMockUser
-import org.springframework.test.util.ReflectionTestUtils
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf
 import org.springframework.test.web.servlet.get
+import org.springframework.test.web.servlet.post
 import org.springframework.web.context.WebApplicationContext
 import uk.gov.communities.prsdb.webapp.database.entity.LocalAuthority
+import uk.gov.communities.prsdb.webapp.models.viewModels.EmailTemplateModel
+import uk.gov.communities.prsdb.webapp.services.EmailNotificationService
 import uk.gov.communities.prsdb.webapp.services.LocalAuthorityDataService
+import uk.gov.communities.prsdb.webapp.services.LocalAuthorityInvitationService
+import java.net.URI
+import java.net.URLEncoder
 import kotlin.test.Test
 
 @WebMvcTest(ManageLocalAuthorityUsersController::class)
 class ManageLocalAuthorityUsersControllerTests(
     @Autowired val webContext: WebApplicationContext,
 ) : ControllerTest(webContext) {
+    @MockBean
+    lateinit var emailNotificationService: EmailNotificationService<EmailTemplateModel>
+
+    @MockBean
+    lateinit var localAuthorityInvitationService: LocalAuthorityInvitationService
+
     @MockBean
     private lateinit var localAuthorityDataService: LocalAuthorityDataService
 
@@ -41,9 +55,7 @@ class ManageLocalAuthorityUsersControllerTests(
     @Test
     @WithMockUser(roles = ["LA_ADMIN"])
     fun `ManageLocalAuthorityUsersController returns 200 for authorized user`() {
-        val localAuthority = LocalAuthority()
-        ReflectionTestUtils.setField(localAuthority, "id", 123)
-        ReflectionTestUtils.setField(localAuthority, "name", "Test Local Authority")
+        val localAuthority = LocalAuthority(123, "Test Local Authority")
         whenever(localAuthorityDataService.getLocalAuthorityForUser("user"))
             .thenReturn(localAuthority)
         whenever(localAuthorityDataService.getPaginatedUsersAndInvitations(localAuthority, 0))
@@ -59,9 +71,7 @@ class ManageLocalAuthorityUsersControllerTests(
     @Test
     @WithMockUser(roles = ["LA_ADMIN"])
     fun `ManageLocalAuthorityUsersController returns 403 for admin user accessing another LA`() {
-        val localAuthority = LocalAuthority()
-        ReflectionTestUtils.setField(localAuthority, "id", 123)
-        ReflectionTestUtils.setField(localAuthority, "name", "Test Local Authority")
+        val localAuthority = LocalAuthority(123, "Test Local Authority")
         whenever(localAuthorityDataService.getLocalAuthorityForUser("user"))
             .thenReturn(localAuthority)
         whenever(localAuthorityDataService.getPaginatedUsersAndInvitations(localAuthority, 0))
@@ -72,5 +82,35 @@ class ManageLocalAuthorityUsersControllerTests(
             .andExpect {
                 status { isForbidden() }
             }
+    }
+
+    @Test
+    @WithMockUser(roles = ["LA_ADMIN"])
+    fun `inviting new user with valid form redirects to confirmation page`() {
+        val localAuthority = LocalAuthority(123, "Test Local Authority")
+        whenever(localAuthorityDataService.getLocalAuthorityForUser("user"))
+            .thenReturn(localAuthority)
+        whenever(localAuthorityInvitationService.createInvitationToken(any(), any()))
+            .thenReturn("test-token")
+        whenever(localAuthorityInvitationService.buildInvitationUri("test-token"))
+            .thenReturn(URI("https://test-service.gov.uk/sign-up-la-user"))
+
+        mvc
+            .post("/local-authority/123/invite-new-user") {
+                contentType = MediaType.APPLICATION_FORM_URLENCODED
+                content = urlEncodedConfirmedEmailDataModel("new-user@example.com")
+                with(csrf())
+            }.andExpect {
+                status { is3xxRedirection() }
+                redirectedUrl("invite-new-user/success")
+                flash { attribute("invitedEmailAddress", "new-user@example.com") }
+            }
+    }
+
+    private fun urlEncodedConfirmedEmailDataModel(
+        @Suppress("SameParameterValue") testEmail: String,
+    ): String {
+        val encodedTestEmail = URLEncoder.encode(testEmail, "UTF-8")
+        return "email=$encodedTestEmail&confirmEmail=$encodedTestEmail"
     }
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/IntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/IntegrationTest.kt
@@ -1,5 +1,6 @@
 package uk.gov.communities.prsdb.webapp.integration
 
+import com.microsoft.playwright.Page
 import com.microsoft.playwright.junit.UsePlaywright
 import org.junit.jupiter.api.BeforeEach
 import org.mockito.kotlin.whenever
@@ -15,6 +16,7 @@ import uk.gov.communities.prsdb.webapp.TestcontainersConfiguration
 import uk.gov.communities.prsdb.webapp.clients.OSPlacesClient
 import uk.gov.communities.prsdb.webapp.config.NotifyConfig
 import uk.gov.communities.prsdb.webapp.config.OSPlacesConfig
+import uk.gov.communities.prsdb.webapp.integration.pageobjects.pages.Navigator
 import uk.gov.service.notify.NotificationClient
 import java.security.Principal
 
@@ -77,5 +79,12 @@ abstract class IntegrationTest {
 
             whenever(clientRegistrationRepository.findByRegistrationId("one-login")).thenReturn(updatedRegistration)
         }
+    }
+
+    lateinit var navigator: Navigator
+
+    @BeforeEach
+    fun setUp(page: Page) {
+        navigator = Navigator(page, port)
     }
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/InvitationUrlTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/InvitationUrlTests.kt
@@ -18,8 +18,11 @@ import uk.gov.communities.prsdb.webapp.controllers.ControllerTest
 import uk.gov.communities.prsdb.webapp.controllers.ExampleInvitationTokenController
 import uk.gov.communities.prsdb.webapp.controllers.ManageLocalAuthorityUsersController
 import uk.gov.communities.prsdb.webapp.database.entity.LocalAuthority
+import uk.gov.communities.prsdb.webapp.models.viewModels.EmailTemplateModel
 import uk.gov.communities.prsdb.webapp.models.viewModels.LocalAuthorityInvitationEmail
+import uk.gov.communities.prsdb.webapp.services.EmailNotificationService
 import uk.gov.communities.prsdb.webapp.services.LocalAuthorityDataService
+import uk.gov.communities.prsdb.webapp.services.LocalAuthorityInvitationService
 import java.net.URLEncoder
 import kotlin.test.Test
 
@@ -28,6 +31,12 @@ import kotlin.test.Test
 class InvitationUrlTests(
     context: WebApplicationContext,
 ) : ControllerTest(context) {
+    @MockBean
+    lateinit var anyEmailNotificationService: EmailNotificationService<EmailTemplateModel>
+
+    @MockBean
+    lateinit var localAuthorityInvitationService: LocalAuthorityInvitationService
+
     @MockBean
     private lateinit var localAuthorityDataService: LocalAuthorityDataService
 

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/InviteLaUsersTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/InviteLaUsersTests.kt
@@ -1,0 +1,22 @@
+package uk.gov.communities.prsdb.webapp.integration
+
+import org.junit.jupiter.api.Test
+
+class InviteLaUsersTests : IntegrationTest() {
+    @Test
+    fun `inviting a new LA user ends with a success page`() {
+        val invitePage = navigator.goToInviteNewLaUser(1)
+        invitePage.fillBothEmailFields("test@example.com")
+        val successPage = invitePage.submit()
+        successPage.confirmationBanner.assertHasMessage("You've sent test@example.com an invitation to the database")
+    }
+
+    @Test
+    fun `inviting a new LA user shows validation errors if the email addresses don't match`() {
+        val invitePage = navigator.goToInviteNewLaUser(1)
+        invitePage.fillEmail("test@example.com")
+        invitePage.fillConfirmEmail("different@example.com")
+        invitePage.submitUnsuccessfully()
+        invitePage.assertConfirmEmailErrorContains("Both email address should match")
+    }
+}

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/ManageLAUsersTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/ManageLAUsersTests.kt
@@ -2,6 +2,7 @@ package uk.gov.communities.prsdb.webapp.integration
 
 import com.microsoft.playwright.Page
 import com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat
+import com.microsoft.playwright.options.AriaRole
 import kotlin.test.Test
 
 class ManageLAUsersTests : IntegrationTest() {
@@ -28,8 +29,8 @@ class ManageLAUsersTests : IntegrationTest() {
     @Test
     fun `buttons render`(page: Page) {
         page.navigate("http://localhost:$port/local-authority/$localAuthorityId/manage-users")
-        assertThat(page.locator("button").getByText("Invite another user")).isVisible()
-        assertThat(page.locator("button").getByText("Return to dashboard")).isVisible()
+        assertThat(page.getByRole(AriaRole.BUTTON).getByText("Invite another user")).isVisible()
+        assertThat(page.getByRole(AriaRole.BUTTON).getByText("Return to dashboard")).isVisible()
     }
 
     @Test

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageobjects/components/BaseComponent.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageobjects/components/BaseComponent.kt
@@ -1,0 +1,16 @@
+package uk.gov.communities.prsdb.webapp.integration.pageobjects.components
+
+import com.microsoft.playwright.Locator
+import org.junit.jupiter.api.Assertions.assertEquals
+
+abstract class BaseComponent(
+    protected val locator: Locator,
+) {
+    init {
+        assertLocatorIsValid()
+    }
+
+    private fun assertLocatorIsValid() {
+        assertEquals(1, locator.count())
+    }
+}

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageobjects/components/ConfirmationPageBanner.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageobjects/components/ConfirmationPageBanner.kt
@@ -1,12 +1,12 @@
 package uk.gov.communities.prsdb.webapp.integration.pageobjects.components
 
 import com.microsoft.playwright.Locator
-import org.junit.jupiter.api.Assertions.assertTrue
+import com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat
 
 class ConfirmationPageBanner(
     locator: Locator,
 ) : BaseComponent(locator) {
     fun assertHasMessage(message: String) {
-        assertTrue(locator.textContent().contains(message))
+        assertThat(locator).containsText(message)
     }
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageobjects/components/ConfirmationPageBanner.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageobjects/components/ConfirmationPageBanner.kt
@@ -1,0 +1,12 @@
+package uk.gov.communities.prsdb.webapp.integration.pageobjects.components
+
+import com.microsoft.playwright.Locator
+import org.junit.jupiter.api.Assertions.assertTrue
+
+class ConfirmationPageBanner(
+    locator: Locator,
+) : BaseComponent(locator) {
+    fun assertHasMessage(message: String) {
+        assertTrue(locator.textContent().contains(message))
+    }
+}

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageobjects/components/TextInput.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageobjects/components/TextInput.kt
@@ -1,7 +1,7 @@
 package uk.gov.communities.prsdb.webapp.integration.pageobjects.components
 
 import com.microsoft.playwright.Locator
-import org.junit.jupiter.api.Assertions.assertTrue
+import com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat
 
 class TextInput(
     locator: Locator,
@@ -9,7 +9,6 @@ class TextInput(
     val input = locator.locator("input")
 
     fun assertErrorMessageContains(message: String) {
-        val foundText = locator.locator(".govuk-error-message").textContent()
-        assertTrue(foundText.contains(message))
+        assertThat(locator.locator(".govuk-error-message")).containsText(message)
     }
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageobjects/components/TextInput.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageobjects/components/TextInput.kt
@@ -1,0 +1,15 @@
+package uk.gov.communities.prsdb.webapp.integration.pageobjects.components
+
+import com.microsoft.playwright.Locator
+import org.junit.jupiter.api.Assertions.assertTrue
+
+class TextInput(
+    locator: Locator,
+) : BaseComponent(locator) {
+    val input = locator.locator("input")
+
+    fun assertErrorMessageContains(message: String) {
+        val foundText = locator.locator(".govuk-error-message").textContent()
+        assertTrue(foundText.contains(message))
+    }
+}

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageobjects/pages/BasePage.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageobjects/pages/BasePage.kt
@@ -1,0 +1,22 @@
+package uk.gov.communities.prsdb.webapp.integration.pageobjects.pages
+
+import com.microsoft.playwright.Page
+import uk.gov.communities.prsdb.webapp.integration.pageobjects.components.TextInput
+
+abstract class BasePage(
+    protected val page: Page,
+) {
+    companion object {
+        inline fun <reified T : BasePage> createValid(page: Page): T {
+            val pageInstance = T::class.constructors.first().call(page)
+            pageInstance.validate()
+            return pageInstance
+        }
+    }
+
+    protected val header = page.locator("main header h1")
+
+    abstract fun validate()
+
+    protected fun inputFormGroup(fieldName: String) = TextInput(page.locator(".govuk-form-group:has(input[name=\"$fieldName\"])"))
+}

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageobjects/pages/InviteNewLaUserPage.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageobjects/pages/InviteNewLaUserPage.kt
@@ -1,0 +1,40 @@
+package uk.gov.communities.prsdb.webapp.integration.pageobjects.pages
+
+import com.microsoft.playwright.Page
+import org.junit.jupiter.api.Assertions.assertEquals
+
+class InviteNewLaUserPage(
+    page: Page,
+) : BasePage(page) {
+    private val emailInputFormGroup = inputFormGroup("email")
+    private val confirmEmailInputFormGroup = inputFormGroup("confirmEmail")
+    private val submitButton = page.locator("button[type=\"submit\"]")
+
+    override fun validate() {
+        assertEquals("Invite someone from Betelgeuse to the database", header.textContent())
+    }
+
+    fun fillEmail(text: String) = emailInputFormGroup.input.fill(text)
+
+    fun fillConfirmEmail(text: String) = confirmEmailInputFormGroup.input.fill(text)
+
+    fun fillBothEmailFields(text: String) {
+        fillEmail(text)
+        fillConfirmEmail(text)
+    }
+
+    fun submit(): InviteNewLaUserSuccessPage {
+        submitButton.click()
+        page.waitForLoadState()
+        return createValid<InviteNewLaUserSuccessPage>(page)
+    }
+
+    fun submitUnsuccessfully() {
+        submitButton.click()
+        page.waitForLoadState()
+    }
+
+    fun assertConfirmEmailErrorContains(text: String) {
+        confirmEmailInputFormGroup.assertErrorMessageContains(text)
+    }
+}

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageobjects/pages/InviteNewLaUserSuccessPage.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageobjects/pages/InviteNewLaUserSuccessPage.kt
@@ -1,0 +1,15 @@
+package uk.gov.communities.prsdb.webapp.integration.pageobjects.pages
+
+import com.microsoft.playwright.Page
+import org.junit.jupiter.api.Assertions.assertEquals
+import uk.gov.communities.prsdb.webapp.integration.pageobjects.components.ConfirmationPageBanner
+
+class InviteNewLaUserSuccessPage(
+    page: Page,
+) : BasePage(page) {
+    override fun validate() {
+        assertEquals("User invited", page.title())
+    }
+
+    val confirmationBanner: ConfirmationPageBanner = ConfirmationPageBanner(page.locator(".govuk-panel--confirmation"))
+}

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageobjects/pages/Navigator.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageobjects/pages/Navigator.kt
@@ -1,0 +1,17 @@
+package uk.gov.communities.prsdb.webapp.integration.pageobjects.pages
+
+import com.microsoft.playwright.Page
+
+class Navigator(
+    private val page: Page,
+    private val port: Int,
+) {
+    fun goToInviteNewLaUser(authorityId: Int): InviteNewLaUserPage {
+        navigate("local-authority/$authorityId/invite-new-user")
+        return BasePage.createValid<InviteNewLaUserPage>(page)
+    }
+
+    private fun navigate(path: String) {
+        page.navigate("http://localhost:$port/$path")
+    }
+}


### PR DESCRIPTION
This PR finishes off the last bits of PRSD-404, namely:

- After inviting a new user, we show a properly styled confirmation page
- The manage LA users page has a button to invite new users, which is now wired up to this page
- There are some controller tests for the invite journey
- There are some e2e tests for the invite journey

Note that as part of the above I've introduced:
- Primary and secondary buttons that look like links
- The beginnings of a Page Object style framework for e2e tests; I'm not that familiar with Playwright, so we might want to evolve a bit as we learn what works well, but here's a starting point