### PR TITLE
Feat/prsd 540 create register la user form

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/constants/JourneyNames.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/constants/JourneyNames.kt
@@ -2,3 +2,4 @@ package uk.gov.communities.prsdb.webapp.constants
 
 // These need to be constants as we cannot use the urlPathSegment from the JourneyType directly in the RequestMapping Annotation
 const val REGISTER_LANDLORD_JOURNEY_URL: String = "register-as-a-landlord"
+const val REGISTER_LA_USER_JOURNEY_URL: String = "register-local-authority-user"

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/constants/enums/JourneyType.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/constants/enums/JourneyType.kt
@@ -1,9 +1,11 @@
 package uk.gov.communities.prsdb.webapp.constants.enums
 
 import uk.gov.communities.prsdb.webapp.constants.REGISTER_LANDLORD_JOURNEY_URL
+import uk.gov.communities.prsdb.webapp.constants.REGISTER_LA_USER_JOURNEY_URL
 
 enum class JourneyType(
     val urlPathSegment: String,
 ) {
     LANDLORD_REGISTRATION(REGISTER_LANDLORD_JOURNEY_URL),
+    LA_USER_REGISTRATION(REGISTER_LA_USER_JOURNEY_URL),
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/RegisterLAUserController.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/RegisterLAUserController.kt
@@ -1,0 +1,47 @@
+package uk.gov.communities.prsdb.webapp.controllers
+
+import org.springframework.stereotype.Controller
+import org.springframework.ui.Model
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import uk.gov.communities.prsdb.webapp.constants.REGISTER_LA_USER_JOURNEY_URL
+import uk.gov.communities.prsdb.webapp.forms.journeys.LaUserRegistrationJourney
+import uk.gov.communities.prsdb.webapp.forms.journeys.PageData
+import java.security.Principal
+
+@Controller
+@RequestMapping("/${REGISTER_LA_USER_JOURNEY_URL}")
+class RegisterLAUserController(
+    var laUserRegistrationJourney: LaUserRegistrationJourney,
+) {
+    @GetMapping("/{stepName}")
+    fun getJourneyStep(
+        @PathVariable("stepName") stepName: String,
+        @RequestParam(value = "subpage", required = false) subpage: Int?,
+        model: Model,
+    ): String =
+        laUserRegistrationJourney.populateModelAndGetViewName(
+            laUserRegistrationJourney.getStepId(stepName),
+            model,
+            subpage,
+        )
+
+    @PostMapping("/{stepName}")
+    fun postJourneyData(
+        @PathVariable("stepName") stepName: String,
+        @RequestParam(value = "subpage", required = false) subpage: Int?,
+        @RequestParam formData: PageData,
+        model: Model,
+        principal: Principal,
+    ): String =
+        laUserRegistrationJourney.updateJourneyDataAndGetViewNameOrRedirect(
+            laUserRegistrationJourney.getStepId(stepName),
+            formData,
+            model,
+            subpage,
+            principal,
+        )
+}

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/LaUserRegistrationJourney.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/LaUserRegistrationJourney.kt
@@ -37,7 +37,7 @@ class LaUserRegistrationJourney(
                                     "backUrl" to "/${JourneyType.LA_USER_REGISTRATION.urlPathSegment}/",
                                 ),
                         ),
-                    nextAction = { _, subPageNumber: Int? -> Pair(RegisterLaUserStepId.Email, subPageNumber?.plus(1)) },
+                    nextAction = { _, subPageNumber: Int? -> Pair(RegisterLaUserStepId.Email, null) },
                 ),
                 Step(
                     id = RegisterLaUserStepId.Email,
@@ -52,17 +52,16 @@ class LaUserRegistrationJourney(
                                     "fieldSetHint" to "registerLAUser.email.fieldSetHint",
                                     "label" to "registerLAUser.email.label",
                                     "submitButtonText" to "forms.buttons.continue",
-                                    "backUrl" to "/${JourneyType.LA_USER_REGISTRATION.urlPathSegment}/${RegisterLaUserStepId.Name}",
                                 ),
                         ),
