### PR TITLE
Chore/axe validation integration tests

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -74,6 +74,7 @@ dependencies {
     testImplementation("com.microsoft.playwright:playwright:1.47.0")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher")
     testImplementation("org.mockito.kotlin:mockito-kotlin:3.2.0")
+    testImplementation("com.deque.html.axe-core:playwright:4.4.1")
 
     // Serialization
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.7.1")

--- a/src/main/resources/templates/fragments/betaBanner.html
+++ b/src/main/resources/templates/fragments/betaBanner.html
@@ -1,5 +1,5 @@
-<div th:fragment="betaBanner" th:if="${hideBetaBanner != true}">
-    <div class="govuk-phase-banner" id="banner">
+<html>
+    <div class="govuk-phase-banner" id="banner" th:fragment="betaBanner" th:if="${hideBetaBanner != true}">
         <p class="govuk-phase-banner__content">
             <strong class="govuk-tag govuk-phase-banner__content__tag">Beta</strong>
             <span class="govuk-phase-banner__text"
@@ -8,4 +8,4 @@
             <span class="govuk-phase-banner__text" th:text="#{betaBanner.afterLink}">betaBanner.afterLink</span>
         </p>
     </div>
-</div>
+</html>

--- a/src/main/resources/templates/fragments/header/header.html
+++ b/src/main/resources/templates/fragments/header/header.html
@@ -1,10 +1,10 @@
 <html xmlns:sec="http://www.thymeleaf.org/extras/spring-security">
-<div th:fragment="header(navLinks)">
-    <div sec:authorize="isAuthenticated()">
-        <div th:replace="~{ fragments/header/authenticatedHeader :: loggedInHeader(${navLinks}) }"></div>
-    </div>
-    <div sec:authorize="isAnonymous()">
-        <div th:replace="~{ fragments/header/anonymousHeader :: anonymousHeader }"></div>
-    </div>
-</div>
+<th:block th:fragment="header(navLinks)">
+    <th:block sec:authorize="isAuthenticated()">
+        <header th:replace="~{ fragments/header/authenticatedHeader :: loggedInHeader(${navLinks}) }"></header>
+    </th:block>
+    <th:block sec:authorize="isAnonymous()">
+        <header th:replace="~{ fragments/header/anonymousHeader :: anonymousHeader }"></header>
+    </th:block>
+</th:block>
 </html>

--- a/src/main/resources/templates/fragments/layout.html
+++ b/src/main/resources/templates/fragments/layout.html
@@ -1,41 +1,38 @@
 <!DOCTYPE html>
 <html th:fragment="layout(title, content, hasErrors)" lang="en" class="govuk-template">
-
-<head>
-    <meta charset="utf-8">
-    <title th:text="((${hasErrors}) ? #{forms.errorMessage.prefix} : '' ) + ${title}">GOV.UK - The best place to find
-        government services and information</title>
-    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
-    <meta name="theme-color" content="#0b0c0c">
-    <link rel="icon" sizes="48x48" href="/static/assets/images/favicon.ico"
-          th:href="@{/assets/images/favicon.ico}">
-    <link rel="icon" sizes="any" href="/static/assets/images/favicon.svg"
-          th:href="@{/assets/images/favicon.svg}"
-          type="image/svg+xml">
-    <link rel="mask-icon" href="/static/assets/images/govuk-icon-mask.svg"
-          th:href="@{/assets/images/govuk-icon-mask.svg}" color="#0b0c0c">
-    <link rel="apple-touch-icon" href="/static/assets/images/govuk-icon-180.png"
-          th:href="@{/assets/images/govuk-icon-180.png}">
-    <link rel="manifest" href="/static/assets/manifest.json" th:href="@{/assets/manifest.json}"
-          crossorigin="use-credentials">
-    <link rel="stylesheet" href="/static/assets/css/govuk-frontend.min.css"
-          th:href="@{/assets/css/govuk-frontend.min.css}">
-    <link rel="stylesheet" href="/static/assets/css/service-header.css" th:href="@{/assets/css/service-header.css}">
-</head>
-
-<body class="govuk-template__body">
-<script>
-    document.body.className += ' js-enabled' + ('noModule' in HTMLScriptElement.prototype ? ' govuk-frontend-supported' : '');
-</script>
-<a href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Skip to main content</a>
-<div th:replace="~{fragments/header/header :: header(${navLinks})}"></div>
-<div class="govuk-width-container">
-    <div th:replace="~{ fragments/betaBanner :: betaBanner }"></div>
-    <div th:replace="${content}"></div>
-</div>
-<div th:replace="~{ fragments/footer :: footer }"></div>
-<script type="module" src="/static/asset/js/index.js" th:src="@{/assets/js/index.js}"></script>
-<script type="module" src="/static/asset/js/service-header.js" th:src="@{/assets/js/service-header.js}"></script>
-</body>
-
+    <head>
+        <meta charset="utf-8">
+        <title th:text="((${hasErrors}) ? #{forms.errorMessage.prefix} : '' ) + ${title}">GOV.UK - The best place to find
+            government services and information</title>
+        <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
+        <meta name="theme-color" content="#0b0c0c">
+        <link rel="icon" sizes="48x48" href="/static/assets/images/favicon.ico"
+              th:href="@{/assets/images/favicon.ico}">
+        <link rel="icon" sizes="any" href="/static/assets/images/favicon.svg"
+              th:href="@{/assets/images/favicon.svg}"
+              type="image/svg+xml">
+        <link rel="mask-icon" href="/static/assets/images/govuk-icon-mask.svg"
+              th:href="@{/assets/images/govuk-icon-mask.svg}" color="#0b0c0c">
+        <link rel="apple-touch-icon" href="/static/assets/images/govuk-icon-180.png"
+              th:href="@{/assets/images/govuk-icon-180.png}">
+        <link rel="manifest" href="/static/assets/manifest.json" th:href="@{/assets/manifest.json}"
+              crossorigin="use-credentials">
+        <link rel="stylesheet" href="/static/assets/css/govuk-frontend.min.css"
+              th:href="@{/assets/css/govuk-frontend.min.css}">
+        <link rel="stylesheet" href="/static/assets/css/service-header.css" th:href="@{/assets/css/service-header.css}">
+    </head>
+    <body class="govuk-template__body">
+        <script>
+            document.body.className += ' js-enabled' + ('noModule' in HTMLScriptElement.prototype ? ' govuk-frontend-supported' : '');
+        </script>
+        <a href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Skip to main content</a>
+        <header th:replace="~{fragments/header/header :: header(${navLinks})}"></header>
+        <div class="govuk-width-container">
+            <div th:replace="~{ fragments/betaBanner :: betaBanner }"></div>
+            <div th:replace="${content}"></div>
+        </div>
+        <div th:replace="~{ fragments/footer :: footer }"></div>
+        <script type="module" src="/static/asset/js/index.js" th:src="@{/assets/js/index.js}"></script>
+        <script type="module" src="/static/asset/js/service-header.js" th:src="@{/assets/js/service-header.js}"></script>
+    </body>
 </html>

--- a/src/main/resources/templates/fragments/layouts/twoThirdsLayout.html
+++ b/src/main/resources/templates/fragments/layouts/twoThirdsLayout.html
@@ -1,7 +1,7 @@
-<div th:fragment="twoThirdsLayout(content)">
-    <div class="govuk-grid-row">
+<html>
+    <div class="govuk-grid-row" th:fragment="twoThirdsLayout(content)">
         <div class="govuk-grid-column-two-thirds">
             <div th:replace="${content}"></div>
         </div>
     </div>
-</div>
+</html>

--- a/src/main/resources/templates/manageLAUsers.html
+++ b/src/main/resources/templates/manageLAUsers.html
@@ -1,54 +1,54 @@
 <!DOCTYPE html>
-<html th:replace="~{fragments/layout :: layout(#{manageLAUsers.title}, ~{::main}, false)}">
-<main class="govuk-main-wrapper" id="main-content">
-    <div id="page-contents"
-         th:replace="~{fragments/layouts/twoThirdsLayout :: twoThirdsLayout(~{::#page-contents/content()})}">
-        <header id="header">
-            <h1 class="govuk-heading-l" th:text="#{manageLAUsers.contentHeader(${localAuthority.name})}">
-                manageLAUsers.contentHeader
-            </h1>
-        </header>
-        <section>
-            <table th:replace="~{fragments/tables/table :: table(
-                    ${ { 'manageLAUsers.table.usernameHeading', 'manageLAUsers.table.accessLevelHeading', 'manageLAUsers.table.accountStatusHeading', '' } },
-                    ~{::tbody}
-                )}
-            ">
-                <tbody class="govuk-table__body">
-                <tr class="govuk_table__row" th:each="user: ${userList}">
-                    <td class="govuk-table__cell" th:text="${user.userName}"></td>
-                    <td class="govuk-table__cell"
-                        th:text="${user.manager} ? #{manageLAUsers.table.admin} : #{manageLAUsers.table.basic}">
-                    </td>
-                    <td class="govuk-table__cell">
-                        <span class="govuk-tag"
-                              th:classappend="${user.pending ? 'govuk-tag--blue' : 'govuk-tag--green'}">
-                            <strong th:text="${user.pending} ? #{manageLAUsers.table.pending} : #{manageLAUsers.table.active}"></strong>
-                        </span>
-                    </td>
-                    <td class="govuk-table__cell">
-                        <a th:href="@{${user.pending ? '#' : 'edit-user/' + user.id}}"
-                           class="govuk-link"
-                           th:text="#{manageLAUsers.table.change}"
-                           th:if="${currentUser.id} != ${user.id}"
-                        >
-                            manageLAUsers.table.change
+<html>
+    <body th:replace="~{fragments/layout :: layout(#{deleteLAUser.title}, ~{::body/content()}, false)}">
+        <main class="govuk-main-wrapper" id="main-content">
+            <th:block id="page-contents"
+                 th:replace="~{fragments/layouts/twoThirdsLayout :: twoThirdsLayout(~{::#page-contents/content()})}">
+                <header id="header">
+                    <h1 class="govuk-heading-l" th:text="#{manageLAUsers.contentHeader(${localAuthority.name})}">
+                        manageLAUsers.contentHeader
+                    </h1>
+                </header>
+                <section>
+                    <table th:replace="~{fragments/tables/table :: table(
+                            ${ { 'manageLAUsers.table.usernameHeading', 'manageLAUsers.table.accessLevelHeading', 'manageLAUsers.table.accountStatusHeading', '' } },
+                            ~{::tbody}
+                        )}
+                    ">
+                        <tbody class="govuk-table__body">
+                        <tr class="govuk_table__row" th:each="user: ${userList}">
+                            <td class="govuk-table__cell" th:text="${user.userName}"></td>
+                            <td class="govuk-table__cell"
+                                th:text="${user.manager} ? #{manageLAUsers.table.admin} : #{manageLAUsers.table.basic}">
+                            </td>
+                            <td class="govuk-table__cell">
+                                <span class="govuk-tag"
+                                      th:classappend="${user.pending ? 'govuk-tag--blue' : 'govuk-tag--green'}">
+                                    <strong th:text="${user.pending} ? #{manageLAUsers.table.pending} : #{manageLAUsers.table.active}"></strong>
+                                </span>
+                            </td>
+                            <td class="govuk-table__cell">
+                                <a th:href="@{${user.pending ? '#' : 'edit-user/' + user.id}}"
+                                   class="govuk-link"
+                                   th:text="#{manageLAUsers.table.change}"
+                                   th:if="${currentUser.id} != ${user.id}"
+                                >
+                                    manageLAUsers.table.change
+                                </a>
+                            </td>
+                        </tr>
+                        </tbody>
+                    </table>
+                    <nav th:if="${totalPages > 1}" th:replace="~{fragments/pagination/pagination :: pagination(${totalPages}, ${currentPage})}">
+                    </nav>
+                    <div class="govuk-button-group" id="action-buttons">
+                        <a th:replace="~{fragments/primaryButtonLink :: primaryButtonLink(@{/local-authority/{id}/invite-new-user(id=${localAuthority.id})}, #{manageLAUsers.inviteAnotherUserButtonText})}">
+                            manageLAUsers.inviteAnotherUserButtonText
                         </a>
