### PR TITLE
PRSD-NONE: ManageLAUsersTests uses page objects

### DIFF
--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/ManageLAUsersTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/ManageLAUsersTests.kt
@@ -2,47 +2,53 @@ package uk.gov.communities.prsdb.webapp.integration
 
 import com.microsoft.playwright.Page
 import com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat
-import com.microsoft.playwright.options.AriaRole
+import org.junit.jupiter.api.Assertions.assertTrue
 import kotlin.test.Test
 
 class ManageLAUsersTests : IntegrationTest() {
     val localAuthorityId = 1
 
     @Test
-    fun `manageLAUsers page renders`(page: Page) {
-        page.navigate("http://localhost:$port/local-authority/$localAuthorityId/manage-users")
-        assertThat(page.locator("h1")).containsText("Manage Betelgeuse's users")
-    }
-
-    @Test
     fun `table of users renders`(page: Page) {
-        page.navigate("http://localhost:$port/local-authority/$localAuthorityId/manage-users")
-        assertThat(page.locator("table")).containsText("Username")
-        assertThat(page.locator("table")).containsText("Access level")
-        assertThat(page.locator("table")).containsText("Account status")
-        assertThat(page.locator("table")).containsText("Arthur Dent")
-        assertThat(page.locator("table")).containsText("Basic")
-        assertThat(page.locator("table")).containsText("ACTIVE")
-        assertThat(page.locator("table")).containsText("Admin")
+        val managePage = navigator.goToManageLaUsers(localAuthorityId)
+
+        val header = managePage.table.header()
+        assertTrue(header.username().contains("Username"))
+        assertTrue(header.accessLevel().contains("Access level"))
+        assertTrue(header.accountStatus().contains("Account status"))
+
+        val topRow = managePage.table.row(0)
+        assertTrue(topRow.username().contains("Arthur Dent"))
+        assertTrue(topRow.accessLevel().contains("Basic"))
+        assertTrue(topRow.accountStatus().contains("ACTIVE"))
+
+        val nextRow = managePage.table.row(1)
+        assertTrue(nextRow.accessLevel().contains("Admin"))
     }
 
     @Test
-    fun `buttons render`(page: Page) {
-        page.navigate("http://localhost:$port/local-authority/$localAuthorityId/manage-users")
-        assertThat(page.getByRole(AriaRole.BUTTON).getByText("Invite another user")).isVisible()
-        assertThat(page.getByRole(AriaRole.BUTTON).getByText("Return to dashboard")).isVisible()
+    fun `invite button goes to invite new user page`() {
+        val managePage = navigator.goToManageLaUsers(localAuthorityId)
+        managePage.inviteNewUser()
+    }
+
+    @Test
+    fun `return to dashboard button is visible`() {
+        val managePage = navigator.goToManageLaUsers(localAuthorityId)
+        assertThat(managePage.returnToDashboardButton).isVisible()
     }
 
     @Test
     fun `pagination component renders with more than 10 table entries`(page: Page) {
-        page.navigate("http://localhost:$port/local-authority/$localAuthorityId/manage-users")
-        assertThat(page.locator("nav.govuk-pagination")).isVisible()
-        assertThat(page.locator("nav.govuk-pagination")).containsText("Next")
-        assertThat(page.locator("li.govuk-pagination__item--current")).containsText("1")
+        var managePage = navigator.goToManageLaUsers(localAuthorityId)
+        managePage.pagination.assertNextIsVisible()
+        managePage.pagination.assertPageNumberIsCurrent(1)
+        managePage.pagination.assertPageNumberIsVisible(2)
 
-        page.navigate("http://localhost:$port/local-authority/$localAuthorityId/manage-users?page=2")
-        assertThat(page.locator("nav.govuk-pagination")).isVisible()
-        assertThat(page.locator("nav.govuk-pagination")).containsText("Previous")
-        assertThat(page.locator("li.govuk-pagination__item--current")).containsText("2")
+        managePage = managePage.pagination.clickLink(2)
+
+        managePage.pagination.assertPreviousIsVisible()
+        managePage.pagination.assertPageNumberIsVisible(1)
+        managePage.pagination.assertPageNumberIsCurrent(2)
     }
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageobjects/components/Pagination.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageobjects/components/Pagination.kt
@@ -1,0 +1,40 @@
+package uk.gov.communities.prsdb.webapp.integration.pageobjects.components
+
+import com.microsoft.playwright.Locator
+import com.microsoft.playwright.Locator.FilterOptions
+import com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat
+import uk.gov.communities.prsdb.webapp.integration.pageobjects.pages.BasePage
+import kotlin.reflect.KClass
+
+class Pagination<TPage : BasePage>(
+    locator: Locator,
+    private val pageClass: KClass<TPage>,
+) : BaseComponent(locator) {
+    fun assertNextIsVisible() {
+        assertThat(linkWithText("Next")).isVisible()
+    }
+
+    fun assertPreviousIsVisible() {
+        assertThat(linkWithText("Previous")).isVisible()
+    }
+
+    fun assertPageNumberIsVisible(pageNum: Int) {
+        assertThat(linkWithText(pageNum.toString())).isVisible()
+    }
+
+    fun assertPageNumberIsCurrent(pageNum: Int) {
+        assertThat(linkWithText(pageNum.toString()).locator("..")).hasClass("govuk-pagination__item govuk-pagination__item--current")
+    }
+
+    fun clickLink(pageNum: Int): TPage {
+        linkWithText(pageNum.toString()).click()
+        return BasePage.createValid(locator.page(), pageClass)
+    }
+
+    private fun linkWithText(text: String): Locator =
+        locator.locator("a.govuk-pagination__link").filter(
+            FilterOptions().apply {
+                hasText = text
+            },
+        )
+}

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageobjects/components/Table.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageobjects/components/Table.kt
@@ -1,0 +1,23 @@
+package uk.gov.communities.prsdb.webapp.integration.pageobjects.components
+
+import com.microsoft.playwright.Locator
+import com.microsoft.playwright.Locator.FilterOptions
+
+open class Table(
+    locator: Locator,
+) : BaseComponent(locator) {
+    fun assertHasHeaderCellWithText(text: String) {
+        locator.locator("thead th").filter(FilterOptions().apply { hasText = text })
+    }
+
+    fun getCellText(
+        rowIndex: Int,
+        colIndex: Int,
+    ): String =
+        locator
+            .locator("tbody tr")
+            .nth(rowIndex)
+            .locator("td")
+            .nth(colIndex)
+            .textContent()
+}

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageobjects/pages/BasePage.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageobjects/pages/BasePage.kt
@@ -2,13 +2,18 @@ package uk.gov.communities.prsdb.webapp.integration.pageobjects.pages
 
 import com.microsoft.playwright.Page
 import uk.gov.communities.prsdb.webapp.integration.pageobjects.components.TextInput
+import kotlin.reflect.KClass
 
 abstract class BasePage(
     protected val page: Page,
 ) {
     companion object {
-        inline fun <reified T : BasePage> createValid(page: Page): T {
-            val pageInstance = T::class.constructors.first().call(page)
+        fun <T : BasePage> createValid(
+            page: Page,
+            targetClass: KClass<T>,
+        ): T {
+            page.waitForLoadState()
+            val pageInstance = targetClass.constructors.first().call(page)
             pageInstance.validate()
             return pageInstance
         }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageobjects/pages/InviteNewLaUserPage.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageobjects/pages/InviteNewLaUserPage.kt
@@ -1,7 +1,7 @@
 package uk.gov.communities.prsdb.webapp.integration.pageobjects.pages
 
 import com.microsoft.playwright.Page
-import org.junit.jupiter.api.Assertions.assertEquals
+import com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat
 
 class InviteNewLaUserPage(
     page: Page,
@@ -11,7 +11,7 @@ class InviteNewLaUserPage(
     private val submitButton = page.locator("button[type=\"submit\"]")
 
     override fun validate() {
-        assertEquals("Invite someone from Betelgeuse to the database", header.textContent())
+        assertThat(header).containsText("Invite someone from Betelgeuse to the database")
     }
 
     fun fillEmail(text: String) = emailInputFormGroup.input.fill(text)
@@ -25,8 +25,7 @@ class InviteNewLaUserPage(
 
     fun submit(): InviteNewLaUserSuccessPage {
         submitButton.click()
-        page.waitForLoadState()
-        return createValid<InviteNewLaUserSuccessPage>(page)
+        return createValid(page, InviteNewLaUserSuccessPage::class)
     }
 
     fun submitUnsuccessfully() {

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageobjects/pages/ManageLaUsersPage.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageobjects/pages/ManageLaUsersPage.kt
@@ -1,0 +1,52 @@
+package uk.gov.communities.prsdb.webapp.integration.pageobjects.pages
+
+import com.microsoft.playwright.Locator
+import com.microsoft.playwright.Page
+import com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat
+import com.microsoft.playwright.options.AriaRole
+import uk.gov.communities.prsdb.webapp.integration.pageobjects.components.BaseComponent
+import uk.gov.communities.prsdb.webapp.integration.pageobjects.components.Pagination
+import uk.gov.communities.prsdb.webapp.integration.pageobjects.components.Table
+
+private const val USERNAME_COL_INDEX: Int = 0
+private const val ACCESS_LEVEL_COL_INDEX: Int = 1
+private const val ACCOUNT_STATUS_COL_INDEX: Int = 2
+
+class ManageLaUsersPage(
+    page: Page,
+) : BasePage(page) {
+    override fun validate() {
+        assertThat(header).containsText("Manage Betelgeuse's users")
+    }
+
+    val table = UsersTable(page)
+
+    val inviteAnotherButton: Locator = page.getByRole(AriaRole.BUTTON).getByText("Invite another user")
+
+    val returnToDashboardButton: Locator = page.getByRole(AriaRole.BUTTON).getByText("Return to dashboard")
+
+    val pagination by lazy { Pagination(page.locator("nav.govuk-pagination"), this::class) }
+
+    fun inviteNewUser(): InviteNewLaUserPage {
+        inviteAnotherButton.click()
+        return createValid(page, InviteNewLaUserPage::class)
+    }
+
+    class UsersTable(
+        page: Page,
+    ) : Table(page.locator("table.govuk-table")) {
+        fun header() = Row(locator.locator("thead tr"))
+
+        fun row(rowIndex: Int) = Row(locator.locator("tbody tr").nth(rowIndex))
+    }
+
+    class Row(
+        rowLocator: Locator,
+    ) : BaseComponent(rowLocator) {
+        fun username(): String = locator.locator("td, th").nth(USERNAME_COL_INDEX).textContent()
+
+        fun accessLevel(): String = locator.locator("td, th").nth(ACCESS_LEVEL_COL_INDEX).textContent()
+
+        fun accountStatus(): String = locator.locator("td, th").nth(ACCOUNT_STATUS_COL_INDEX).textContent()
+    }
+}

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageobjects/pages/Navigator.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageobjects/pages/Navigator.kt
@@ -8,7 +8,12 @@ class Navigator(
 ) {
     fun goToInviteNewLaUser(authorityId: Int): InviteNewLaUserPage {
         navigate("local-authority/$authorityId/invite-new-user")
-        return BasePage.createValid<InviteNewLaUserPage>(page)
+        return BasePage.createValid(page, InviteNewLaUserPage::class)
+    }
+
+    fun goToManageLaUsers(authorityId: Int): ManageLaUsersPage {
+        navigate("local-authority/$authorityId/manage-users")
+        return BasePage.createValid(page, ManageLaUsersPage::class)
     }
 
     private fun navigate(path: String) {


### PR DESCRIPTION
The ManageLAUsersTests were written as the same time as I was introducing the page objects pattern for integration tests. I've rewritten them in that style, here.