### PR TITLE
PRSD-NONE: Add missing hasErrors parameter to layout fragment call in exampleConfirmSignOut.html

### DIFF
--- a/src/main/resources/templates/exampleConfirmSignOut.html
+++ b/src/main/resources/templates/exampleConfirmSignOut.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html th:replace="~{fragments/layout :: layout('Confirm Log Out', ~{::main})}">
+<html th:replace="~{fragments/layout :: layout('Confirm Log Out', ~{::main}, false)}">
 <main class="govuk-main-wrapper" id="main-content">
     <form method="post" th:action="@{/logout}">
         <h1 class="govuk-heading-l">


### PR DESCRIPTION
I think the sign out page must have been added at the same time as the layout fragment got the hasErrors parameter, and it got missed in the merge.

This change just adds in this parameter (as false - there are no errors on this page) to fix the exception when trying to render this page.