-                    nextAction = { _, subPageNumber: Int? -> Pair(RegisterLaUserStepId.CheckAnswers, subPageNumber?.plus(1)) },
+                    nextAction = { _, subPageNumber: Int? -> Pair(RegisterLaUserStepId.CheckAnswers, null) },
                 ),
                 /*TODO: PRSD-541 - check answers page
                 Step(
                     id = RegisterLaUserStepId.CheckAnswers,
                     page =
                         Page(),
-                    nextAction = { _, subPageNumber: Int? -> Pair(RegisterLaUserStepId.CheckAnswers, subPageNumber?.plus(1)) },
+                    nextAction = { _, subPageNumber: Int? -> Pair(RegisterLaUserStepId.CheckAnswers, null) },
                 ),*/
             ),
     )

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/LaUserRegistrationJourney.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/LaUserRegistrationJourney.kt
@@ -1,0 +1,52 @@
+package uk.gov.communities.prsdb.webapp.forms.journeys
+
+import org.springframework.stereotype.Component
+import org.springframework.validation.Validator
+import uk.gov.communities.prsdb.webapp.constants.enums.JourneyType
+import uk.gov.communities.prsdb.webapp.forms.pages.Page
+import uk.gov.communities.prsdb.webapp.forms.steps.RegisterLaUserStepId
+import uk.gov.communities.prsdb.webapp.forms.steps.Step
+import uk.gov.communities.prsdb.webapp.models.formModels.EmailFormModel
+import uk.gov.communities.prsdb.webapp.services.JourneyDataService
+
+@Component
+class LaUserRegistrationJourney(
+    validator: Validator,
+    journeyDataService: JourneyDataService,
+) : Journey<RegisterLaUserStepId>(
+        journeyType = JourneyType.LA_USER_REGISTRATION,
+        initialStepId = RegisterLaUserStepId.Email,
+        validator = validator,
+        journeyDataService = journeyDataService,
+        steps =
+            listOf(
+                /*Step(
+                    id = RegisterLaUserStepId.Name,
+                    page =
+                        Page(),
+                    nextAction = { _, subPageNumber: Int? -> Pair(RegisterLaUserStepId.Email, subPageNumber?.plus(1)) },
+                ),*/
+                Step(
+                    id = RegisterLaUserStepId.Email,
+                    page =
+                        Page(
+                            formModel = EmailFormModel::class,
+                            templateName = "forms/emailForm",
+                            contentKeys =
+                                mapOf(
+                                    "title" to "registerLAUser.title",
+                                    "fieldSetHeading" to "forms.email.fieldSetHeading",
+                                    "fieldSetHint" to "forms.email.fieldSetHint",
+                                    "label" to "forms.email.label",
+                                ),
+                        ),
+                    nextAction = { _, subPageNumber: Int? -> Pair(RegisterLaUserStepId.CheckAnswers, subPageNumber?.plus(1)) },
+                ),
+                /*Step(
+                    id = RegisterLaUserStepId.CheckAnswers,
+                    page =
+                        Page(),
+                    nextAction = { _, subPageNumber: Int? -> Pair(RegisterLaUserStepId.CheckAnswers, subPageNumber?.plus(1)) },
+                ),*/
+            ),
+    )

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/LaUserRegistrationJourney.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/LaUserRegistrationJourney.kt
@@ -7,6 +7,7 @@ import uk.gov.communities.prsdb.webapp.forms.pages.Page
 import uk.gov.communities.prsdb.webapp.forms.steps.RegisterLaUserStepId
 import uk.gov.communities.prsdb.webapp.forms.steps.Step
 import uk.gov.communities.prsdb.webapp.models.formModels.EmailFormModel
+import uk.gov.communities.prsdb.webapp.models.formModels.NameFormModel
 import uk.gov.communities.prsdb.webapp.services.JourneyDataService
 
 @Component
