### PR TITLE
PRSD-NONE: Use 'invite' instead of 'invitation' in user facing copy

### DIFF
--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -112,9 +112,9 @@ addLAUser.error.noConfirmation=You must enter and confirm your email address
 addLAUser.error.confirmationDoesNotMatch=Both email address should match
 addLAUser.error.retryable=Please try again
 
-addLAUserSuccess.title=User invited
-addLAUserSuccess.banner.title=User invited
-addLAUserSuccess.banner.body=You''ve sent {0,,invitedEmailAddress} an invitation to the database
+addLAUserSuccess.title=Invite sent
+addLAUserSuccess.banner.title=Invite sent
+addLAUserSuccess.banner.body=You''ve sent {0,,invitedEmailAddress} an invite to the database
 addLAUserSuccess.whatHappensNext.paragraph.one=They'll receive a link in their email to register on the database.
 addLAUserSuccess.whatHappensNext.paragraph.two=Once they''ve registered, they can view property and landlord records that fall under {0}''s local area.
 addLAUserSuccess.inviteAnother=Invite another user

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/InviteLaUsersTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/InviteLaUsersTests.kt
@@ -8,7 +8,7 @@ class InviteLaUsersTests : IntegrationTest() {
         val invitePage = navigator.goToInviteNewLaUser(1)
         invitePage.fillBothEmailFields("test@example.com")
         val successPage = invitePage.submit()
-        successPage.confirmationBanner.assertHasMessage("You've sent test@example.com an invitation to the database")
+        successPage.confirmationBanner.assertHasMessage("You've sent test@example.com an invite to the database")
     }
 
     @Test

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageobjects/pages/InviteNewLaUserSuccessPage.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageobjects/pages/InviteNewLaUserSuccessPage.kt
@@ -8,7 +8,7 @@ class InviteNewLaUserSuccessPage(
     page: Page,
 ) : BasePage(page) {
     override fun validate() {
-        assertEquals("User invited", page.title())
+        assertEquals("Invite sent", page.title())
     }
 
     val confirmationBanner: ConfirmationPageBanner = ConfirmationPageBanner(page.locator(".govuk-panel--confirmation"))


### PR DESCRIPTION
Andrea has requested that we use the word "invite" instead of "invitation" in user facing copy, on the basis that it's less formal and helps with reading comprehension.