### PR TITLE
PRSD-407: Delete LA users (via confirm screen)

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/ManageLocalAuthorityUsersController.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/ManageLocalAuthorityUsersController.kt
@@ -105,6 +105,46 @@ class ManageLocalAuthorityUsersController(
         return "redirect:/local-authority/{localAuthorityId}/manage-users"
     }
 
+    @GetMapping("/delete-user/{localAuthorityUserId}")
+    fun confirmDeleteUser(
+        @PathVariable localAuthorityId: Int,
+        @PathVariable localAuthorityUserId: Long,
+        model: Model,
+        principal: Principal,
+    ): String {
+        localAuthorityDataService.getLocalAuthorityIfAuthorizedUser(localAuthorityId, principal.name)
+        val user = localAuthorityDataService.getLocalAuthorityUserIfAuthorizedLA(localAuthorityUserId, localAuthorityId)
+        model.addAttribute("user", user)
+        return "deleteLAUser"
+    }
+
+    @PostMapping("/delete-user/{localAuthorityUserId}")
+    fun deleteUser(
+        @PathVariable localAuthorityId: Int,
+        @PathVariable localAuthorityUserId: Long,
+        principal: Principal,
+        redirectAttributes: RedirectAttributes,
+    ): String {
+        localAuthorityDataService.getLocalAuthorityIfAuthorizedUser(localAuthorityId, principal.name)
+        val user = localAuthorityDataService.getLocalAuthorityUserIfAuthorizedLA(localAuthorityUserId, localAuthorityId)
+
+        localAuthorityDataService.deleteUser(localAuthorityUserId)
+
+        redirectAttributes.addFlashAttribute("deletedUserName", user.userName)
+        return "redirect:../delete-user/success"
+    }
+
+    @GetMapping("/delete-user/success")
+    fun deleteUserSuccess(
+        @PathVariable localAuthorityId: Int,
+        model: Model,
+        principal: Principal,
+    ): String {
+        val authority = localAuthorityDataService.getLocalAuthorityIfAuthorizedUser(localAuthorityId, principal.name)
+        model.addAttribute("localAuthority", authority)
+        return "deleteLAUserSuccess"
+    }
+
     @GetMapping("/invite-new-user")
     fun inviteNewUser(
         @PathVariable localAuthorityId: Int,

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/ManageLocalAuthorityUsersController.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/ManageLocalAuthorityUsersController.kt
@@ -71,6 +71,7 @@ class ManageLocalAuthorityUsersController(
         val localAuthorityUser =
             localAuthorityDataService.getLocalAuthorityUserIfAuthorizedLA(localAuthorityUserId, localAuthorityId)
 
+        model.addAttribute("backLinkPath", "../manage-users")
         model.addAttribute("localAuthorityUser", localAuthorityUser)
         model.addAttribute(
             "options",
@@ -115,6 +116,7 @@ class ManageLocalAuthorityUsersController(
         localAuthorityDataService.getLocalAuthorityIfAuthorizedUser(localAuthorityId, principal.name)
         val user = localAuthorityDataService.getLocalAuthorityUserIfAuthorizedLA(localAuthorityUserId, localAuthorityId)
         model.addAttribute("user", user)
+        model.addAttribute("backLinkPath", "../edit-user/$localAuthorityUserId")
         return "deleteLAUser"
     }
 

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/LocalAuthorityDataService.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/LocalAuthorityDataService.kt
@@ -90,4 +90,8 @@ class LocalAuthorityDataService(
         localAuthorityUser.isManager = localAuthorityUserAccessLevel.isManager
         localAuthorityUserRepository.save(localAuthorityUser)
     }
+
+    fun deleteUser(localAuthorityUserId: Long) {
+        localAuthorityUserRepository.deleteById(localAuthorityUserId)
+    }
 }

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -129,6 +129,21 @@ editLAUserAccess.radios.option.admin.hint=Manage users within this local authori
 editLAUserAccess.saveButton=Save and return
 editLAUserAccess.deleteAccountButton=Remove this account
 
+deleteLAUser.title=Remove a user
+deleteLAUser.heading=Before you remove this account
+deleteLAUser.emailLabel=Email
+deleteLAUser.para.one=Once removed, the user can not access this local authority on the database.
+deleteLAUser.para.two=You'll need to invite this user again to give them access.
+deleteLAUser.warning=Make sure you are removing the right user before you continue
+deleteLAUser.deleteAccountButton=Remove this account
+
+deleteLAUserSuccess.title=User removed
+deleteLAUserSuccess.banner.title=User removed
+deleteLAUserSuccess.banner.body=You''ve removed {0,,deletedUserName}''s account from {1,,localAuthorityName}
+deleteLAUserSuccess.whatHappensNext.paragraph.one=The user account is removed and they can no longer access {0,,localAuthorityName}''s dashboard.
+deleteLAUserSuccess.whatHappensNext.paragraph.two=You''ll need to invite this user again to give them access to {0,,localAuthorityName} on the database.
+deleteLAUserSuccess.returnToManageUsers=Return to manage users
+
 registerAHome=Register a home to rent
 registerAHome.navLink.one=Service Link 1
 registerAHome.navLink.two=Service Link 2

--- a/src/main/resources/templates/deleteLAUser.html
+++ b/src/main/resources/templates/deleteLAUser.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html th:replace="~{fragments/layout :: layout(#{deleteLAUser.title}, ~{::main}, false)}">
+<main class="govuk-main-wrapper" id="main-content">
+    <div id="page-content" th:replace="~{fragments/layouts/twoThirdsLayout :: twoThirdsLayout(~{::#page-content/content()})}">
+        <header id="header">
+            <h1 class="govuk-heading-l" th:text="#{deleteLAUser.heading}">deleteLAUser.heading</h1>
+        </header>
+        <section>
+            <p class="govuk-body">
+                <strong th:text="${user.userName}">user.name</strong>
+            </p>
+            <p class="govuk-body">
+                <strong th:text="#{deleteLAUser.emailLabel}+':'">deleteLAUser.emailLabel:</strong>
+                <span th:text="${user.email}" th:remove="tag">user.email</span>
+            </p>
+        </section>
+        <section>
+            <p class="govuk-body" th:text="#{deleteLAUser.para.one}">deleteLAUser.para.one</p>
+            <p class="govuk-body" th:text="#{deleteLAUser.para.two}">deleteLAUser.para.two</p>
+            <div th:replace="~{fragments/warningText :: warningText(#{deleteLAUser.warning})}">deleteLAUser.warning</div>
+        </section>
+        <form method="post" th:action="@{''}">
+            <button th:replace="~{fragments/buttons/warningButton :: warningButton(buttonText=#{deleteLAUser.deleteAccountButton})}"></button>
+        </form>
+    </div>
+</main>
+</html>

--- a/src/main/resources/templates/deleteLAUser.html
+++ b/src/main/resources/templates/deleteLAUser.html
@@ -1,27 +1,30 @@
 <!DOCTYPE html>
-<html th:replace="~{fragments/layout :: layout(#{deleteLAUser.title}, ~{::main}, false)}">
-<main class="govuk-main-wrapper" id="main-content">
-    <div id="page-content" th:replace="~{fragments/layouts/twoThirdsLayout :: twoThirdsLayout(~{::#page-content/content()})}">
-        <header id="header">
-            <h1 class="govuk-heading-l" th:text="#{deleteLAUser.heading}">deleteLAUser.heading</h1>
-        </header>
-        <section>
-            <p class="govuk-body">
-                <strong th:text="${user.userName}">user.name</strong>
-            </p>
-            <p class="govuk-body">
-                <strong th:text="#{deleteLAUser.emailLabel}+':'">deleteLAUser.emailLabel:</strong>
-                <span th:text="${user.email}" th:remove="tag">user.email</span>
-            </p>
-        </section>
-        <section>
-            <p class="govuk-body" th:text="#{deleteLAUser.para.one}">deleteLAUser.para.one</p>
-            <p class="govuk-body" th:text="#{deleteLAUser.para.two}">deleteLAUser.para.two</p>
-            <div th:replace="~{fragments/warningText :: warningText(#{deleteLAUser.warning})}">deleteLAUser.warning</div>
-        </section>
-        <form method="post" th:action="@{''}">
-            <button th:replace="~{fragments/buttons/warningButton :: warningButton(buttonText=#{deleteLAUser.deleteAccountButton})}"></button>
-        </form>
-    </div>
-</main>
+<html>
+    <body th:replace="~{fragments/layout :: layout(#{deleteLAUser.title}, ~{::body/content()}, false)}">
+        <a th:replace="~{fragments/forms/backLink :: backLink(${backLinkPath})}">backLink</a>
+        <th:block th:replace="~{fragments/layouts/twoThirdsLayout :: twoThirdsLayout(~{::main})}">
+        <main class="govuk-main-wrapper">
+            <header id="header">
+                <h1 class="govuk-heading-l" th:text="#{deleteLAUser.heading}">deleteLAUser.heading</h1>
+            </header>
+            <section>
+                <p class="govuk-body">
+                    <strong th:text="${user.userName}">user.name</strong>
+                </p>
+                <p class="govuk-body">
+                    <strong th:text="#{deleteLAUser.emailLabel}+':'">deleteLAUser.emailLabel:</strong>
+                    <span th:text="${user.email}" th:remove="tag">user.email</span>
+                </p>
+            </section>
+            <section>
+                <p class="govuk-body" th:text="#{deleteLAUser.para.one}">deleteLAUser.para.one</p>
+                <p class="govuk-body" th:text="#{deleteLAUser.para.two}">deleteLAUser.para.two</p>
+                <div th:replace="~{fragments/warningText :: warningText(#{deleteLAUser.warning})}">deleteLAUser.warning</div>
+            </section>
+            <form method="post" th:action="@{''}">
+                <button th:replace="~{fragments/buttons/warningButton :: warningButton(buttonText=#{deleteLAUser.deleteAccountButton})}"></button>
+            </form>
+        </main>
+        </th:block>
+    </body>
 </html>

--- a/src/main/resources/templates/deleteLAUserSuccess.html
+++ b/src/main/resources/templates/deleteLAUserSuccess.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html th:replace="~{fragments/layout :: layout(#{deleteLAUserSuccess.title}, ~{::main}, false)}">
+<main class="govuk-main-wrapper" id="main-content">
+    <div id="page-contents" th:replace="~{fragments/layouts/twoThirdsLayout :: twoThirdsLayout(~{::#page-contents/content()})}">
+        <div id="confirmation-banner" th:replace="~{fragments/confirmationPageBanner :: confirmationPageBanner(#{deleteLAUserSuccess.banner.title}, ~{::#confirmation-banner/content()})}">
+            <span th:text="#{deleteLAUserSuccess.banner.body(${deletedUserName}, ${localAuthority.name})}" th:remove="tag">deleteLAUserSuccess.banner.body</span>
+        </div>
+        <h2 class="govuk-heading-m" th:text="#{common.confirmationPage.whatHappensNext}">common.whatHappensNext</h2>
+        <p class="govuk-body" th:text="#{deleteLAUserSuccess.whatHappensNext.paragraph.one(${localAuthority.name})}">
+            deleteLAUserSuccess.whatHappensNext.para1
+        </p>
+        <p class="govuk-body" th:text="#{deleteLAUserSuccess.whatHappensNext.paragraph.two(${localAuthority.name})}">
+            deleteLAUserSuccess.whatHappensNext.para2
+        </p>
+        <div class="govuk-button-group">
+            <a th:replace="~{fragments/primaryButtonLink :: primaryButtonLink(@{/local-authority/{id}/manage-users(id=${localAuthority.id})}, #{deleteLAUserSuccess.returnToManageUsers})}">
+                deleteLAUserSuccess.returnToManageUsers
+            </a>
+        </div>
+    </div>
+</main>
+</html>

--- a/src/main/resources/templates/editLAUserAccess.html
+++ b/src/main/resources/templates/editLAUserAccess.html
@@ -14,7 +14,11 @@
                 <div th:replace="~{fragments/radioButtons :: radioButtons(#{editLAUserAccess.radios.heading}, 'isManager', ${options})}"></div>
                 <div class="govuk-button-group">
                     <button th:replace="~{fragments/buttons/primaryButton :: primaryButton(#{editLAUserAccess.saveButton})}"></button>
-                    <button th:replace="~{fragments/buttons/warningButton :: warningButton(buttonText=#{editLAUserAccess.deleteAccountButton},href='#')}"></button>
+                    <button th:replace="~{fragments/buttons/warningButton :: warningButton(
+                            buttonText=#{editLAUserAccess.deleteAccountButton},
+                            href=@{/local-authority/{laId}/delete-user/{uid}(laId=${localAuthorityId}, uid=${localAuthorityUserId})}
+                        )}"
+                    ></button>
                 </div>
             </form>
         </div>