@@ -15,17 +16,29 @@ class LaUserRegistrationJourney(
     journeyDataService: JourneyDataService,
 ) : Journey<RegisterLaUserStepId>(
         journeyType = JourneyType.LA_USER_REGISTRATION,
-        initialStepId = RegisterLaUserStepId.Email,
+        initialStepId = RegisterLaUserStepId.Name,
         validator = validator,
         journeyDataService = journeyDataService,
         steps =
             listOf(
-                /*Step(
+                Step(
                     id = RegisterLaUserStepId.Name,
                     page =
-                        Page(),
+                        Page(
+                            formModel = NameFormModel::class,
+                            templateName = "forms/nameForm",
+                            contentKeys =
+                                mapOf(
+                                    "title" to "registerLAUser.title",
+                                    "fieldSetHeading" to "forms.name.fieldSetHeading",
+                                    "fieldSetHint" to "forms.name.fieldSetHint",
+                                    "label" to "forms.name.label",
+                                    "submitButtonText" to "forms.buttons.continue",
+                                    "backUrl" to "/${JourneyType.LA_USER_REGISTRATION.urlPathSegment}/",
+                                ),
+                        ),
                     nextAction = { _, subPageNumber: Int? -> Pair(RegisterLaUserStepId.Email, subPageNumber?.plus(1)) },
-                ),*/
+                ),
                 Step(
                     id = RegisterLaUserStepId.Email,
                     page =
@@ -37,15 +50,15 @@ class LaUserRegistrationJourney(
                                     "title" to "registerLAUser.title",
                                     "fieldSetHeading" to "registerLAUser.email.fieldSetHeading",
                                     "fieldSetHint" to "registerLAUser.email.fieldSetHint",
-                                    "label" to "forms.email.label",
+                                    "label" to "registerLAUser.email.label",
                                     "submitButtonText" to "forms.buttons.continue",
-                                    // TODO: PRSD-540 check what this needs to be, may need to update after PRSD-369
-                                    // "backUrl" to "/${JourneyType.LANDLORD_REGISTRATION.urlPathSegment}/"
+                                    "backUrl" to "/${JourneyType.LA_USER_REGISTRATION.urlPathSegment}/${RegisterLaUserStepId.Name}",
                                 ),
                         ),
                     nextAction = { _, subPageNumber: Int? -> Pair(RegisterLaUserStepId.CheckAnswers, subPageNumber?.plus(1)) },
                 ),