-                    </td>
-                </tr>
-                </tbody>
-            </table>
-            <div th:if="${totalPages > 1}">
-                <nav th:replace="~{fragments/pagination/pagination :: pagination(${totalPages}, ${currentPage})}">
-                </nav>
-            </div>
-            <div class="govuk-button-group" id="action-buttons">
-                <a th:replace="~{fragments/primaryButtonLink :: primaryButtonLink(@{/local-authority/{id}/invite-new-user(id=${localAuthority.id})}, #{manageLAUsers.inviteAnotherUserButtonText})}">
-                    manageLAUsers.inviteAnotherUserButtonText
-                </a>
-                <button th:replace="~{fragments/buttons/secondaryButton :: secondaryButton(#{manageLAUsers.returnToDashboardButton})}"></button>
-            </div>
-        </section>
-    </div>
-</main>
+                        <button th:replace="~{fragments/buttons/secondaryButton :: secondaryButton(#{manageLAUsers.returnToDashboardButton})}"></button>
+                    </div>
+                </section>
+            </th:block>
+        </main>
+    </body>
 </html>

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageobjects/pages/BasePage.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageobjects/pages/BasePage.kt
@@ -1,8 +1,10 @@
 package uk.gov.communities.prsdb.webapp.integration.pageobjects.pages
 