--- a/src/main/resources/templates/editLAUserAccess.html
+++ b/src/main/resources/templates/editLAUserAccess.html
@@ -1,8 +1,9 @@
 <!DOCTYPE html>
-<html th:replace="~{fragments/layout :: layout(#{manageLAUsers.title}, ~{::main}, false)}">
-<main class="govuk-main-wrapper" id="main-content">
-    <div th:replace="~{fragments/layouts/twoThirdsLayout :: twoThirdsLayout(~{::#page-content})}">
-        <div id="page-content">
+<html>
+    <body th:replace="~{fragments/layout :: layout(#{manageLAUsers.title}, ~{::body/content()}, false)}">
+        <a th:replace="~{fragments/forms/backLink :: backLink(${backLinkPath})}">backLink</a>
+        <th:block th:replace="~{fragments/layouts/twoThirdsLayout :: twoThirdsLayout(~{::main})}">
+        <main class="govuk-main-wrapper">
             <header>
                 <h1 class="govuk-heading-l" th:text="${localAuthorityUser.userName}"></h1>
                 <p class="govuk-body">
@@ -21,7 +22,7 @@
                     ></button>
                 </div>
             </form>
-        </div>
-    </div>
-</main>
+        </main>
+        </th:block>
+    </body>
 </html>