-                /*Step(
+                /*TODO: PRSD-541 - check answers page
+                Step(
                     id = RegisterLaUserStepId.CheckAnswers,
                     page =
                         Page(),

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/LaUserRegistrationJourney.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/LaUserRegistrationJourney.kt
@@ -35,9 +35,12 @@ class LaUserRegistrationJourney(
                             contentKeys =
                                 mapOf(
                                     "title" to "registerLAUser.title",
-                                    "fieldSetHeading" to "forms.email.fieldSetHeading",
-                                    "fieldSetHint" to "forms.email.fieldSetHint",
+                                    "fieldSetHeading" to "registerLAUser.email.fieldSetHeading",
+                                    "fieldSetHint" to "registerLAUser.email.fieldSetHint",
                                     "label" to "forms.email.label",
+                                    "submitButtonText" to "forms.buttons.continue",
+                                    // TODO: PRSD-540 check what this needs to be, may need to update after PRSD-369
+                                    // "backUrl" to "/${JourneyType.LANDLORD_REGISTRATION.urlPathSegment}/"
                                 ),
                         ),
                     nextAction = { _, subPageNumber: Int? -> Pair(RegisterLaUserStepId.CheckAnswers, subPageNumber?.plus(1)) },

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/LandlordRegistrationJourney.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/LandlordRegistrationJourney.kt
@@ -33,6 +33,7 @@ class LandlordRegistrationJourney(
                                     "fieldSetHeading" to "forms.email.fieldSetHeading",
                                     "fieldSetHint" to "forms.email.fieldSetHint",
                                     "label" to "forms.email.label",
+                                    "submitButtonText" to "forms.buttons.saveAndContinue",
                                     "backUrl" to "/${JourneyType.LANDLORD_REGISTRATION.urlPathSegment}",
                                 ),
                         ),

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/steps/RegisterLaUserStepId.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/steps/RegisterLaUserStepId.kt
@@ -1,0 +1,9 @@
+package uk.gov.communities.prsdb.webapp.forms.steps
+
+enum class RegisterLaUserStepId(
+    override val urlPathSegment: String,
+) : StepId {
+    Name("name"),
+    Email("email"),
+    CheckAnswers("check-answers"),
+}

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/formModels/NameFormModel.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/formModels/NameFormModel.kt
@@ -1,0 +1,19 @@
+package uk.gov.communities.prsdb.webapp.models.formModels
+
+import uk.gov.communities.prsdb.webapp.validation.ConstraintDescriptor
+import uk.gov.communities.prsdb.webapp.validation.IsValidPrioritised
+import uk.gov.communities.prsdb.webapp.validation.NotBlankConstraintValidator
+import uk.gov.communities.prsdb.webapp.validation.ValidatedBy
+
+@IsValidPrioritised
+class NameFormModel : FormModel {
+    @ValidatedBy(
+        constraints = [
+            ConstraintDescriptor(
+                messageKey = "forms.name.error.missing",
+                validatorType = NotBlankConstraintValidator::class,
+            ),
+        ],
+    )
+    var name: String? = null
+}

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -189,7 +189,7 @@ forms.email.error.invalidFormat=Enter an email address in the right format
 forms.name.fieldSetHeading=What is your full name?
 forms.name.fieldSetHint=Enter your name as it's written on your passport or driving licence
 forms.name.label=Full name
-forms.name.error.missing=You must provide your name
+forms.name.error.missing=You must enter your full name
 
 pagination.previousText=Previous
 pagination.pageText=page

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -144,6 +144,8 @@ deleteLAUserSuccess.whatHappensNext.paragraph.one=The user account is removed an
 deleteLAUserSuccess.whatHappensNext.paragraph.two=You''ll need to invite this user again to give them access to {0,,localAuthorityName} on the database.
 deleteLAUserSuccess.returnToManageUsers=Return to manage users
 
+registerLAUser.title=Register as a Local Authority user
+
 registerAHome=Register a home to rent
 registerAHome.navLink.one=Service Link 1
 registerAHome.navLink.two=Service Link 2

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -147,6 +147,7 @@ deleteLAUserSuccess.returnToManageUsers=Return to manage users
 registerLAUser.title=Register as a Local Authority user
 registerLAUser.email.fieldSetHeading=What is your work email address?
 registerLAUser.email.fieldSetHint=This is the email you use for work at the local authority
+registerLAUser.email.label=Email address
 
 registerAHome=Register a home to rent
 registerAHome.navLink.one=Service Link 1
@@ -184,6 +185,11 @@ forms.email.fieldSetHint=We'll use this to send information and updates about yo
 forms.email.label=Enter your email address
 forms.email.error.missing=Enter a valid email address to continue. An email is required for contact purposes.
 forms.email.error.invalidFormat=Enter an email address in the right format
+
+forms.name.fieldSetHeading=What is your full name?
+forms.name.fieldSetHint=Enter your name as it's written on your passport or driving licence
+forms.name.label=Full name
+forms.name.error.missing=You must provide your name
 
 pagination.previousText=Previous
 pagination.pageText=page

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -145,6 +145,8 @@ deleteLAUserSuccess.whatHappensNext.paragraph.two=You''ll need to invite this us
 deleteLAUserSuccess.returnToManageUsers=Return to manage users
 
 registerLAUser.title=Register as a Local Authority user
+registerLAUser.email.fieldSetHeading=What is your work email address?
+registerLAUser.email.fieldSetHint=This is the email you use for work at the local authority
 
 registerAHome=Register a home to rent
 registerAHome.navLink.one=Service Link 1
@@ -167,6 +169,7 @@ forms.errorMessage.prefix=Error:
 
 forms.buttons.startNow=Start Now
 forms.buttons.saveAndContinue=Save and continue
+forms.buttons.continue=Continue
 forms.buttons.back=Back
 
 forms.phoneNumber.fieldSetHeading=What is your phone number?

--- a/src/main/resources/templates/forms/emailForm.html
+++ b/src/main/resources/templates/forms/emailForm.html
@@ -3,6 +3,7 @@
 <!--/*@thymesVar id="fieldSetHeading" type="java.lang.String"*/-->
 <!--/*@thymesVar id="fieldSetHint" type="java.lang.String"*/-->
 <!--/*@thymesVar id="label" type="java.lang.String"*/-->
+<!--/*@thymesVar id="submitButtonText" type="java.lang.String"*/-->
 <!--/*@thymesVar id="backUrl" type="java.lang.String"*/-->
 <!DOCTYPE html>
 <html th:replace="~{fragments/forms/questionPage :: questionPage(#{${title}}, ${formModel}, ~{::#form-content}, ${backUrl})}">
@@ -12,6 +13,6 @@
         <div th:replace="~{fragments/forms/emailInput :: emailInput(#{${label}}, 'emailAddress', null)}">
         </div>
     </th:block>
-    <button th:replace="~{fragments/buttons/primaryButton :: primaryButton(#{forms.buttons.saveAndContinue})}"></button>
+    <button th:replace="~{fragments/buttons/primaryButton :: primaryButton(#{${submitButtonText}})}"></button>
 </th:block>
 </html>