+import com.deque.html.axecore.playwright.AxeBuilder
 import com.microsoft.playwright.Page
 import uk.gov.communities.prsdb.webapp.integration.pageobjects.components.TextInput
 import kotlin.reflect.KClass
+import kotlin.test.assertEquals
 
 abstract class BasePage(
     protected val page: Page,
@@ -15,6 +17,15 @@ abstract class BasePage(
             page.waitForLoadState()
             val pageInstance = targetClass.constructors.first().call(page)
             pageInstance.validate()
+            val axeResults =
+                AxeBuilder(page)
+                    .withTags(listOf("wcag2a", "wcag2aa", "wcag21a", "wcag21aa"))
+                    .analyze()
+            assertEquals(
+                listOf(),
+                axeResults.violations,
+                "There were Axe violations after creating and validating a ${targetClass.simpleName}",
+            )
             return pageInstance
         }
     }


### PR DESCRIPTION
This adds basic axe analysis to our integration tests, running every time we create page (in the page object sense) and failing the test if any violations are found.

I've selected only the WCAG rulesets; the 'best practice' ruleset was reporting violations of the ["all page content must be contained by landmarks" rule](https://dequeuniversity.com/rules/axe/4.4/region?application=PlaywrightJava) (because of the beta banner). As far as I can see, other services in public beta would fail the same rule, so I don't think it's one we want to adhere to.

While I was investigating that violation, I also tidied up various bits of Thymeleaf templates that resulted in pointless `<div>` elements - elements that weren't meaningful to our final output, and had only been introduced because of how we were using Thymeleaf.