--- a/src/main/resources/templates/fragments/warningText.html
+++ b/src/main/resources/templates/fragments/warningText.html
@@ -1,0 +1,7 @@
+<div th:fragment="warningText(text)" class="govuk-warning-text">
+    <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+    <strong class="govuk-warning-text__text">
+        <span class="govuk-visually-hidden">Warning</span>
+        <span th:text="${text}" th:remove="tag">You can be fined up to £5,000 if you do not register.</span>
+    </strong>
+</div>

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/EditLAUserTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/EditLAUserTests.kt
@@ -19,7 +19,7 @@ class EditLAUserTests : IntegrationTest() {
         // Editing the user shows Arthur Dent's page
         var editUserPage = row.editUser()
         assertThat(editUserPage.userName).containsText("Arthur Dent")
-        assertThat(editUserPage.email).containsText("Arthur Dent") // TODO: fix when LA users have email addresses
+        assertThat(editUserPage.email).containsText("Arthur Dent") // TODO PRSD-405: fix when LA users have email addresses
         assertEquals(EditLaUserPage.AccessLevelSelection.BASIC, editUserPage.accessLevel())
 
         // Update the user's access level to admin
@@ -47,7 +47,7 @@ class EditLAUserTests : IntegrationTest() {
         // Delete the user
         val confirmDeletePage = editUserPage.deleteUser()
         confirmDeletePage.assertUserNameVisible("Arthur Dent")
-        confirmDeletePage.assertEmailVisible("Arthur Dent") // TODO: fix when LA users have email addresses
+        confirmDeletePage.assertEmailVisible("Arthur Dent") // TODO PRSD-405: fix when LA users have email addresses
         val successPage = confirmDeletePage.deleteUser()
 
         // The success page confirms the user is deleted

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/EditLAUserTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/EditLAUserTests.kt
@@ -1,6 +1,7 @@
 package uk.gov.communities.prsdb.webapp.integration
 
 import com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat
+import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import uk.gov.communities.prsdb.webapp.integration.pageobjects.pages.EditLaUserPage
@@ -33,5 +34,28 @@ class EditLAUserTests : IntegrationTest() {
         // The user's page also now defaults to admin
         editUserPage = manageUsersPage.table.row(0).editUser()
         assertEquals(EditLaUserPage.AccessLevelSelection.ADMIN, editUserPage.accessLevel())
+    }
+
+    @Test
+    fun `a user can be deleted`() {
+        // Edit Arthur Dent
+        var manageUsersPage = navigator.goToManageLaUsers(1)
+        var row = manageUsersPage.table.row(0)
+        assertTrue(row.username().contains("Arthur Dent"))
+        var editUserPage = row.editUser()
+
+        // Delete the user
+        val confirmDeletePage = editUserPage.deleteUser()
+        confirmDeletePage.assertUserNameVisible("Arthur Dent")
+        confirmDeletePage.assertEmailVisible("Arthur Dent") // TODO: fix when LA users have email addresses
+        val successPage = confirmDeletePage.deleteUser()
+
+        // The success page confirms the user is deleted
+        successPage.confirmationBanner.assertHasMessage("You've removed Arthur Dent's account from Betelgeuse")
+        manageUsersPage = successPage.returnToManageUsers()
+
+        // The user is no longer in the table
+        row = manageUsersPage.table.row(0)
+        assertFalse(row.username().contains("Arthur Dent"))
     }
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageobjects/pages/ConfirmDeleteLaUserPage.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageobjects/pages/ConfirmDeleteLaUserPage.kt
@@ -1,0 +1,28 @@
+package uk.gov.communities.prsdb.webapp.integration.pageobjects.pages
+
+import com.microsoft.playwright.Page
+import com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat
+
+class ConfirmDeleteLaUserPage(
+    page: Page,
+) : BasePage(page) {
+    private val userDetailsSection = page.locator("section").nth(0)
+    private val deleteButton = page.locator("button[type='submit']")
+
+    override fun validate() {
+        assertThat(header).containsText("Before you remove this account")
+    }
+
+    fun assertUserNameVisible(name: String) {
+        assertThat(userDetailsSection).containsText(name)
+    }
+
+    fun assertEmailVisible(email: String) {
+        assertThat(userDetailsSection).containsText(email)
+    }
+
+    fun deleteUser(): DeleteLaUserSuccessPage {
+        deleteButton.click()
+        return createValid(page, DeleteLaUserSuccessPage::class)
+    }
+}

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageobjects/pages/DeleteLaUserSuccessPage.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageobjects/pages/DeleteLaUserSuccessPage.kt
@@ -1,0 +1,22 @@
+package uk.gov.communities.prsdb.webapp.integration.pageobjects.pages
+
+import com.microsoft.playwright.Locator
+import com.microsoft.playwright.Page
+import org.junit.jupiter.api.Assertions.assertEquals
+import uk.gov.communities.prsdb.webapp.integration.pageobjects.components.ConfirmationPageBanner
+
+class DeleteLaUserSuccessPage(
+    page: Page,
+) : BasePage(page) {
+    val confirmationBanner: ConfirmationPageBanner = ConfirmationPageBanner(page.locator(".govuk-panel--confirmation"))
+    private val returnButton: Locator = page.locator("main a")
+
+    override fun validate() {
+        assertEquals("User removed", page.title())
+    }
+
+    fun returnToManageUsers(): ManageLaUsersPage {
+        returnButton.click()
+        return createValid(page, ManageLaUsersPage::class)
+    }
+}

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageobjects/pages/EditLaUserPage.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageobjects/pages/EditLaUserPage.kt
@@ -12,6 +12,7 @@ class EditLaUserPage(
     val basicRadio: Locator = page.locator("form input[value='false']")
     val adminRadio: Locator = page.locator("form input[value='true']")
     private val submitButton = page.locator("button[type=\"submit\"]").filter(Locator.FilterOptions().apply { hasText = "Save" })
+    private val deleteButton = page.locator("form a").filter(Locator.FilterOptions().apply { hasText = "Remove" })
 
     override fun validate() {
         assertEquals("Manage Local Authority Users", page.title())
@@ -37,6 +38,11 @@ class EditLaUserPage(
     fun submit(): ManageLaUsersPage {
         submitButton.click()
         return createValid(page, ManageLaUsersPage::class)
+    }
+
+    fun deleteUser(): ConfirmDeleteLaUserPage {
+        deleteButton.click()
+        return createValid(page, ConfirmDeleteLaUserPage::class)
     }
 
     enum class AccessLevelSelection {


### PR DESCRIPTION
This PR allows LA admins to delete other users in their LA. In particular:
- Adds an "are you sure" style screen, and wires the delete button the edit page up to that
- Handles the delete POST from that page, deleting the user
- Redirects to a confirmation screen
- Adds a [Warning Text](https://design-system.service.gov.uk/components/warning-text/) fragment