--- a/src/main/resources/templates/forms/nameForm.html
+++ b/src/main/resources/templates/forms/nameForm.html
@@ -7,12 +7,12 @@
 <!--/*@thymesVar id="backUrl" type="java.lang.String"*/-->
 <!DOCTYPE html>
 <html th:replace="~{fragments/forms/questionPage :: questionPage(#{${title}}, ${formModel}, ~{::#form-content}, ${backUrl})}">
-<th:block id="form-content">
-    <th:block id="fieldset-content"
-              th:replace="~{fragments/forms/fieldSet :: fieldSet(~{::#fieldset-content/content()}, 'name', #{${fieldSetHeading}}, #{${fieldSetHint}})}">
-        <div th:replace="~{fragments/forms/nameInput :: nameInput(#{${label}}, 'name', null)}">
+<!--/*/ <th:block id="form-content"> /*/-->
+<!--/*/    <th:block id="fieldset-content"
+              th:replace="~{fragments/forms/fieldSet :: fieldSet(~{::#fieldset-content/content()}, 'name', #{${fieldSetHeading}}, #{${fieldSetHint}})}"> /*/-->
+        <div th:replace="~{fragments/forms/basicTextInput :: textInput(#{${label}}, 'name', null)}">
         </div>
-    </th:block>
+<!--/*/    </th:block> /*/-->
     <button th:replace="~{fragments/buttons/primaryButton :: primaryButton(#{${submitButtonText}})}"></button>
-</th:block>
+<!--/*/</th:block> /*/-->
 </html>

--- a/src/main/resources/templates/forms/nameForm.html
+++ b/src/main/resources/templates/forms/nameForm.html
@@ -1,0 +1,18 @@
+<!--/*@thymesVar id="title" type="java.lang.String"*/-->
+<!--/*@thymesVar id="formModel" type="java.lang.Object"*/-->
+<!--/*@thymesVar id="fieldSetHeading" type="java.lang.String"*/-->
+<!--/*@thymesVar id="fieldSetHint" type="java.lang.String"*/-->
+<!--/*@thymesVar id="label" type="java.lang.String"*/-->
+<!--/*@thymesVar id="submitButtonText" type="java.lang.String"*/-->
+<!--/*@thymesVar id="backUrl" type="java.lang.String"*/-->
+<!DOCTYPE html>
+<html th:replace="~{fragments/forms/questionPage :: questionPage(#{${title}}, ${formModel}, ~{::#form-content}, ${backUrl})}">
+<th:block id="form-content">
+    <th:block id="fieldset-content"
+              th:replace="~{fragments/forms/fieldSet :: fieldSet(~{::#fieldset-content/content()}, 'name', #{${fieldSetHeading}}, #{${fieldSetHint}})}">
+        <div th:replace="~{fragments/forms/nameInput :: nameInput(#{${label}}, 'name', null)}">
+        </div>
+    </th:block>
+    <button th:replace="~{fragments/buttons/primaryButton :: primaryButton(#{${submitButtonText}})}"></button>
+</th:block>
+</html>

--- a/src/main/resources/templates/fragments/forms/basicTextInput.html
+++ b/src/main/resources/templates/fragments/forms/basicTextInput.html
@@ -1,5 +1,6 @@
-<th:block th:fragment="textInput(label, fieldName)"
-          th:replace="~{fragments/forms/inputGroup :: inputGroup(${label}, ${fieldName}, ~{::input}, null)}">
+<th:block th:fragment="textInput(label, fieldName, hint)"
+          th:replace="~{fragments/forms/inputGroup :: inputGroup(${label}, ${fieldName}, ~{::input}, ${hint})}">
     <input class="govuk-input" th:classappend='${#fields.hasErrors(fieldName) ? "govuk-input--error" : ""}' type="text"
-           th:field="*{__${fieldName}__}">
+           th:field="*{__${fieldName}__}"
+           th:attrappend="aria-describedby=${hint != null} ? ${fieldName}+'-details-hint'">
 </th:block>

--- a/src/main/resources/templates/fragments/forms/nameInput.html
+++ b/src/main/resources/templates/fragments/forms/nameInput.html
@@ -1,0 +1,6 @@
+<th:block th:fragment="nameInput(label, fieldName, hint)"
+          th:replace="~{fragments/forms/inputGroup :: inputGroup(${label}, ${fieldName}, ~{::input}, ${hint})}">
+    <input class="govuk-input" th:classappend='${#fields.hasErrors(fieldName) ? "govuk-input--error" : ""}' type="text"
+           th:field="*{__${fieldName}__}"
+           th:attrappend="aria-describedby=${hint != null} ? ${fieldName}+'-details-hint'">
+</th:block>

