### PR TITLE
PRSD-406 / PRSD-407: Disallow LA admins editing or removing themselves

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/ManageLocalAuthorityUsersController.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/ManageLocalAuthorityUsersController.kt
@@ -121,9 +121,12 @@ class ManageLocalAuthorityUsersController(
         model: Model,
         principal: Principal,
     ): String {
-        localAuthorityDataService.getLocalAuthorityIfAuthorizedUser(localAuthorityId, principal.name)
-        val user = localAuthorityDataService.getLocalAuthorityUserIfAuthorizedLA(localAuthorityUserId, localAuthorityId)
-        model.addAttribute("user", user)
+        val (currentUser, _) = localAuthorityDataService.getUserAndLocalAuthorityIfAuthorizedUser(localAuthorityId, principal.name)
+        if (currentUser.id == localAuthorityUserId) {
+            throw AccessDeniedException("Local authority users cannot delete their own accounts; another admin must do so")
+        }
+        val userToDelete = localAuthorityDataService.getLocalAuthorityUserIfAuthorizedLA(localAuthorityUserId, localAuthorityId)
+        model.addAttribute("user", userToDelete)
         model.addAttribute("backLinkPath", "../edit-user/$localAuthorityUserId")
         return "deleteLAUser"
     }
@@ -135,7 +138,10 @@ class ManageLocalAuthorityUsersController(
         principal: Principal,
         redirectAttributes: RedirectAttributes,
     ): String {
-        localAuthorityDataService.getLocalAuthorityIfAuthorizedUser(localAuthorityId, principal.name)
+        val (currentUser, _) = localAuthorityDataService.getUserAndLocalAuthorityIfAuthorizedUser(localAuthorityId, principal.name)
+        if (currentUser.id == localAuthorityUserId) {
+            throw AccessDeniedException("Local authority users cannot delete their own accounts; another admin must do so")
+        }
         val user = localAuthorityDataService.getLocalAuthorityUserIfAuthorizedLA(localAuthorityUserId, localAuthorityId)
 
         localAuthorityDataService.deleteUser(localAuthorityUserId)
@@ -150,7 +156,7 @@ class ManageLocalAuthorityUsersController(
         model: Model,
         principal: Principal,
     ): String {
-        val authority = localAuthorityDataService.getLocalAuthorityIfAuthorizedUser(localAuthorityId, principal.name)
+        val (_, authority) = localAuthorityDataService.getUserAndLocalAuthorityIfAuthorizedUser(localAuthorityId, principal.name)
         model.addAttribute("localAuthority", authority)
         return "deleteLAUserSuccess"
     }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/database/entity/LocalAuthorityUser.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/database/entity/LocalAuthorityUser.kt
@@ -13,7 +13,7 @@ import jakarta.persistence.OneToOne
 class LocalAuthorityUser(
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private val id: Long? = null,
+    val id: Long? = null,
 ) : ModifiableAuditableEntity() {
     @OneToOne(optional = false)
     @JoinColumn(name = "subject_identifier", nullable = false, foreignKey = ForeignKey(name = "FK_LA_USER_1L_USER"))

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/LocalAuthorityDataService.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/LocalAuthorityDataService.kt
@@ -20,21 +20,28 @@ class LocalAuthorityDataService(
     val localAuthorityUserRepository: LocalAuthorityUserRepository,
     val localAuthorityUserOrInvitationRepository: LocalAuthorityUserOrInvitationRepository,
 ) {
-    fun getLocalAuthorityIfAuthorizedUser(
+    fun getUserAndLocalAuthorityIfAuthorizedUser(
         localAuthorityId: Int,
         subjectId: String,
-    ): LocalAuthority {
-        val localAuthority =
-            localAuthorityUserRepository.findByBaseUser_Id(subjectId)?.localAuthority
+    ): Pair<LocalAuthorityUserDataModel, LocalAuthority> {
+        val localAuthorityUser =
+            localAuthorityUserRepository.findByBaseUser_Id(subjectId)
                 ?: throw ResponseStatusException(HttpStatus.NOT_FOUND, "User $subjectId is not an LA user")
+        val userModel =
+            LocalAuthorityUserDataModel(
+                localAuthorityUser.id!!,
+                localAuthorityUser.baseUser.name,
+                localAuthorityUser.localAuthority.name,
+                localAuthorityUser.isManager,
+            )
 
-        if (localAuthority.id != localAuthorityId) {
+        if (localAuthorityUser.localAuthority.id != localAuthorityId) {
             throw AccessDeniedException(
-                "Local authority user for LA ${localAuthority.id} tried to manage users for LA $localAuthorityId",
+                "Local authority user for LA ${localAuthorityUser.localAuthority.id} tried to manage users for LA $localAuthorityId",
             )
         }
 
-        return localAuthority
+        return Pair(userModel, localAuthorityUser.localAuthority)
     }
 
     fun getLocalAuthorityUserIfAuthorizedLA(

--- a/src/main/resources/templates/manageLAUsers.html
+++ b/src/main/resources/templates/manageLAUsers.html
@@ -29,7 +29,10 @@
                     <td class="govuk-table__cell">
                         <a th:href="@{${user.pending ? '#' : 'edit-user/' + user.id}}"
                            class="govuk-link"
-                           th:text="#{manageLAUsers.table.change}">
+                           th:text="#{manageLAUsers.table.change}"
+                           th:if="${currentUser.id} != ${user.id}"
+                        >
+                            manageLAUsers.table.change
                         </a>
                     </td>
                 </tr>

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/InvitationUrlTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/InvitationUrlTests.kt
@@ -18,6 +18,7 @@ import uk.gov.communities.prsdb.webapp.controllers.ControllerTest
 import uk.gov.communities.prsdb.webapp.controllers.ExampleInvitationTokenController
 import uk.gov.communities.prsdb.webapp.controllers.ManageLocalAuthorityUsersController
 import uk.gov.communities.prsdb.webapp.database.entity.LocalAuthority
+import uk.gov.communities.prsdb.webapp.mockObjects.MockLocalAuthorityData.Companion.createdLoggedInUserModel
 import uk.gov.communities.prsdb.webapp.models.viewModels.EmailTemplateModel
 import uk.gov.communities.prsdb.webapp.models.viewModels.LocalAuthorityInvitationEmail
 import uk.gov.communities.prsdb.webapp.services.EmailNotificationService
@@ -44,11 +45,17 @@ class InvitationUrlTests(
     @WithMockUser(roles = ["LA_ADMIN"])
     fun `The invitation URL generated when a new user is invited is routed to the accept invitation controller method`() {
         // Arrange
+        val loggedInUser = createdLoggedInUserModel()
         val localAuthority = createTestLocalAuthority()
         val testToken = "test token"
         val testEmail = "test@example.com"
 
-        whenever(localAuthorityDataService.getLocalAuthorityIfAuthorizedUser(123, "user")).thenReturn(localAuthority)
+        whenever(localAuthorityDataService.getUserAndLocalAuthorityIfAuthorizedUser(123, "user")).thenReturn(
+            Pair(
+                loggedInUser,
+                localAuthority,
+            ),
+        )
 
         whenever(localAuthorityInvitationService.createInvitationToken(testEmail, localAuthority)).thenReturn(testToken)
         whenever(localAuthorityInvitationService.getAuthorityForToken(testToken)).thenReturn(localAuthority)

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/ManageLAUsersTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/ManageLAUsersTests.kt
@@ -24,6 +24,9 @@ class ManageLAUsersTests : IntegrationTest() {
 
         val nextRow = managePage.table.row(1)
         assertTrue(nextRow.accessLevel().contains("Admin"))
+
+        val loggedInUsersRow = managePage.table.row(4)
+        loggedInUsersRow.assertHasNoEditLink()
     }
 
     @Test

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageobjects/pages/ManageLaUsersPage.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageobjects/pages/ManageLaUsersPage.kt
@@ -56,5 +56,9 @@ class ManageLaUsersPage(
             changeLink.click()
             return createValid(locator.page(), EditLaUserPage::class)
         }
+
+        fun assertHasNoEditLink() {
+            assertThat(changeLink).hasCount(0)
+        }
     }
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/mockObjects/MockLocalAuthorityData.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/mockObjects/MockLocalAuthorityData.kt
@@ -3,6 +3,7 @@ package uk.gov.communities.prsdb.webapp.mockObjects
 import uk.gov.communities.prsdb.webapp.database.entity.LocalAuthority
 import uk.gov.communities.prsdb.webapp.database.entity.LocalAuthorityUser
 import uk.gov.communities.prsdb.webapp.database.entity.OneLoginUser
+import uk.gov.communities.prsdb.webapp.models.dataModels.LocalAuthorityUserDataModel
 
 class MockLocalAuthorityData {
     companion object {
@@ -25,5 +26,19 @@ class MockLocalAuthorityData {
             id: Long = DEFAULT_LA_USER_ID,
             isManager: Boolean = true,
         ): LocalAuthorityUser = LocalAuthorityUser(id, baseUser, isManager, localAuthority)
+
+        const val DEFAULT_LOGGED_IN_LA_USER_ID = 789L
+
+        fun createdLoggedInUserModel(userId: Long = DEFAULT_LOGGED_IN_LA_USER_ID): LocalAuthorityUserDataModel {
+            val defaultLA = createLocalAuthority()
+            return LocalAuthorityUserDataModel(
+                id = userId,
+                localAuthorityName = defaultLA.name,
+                isManager = true,
+                userName = "Logged In User",
+                isPending = false,
+                email = "loggedinuser@example.gov.uk",
+            )
+        }
     }
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/LocalAuthorityDataServiceTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/LocalAuthorityDataServiceTests.kt
@@ -48,7 +48,7 @@ class LocalAuthorityDataServiceTests {
     private lateinit var localAuthorityDataService: LocalAuthorityDataService
 
     @Test
-    fun `getLocalAuthorityIfAuthorizedUser returns the local authority if the baseUser is authorized to access it`() {
+    fun `getUserAndLocalAuthorityIfAuthorizedUser returns the user and local authority if the baseUser is authorized to access it`() {
         // Arrange
         val baseUser = createOneLoginUser()
         val localAuthority = createLocalAuthority()
@@ -57,22 +57,31 @@ class LocalAuthorityDataServiceTests {
             .thenReturn(localAuthorityUser)
 
         // Act
-        val returnedLocalAuthority =
-            localAuthorityDataService.getLocalAuthorityIfAuthorizedUser(DEFAULT_LA_ID, get1LID(DEFAULT_1L_USER_NAME))
+        val (returnedUserModel, returnedLocalAuthority) =
+            localAuthorityDataService.getUserAndLocalAuthorityIfAuthorizedUser(DEFAULT_LA_ID, get1LID(DEFAULT_1L_USER_NAME))
 
         // Assert
+        Assertions.assertEquals(
+            LocalAuthorityUserDataModel(
+                localAuthorityUser.id!!,
+                baseUser.name,
+                localAuthority.name,
+                localAuthorityUser.isManager,
+            ),
+            returnedUserModel,
+        )
         Assertions.assertEquals(localAuthority, returnedLocalAuthority)
     }
 
     @Test
-    fun `getLocalAuthorityIfAuthorizedUser throws an AccessDeniedException if the user is not an LA user`() {
+    fun `getUserAndLocalAuthorityIfAuthorizedUser throws an AccessDeniedException if the user is not an LA user`() {
         // Arrange
         whenever(localAuthorityUserRepository.findByBaseUser_Id(anyString()))
             .thenThrow(AccessDeniedException(""))
 
         // Act and Assert
         assertThrows<AccessDeniedException> {
-            localAuthorityDataService.getLocalAuthorityIfAuthorizedUser(
+            localAuthorityDataService.getUserAndLocalAuthorityIfAuthorizedUser(
                 DEFAULT_LA_ID,
                 get1LID(DEFAULT_1L_USER_NAME),
             )
@@ -80,7 +89,7 @@ class LocalAuthorityDataServiceTests {
     }
 
     @Test
-    fun `getLocalAuthorityIfAuthorizedUser throws an AccessDeniedException if the user's LA is not the given LA'`() {
+    fun `getUserAndLocalAuthorityIfAuthorizedUser throws an AccessDeniedException if the user's LA is not the given LA'`() {
         // Arrange
         val baseUser = createOneLoginUser()
         val localAuthority = createLocalAuthority()
@@ -90,7 +99,7 @@ class LocalAuthorityDataServiceTests {
 
         // Act and Assert
         assertThrows<AccessDeniedException> {
-            localAuthorityDataService.getLocalAuthorityIfAuthorizedUser(
+            localAuthorityDataService.getUserAndLocalAuthorityIfAuthorizedUser(
                 DEFAULT_LA_ID - 1,
                 get1LID(DEFAULT_1L_USER_NAME),
             )


### PR DESCRIPTION
As discussed on Slack, we think it makes sense to prevent LA admin users from editing their own accounts (so they can't downgrade themselves to basic access, and leave the LA with no admins) or removing themselves from their LA. This PR achieves that by:
- Removing the "Change" link the manage users table for the current user
- Throwing a 403 Forbidden if the user tries to access any pages / make any posts to edit themselves
- Throwing a 403 Forbidden if the user tries to access nay pages / make any posts to remove themselves