### PR TITLE
Feat/prsd 422 multi page form tests

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/database/repository/FormContextRepository.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/database/repository/FormContextRepository.kt
@@ -3,4 +3,4 @@ package uk.gov.communities.prsdb.webapp.database.repository
 import org.springframework.data.jpa.repository.JpaRepository
 import uk.gov.communities.prsdb.webapp.database.entity.FormContext
 
-interface FormContextRepository : JpaRepository<FormContext?, Long?>
+interface FormContextRepository : JpaRepository<FormContext, Long?>

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/JourneyData.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/JourneyData.kt
@@ -6,7 +6,7 @@ typealias PageData = MutableMap<String, Any?>
 
 fun objectToStringKeyedMap(obj: Any?): JourneyData? {
     if (obj == null) return null
-    val initialMap: MutableMap<*, *> = obj as MutableMap<*, *>
+    val initialMap: MutableMap<*, *> = obj as? MutableMap<*, *> ?: return null
     val result: JourneyData = mutableMapOf()
     for ((key, value) in initialMap) {
         val stringKey = key as? String ?: return null

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/forms/JourneyDataTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/forms/JourneyDataTests.kt
@@ -1,0 +1,55 @@
+package uk.gov.communities.prsdb.webapp.forms
+
+import uk.gov.communities.prsdb.webapp.forms.journeys.objectToStringKeyedMap
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class JourneyDataTests {
+    @Test
+    fun `objectToStringKeyedMap casts map from object back to map`() {
+        // Arrange
+        val key = "testKey"
+        val value = "testValue"
+        val mapAsObject: Any = mutableMapOf(key to value)
+
+        // Act
+        val reconstructedMap = objectToStringKeyedMap(mapAsObject)
+
+        // Assert
+        assertEquals(reconstructedMap?.get(key), value)
+    }
+
+    @Test
+    fun `objectToStringKeyedMap returns null when the object is null`() {
+        // Arrange and Act
+        val reconstructedMap = objectToStringKeyedMap(null)
+
+        // Assert
+        assertNull(reconstructedMap)
+    }
+
+    @Test
+    fun `objectToStringKeyedMap returns null when the object cannot be cast to a map`() {
+        // Arrange
+        val notAMap: Any = "not a map"
+
+        // Act
+        val reconstructedMap = objectToStringKeyedMap(notAMap)
+
+        // Assert
+        assertNull(reconstructedMap)
+    }
+
+    @Test
+    fun `objectToStringKeyedMap returns null when the map keys are not strings`() {
+        // Arrange
+        val intKeyedMap: Any = mutableMapOf(1 to "one", 2 to "two", 3 to "three")
+
+        // Act
+        val reconstructedMap = objectToStringKeyedMap(intKeyedMap)
+
+        // Assert
+        assertNull(reconstructedMap)
+    }
+}

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/forms/JourneyTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/forms/JourneyTests.kt
@@ -1,0 +1,722 @@
+package uk.gov.communities.prsdb.webapp.forms
+
+import jakarta.validation.Validation
+import jakarta.validation.ValidatorFactory
+import jakarta.validation.constraints.NotNull
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.mockito.ArgumentMatchers.anyLong
+import org.mockito.ArgumentMatchers.anyMap
+import org.mockito.ArgumentMatchers.anyString
+import org.mockito.Mock
+import org.mockito.Mockito.mock
+import org.mockito.kotlin.anyOrNull
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.springframework.http.HttpStatus
+import org.springframework.validation.BindingResult
+import org.springframework.validation.Validator
+import org.springframework.validation.beanvalidation.SpringValidatorAdapter
+import org.springframework.validation.support.BindingAwareModelMap
+import org.springframework.web.server.ResponseStatusException
+import uk.gov.communities.prsdb.webapp.constants.REGISTER_LANDLORD_JOURNEY_URL
+import uk.gov.communities.prsdb.webapp.constants.enums.JourneyType
+import uk.gov.communities.prsdb.webapp.forms.journeys.Journey
+import uk.gov.communities.prsdb.webapp.forms.journeys.JourneyData
+import uk.gov.communities.prsdb.webapp.forms.journeys.PageData
+import uk.gov.communities.prsdb.webapp.forms.journeys.objectToStringKeyedMap
+import uk.gov.communities.prsdb.webapp.forms.pages.Page
+import uk.gov.communities.prsdb.webapp.forms.steps.Step
+import uk.gov.communities.prsdb.webapp.forms.steps.StepId
+import uk.gov.communities.prsdb.webapp.models.formModels.FormModel
+import uk.gov.communities.prsdb.webapp.services.JourneyDataService
+import java.security.Principal
+import kotlin.test.assertContains
+import kotlin.test.assertEquals
+import kotlin.test.assertIs
+import kotlin.test.assertNull
+
+class JourneyTests {
+    private lateinit var validatorFactory: ValidatorFactory
+    private lateinit var validator: Validator
+
+    enum class TestStepId(
+        override val urlPathSegment: String,
+    ) : StepId {
+        StepOne("step1"),
+        StepTwo("step2"),
+        StepThree("step3"),
+    }
+
+    class TestJourney(
+        journeyType: JourneyType,
+        steps: List<Step<TestStepId>>,
+        initialStepId: TestStepId,
+        validator: Validator,
+        journeyDataService: JourneyDataService,
+    ) : Journey<TestStepId>(journeyType, steps, initialStepId, validator, journeyDataService)
+
+    class TestFormModel : FormModel {
+        @NotNull
+        var testProperty: String? = null
+    }
+
+    @Mock
+    lateinit var mockJourneyDataService: JourneyDataService
+
+    @BeforeEach
+    fun setup() {
+        mockJourneyDataService = mock()
+        validatorFactory = Validation.buildDefaultValidatorFactory()
+        validator = SpringValidatorAdapter(validatorFactory.validator)
+    }
+
+    @AfterEach
+    fun tearDown() {
+        validatorFactory.close()
+    }
+
+    @Nested
+    inner class GetStepIdTests {
+        @Test
+        fun `returns correct step id when present`() {
+            // Arrange
+            val testJourney =
+                TestJourney(
+                    JourneyType.LANDLORD_REGISTRATION,
+                    initialStepId = TestStepId.StepOne,
+                    journeyDataService = mockJourneyDataService,
+                    validator = validator,
+                    steps =
+                        listOf(
+                            Step(
+                                TestStepId.StepOne,
+                                page =
+                                    Page(
+                                        TestFormModel::class,
+                                        "index",
+                                        mutableMapOf("testKey" to "testValue"),
+                                    ),
+                            ),
+                        ),
+                )
+
+            // Act
+            val foundStepId = testJourney.getStepId(TestStepId.StepOne.urlPathSegment)
+
+            // Assert
+            assertEquals(TestStepId.StepOne, foundStepId)
+        }
+
+        @Test
+        fun `throws not found exception when step is missing`() {
+            // Arrange
+            val testJourney =
+                TestJourney(
+                    JourneyType.LANDLORD_REGISTRATION,
+                    initialStepId = TestStepId.StepOne,
+                    journeyDataService = mockJourneyDataService,
+                    validator = validator,
+                    steps =
+                        listOf(
+                            Step(
+                                TestStepId.StepOne,
+                                page =
+                                    Page(
+                                        TestFormModel::class,
+                                        "index",
+                                        mutableMapOf("testKey" to "testValue"),
+                                    ),
+                            ),
+                        ),
+                )
+
+            // Act and Assert
+            val exception =
+                assertThrows<ResponseStatusException> { testJourney.getStepId(TestStepId.StepTwo.urlPathSegment) }
+            assertEquals(HttpStatus.NOT_FOUND, exception.statusCode)
+        }
+    }
+
+    @Nested
+    inner class PopulateModelAndGetViewNameTests {
+        @Test
+        fun `throws not found exception when step is missing`() {
+            // Arrange
+            val testJourney =
+                TestJourney(
+                    JourneyType.LANDLORD_REGISTRATION,
+                    initialStepId = TestStepId.StepOne,
+                    journeyDataService = mockJourneyDataService,
+                    validator = validator,
+                    steps =
+                        listOf(
+                            Step(
+                                TestStepId.StepOne,
+                                page =
+                                    Page(
+                                        TestFormModel::class,
+                                        "index",
+                                        mutableMapOf("testKey" to "testValue"),
+                                    ),
+                            ),
+                        ),
+                )
+            val model = BindingAwareModelMap()
+
+            // Act and Assert
+            val exception =
+                assertThrows<ResponseStatusException> {
+                    testJourney.populateModelAndGetViewName(
+                        TestStepId.StepTwo,
+                        model,
+                        null,
+                    )
+                }
+            assertEquals(HttpStatus.NOT_FOUND, exception.statusCode)
+        }
+
+        @Test
+        fun `returns redirect when step is not reachable`() {
+            // Arrange
+            val testJourney =
+                TestJourney(
+                    JourneyType.LANDLORD_REGISTRATION,
+                    initialStepId = TestStepId.StepOne,
+                    journeyDataService = mockJourneyDataService,
+                    validator = validator,
+                    steps =
+                        listOf(
+                            Step(
+                                TestStepId.StepOne,
+                                page =
+                                    Page(
+                                        TestFormModel::class,
+                                        "index",
+                                        mutableMapOf("testKey" to "testValue"),
+                                    ),
+                                nextAction = { _, _ -> Pair(TestStepId.StepThree, null) },
+                            ),
+                            Step(
+                                TestStepId.StepTwo,
+                                page =
+                                    Page(
+                                        TestFormModel::class,
+                                        "index",
+                                        mutableMapOf("testKey" to "testValue"),
+                                    ),
+                            ),
+                            Step(
+                                TestStepId.StepThree,
+                                page =
+                                    Page(
+                                        TestFormModel::class,
+                                        "index",
+                                        mutableMapOf("testKey" to "testValue"),
+                                    ),
+                            ),
+                        ),
+                )
+            val model = BindingAwareModelMap()
+            val pageData: PageData = mutableMapOf("testProperty" to "testPropertyValue")
+            val journeyData: JourneyData =
+                mutableMapOf(TestStepId.StepOne.urlPathSegment to pageData)
+            whenever(
+                mockJourneyDataService.getPageData(
+                    anyMap(),
+                    anyString(),
+                    anyOrNull(),
+                ),
+            ).thenReturn(
+                pageData,
+            )
+            whenever(mockJourneyDataService.getJourneyDataFromSession()).thenReturn(journeyData)
+
+            // Act
+            val result = testJourney.populateModelAndGetViewName(TestStepId.StepTwo, model, null, null)
+
+            // Assert
+            assertEquals("redirect:/${REGISTER_LANDLORD_JOURNEY_URL}/${TestStepId.StepOne.urlPathSegment}", result)
+        }
+
+        @Test
+        fun `returns redirect when earlier step has validation errors`() {
+            // Arrange
+            val testJourney =
+                TestJourney(
+                    JourneyType.LANDLORD_REGISTRATION,
+                    initialStepId = TestStepId.StepOne,
+                    journeyDataService = mockJourneyDataService,
+                    validator = validator,
+                    steps =
+                        listOf(
+                            Step(
+                                TestStepId.StepOne,
+                                page =
+                                    Page(
+                                        TestFormModel::class,
+                                        "index",
+                                        mutableMapOf("testKey" to "testValue"),
+                                    ),
+                                nextAction = { _, _ -> Pair(TestStepId.StepTwo, null) },
+                            ),
+                            Step(
+                                TestStepId.StepTwo,
+                                page =
+                                    Page(
+                                        TestFormModel::class,
+                                        "index",
+                                        mutableMapOf("testKey" to "testValue"),
+                                    ),
+                            ),
+                        ),
+                )
+            val model = BindingAwareModelMap()
+            val journeyData: JourneyData =
+                mutableMapOf()
+            whenever(
+                mockJourneyDataService.getPageData(
+                    anyMap(),
+                    anyString(),
+                    anyOrNull(),
+                ),
+            ).thenReturn(
+                mutableMapOf(),
+            )
+            whenever(mockJourneyDataService.getJourneyDataFromSession()).thenReturn(journeyData)
+
+            // Act
+            val result = testJourney.populateModelAndGetViewName(TestStepId.StepTwo, model, null, null)
+
+            // Assert
+            assertEquals("redirect:/${REGISTER_LANDLORD_JOURNEY_URL}/${TestStepId.StepOne.urlPathSegment}", result)
+        }
+
+        @Test
+        fun `returns populated model and template name when step is reachable`() {
+            // Arrange
+            val testJourney =
+                TestJourney(
+                    JourneyType.LANDLORD_REGISTRATION,
+                    initialStepId = TestStepId.StepOne,
+                    journeyDataService = mockJourneyDataService,
+                    validator = validator,
+                    steps =
+                        listOf(
+                            Step(
+                                TestStepId.StepOne,
+                                page =
+                                    Page(
+                                        TestFormModel::class,
+                                        "index",
+                                        mutableMapOf(),
+                                    ),
+                                nextAction = { _, _ -> Pair(TestStepId.StepTwo, null) },
+                            ),
+                            Step(
+                                TestStepId.StepTwo,
+                                page =
+                                    Page(
+                                        TestFormModel::class,
+                                        "templateName",
+                                        mutableMapOf("testKey" to "testValue"),
+                                    ),
+                            ),
+                        ),
+                )
+            val model = BindingAwareModelMap()
+            val pageData: PageData = mutableMapOf("testProperty" to "testPropertyValue")
+            val journeyData: JourneyData =
+                mutableMapOf(TestStepId.StepOne.urlPathSegment to pageData)
+            whenever(
+                mockJourneyDataService.getPageData(
+                    anyMap(),
+                    anyString(),
+                    anyOrNull(),
+                ),
+            ).thenReturn(
+                pageData,
+            )
+            whenever(mockJourneyDataService.getJourneyDataFromSession()).thenReturn(journeyData)
+
+            // Act
+            val result = testJourney.populateModelAndGetViewName(TestStepId.StepTwo, model, null, null)
+
+            // Assert
+            assertIs<BindingResult>(model[BindingResult.MODEL_KEY_PREFIX + "formModel"])
+            val bindingResult: BindingResult = model[BindingResult.MODEL_KEY_PREFIX + "formModel"] as BindingResult
+            assertContains(model, "testKey")
+            assertEquals("testValue", model["testKey"])
+            assertContains(model, "backUrl")
+            assertEquals(TestStepId.StepOne.urlPathSegment, model["backUrl"])
+            val propertyValue = bindingResult.getRawFieldValue("testProperty")
+            assertEquals("testPropertyValue", propertyValue)
+            assertEquals("templateName", result)
+        }
+    }
+
+    @Nested
+    inner class UpdateJourneyDataAndGetViewNameOrRedirectTests {
+        @Test
+        fun `throws not found exception when step is missing`() {
+            // Arrange
+            val testJourney =
+                TestJourney(
+                    JourneyType.LANDLORD_REGISTRATION,
+                    initialStepId = TestStepId.StepOne,
+                    journeyDataService = mockJourneyDataService,
+                    validator = validator,
+                    steps =
+                        listOf(
+                            Step(
+                                TestStepId.StepOne,
+                                page =
+                                    Page(
+                                        TestFormModel::class,
+                                        "index",
+                                        mutableMapOf("testKey" to "testValue"),
+                                    ),
+                            ),
+                        ),
+                )
+            val model = BindingAwareModelMap()
+            val pageData: PageData = mutableMapOf()
+            val principal = Principal { "testPrincipalId" }
+
+            // Act and Assert
+            val exception =
+                assertThrows<ResponseStatusException> {
+                    testJourney.updateJourneyDataAndGetViewNameOrRedirect(
+                        TestStepId.StepTwo,
+                        pageData,
+                        model,
+                        null,
+                        principal,
+                    )
+                }
+            assertEquals(HttpStatus.NOT_FOUND, exception.statusCode)
+        }
+
+        @Test
+        fun `returns populated current step view when page has validation errors`() {
+            // Arrange
+            val testJourney =
+                TestJourney(
+                    JourneyType.LANDLORD_REGISTRATION,
+                    initialStepId = TestStepId.StepOne,
+                    journeyDataService = mockJourneyDataService,
+                    validator = validator,
+                    steps =
+                        listOf(
+                            Step(
+                                TestStepId.StepOne,
+                                page =
+                                    Page(
+                                        TestFormModel::class,
+                                        "stepOneTemplate",
+                                        mutableMapOf("testKey" to "testValue"),
+                                    ),
+                                nextAction = { _, _ -> Pair(TestStepId.StepTwo, null) },
+                            ),
+                            Step(
+                                TestStepId.StepTwo,
+                                page =
+                                    Page(
+                                        TestFormModel::class,
+                                        "stepTwoTemplate",
+                                        mutableMapOf("anotherTestKey" to "anotherTestValue"),
+                                    ),
+                            ),
+                        ),
+                )
+            val model = BindingAwareModelMap()
+            val principal = Principal { "testPrincipalId" }
+            val pageData: PageData = mutableMapOf()
+            val journeyData: JourneyData =
+                mutableMapOf(TestStepId.StepOne.urlPathSegment to pageData)
+            whenever(
+                mockJourneyDataService.getPageData(
+                    anyMap(),
+                    anyString(),
+                    anyOrNull(),
+                ),
+            ).thenReturn(
+                pageData,
+            )
+            whenever(mockJourneyDataService.getJourneyDataFromSession()).thenReturn(journeyData)
+
+            // Act
+            val result =
+                testJourney.updateJourneyDataAndGetViewNameOrRedirect(
+                    TestStepId.StepOne,
+                    pageData,
+                    model,
+                    null,
+                    principal,
+                )
+
+            // Assert
+            assertIs<BindingResult>(model[BindingResult.MODEL_KEY_PREFIX + "formModel"])
+            val bindingResult: BindingResult = model[BindingResult.MODEL_KEY_PREFIX + "formModel"] as BindingResult
+            assertContains(model, "testKey")
+            assertEquals("testValue", model["testKey"])
+            val propertyValue = bindingResult.getRawFieldValue("testProperty")
+            assertNull(propertyValue)
+            assertEquals("stepOneTemplate", result)
+        }
+
+        @Test
+        fun `returns redirect to next step when valid data and updates the journey data when the page data is valid`() {
+            // Arrange
+            val testJourney =
+                TestJourney(
+                    JourneyType.LANDLORD_REGISTRATION,
+                    initialStepId = TestStepId.StepOne,
+                    journeyDataService = mockJourneyDataService,
+                    validator = validator,
+                    steps =
+                        listOf(
+                            Step(
+                                TestStepId.StepOne,
+                                page =
+                                    Page(
+                                        TestFormModel::class,
+                                        "stepOneTemplate",
+                                        mutableMapOf("testKey" to "testValue"),
+                                    ),
+                                nextAction = { _, _ -> Pair(TestStepId.StepTwo, null) },
+                            ),
+                            Step(
+                                TestStepId.StepTwo,
+                                page =
+                                    Page(
+                                        TestFormModel::class,
+                                        "stepTwoTemplate",
+                                        mutableMapOf("anotherTestKey" to "anotherTestValue"),
+                                    ),
+                            ),
+                        ),
+                )
+            val model = BindingAwareModelMap()
+            val principal = Principal { "testPrincipalId" }
+            val pageData: PageData = mutableMapOf("testProperty" to "testPropertyValue")
+            val journeyData: JourneyData = mutableMapOf()
+            whenever(
+                mockJourneyDataService.getPageData(
+                    anyMap(),
+                    anyString(),
+                    anyOrNull(),
+                ),
+            ).thenReturn(
+                pageData,
+            )
+            whenever(mockJourneyDataService.getJourneyDataFromSession()).thenReturn(journeyData)
+
+            // Act
+            val result =
+                testJourney.updateJourneyDataAndGetViewNameOrRedirect(
+                    TestStepId.StepOne,
+                    pageData,
+                    model,
+                    null,
+                    principal,
+                )
+            val journeyDataCaptor = argumentCaptor<JourneyData>()
+            verify(mockJourneyDataService).setJourneyData(journeyDataCaptor.capture())
+
+            // Assert
+            assertEquals("redirect:/${REGISTER_LANDLORD_JOURNEY_URL}/${TestStepId.StepTwo.urlPathSegment}", result)
+            assertIs<PageData>(journeyDataCaptor.firstValue[TestStepId.StepOne.urlPathSegment]!!)
+            val resultPageData = objectToStringKeyedMap(journeyDataCaptor.firstValue[TestStepId.StepOne.urlPathSegment])
+            assertEquals("testPropertyValue", resultPageData?.get("testProperty"))
+        }
+
+        @Test
+        fun `saves the journey data when saveAfterSubmit is set on the step`() {
+            // Arrange
+            val testJourney =
+                TestJourney(
+                    JourneyType.LANDLORD_REGISTRATION,
+                    initialStepId = TestStepId.StepOne,
+                    journeyDataService = mockJourneyDataService,
+                    validator = validator,
+                    steps =
+                        listOf(
+                            Step(
+                                TestStepId.StepOne,
+                                page =
+                                    Page(
+                                        TestFormModel::class,
+                                        "stepOneTemplate",
+                                        mutableMapOf("testKey" to "testValue"),
+                                    ),
+                                nextAction = { _, _ -> Pair(TestStepId.StepTwo, null) },
+                                saveAfterSubmit = true,
+                            ),
+                            Step(
+                                TestStepId.StepTwo,
+                                page =
+                                    Page(
+                                        TestFormModel::class,
+                                        "stepTwoTemplate",
+                                        mutableMapOf("anotherTestKey" to "anotherTestValue"),
+                                    ),
+                            ),
+                        ),
+                )
+            val model = BindingAwareModelMap()
+            val principal = Principal { "testPrincipalId" }
+            val pageData: PageData = mutableMapOf("testProperty" to "testPropertyValue")
+            val journeyData: JourneyData = mutableMapOf()
+            whenever(
+                mockJourneyDataService.getPageData(
+                    anyMap(),
+                    anyString(),
+                    anyOrNull(),
+                ),
+            ).thenReturn(
+                pageData,
+            )
+            whenever(mockJourneyDataService.getJourneyDataFromSession()).thenReturn(journeyData)
+
+            // Act
+            val result =
+                testJourney.updateJourneyDataAndGetViewNameOrRedirect(
+                    TestStepId.StepOne,
+                    pageData,
+                    model,
+                    null,
+                    principal,
+                )
+            val journeyDataCaptor = argumentCaptor<JourneyData>()
+            verify(mockJourneyDataService).saveJourneyData(
+                anyLong(),
+                journeyDataCaptor.capture(),
+                eq(JourneyType.LANDLORD_REGISTRATION),
+                eq(principal),
+            )
+
+            // Assert
+            assertEquals("redirect:/${REGISTER_LANDLORD_JOURNEY_URL}/${TestStepId.StepTwo.urlPathSegment}", result)
+            assertIs<PageData>(journeyDataCaptor.firstValue[TestStepId.StepOne.urlPathSegment]!!)
+            val resultPageData = objectToStringKeyedMap(journeyDataCaptor.firstValue[TestStepId.StepOne.urlPathSegment])
+            assertEquals("testPropertyValue", resultPageData?.get("testProperty"))
+        }
+
+        @Test
+        fun `delegates to the handleSubmitAndRedirect function when present on the current step`() {
+            // Arrange
+            val testJourney =
+                TestJourney(
+                    JourneyType.LANDLORD_REGISTRATION,
+                    initialStepId = TestStepId.StepOne,
+                    journeyDataService = mockJourneyDataService,
+                    validator = validator,
+                    steps =
+                        listOf(
+                            Step(
+                                TestStepId.StepOne,
+                                page =
+                                    Page(
+                                        TestFormModel::class,
+                                        "stepOneTemplate",
+                                        mutableMapOf("testKey" to "testValue"),
+                                    ),
+                                handleSubmitAndRedirect = { _, _ -> "/customRedirect" },
+                            ),
+                            Step(
+                                TestStepId.StepTwo,
+                                page =
+                                    Page(
+                                        TestFormModel::class,
+                                        "stepTwoTemplate",
+                                        mutableMapOf("anotherTestKey" to "anotherTestValue"),
+                                    ),
+                            ),
+                        ),
+                )
+            val model = BindingAwareModelMap()
+            val principal = Principal { "testPrincipalId" }
+            val pageData: PageData = mutableMapOf("testProperty" to "testPropertyValue")
+            val journeyData: JourneyData = mutableMapOf()
+            whenever(
+                mockJourneyDataService.getPageData(
+                    anyMap(),
+                    anyString(),
+                    anyOrNull(),
+                ),
+            ).thenReturn(
+                pageData,
+            )
+            whenever(mockJourneyDataService.getJourneyDataFromSession()).thenReturn(journeyData)
+
+            // Act
+            val result =
+                testJourney.updateJourneyDataAndGetViewNameOrRedirect(
+                    TestStepId.StepOne,
+                    pageData,
+                    model,
+                    null,
+                    principal,
+                )
+
+            // Assert
+            assertEquals("redirect:/customRedirect", result)
+        }
+
+        @Test
+        fun `throws illegal state exception when nextAction function returns null`() {
+            // Arrange
+            val testJourney =
+                TestJourney(
+                    JourneyType.LANDLORD_REGISTRATION,
+                    initialStepId = TestStepId.StepOne,
+                    journeyDataService = mockJourneyDataService,
+                    validator = validator,
+                    steps =
+                        listOf(
+                            Step(
+                                TestStepId.StepOne,
+                                page =
+                                    Page(
+                                        TestFormModel::class,
+                                        "stepOneTemplate",
+                                        mutableMapOf("testKey" to "testValue"),
+                                    ),
+                                nextAction = { _, _ -> Pair(null, null) },
+                            ),
+                        ),
+                )
+            val model = BindingAwareModelMap()
+            val principal = Principal { "testPrincipalId" }
+            val pageData: PageData = mutableMapOf("testProperty" to "testPropertyValue")
+            val journeyData: JourneyData = mutableMapOf()
+            whenever(
+                mockJourneyDataService.getPageData(
+                    anyMap(),
+                    anyString(),
+                    anyOrNull(),
+                ),
+            ).thenReturn(
+                pageData,
+            )
+            whenever(mockJourneyDataService.getJourneyDataFromSession()).thenReturn(journeyData)
+
+            // Act and Assert
+            assertThrows<IllegalStateException> {
+                testJourney.updateJourneyDataAndGetViewNameOrRedirect(
+                    TestStepId.StepOne,
+                    pageData,
+                    model,
+                    null,
+                    principal,
+                )
+            }
+        }
+    }
+}

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/forms/PageTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/forms/PageTests.kt
@@ -1,4 +1,93 @@
 package uk.gov.communities.prsdb.webapp.forms
 
+import jakarta.validation.Validation
+import jakarta.validation.ValidatorFactory
+import jakarta.validation.constraints.NotNull
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.springframework.validation.BindingResult
+import org.springframework.validation.Validator
+import org.springframework.validation.beanvalidation.SpringValidatorAdapter
+import org.springframework.validation.support.BindingAwareModelMap
+import uk.gov.communities.prsdb.webapp.forms.pages.Page
+import uk.gov.communities.prsdb.webapp.models.formModels.FormModel
+import kotlin.test.Test
+import kotlin.test.assertContains
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+
+class TestFormModel : FormModel {
+    @NotNull
+    var testProperty: String? = null
+}
+
 class PageTests {
+    private lateinit var testPage: Page
+    private lateinit var validatorFactory: ValidatorFactory
+    private lateinit var validator: Validator
+
+    @BeforeEach
+    fun setup() {
+        testPage =
+            Page(
+                TestFormModel::class,
+                "index",
+                mutableMapOf("testKey" to "testValue"),
+            )
+        validatorFactory = Validation.buildDefaultValidatorFactory()
+        validator = SpringValidatorAdapter(validatorFactory.validator)
+    }
+
+    @AfterEach
+    fun tearDown() {
+        validatorFactory.close()
+    }
+
+    @Test
+    fun `isSatisfied returns true when validation is satisfied`() {
+        // Arrange
+        val formData = mapOf("testProperty" to "testPropertyValue")
+
+        // Act
+        val result = testPage.isSatisfied(validator, formData)
+
+        // Assert
+        assertTrue(result)
+    }
+
+    @Test
+    fun `isSatisfied returns false when validation is not satisfied`() {
+        // Arrange
+        val formData = mapOf("anotherProperty" to "testPropertyValue", "testProperty" to null)
+
+        // Act
+        val result = testPage.isSatisfied(validator, formData)
+
+        // Assert
+        assertFalse(result)
+    }
+
+    @Test
+    fun `populateModelAndGetTemplateName populates the model and returns the template name`() {
+        // Arrange
+        val formData = mapOf("testProperty" to "testPropertyValue")
+        val model = BindingAwareModelMap()
+        val previousUrl = "/previous"
+
+        // Act
+        val result = testPage.populateModelAndGetTemplateName(validator, model, formData, previousUrl)
+
+        // Assert
+        assertIs<BindingResult>(model[BindingResult.MODEL_KEY_PREFIX + "formModel"])
+        val bindingResult: BindingResult = model[BindingResult.MODEL_KEY_PREFIX + "formModel"] as BindingResult
+        assertContains(model, "testKey")
+        assertEquals("testValue", model["testKey"])
+        assertContains(model, "backUrl")
+        assertEquals(previousUrl, model["backUrl"])
+        val propertyValue = bindingResult.getRawFieldValue("testProperty")
+        assertEquals("testPropertyValue", propertyValue)
+        assertEquals("index", result)
+    }
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/forms/PageTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/forms/PageTests.kt
@@ -1,0 +1,4 @@
+package uk.gov.communities.prsdb.webapp.forms
+
+class PageTests {
+}

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/forms/StepTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/forms/StepTests.kt
@@ -1,0 +1,84 @@
+package uk.gov.communities.prsdb.webapp.forms
+
+import org.mockito.Mock
+import org.mockito.Mockito.mock
+import uk.gov.communities.prsdb.webapp.forms.journeys.JourneyData
+import uk.gov.communities.prsdb.webapp.forms.journeys.PageData
+import uk.gov.communities.prsdb.webapp.forms.journeys.objectToStringKeyedMap
+import uk.gov.communities.prsdb.webapp.forms.pages.Page
+import uk.gov.communities.prsdb.webapp.forms.steps.Step
+import uk.gov.communities.prsdb.webapp.forms.steps.StepId
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class StepTests {
+    @Mock
+    val mockPage: Page = mock()
+
+    enum class TestStepId(
+        override val urlPathSegment: String,
+    ) : StepId {
+        StepOne("step1"),
+        StepTwo("step2"),
+    }
+
+    @Test
+    fun `updateJourneyData adds pageData when subPageNumber is null`() {
+        // Arrange
+        val journeyData: JourneyData =
+            mutableMapOf("existingPage" to mutableMapOf("existingProperty" to "existingValue"))
+        val pageData: PageData = mutableMapOf("newProperty" to "newValue")
+        val testStep = Step<TestStepId>(TestStepId.StepOne, mockPage)
+
+        // Act
+        testStep.updateJourneyData(journeyData, pageData, null)
+        val newJourneyData = objectToStringKeyedMap(journeyData)
+        val existingPageData = objectToStringKeyedMap(newJourneyData?.get("existingPage"))
+        val newPageData = objectToStringKeyedMap(newJourneyData?.get(testStep.name))
+
+        // Assert
+        assertEquals("existingValue", existingPageData?.get("existingProperty"))
+        assertEquals("newValue", newPageData?.get("newProperty"))
+    }
+
+    @Test
+    fun `updateJourneyData adds subPage data to existing pageData`() {
+        // Arrange
+        val subPageNumber = 12
+        val pageData: PageData = mutableMapOf("newProperty" to "newValue")
+        val testStep = Step<TestStepId>(TestStepId.StepOne, mockPage)
+        val journeyData: JourneyData =
+            mutableMapOf(testStep.name to mutableMapOf(("existingProperty" to "existingValue")))
+
+        // Act
+        testStep.updateJourneyData(journeyData, pageData, subPageNumber)
+        val newJourneyData = objectToStringKeyedMap(journeyData)
+        val existingPageData = objectToStringKeyedMap(newJourneyData?.get(testStep.name))
+        val subPageData = objectToStringKeyedMap(existingPageData?.get(subPageNumber.toString()))
+
+        // Assert
+        assertEquals("existingValue", existingPageData?.get("existingProperty"))
+        assertEquals("newValue", subPageData?.get("newProperty"))
+    }
+
+    @Test
+    fun `updateJourneyData adds subPage data to new pageData when it does not already exist`() {
+        // Arrange
+        val subPageNumber = 12
+        val journeyData: JourneyData =
+            mutableMapOf("existingPage" to mutableMapOf(("existingProperty" to "existingValue")))
+        val pageData: PageData = mutableMapOf("newProperty" to "newValue")
+        val testStep = Step<TestStepId>(TestStepId.StepOne, mockPage)
+
+        // Act
+        testStep.updateJourneyData(journeyData, pageData, subPageNumber)
+        val newJourneyData = objectToStringKeyedMap(journeyData)
+        val existingPageData = objectToStringKeyedMap(newJourneyData?.get("existingPage"))
+        val newPageData = objectToStringKeyedMap(newJourneyData?.get(TestStepId.StepOne.urlPathSegment))
+        val subPageData = objectToStringKeyedMap(newPageData?.get(subPageNumber.toString()))
+
+        // Assert
+        assertEquals("existingValue", existingPageData?.get("existingProperty"))
+        assertEquals("newValue", subPageData?.get("newProperty"))
+    }
+}

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/forms/StepTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/forms/StepTests.kt
@@ -19,7 +19,6 @@ class StepTests {
         override val urlPathSegment: String,
     ) : StepId {
         StepOne("step1"),
-        StepTwo("step2"),
     }
 
     @Test

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/JourneyDataServiceTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/JourneyDataServiceTests.kt
@@ -45,7 +45,7 @@ class JourneyDataServiceTests {
     @Nested
     inner class GetPageDataTests {
         @Test
-        fun `getPageData returns page data from journeyData if subPageNumber is null`() {
+        fun `returns page data from journeyData if subPageNumber is null`() {
             // Arrange
             val pageName = "testPage"
             val key = "testKey"
@@ -70,7 +70,7 @@ class JourneyDataServiceTests {
         }
 
         @Test
-        fun `getPageData returns null if page data is missing`() {
+        fun `returns null if page data is missing`() {
             // Arrange
             val pageName = "testPage"
             val journeyData: JourneyData = mutableMapOf()
@@ -90,7 +90,7 @@ class JourneyDataServiceTests {
         }
 
         @Test
-        fun `getPageData returns subPage data from journeyData if subPageNumber is provided`() {
+        fun `returns subPage data from journeyData if subPageNumber is provided`() {
             // Arrange
             val pageName = "testPage"
             val subPageNumber = 12
@@ -116,7 +116,7 @@ class JourneyDataServiceTests {
         }
 
         @Test
-        fun `getPageData returns null if sub page data is missing`() {
+        fun `returns null if sub page data is missing`() {
             // Arrange
             val pageName = "testPage"
             val subPageNumber = 12
@@ -140,7 +140,7 @@ class JourneyDataServiceTests {
     @Nested
     inner class SaveJourneyDataTests {
         @Test
-        fun `saveJourneyData creates new form context if contextId is null`() {
+        fun `creates new form context if contextId is null`() {
             // Arrange
             // Function Args
             val journeyType = JourneyType.LANDLORD_REGISTRATION
@@ -194,7 +194,7 @@ class JourneyDataServiceTests {
         }
 
         @Test
-        fun `saveJourneyData updates existing form context if it exists`() {
+        fun `updates existing form context if it exists`() {
             // Arrange
             // Function Args
             val journeyType = JourneyType.LANDLORD_REGISTRATION
@@ -254,7 +254,7 @@ class JourneyDataServiceTests {
         }
 
         @Test
-        fun `saveJourneyData throws an illegal state exception if form context is missing`() {
+        fun `throws an illegal state exception if form context is missing`() {
             // Arrange
             val journeyType = JourneyType.LANDLORD_REGISTRATION
             val principalId = "testPrincipleSub"
@@ -289,7 +289,7 @@ class JourneyDataServiceTests {
     @Nested
     inner class LoadJourneyDataIntoSessionTests {
         @Test
-        fun `loadJourneyDataIntoSession stores the new journey data in the session`() {
+        fun `stores the new journey data in the session`() {
             // Function Args
             val journeyType = JourneyType.LANDLORD_REGISTRATION
             val principalId = "testPrincipleSub"
@@ -338,7 +338,7 @@ class JourneyDataServiceTests {
         }
 
         @Test
-        fun `loadJourneyDataIntoSession throws an illegal state exception if form context is missing`() {
+        fun `throws an illegal state exception if form context is missing`() {
             // Arrange
             val contextId: Long = 123
             whenever(mockFormContextRepository.findById(contextId)).thenReturn(Optional.ofNullable(null))

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/JourneyDataServiceTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/JourneyDataServiceTests.kt
@@ -9,7 +9,6 @@ import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.ArgumentCaptor.captor
 import org.mockito.Mock
-import org.mockito.internal.matchers.apachecommons.ReflectionEquals
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.any
 import org.mockito.kotlin.eq
@@ -25,9 +24,7 @@ import uk.gov.communities.prsdb.webapp.forms.journeys.JourneyData
 import java.security.Principal
 import java.util.Optional
 import kotlin.test.assertEquals
-import kotlin.test.assertFalse
 import kotlin.test.assertNull
-import kotlin.test.assertTrue
 
 @ExtendWith(MockitoExtension::class)
 class JourneyDataServiceTests {
@@ -287,28 +284,6 @@ class JourneyDataServiceTests {
             assertThrows<IllegalStateException> {
                 journeyDataService.loadJourneyDataIntoSession(contextId)
             }
-        }
-
-        inner class ParentDummy(
-            val child: ChildDummy,
-        )
-
-        inner class ChildDummy(
-            val prop: String,
-        )
-
-        @Test
-        fun `reflectionEquals does deep matching`() {
-            val child1 = ChildDummy("Hello")
-            val child2 = ChildDummy("Hello")
-            val parent1 = ParentDummy(child1)
-            val parent2 = ParentDummy(child2)
-
-            val childResult = ReflectionEquals(child1).matches(child2)
-            val parentResult = ReflectionEquals(parent1).matches(parent2)
-
-            assertTrue(childResult)
-            assertFalse(parentResult)
         }
     }
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/JourneyDataServiceTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/JourneyDataServiceTests.kt
@@ -1,0 +1,361 @@
+package uk.gov.communities.prsdb.webapp.services
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import jakarta.servlet.http.HttpSession
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.mockito.ArgumentCaptor.captor
+import org.mockito.Mock
+import org.mockito.Mockito.mock
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.spy
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import uk.gov.communities.prsdb.webapp.constants.enums.JourneyType
+import uk.gov.communities.prsdb.webapp.database.entity.FormContext
+import uk.gov.communities.prsdb.webapp.database.entity.OneLoginUser
+import uk.gov.communities.prsdb.webapp.database.repository.FormContextRepository
+import uk.gov.communities.prsdb.webapp.database.repository.OneLoginUserRepository
+import uk.gov.communities.prsdb.webapp.forms.journeys.JourneyData
+import java.security.Principal
+import java.util.Optional
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class JourneyDataServiceTests {
+    @Mock
+    private lateinit var mockHttpSession: HttpSession
+
+    @Mock
+    private lateinit var mockFormContextRepository: FormContextRepository
+
+    @Mock
+    private lateinit var mockOneLoginUserRepository: OneLoginUserRepository
+
+    @BeforeEach
+    fun setup() {
+        mockHttpSession = mock()
+        mockFormContextRepository = mock()
+        mockOneLoginUserRepository = mock()
+    }
+
+    @Nested
+    inner class GetPageDataTests {
+        @Test
+        fun `getPageData returns page data from journeyData if subPageNumber is null`() {
+            // Arrange
+            val pageName = "testPage"
+            val key = "testKey"
+            val value = "testValue"
+            val journeyData: JourneyData =
+                mutableMapOf(
+                    pageName to mutableMapOf(key to value),
+                )
+            val journeyDataService =
+                JourneyDataService(
+                    mockHttpSession,
+                    mockFormContextRepository,
+                    mockOneLoginUserRepository,
+                    ObjectMapper(),
+                )
+
+            // Act
+            val pageData = journeyDataService.getPageData(journeyData, pageName, null)
+
+            // Assert
+            assertEquals(pageData?.get(key), value)
+        }
+
+        @Test
+        fun `getPageData returns null if page data is missing`() {
+            // Arrange
+            val pageName = "testPage"
+            val journeyData: JourneyData = mutableMapOf()
+            val journeyDataService =
+                JourneyDataService(
+                    mockHttpSession,
+                    mockFormContextRepository,
+                    mockOneLoginUserRepository,
+                    ObjectMapper(),
+                )
+
+            // Act
+            val pageData = journeyDataService.getPageData(journeyData, pageName, null)
+
+            // Assert
+            assertNull(pageData)
+        }
+
+        @Test
+        fun `getPageData returns subPage data from journeyData if subPageNumber is provided`() {
+            // Arrange
+            val pageName = "testPage"
+            val subPageNumber = 12
+            val key = "testKey"
+            val value = "testValue"
+            val journeyData: JourneyData =
+                mutableMapOf(
+                    pageName to mutableMapOf(subPageNumber.toString() to mutableMapOf(key to value)),
+                )
+            val journeyDataService =
+                JourneyDataService(
+                    mockHttpSession,
+                    mockFormContextRepository,
+                    mockOneLoginUserRepository,
+                    ObjectMapper(),
+                )
+
+            // Act
+            val subPageData = journeyDataService.getPageData(journeyData, pageName, subPageNumber)
+
+            // Assert
+            assertEquals(subPageData?.get(key), value)
+        }
+
+        @Test
+        fun `getPageData returns null if sub page data is missing`() {
+            // Arrange
+            val pageName = "testPage"
+            val subPageNumber = 12
+            val journeyData: JourneyData = mutableMapOf(pageName to mutableMapOf<String, Any>())
+            val journeyDataService =
+                JourneyDataService(
+                    mockHttpSession,
+                    mockFormContextRepository,
+                    mockOneLoginUserRepository,
+                    ObjectMapper(),
+                )
+
+            // Act
+            val subPageData = journeyDataService.getPageData(journeyData, pageName, subPageNumber)
+
+            // Assert
+            assertNull(subPageData)
+        }
+    }
+
+    @Nested
+    inner class SaveJourneyDataTests {
+        @Test
+        fun `saveJourneyData creates new form context if contextId is null`() {
+            // Arrange
+            // Function Args
+            val journeyType = JourneyType.LANDLORD_REGISTRATION
+            val principalId = "testPrincipleSub"
+            val principal = Principal { principalId }
+
+            // JourneyData
+            val pageName = "testPage"
+            val key = "testKey"
+            val value = "testValue"
+            val journeyData: JourneyData =
+                mutableMapOf(
+                    pageName to mutableMapOf(key to value),
+                )
+            val serializedJourneyData = ObjectMapper().writeValueAsString(journeyData)
+
+            // OneLoginUser
+            val oneLoginUser = OneLoginUser()
+            whenever(mockOneLoginUserRepository.getReferenceById(principalId)).thenReturn(
+                oneLoginUser,
+            )
+
+            // FormContext
+            val contextId: Long = 123
+            val spiedOnFormContext = spy(FormContext())
+            whenever(spiedOnFormContext.id).thenReturn(contextId)
+            whenever(mockFormContextRepository.save(any())).thenReturn(spiedOnFormContext)
+
+            // Service under test
+            val journeyDataService =
+                JourneyDataService(
+                    mockHttpSession,
+                    mockFormContextRepository,
+                    mockOneLoginUserRepository,
+                    ObjectMapper(),
+                )
+
+            // Act
+            val result = journeyDataService.saveJourneyData(null, journeyData, journeyType, principal)
+            val formContextCaptor = captor<FormContext>()
+            verify(mockFormContextRepository).save(formContextCaptor.capture())
+            val oneLoginCaptor = captor<String>()
+            verify(mockOneLoginUserRepository).getReferenceById(oneLoginCaptor.capture())
+
+            // Assert
+            assertEquals(contextId, result)
+            assertEquals(journeyType, formContextCaptor.value.journeyType)
+            assertEquals(oneLoginUser, formContextCaptor.value.user)
+            assertEquals(serializedJourneyData, formContextCaptor.value.context)
+            assertEquals(principalId, oneLoginCaptor.value)
+        }
+
+        @Test
+        fun `saveJourneyData updates existing form context if it exists`() {
+            // Arrange
+            // Function Args
+            val journeyType = JourneyType.LANDLORD_REGISTRATION
+            val principalId = "testPrincipleSub"
+            val principal = Principal { principalId }
+
+            // Original JourneyData
+            val pageName = "testPage"
+            val journeyData: JourneyData =
+                mutableMapOf(
+                    pageName to mutableMapOf<String, Any>(),
+                )
+            val serializedJourneyData = ObjectMapper().writeValueAsString(journeyData)
+
+            // New JourneyData
+            val newKey = "newTestKey"
+            val newValue = "newTestValue"
+            val newJourneyData: JourneyData =
+                mutableMapOf(
+                    pageName to mutableMapOf(newKey to newValue),
+                )
+            val newSerializedJourneyData = ObjectMapper().writeValueAsString(newJourneyData)
+
+            // OneLoginUser
+            val oneLoginUser = OneLoginUser()
+            whenever(mockOneLoginUserRepository.getReferenceById(principalId)).thenReturn(
+                oneLoginUser,
+            )
+
+            // FormContext
+            val contextId: Long = 123
+            val spiedOnFormContext = spy(FormContext())
+            whenever(spiedOnFormContext.id).thenReturn(contextId)
+            whenever(mockFormContextRepository.save(any())).thenReturn(spiedOnFormContext)
+            val originalFormContext = FormContext(journeyType, serializedJourneyData, oneLoginUser)
+            whenever(mockFormContextRepository.findById(contextId)).thenReturn(Optional.ofNullable(originalFormContext))
+
+            // Service under test
+            val journeyDataService =
+                JourneyDataService(
+                    mockHttpSession,
+                    mockFormContextRepository,
+                    mockOneLoginUserRepository,
+                    ObjectMapper(),
+                )
+
+            // Act
+            val result = journeyDataService.saveJourneyData(contextId, newJourneyData, journeyType, principal)
+            val formContextCaptor = captor<FormContext>()
+            verify(mockFormContextRepository).save(formContextCaptor.capture())
+
+            // Assert
+            assertEquals(contextId, result)
+            assertEquals(journeyType, formContextCaptor.value.journeyType)
+            assertEquals(oneLoginUser, formContextCaptor.value.user)
+            assertEquals(newSerializedJourneyData, formContextCaptor.value.context)
+        }
+
+        @Test
+        fun `saveJourneyData throws an illegal state exception if form context is missing`() {
+            // Arrange
+            val journeyType = JourneyType.LANDLORD_REGISTRATION
+            val principalId = "testPrincipleSub"
+            val principal = Principal { principalId }
+            val journeyData: JourneyData = mutableMapOf<String, Any?>()
+
+            // FormContext
+            val contextId: Long = 123
+            whenever(mockFormContextRepository.findById(contextId)).thenReturn(Optional.ofNullable(null))
+
+            // Service under test
+            val journeyDataService =
+                JourneyDataService(
+                    mockHttpSession,
+                    mockFormContextRepository,
+                    mockOneLoginUserRepository,
+                    ObjectMapper(),
+                )
+
+            // Act and Assert
+            assertThrows<IllegalStateException> {
+                journeyDataService.saveJourneyData(
+                    contextId,
+                    journeyData,
+                    journeyType,
+                    principal,
+                )
+            }
+        }
+    }
+
+    @Nested
+    inner class LoadJourneyDataIntoSessionTests {
+        @Test
+        fun `loadJourneyDataIntoSession stores the new journey data in the session`() {
+            // Function Args
+            val journeyType = JourneyType.LANDLORD_REGISTRATION
+            val principalId = "testPrincipleSub"
+            val principal = Principal { principalId }
+
+            // JourneyData
+            val pageName = "testPage"
+            val key = "testKey"
+            val value = "testValue"
+            val journeyData: JourneyData =
+                mutableMapOf(
+                    pageName to mutableMapOf(key to value),
+                )
+            val serializedJourneyData = ObjectMapper().writeValueAsString(journeyData)
+
+            // OneLoginUser
+            val oneLoginUser = OneLoginUser()
+            whenever(mockOneLoginUserRepository.getReferenceById(principalId)).thenReturn(
+                oneLoginUser,
+            )
+
+            // FormContext
+            val contextId: Long = 123
+            val formContext = FormContext(journeyType, serializedJourneyData, oneLoginUser)
+            whenever(mockFormContextRepository.findById(contextId)).thenReturn(Optional.ofNullable(formContext))
+
+            // Service under test
+            val journeyDataService =
+                JourneyDataService(
+                    mockHttpSession,
+                    mockFormContextRepository,
+                    mockOneLoginUserRepository,
+                    ObjectMapper(),
+                )
+
+            // Act
+            journeyDataService.loadJourneyDataIntoSession(contextId)
+            val formContextCaptor = captor<JourneyData>()
+            verify(mockHttpSession).setAttribute(eq("journeyData"), formContextCaptor.capture())
+            val contextIdCaptor = captor<Long>()
+            verify(mockHttpSession).setAttribute(eq("contextId"), contextIdCaptor.capture())
+
+            // Assert
+            assertEquals(journeyData, formContextCaptor.value)
+            assertEquals(contextId, contextIdCaptor.value)
+        }
+
+        @Test
+        fun `loadJourneyDataIntoSession throws an illegal state exception if form context is missing`() {
+            // Arrange
+            val contextId: Long = 123
+            whenever(mockFormContextRepository.findById(contextId)).thenReturn(Optional.ofNullable(null))
+
+            // Service under test
+            val journeyDataService =
+                JourneyDataService(
+                    mockHttpSession,
+                    mockFormContextRepository,
+                    mockOneLoginUserRepository,
+                    ObjectMapper(),
+                )
+
+            // Act and Assert
+            assertThrows<IllegalStateException> {
+                journeyDataService.loadJourneyDataIntoSession(contextId)
+            }
+        }
+    }
+}


### PR DESCRIPTION
Notes: 
- The commits should be almost entirely isolated into different sets of tests and should be able to be reviewed independently
- Some of the tests are more verbose and repetitive than usual, especially the `Journey` tests. This is deliberate as the code they're testing is central to the webApp as a whole, so I wanted the tests to be as explicit as possible about how the component under test is being configured when read in isolation