--- a/src/main/resources/templates/fragments/forms/nameInput.html
+++ b/src/main/resources/templates/fragments/forms/nameInput.html
@@ -1,6 +1,0 @@
-<th:block th:fragment="nameInput(label, fieldName, hint)"
-          th:replace="~{fragments/forms/inputGroup :: inputGroup(${label}, ${fieldName}, ~{::input}, ${hint})}">
-    <input class="govuk-input" th:classappend='${#fields.hasErrors(fieldName) ? "govuk-input--error" : ""}' type="text"
-           th:field="*{__${fieldName}__}"
-           th:attrappend="aria-describedby=${hint != null} ? ${fieldName}+'-details-hint'">
-</th:block>

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/LaUserRegistrationJourneyTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/LaUserRegistrationJourneyTests.kt
@@ -10,7 +10,8 @@ class LaUserRegistrationJourneyTests : IntegrationTest() {
         fun `Submitting a valid name redirects to the next step`() {
             val formPage = navigator.goToLaUserRegistrationNameFormPage()
             formPage.fillName("Test User")
-            formPage.submit()
+            val nextStep = formPage.submit()
+            nextStep.assertHeadingContains("What is your work email address?")
         }
 
         @Test
@@ -18,7 +19,7 @@ class LaUserRegistrationJourneyTests : IntegrationTest() {
             val formPage = navigator.goToLaUserRegistrationNameFormPage()
             formPage.fillName("")
             formPage.submitUnsuccessfully()
-            formPage.assertNameFormErrorContains("You must provide your name")
+            formPage.assertNameFormErrorContains("You must enter your full name")
         }
     }
 
