### PR TITLE
Spike/prsd 546 multi oauth poc

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/config/AdditionalParameterAddingRequestResolver.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/config/AdditionalParameterAddingRequestResolver.kt
@@ -7,11 +7,11 @@ import org.springframework.security.oauth2.client.web.OAuth2AuthorizationRequest
 import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest
 
 class AdditionalParameterAddingRequestResolver(
-    repo: ClientRegistrationRepository,
+    clientRegistrationRepository: ClientRegistrationRepository,
     private val additionalKey: String,
     private val additionalValue: Any,
 ) : OAuth2AuthorizationRequestResolver {
-    private val innerResolver = DefaultOAuth2AuthorizationRequestResolver(repo, "/oauth2/authorization")
+    private val innerResolver = DefaultOAuth2AuthorizationRequestResolver(clientRegistrationRepository, "/oauth2/authorization")
 
     override fun resolve(request: HttpServletRequest?): OAuth2AuthorizationRequest? {
         val authRequest = innerResolver.resolve(request) ?: return null
@@ -24,7 +24,7 @@ class AdditionalParameterAddingRequestResolver(
         clientRegistrationId: String?,
     ): OAuth2AuthorizationRequest? {
         val authRequest = innerResolver.resolve(request, clientRegistrationId) ?: return null
-        val additionalParams = LinkedHashMap(authRequest.additionalParameters).apply { put("vtr", "Cl.Cm.P2") }
+        val additionalParams = LinkedHashMap(authRequest.additionalParameters).apply { put(additionalKey, additionalValue) }
         return OAuth2AuthorizationRequest.from(authRequest).additionalParameters(additionalParams).build()
     }
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/config/AdditionalParameterAddingRequestResolver.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/config/AdditionalParameterAddingRequestResolver.kt
@@ -1,0 +1,30 @@
+package uk.gov.communities.prsdb.webapp.config
+
+import jakarta.servlet.http.HttpServletRequest
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository
+import org.springframework.security.oauth2.client.web.DefaultOAuth2AuthorizationRequestResolver
+import org.springframework.security.oauth2.client.web.OAuth2AuthorizationRequestResolver
+import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest
+
+class AdditionalParameterAddingRequestResolver(
+    repo: ClientRegistrationRepository,
+    private val additionalKey: String,
+    private val additionalValue: Any,
+) : OAuth2AuthorizationRequestResolver {
+    private val innerResolver = DefaultOAuth2AuthorizationRequestResolver(repo, "/oauth2/authorization")
+
+    override fun resolve(request: HttpServletRequest?): OAuth2AuthorizationRequest? {
+        val authRequest = innerResolver.resolve(request) ?: return null
+        val additionalParams = LinkedHashMap(authRequest.additionalParameters).apply { put(additionalKey, additionalValue) }
+        return OAuth2AuthorizationRequest.from(authRequest).additionalParameters(additionalParams).build()
+    }
+
+    override fun resolve(
+        request: HttpServletRequest?,
+        clientRegistrationId: String?,
+    ): OAuth2AuthorizationRequest? {
+        val authRequest = innerResolver.resolve(request, clientRegistrationId) ?: return null
+        val additionalParams = LinkedHashMap(authRequest.additionalParameters).apply { put("vtr", "Cl.Cm.P2") }
+        return OAuth2AuthorizationRequest.from(authRequest).additionalParameters(additionalParams).build()
+    }
+}

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/config/CustomSecurityConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/config/CustomSecurityConfig.kt
@@ -1,21 +1,33 @@
 package uk.gov.communities.prsdb.webapp.config
 
+import jakarta.servlet.Filter
+import jakarta.servlet.FilterChain
+import jakarta.servlet.ServletRequest
+import jakarta.servlet.ServletResponse
+import jakarta.servlet.http.HttpServletRequest
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
-import org.springframework.security.config.Customizer
+import org.springframework.core.annotation.Order
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.core.GrantedAuthority
 import org.springframework.security.core.authority.SimpleGrantedAuthority
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken
 import org.springframework.security.oauth2.client.oidc.userinfo.OidcUserRequest
 import org.springframework.security.oauth2.client.oidc.userinfo.OidcUserService
 import org.springframework.security.oauth2.client.oidc.web.logout.OidcClientInitiatedLogoutSuccessHandler
 import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserService
+import org.springframework.security.oauth2.client.web.DefaultOAuth2AuthorizationRequestResolver
+import org.springframework.security.oauth2.client.web.OAuth2AuthorizationRequestResolver
+import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest
 import org.springframework.security.oauth2.core.oidc.user.DefaultOidcUser
 import org.springframework.security.oauth2.core.oidc.user.OidcUser
 import org.springframework.security.web.SecurityFilterChain
 import org.springframework.security.web.authentication.logout.LogoutSuccessHandler
+import org.springframework.security.web.context.SecurityContextHolderFilter
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher
 import uk.gov.communities.prsdb.webapp.services.UserRolesService
 
 @Configuration
@@ -24,6 +36,36 @@ class CustomSecurityConfig(
     val clientRegistrationRepository: ClientRegistrationRepository,
 ) {
     @Bean
+    @Order(1)
+    fun verificationFilterChain(http: HttpSecurity): SecurityFilterChain {
+        http
+            .securityMatchers { config ->
+                config.requestMatchers(
+                    AntPathRequestMatcher("/local-authority/**"),
+                    AntPathRequestMatcher("/login/oauth2/code/one-login-id"),
+                )
+            }.authorizeHttpRequests { requests ->
+                requests
+                    .requestMatchers("/local/**")
+                    .permitAll()
+                    .anyRequest()
+                    .authenticated()
+            }.oauth2Login { config ->
+                config.loginPage("/oauth2/authorization/one-login-id")
+                config.authorizationEndpoint { customizer ->
+                    customizer.authorizationRequestResolver(MyRequestResolver(clientRegistrationRepository))
+                }
+            }.logout { logout ->
+                logout.logoutSuccessHandler(oidcLogoutSuccessHandler())
+            }.csrf { requests ->
+                requests.ignoringRequestMatchers("/local/**")
+            }.addFilterAfter(MyFilter(), SecurityContextHolderFilter::class.java)
+
+        return http.build()
+    }
+
+    @Bean
+    @Order(2)
     fun filterChain(http: HttpSecurity): SecurityFilterChain {
         http
             .authorizeHttpRequests { requests ->
@@ -44,8 +86,9 @@ class CustomSecurityConfig(
                     .permitAll()
                     .anyRequest()
                     .authenticated()
-            }.oauth2Login(Customizer.withDefaults())
-            .logout { logout ->
+            }.oauth2Login { config ->
+                config.loginPage("/oauth2/authorization/one-login")
+            }.logout { logout ->
                 logout.logoutSuccessHandler(oidcLogoutSuccessHandler())
             }.csrf { requests ->
                 requests.ignoringRequestMatchers("/local/**")
@@ -79,5 +122,44 @@ class CustomSecurityConfig(
         oidcLogoutSuccessHandler.setPostLogoutRedirectUri("{baseUrl}/signout")
         oidcLogoutSuccessHandler.setDefaultTargetUrl("/signout")
         return oidcLogoutSuccessHandler
+    }
+}
+
+class MyFilter : Filter {
+    override fun doFilter(
+        request: ServletRequest?,
+        response: ServletResponse?,
+        chain: FilterChain?,
+    ) {
+        val securityContext = SecurityContextHolder.getContext()
+        val auth = securityContext.authentication
+        if (auth != null) {
+            if (!(auth is OAuth2AuthenticationToken && auth.principal.attributes["vot"] == "Cl.Cm.P2")) {
+                SecurityContextHolder.setContext(SecurityContextHolder.createEmptyContext())
+            }
+        }
+
+        chain!!.doFilter(request, response)
+    }
+}
+
+class MyRequestResolver(
+    repo: ClientRegistrationRepository,
+) : OAuth2AuthorizationRequestResolver {
+    private val innerResolver = DefaultOAuth2AuthorizationRequestResolver(repo, "/oauth2/authorization")
+
+    override fun resolve(request: HttpServletRequest?): OAuth2AuthorizationRequest? {
+        val authRequest = innerResolver.resolve(request) ?: return null
+        val additionalParams = LinkedHashMap(authRequest.additionalParameters).apply { put("vtr", "ClCm.P2") }
+        return OAuth2AuthorizationRequest.from(authRequest).additionalParameters(additionalParams).build()
+    }
+
+    override fun resolve(
+        request: HttpServletRequest?,
+        clientRegistrationId: String?,
+    ): OAuth2AuthorizationRequest? {
+        val authRequest = innerResolver.resolve(request, clientRegistrationId) ?: return null
+        val additionalParams = LinkedHashMap(authRequest.additionalParameters).apply { put("vtr", "ClCm.P2") }
+        return OAuth2AuthorizationRequest.from(authRequest).additionalParameters(additionalParams).build()
     }
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/config/OauthTokenSecondaryValidatingFilter.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/config/OauthTokenSecondaryValidatingFilter.kt
@@ -1,0 +1,28 @@
+package uk.gov.communities.prsdb.webapp.config
+
+import jakarta.servlet.Filter
+import jakarta.servlet.FilterChain
+import jakarta.servlet.ServletRequest
+import jakarta.servlet.ServletResponse
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken
+
+class OauthTokenSecondaryValidatingFilter(
+    val isOauthTokenAcceptable: (OAuth2AuthenticationToken) -> Boolean,
+) : Filter {
+    override fun doFilter(
+        request: ServletRequest?,
+        response: ServletResponse?,
+        chain: FilterChain?,
+    ) {
+        val securityContext = SecurityContextHolder.getContext()
+        val auth = securityContext.authentication
+        if (auth != null) {
+            if (!(auth is OAuth2AuthenticationToken && isOauthTokenAcceptable(auth))) {
+                SecurityContextHolder.setContext(SecurityContextHolder.createEmptyContext())
+            }
+        }
+
+        chain!!.doFilter(request, response)
+    }
+}

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/local/api/controllers/LocalAuthorityMockOneLoginController.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/local/api/controllers/LocalAuthorityMockOneLoginController.kt
@@ -1,0 +1,162 @@
+package uk.gov.communities.prsdb.webapp.local.api.controllers
+
+import com.nimbusds.jose.Algorithm
+import com.nimbusds.jose.JOSEObjectType
+import com.nimbusds.jose.JWSAlgorithm
+import com.nimbusds.jose.JWSHeader
+import com.nimbusds.jose.crypto.ECDSASigner
+import com.nimbusds.jose.jwk.Curve
+import com.nimbusds.jose.jwk.ECKey
+import com.nimbusds.jose.jwk.KeyUse
+import com.nimbusds.jose.jwk.gen.ECKeyGenerator
+import com.nimbusds.jwt.JWTClaimsSet
+import com.nimbusds.jwt.SignedJWT
+import org.springframework.context.annotation.Profile
+import org.springframework.http.MediaType
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.util.UriComponentsBuilder
+import java.io.File
+import java.net.URI
+import java.time.Instant
+import java.util.Date
+import java.util.UUID
+
+@Profile("local")
+@RestController
+@RequestMapping("/local/one-login-id")
+class LocalAuthorityMockOneLoginController {
+    companion object {
+        val keyId = UUID.randomUUID().toString()
+
+        val ecKey = generateSecretKey()
+
+        private fun generateSecretKey(): ECKey {
+            val ecKey =
+                ECKeyGenerator(Curve.P_256)
+                    .keyUse(KeyUse.SIGNATURE)
+                    .keyID(keyId)
+                    .algorithm(Algorithm("ES256"))
+                    .generate()
+
+            return ecKey
+        }
+    }
+
+    private val userId = "urn:fdc:gov.uk:2022:UVWXY"
+
+    // These values are from One-Login's publicly available docs (https://docs.sign-in.service.gov.uk/integrate-with-integration-environment/authenticate-your-user/)
+    private val userEmail = "test@example.com"
+    private val userNumber = "01406946277"
+
+    var lastReceivedNonce: String? = null
+
+    @GetMapping("/.well-known/openid-configuration")
+    fun openidConfiguration(): String =
+        File("src/main/kotlin/uk/gov/communities/prsdb/webapp/local/api/mockOneLoginResponses/openid-configuration.json")
+            .readText(Charsets.UTF_8)
+
+    @GetMapping("/.well-known/jwks.json")
+    fun jwksJson(): String =
+        File("src/main/kotlin/uk/gov/communities/prsdb/webapp/local/api/mockOneLoginResponses/jwks.json")
+            .readText(Charsets.UTF_8)
+            .replace("keyId", keyId)
+            .replace(
+                "publicJWK_x",
+                ecKey
+                    .toPublicJWK()
+                    .x
+                    .toString(),
+            ).replace(
+                "publicJWK_y",
+                ecKey
+                    .toPublicJWK()
+                    .y
+                    .toString(),
+            )
+
+    @GetMapping("/authorize")
+    fun authorize(
+        @RequestParam response_type: String,
+        @RequestParam client_id: String,
+        @RequestParam scope: String,
+        @RequestParam state: String,
+        @RequestParam redirect_uri: String,
+        @RequestParam nonce: String,
+    ): ResponseEntity<Unit> {
+        lastReceivedNonce = nonce
+        val locationURI: URI =
+            UriComponentsBuilder
+                .newInstance()
+                .uri(URI.create(redirect_uri))
+                .query("code=SplxlOBeZQQYbYS6WxSbIA")
+                .queryParam("state", state)
+                .build()
+                .toUri()
+
+        return ResponseEntity.status(302).location(locationURI).build()
+    }
+
+    @PostMapping("/token")
+    fun token(
+        @RequestParam grant_type: String,
+        @RequestParam redirect_uri: String,
+        @RequestParam client_assertion: String,
+        @RequestParam client_assertion_type: String,
+        @RequestParam code: String,
+    ): ResponseEntity<String> {
+        val responseBody =
+            File("src/main/kotlin/uk/gov/communities/prsdb/webapp/local/api/mockOneLoginResponses/token.json")
+                .readText(Charsets.UTF_8)
+                .replace("idToken", getIdToken())
+
+        val responseBuild = ResponseEntity.ok().contentType(MediaType.APPLICATION_JSON).body(responseBody)
+
+        return responseBuild
+    }
+
+    @GetMapping("/userinfo")
+    fun userInfo(): ResponseEntity<String> {
+        val responseBody =
+            File("src/main/kotlin/uk/gov/communities/prsdb/webapp/local/api/mockOneLoginResponses/userInfo.json")
+                .readText(Charsets.UTF_8)
+                .replace("userId", userId)
+                .replace("userEmail", userEmail)
+                .replace("userNumber", userNumber)
+
+        val responseBuild = ResponseEntity.ok().contentType(MediaType.APPLICATION_JSON).body(responseBody)
+
+        return responseBuild
+    }
+
+    private fun getIdToken(): String {
+        val headerBuilder: JWSHeader.Builder =
+            JWSHeader
+                .Builder(JWSAlgorithm.ES256)
+                .type(JOSEObjectType.JWT)
+                .jwk(ecKey.toPublicJWK())
+
+        val claimSetBBuilder: JWTClaimsSet.Builder =
+            JWTClaimsSet
+                .Builder()
+                .subject(userId)
+                .audience("l0AE7SbEHrEa8QeQCGdml9KQ4bc")
+                .issuer("http://localhost:8080/one-login-local/")
+                .issueTime(Date())
+                .expirationTime(Date.from(Instant.now().plusSeconds(300)))
+                .claim("vot", "Cl.Cm.P2")
+                .claim("nonce", lastReceivedNonce)
+                .claim("vtm", "http://localhost:8080/one-login-local/trustmark")
+                .claim("sid", "dX5xv0XgHh6yfD1xy-ss_1EDK0I")
+
+        val signedJwt = SignedJWT(headerBuilder.build(), claimSetBBuilder.build())
+
+        signedJwt.sign(ECDSASigner(ecKey))
+
+        return signedJwt.serialize()
+    }
+}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -72,12 +72,25 @@ spring:
             authorization-grant-type: authorization_code
             scope: openid
             redirect-uri: http://localhost:8080/login/oauth2/code/one-login
+          one-login-id:
+            client-name: one-login
+            client-id: l0AE7SbEHrEa8QeQCGdml9KQ4bc
+            client-authentication-method: private_key_jwt
+            authorization-grant-type: authorization_code
+            scope: openid
+            redirect-uri: http://localhost:8080/login/oauth2/code/one-login-id
         provider:
           one-login:
             authorization-uri: http://localhost:8080/local/one-login/authorize
             token-uri: http://localhost:8080/local/one-login/token
             jwk-set-uri: http://localhost:8080/local/one-login/.well-known/jwks.json
             user-info-uri: http://localhost:8080/local/one-login/userinfo
+            userNameAttribute: "sub"
+          one-login-id:
+            authorization-uri: http://localhost:8080/local/one-login-id/authorize
+            token-uri: http://localhost:8080/local/one-login-id/token
+            jwk-set-uri: http://localhost:8080/local/one-login-id/.well-known/jwks.json
+            user-info-uri: http://localhost:8080/local/one-login-id/userinfo
             userNameAttribute: "sub"
 
 ---


### PR DESCRIPTION
Proof of concept for re-validating the user with ID verification only on some routes. For the POC this validates on any "local authority" route. Draft PR as this should never be merged - this is to get feedback/agreement on the approach.

Also, I've fully duplicated the mock one login controller for simplicity (the only difference is in the "vot" field that is set when it returns (used in the custom filter to validate the authentication). 

Don't worry about the package the extra classes are in - they'll find themselves a home in the main ticket.