### PR TITLE
PRSD-NONE: Back link is in nav, uses JS if available

### DIFF
--- a/src/main/resources/templates/fragments/forms/backLink.html
+++ b/src/main/resources/templates/fragments/forms/backLink.html
@@ -1,2 +1,9 @@
-<a th:fragment="backLink(backUrl)" th:href="@{${backUrl}}" class="govuk-back-link"
-   th:text="#{forms.buttons.back}">forms.buttons.back</a>
+<nav th:fragment="backLink(backUrl)">
+    <a th:href="@{${backUrl}}"
+       class="govuk-back-link"
+       th:text="#{forms.buttons.back}"
+       onclick="history.go(-1); return false"
+    >
+        forms.buttons.back
+    </a>
+</nav>

--- a/src/main/resources/templates/fragments/forms/backLink.html
+++ b/src/main/resources/templates/fragments/forms/backLink.html
@@ -1,9 +1,11 @@
 <nav th:fragment="backLink(backUrl)">
-    <a th:href="@{${backUrl}}"
-       class="govuk-back-link"
-       th:text="#{forms.buttons.back}"
-       onclick="history.go(-1); return false"
-    >
-        forms.buttons.back
+    <a th:href="@{${backUrl}}" class="govuk-back-link">
+        <span th:text="#{forms.buttons.back}" th:remove="tag">forms.buttons.back</span>
+        <script>
+            if (document.currentScript && history) {
+                let anchorNode = document.currentScript.parentElement;
+                anchorNode.href = "javascript:history.back()"
+            }
+        </script>
     </a>
 </nav>


### PR DESCRIPTION
This is a tiny change to:

1. Enclose the "Back" link in `<nav>`, which I think makes sense
2. Use the browser back functionality via JS, if JS is available

I've tested this works happily in Chrome both with JS enabled (back/forward works as you'd expect) and disabled (clicking the back link adds a new item to history).