@@ -26,14 +27,17 @@ class LaUserRegistrationJourneyTests : IntegrationTest() {
     inner class LaUserRegistrationStepEmail {
         @Test
         fun `Navigating directly to this step redirects to the name step`() {
-            navigator.skipToLaUserRegistrationEmailFormPage()
+            val firstStep = navigator.skipToLaUserRegistrationEmailFormPage()
+            firstStep.assertHeadingContains("What is your full name?")
         }
 
         @Test
         fun `Submitting a valid email redirects to the next step`() {
             val formPage = navigator.goToLaUserRegistrationEmailFormPage()
             formPage.fillEmail("test@example.com")
-            formPage.submit()
+            val nextStep = formPage.submit()
+            // This will need to change when the "check answers" page is implemented
+            nextStep.assertHeadingContains("Page not found")
         }
 
         @Test

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/LaUserRegistrationJourneyTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/LaUserRegistrationJourneyTests.kt
@@ -1,0 +1,55 @@
+package uk.gov.communities.prsdb.webapp.integration
+
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+class LaUserRegistrationJourneyTests : IntegrationTest() {
+    @Nested
+    inner class LaUserRegistrationStepName {
+        @Test
+        fun `Submitting a valid name redirects to the next step`() {
+            val formPage = navigator.goToLaUserRegistrationNameFormPage()
+            formPage.fillName("Test User")
+            formPage.submit()
+        }
+
+        @Test
+        fun `Submitting an empty name returns an error`() {
+            val formPage = navigator.goToLaUserRegistrationNameFormPage()
+            formPage.fillName("")
+            formPage.submitUnsuccessfully()
+            formPage.assertNameFormErrorContains("You must provide your name")
+        }
+    }
+
+    @Nested
+    inner class LaUserRegistrationStepEmail {
+        @Test
+        fun `Navigating directly to this step redirects to the name step`() {
+            navigator.skipToLaUserRegistrationEmailFormPage()
+        }
+
+        @Test
+        fun `Submitting a valid email redirects to the next step`() {
+            val formPage = navigator.goToLaUserRegistrationEmailFormPage()
+            formPage.fillEmail("test@example.com")
+            formPage.submit()
+        }
+
+        @Test
+        fun `Submitting an empty e-mail address returns an error`() {
+            val formPage = navigator.goToLaUserRegistrationEmailFormPage()
+            formPage.fillEmail("")
+            formPage.submitUnsuccessfully()
+            formPage.assertEmailFormErrorContains("Enter a valid email address to continue. An email is required for contact purposes.")
+        }
+
+        @Test
+        fun `Submitting an invalid e-mail address returns an error`() {
+            val formPage = navigator.goToLaUserRegistrationEmailFormPage()
+            formPage.fillEmail("notAnEmail")
+            formPage.submitUnsuccessfully()
+            formPage.assertEmailFormErrorContains("Enter an email address in the right format")
+        }
+    }
+}

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageobjects/pages/Navigator.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageobjects/pages/Navigator.kt
@@ -2,6 +2,8 @@ package uk.gov.communities.prsdb.webapp.integration.pageobjects.pages
 
 import com.microsoft.playwright.Page
 import uk.gov.communities.prsdb.webapp.integration.pageobjects.pages.basePages.BasePage
+import uk.gov.communities.prsdb.webapp.integration.pageobjects.pages.laUserRegistrationJourneyPages.EmailFormPageLaUserRegistration
+import uk.gov.communities.prsdb.webapp.integration.pageobjects.pages.laUserRegistrationJourneyPages.NameFormPageLaUserRegistration
 import uk.gov.communities.prsdb.webapp.integration.pageobjects.pages.landlordRegistrationJourneyPages.EmailFormPageLandlordRegistration
 import uk.gov.communities.prsdb.webapp.integration.pageobjects.pages.landlordRegistrationJourneyPages.PhoneNumberFormPageLandlordRegistration
 
@@ -35,6 +37,24 @@ class Navigator(
     fun goToLandlordRegistrationPhoneNumberFormPage(): PhoneNumberFormPageLandlordRegistration {
         navigate("register-as-a-landlord/phone-number")
         return BasePage.createValid(page, PhoneNumberFormPageLandlordRegistration::class)
+    }
+
+    fun goToLaUserRegistrationNameFormPage(): NameFormPageLaUserRegistration {
+        navigate("register-local-authority-user/name")
+        return BasePage.createValid(page, NameFormPageLaUserRegistration::class)
+    }
+
+    private fun completeLaUserRegistrationNameStep(): EmailFormPageLaUserRegistration {
+        val namePage = goToLaUserRegistrationNameFormPage()
+        namePage.fillName("Test user")
+        return namePage.submit()
+    }
+
+    fun goToLaUserRegistrationEmailFormPage(): EmailFormPageLaUserRegistration = completeLaUserRegistrationNameStep()
+
+    fun skipToLaUserRegistrationEmailFormPage(): NameFormPageLaUserRegistration {
+        navigate("register-local-authority-user/email")
+        return BasePage.createValid(page, NameFormPageLaUserRegistration::class)
     }
 
     private fun navigate(path: String) {

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageobjects/pages/PageNotFoundPage.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageobjects/pages/PageNotFoundPage.kt
@@ -1,0 +1,14 @@
+package uk.gov.communities.prsdb.webapp.integration.pageobjects.pages
+
+import com.microsoft.playwright.Page
+import com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat
+import uk.gov.communities.prsdb.webapp.integration.pageobjects.pages.basePages.BasePage
+
+class PageNotFoundPage(
+    page: Page,
+) : BasePage(page) {
+    override fun validate() {
+        val heading = page.locator(".govuk-heading-l")
+        assertThat(heading).containsText("Page not found")
+    }
+}

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageobjects/pages/PageNotFoundPage.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageobjects/pages/PageNotFoundPage.kt
@@ -11,4 +11,9 @@ class PageNotFoundPage(
         val heading = page.locator(".govuk-heading-l")
         assertThat(heading).containsText("Page not found")
     }
+
+    fun assertHeadingContains(text: String) {
+        val heading = page.locator(".govuk-heading-l")
+        assertThat(heading).containsText(text)
+    }
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageobjects/pages/laUserRegistrationJourneyPages/EmailFormPageLaUserRegistration.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageobjects/pages/laUserRegistrationJourneyPages/EmailFormPageLaUserRegistration.kt
@@ -1,0 +1,15 @@
+package uk.gov.communities.prsdb.webapp.integration.pageobjects.pages.laUserRegistrationJourneyPages
+
+import com.microsoft.playwright.Page
+import uk.gov.communities.prsdb.webapp.integration.pageobjects.pages.PageNotFoundPage
+import uk.gov.communities.prsdb.webapp.integration.pageobjects.pages.basePages.EmailFormBasePage
+
+class EmailFormPageLaUserRegistration(
+    page: Page,
+) : EmailFormBasePage(page, pageHeading = "What is your work email address?") {
+    // When the "create answers" page is written, submitting this page should redirect to there
+    override fun submit(): PageNotFoundPage {
+        submitButton.click()
+        return createValid(page, PageNotFoundPage::class)
+    }
+}

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageobjects/pages/laUserRegistrationJourneyPages/EmailFormPageLaUserRegistration.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageobjects/pages/laUserRegistrationJourneyPages/EmailFormPageLaUserRegistration.kt
@@ -1,6 +1,7 @@
 package uk.gov.communities.prsdb.webapp.integration.pageobjects.pages.laUserRegistrationJourneyPages
 
 import com.microsoft.playwright.Page
+import com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat
 import uk.gov.communities.prsdb.webapp.integration.pageobjects.pages.PageNotFoundPage
 import uk.gov.communities.prsdb.webapp.integration.pageobjects.pages.basePages.EmailFormBasePage
 
@@ -11,5 +12,13 @@ class EmailFormPageLaUserRegistration(
     override fun submit(): PageNotFoundPage {
         submitButton.click()
         return createValid(page, PageNotFoundPage::class)
+    }
+
+    override fun validate() {
+        assertThat(fieldSetHeading).containsText("What is your work email address?")
+    }
+
+    fun assertHeadingContains(text: String) {
+        assertThat(fieldSetHeading).containsText(text)
     }
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageobjects/pages/laUserRegistrationJourneyPages/NameFormPageLaUserRegistration.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageobjects/pages/laUserRegistrationJourneyPages/NameFormPageLaUserRegistration.kt
@@ -29,4 +29,8 @@ class NameFormPageLaUserRegistration(
     fun assertNameFormErrorContains(error: String) {
         nameInputFormGroup.assertErrorMessageContains(error)
     }
+
+    fun assertHeadingContains(text: String) {
+        assertThat(fieldSetHeading).containsText(text)
+    }
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageobjects/pages/laUserRegistrationJourneyPages/NameFormPageLaUserRegistration.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageobjects/pages/laUserRegistrationJourneyPages/NameFormPageLaUserRegistration.kt
@@ -1,0 +1,32 @@
+package uk.gov.communities.prsdb.webapp.integration.pageobjects.pages.laUserRegistrationJourneyPages
+
+import com.microsoft.playwright.Page
+import com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat
+import uk.gov.communities.prsdb.webapp.integration.pageobjects.pages.basePages.BasePage
+
+class NameFormPageLaUserRegistration(
+    page: Page,
+) : BasePage(page) {
+    private val nameInputFormGroup = fieldsetInput("name")
+    val submitButton = page.locator("button[type=\"submit\"]")
+
+    fun fillName(text: String) = nameInputFormGroup.input.fill(text)
+
+    override fun validate() {
+        assertThat(fieldSetHeading).containsText("What is your full name?")
+    }
+
+    fun submit(): EmailFormPageLaUserRegistration {
+        submitButton.click()
+        return createValid(page, EmailFormPageLaUserRegistration::class)
+    }
+
+    fun submitUnsuccessfully() {
+        submitButton.click()
+        page.waitForLoadState()
+    }
+
+    fun assertNameFormErrorContains(error: String) {
+        nameInputFormGroup.assertErrorMessageContains(error)
+    }
+}


### PR DESCRIPTION
This is the first part of PRSD-405 (I've broken it into sub-tasks)

This code:

- Sets up the RegisterLAUserController
- Sets up the LAUserRegistrationJourney with the first two steps
    - Name which is a new component
    - Email which modifies the existing component to allow different text on the button
    - Includes validation for both of these steps
    - Journey tests

Later tickets will cover
- The "check answers" page
- Handling the form completion
- Accessing the form from the email link
- Controller tests / page tests (these would cover the entry point and the form completion)

![image](https://github.com/user-attachments/assets/5c5060b4-9a42-4d9a-93be-791cb63e0834)
![image](https://github.com/user-attachments/assets/9b709af0-238f-42d6-82e8-2f77d5f8a7e5)
![image](https://github.com/user-attachments/assets/1d31c4d2-6537-4177-8618-36d3bbea38d5)
![image](https://github.com/user-attachments/assets/55a6c832-b87d-48d2-a2f6-f75942fcd3be)


