### PR TITLE
Feat/prsd 541 handle la registration form completion

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/RegisterLAUserController.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/RegisterLAUserController.kt
@@ -101,8 +101,13 @@ class RegisterLAUserController(
         val localAuthority = invitationService.getAuthorityForToken(token)
 
         val journeyData = journeyDataService.getJourneyDataFromSession()
+        val name = (journeyData["name"] as PageData)["name"].toString()
+        val email = (journeyData["email"] as PageData)["emailAddress"].toString()
 
-        localAuthorityDataService.registerNewUser(principal.name, localAuthority, "Hardcoded name", "hardcoded@email.com")
+        localAuthorityDataService.registerNewUser(principal.name, localAuthority, name, email)
+
+        val invitation = invitationService.getInvitationFromToken(token)
+        invitationService.deleteInvitation(invitation)
 
         model.addAttribute("localAuthority", localAuthority.name)
 

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/RegisterLAUserController.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/RegisterLAUserController.kt
@@ -85,4 +85,13 @@ class RegisterLAUserController(
 
         journeyDataService.setJourneyData(journeyData)
     }
+
+    @GetMapping("/success")
+    fun submitRegistration(model: Model): String {
+        val journeyData = journeyDataService.getJourneyDataFromSession()
+
+        model.addAttribute("localAuthority", "HARDCODED LA")
+
+        return "registerLAUserSuccess"
+    }
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/database/entity/LocalAuthorityUser.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/database/entity/LocalAuthorityUser.kt
@@ -23,14 +23,23 @@ class LocalAuthorityUser(
     @Column(nullable = false)
     var isManager: Boolean = false
 
+    @Column(nullable = false)
+    var name: String = ""
+
+    @Column(nullable = false)
+    var email: String = ""
+
     @OneToOne(optional = false)
     @JoinColumn(name = "local_authority_id", nullable = false, foreignKey = ForeignKey(name = "FK_LA_USER_LA"))
     lateinit var localAuthority: LocalAuthority
         private set
 
-    constructor(id: Long, baseUser: OneLoginUser, isManager: Boolean, localAuthority: LocalAuthority) : this(id) {
+    constructor(id: Long, baseUser: OneLoginUser, isManager: Boolean, localAuthority: LocalAuthority, name: String, email: String) :
+        this(id) {
         this.baseUser = baseUser
         this.isManager = isManager
         this.localAuthority = localAuthority
+        this.name = name
+        this.email = email
     }
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/database/entity/LocalAuthorityUser.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/database/entity/LocalAuthorityUser.kt
@@ -34,8 +34,14 @@ class LocalAuthorityUser(
     lateinit var localAuthority: LocalAuthority
         private set
 
-    constructor(id: Long, baseUser: OneLoginUser, isManager: Boolean, localAuthority: LocalAuthority, name: String, email: String) :
+    constructor(id: Long, baseUser: OneLoginUser, isManager: Boolean, localAuthority: LocalAuthority) :
         this(id) {
+        this.baseUser = baseUser
+        this.isManager = isManager
+        this.localAuthority = localAuthority
+    }
+
+    constructor(baseUser: OneLoginUser, isManager: Boolean, localAuthority: LocalAuthority, name: String, email: String) : this() {
         this.baseUser = baseUser
         this.isManager = isManager
         this.localAuthority = localAuthority

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/LaUserRegistrationJourney.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/LaUserRegistrationJourney.kt
@@ -3,6 +3,7 @@ package uk.gov.communities.prsdb.webapp.forms.journeys
 import org.springframework.stereotype.Component
 import org.springframework.validation.Validator
 import uk.gov.communities.prsdb.webapp.constants.enums.JourneyType
+import uk.gov.communities.prsdb.webapp.forms.pages.LaUserRegistrationSummaryPage
 import uk.gov.communities.prsdb.webapp.forms.pages.Page
 import uk.gov.communities.prsdb.webapp.forms.steps.RegisterLaUserStepId
 import uk.gov.communities.prsdb.webapp.forms.steps.Step
@@ -11,11 +12,13 @@ import uk.gov.communities.prsdb.webapp.models.formModels.EmailFormModel
 import uk.gov.communities.prsdb.webapp.models.formModels.LandingPageFormModel
 import uk.gov.communities.prsdb.webapp.models.formModels.NameFormModel
 import uk.gov.communities.prsdb.webapp.services.JourneyDataService
+import uk.gov.communities.prsdb.webapp.services.LocalAuthorityInvitationService
 
 @Component
 class LaUserRegistrationJourney(
     validator: Validator,
     journeyDataService: JourneyDataService,
+    invitationService: LocalAuthorityInvitationService,
 ) : Journey<RegisterLaUserStepId>(
         journeyType = JourneyType.LA_USER_REGISTRATION,
         initialStepId = RegisterLaUserStepId.LandingPage,
@@ -74,7 +77,7 @@ class LaUserRegistrationJourney(
                 Step(
                     id = RegisterLaUserStepId.CheckAnswers,
                     page =
-                        Page(
+                        LaUserRegistrationSummaryPage(
                             formModel = CheckAnswersFormModel::class,
                             templateName = "forms/checkAnswersForm",
                             content =
@@ -83,14 +86,10 @@ class LaUserRegistrationJourney(
                                     "summaryName" to "registerLaUser.checkAnswers.summaryName",
                                     "submitButtonText" to "forms.buttons.confirm",
                                 ),
+                            journeyDataService,
+                            invitationService,
                         ),
+                    handleSubmitAndRedirect = { _, _ -> "/submitForm" },
                 ),
-        /*TODO: PRSD-541 - check answers page
-        Step(
-            id = RegisterLaUserStepId.CheckAnswers,
-            page =
-                Page(),
-            nextAction = { _, subPageNumber: Int? -> Pair(RegisterLaUserStepId.CheckAnswers, null) },
-        ),*/
             ),
     )

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/LaUserRegistrationJourney.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/LaUserRegistrationJourney.kt
@@ -89,7 +89,7 @@ class LaUserRegistrationJourney(
                             journeyDataService,
                             invitationService,
                         ),
-                    handleSubmitAndRedirect = { _, _ -> "/submitForm" },
+                    handleSubmitAndRedirect = { _, _ -> "/${JourneyType.LA_USER_REGISTRATION.urlPathSegment}/success" },
                 ),
             ),
     )

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/LaUserRegistrationJourney.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/LaUserRegistrationJourney.kt
@@ -6,6 +6,7 @@ import uk.gov.communities.prsdb.webapp.constants.enums.JourneyType
 import uk.gov.communities.prsdb.webapp.forms.pages.Page
 import uk.gov.communities.prsdb.webapp.forms.steps.RegisterLaUserStepId
 import uk.gov.communities.prsdb.webapp.forms.steps.Step
+import uk.gov.communities.prsdb.webapp.models.formModels.CheckAnswersFormModel
 import uk.gov.communities.prsdb.webapp.models.formModels.EmailFormModel
 import uk.gov.communities.prsdb.webapp.models.formModels.LandingPageFormModel
 import uk.gov.communities.prsdb.webapp.models.formModels.NameFormModel
@@ -69,6 +70,20 @@ class LaUserRegistrationJourney(
                                 ),
                         ),
                     nextAction = { _, _ -> Pair(RegisterLaUserStepId.CheckAnswers, null) },
+                ),
+                Step(
+                    id = RegisterLaUserStepId.CheckAnswers,
+                    page =
+                        Page(
+                            formModel = CheckAnswersFormModel::class,
+                            templateName = "forms/checkAnswersForm",
+                            content =
+                                mapOf(
+                                    "title" to "registerLAUser.title",
+                                    "summaryName" to "registerLaUser.checkAnswers.summaryName",
+                                    "submitButtonText" to "forms.buttons.confirm",
+                                ),
+                        ),
                 ),
         /*TODO: PRSD-541 - check answers page
         Step(

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/pages/LaUserRegistrationSummaryPage.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/pages/LaUserRegistrationSummaryPage.kt
@@ -1,0 +1,61 @@
+package uk.gov.communities.prsdb.webapp.forms.pages
+
+import org.springframework.ui.Model
+import org.springframework.validation.Validator
+import uk.gov.communities.prsdb.webapp.forms.journeys.PageData
+import uk.gov.communities.prsdb.webapp.forms.steps.RegisterLaUserStepId
+import uk.gov.communities.prsdb.webapp.models.dataModels.FormSummaryDataModel
+import uk.gov.communities.prsdb.webapp.models.formModels.FormModel
+import uk.gov.communities.prsdb.webapp.services.JourneyDataService
+import uk.gov.communities.prsdb.webapp.services.LocalAuthorityInvitationService
+import kotlin.reflect.KClass
+
+class LaUserRegistrationSummaryPage(
+    private val formModel: KClass<out FormModel>,
+    private val templateName: String,
+    private val content: Map<String, Any>,
+    private val journeyDataService: JourneyDataService,
+    private val invitationService: LocalAuthorityInvitationService,
+) : Page(formModel, templateName, content) {
+    override fun populateModelAndGetTemplateName(
+        validator: Validator,
+        model: Model,
+        pageData: Map<String, Any?>?,
+        prevStepUrl: String?,
+    ): String {
+        val journeyData = journeyDataService.getJourneyDataFromSession()
+        val formData = mutableListOf<FormSummaryDataModel>()
+        val sessionToken = invitationService.getTokenFromSession()
+
+        val localAuthority =
+            if (sessionToken != null) {
+                invitationService.getAuthorityForToken(sessionToken)
+            } else {
+                null
+            }
+
+        formData.add(
+            FormSummaryDataModel(
+                "registerLaUser.checkAnswers.rowHeading.localAuthority",
+                localAuthority?.name,
+                null,
+            ),
+        )
+        formData.add(
+            FormSummaryDataModel(
+                "registerLaUser.checkAnswers.rowHeading.name",
+                (journeyData["name"] as PageData)["name"],
+                "/${RegisterLaUserStepId.Name.urlPathSegment}",
+            ),
+        )
+        formData.add(
+            FormSummaryDataModel(
+                "registerLaUser.checkAnswers.rowHeading.email",
+                (journeyData["email"] as PageData)["emailAddress"],
+                "/${RegisterLaUserStepId.Email.urlPathSegment}",
+            ),
+        )
+        model.addAttribute("formData", formData)
+        return super.populateModelAndGetTemplateName(validator, model, pageData, prevStepUrl)
+    }
+}

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/pages/LaUserRegistrationSummaryPage.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/pages/LaUserRegistrationSummaryPage.kt
@@ -2,6 +2,7 @@ package uk.gov.communities.prsdb.webapp.forms.pages
 
 import org.springframework.ui.Model
 import org.springframework.validation.Validator
+import uk.gov.communities.prsdb.webapp.constants.enums.JourneyType
 import uk.gov.communities.prsdb.webapp.forms.journeys.PageData
 import uk.gov.communities.prsdb.webapp.forms.steps.RegisterLaUserStepId
 import uk.gov.communities.prsdb.webapp.models.dataModels.FormSummaryDataModel
@@ -11,9 +12,9 @@ import uk.gov.communities.prsdb.webapp.services.LocalAuthorityInvitationService
 import kotlin.reflect.KClass
 
 class LaUserRegistrationSummaryPage(
-    private val formModel: KClass<out FormModel>,
-    private val templateName: String,
-    private val content: Map<String, Any>,
+    formModel: KClass<out FormModel>,
+    templateName: String,
+    content: Map<String, Any>,
     private val journeyDataService: JourneyDataService,
     private val invitationService: LocalAuthorityInvitationService,
 ) : Page(formModel, templateName, content) {
@@ -45,14 +46,14 @@ class LaUserRegistrationSummaryPage(
             FormSummaryDataModel(
                 "registerLaUser.checkAnswers.rowHeading.name",
                 (journeyData["name"] as PageData)["name"],
-                "/${RegisterLaUserStepId.Name.urlPathSegment}",
+                "/${JourneyType.LA_USER_REGISTRATION.urlPathSegment}/${RegisterLaUserStepId.Name.urlPathSegment}",
             ),
         )
         formData.add(
             FormSummaryDataModel(
                 "registerLaUser.checkAnswers.rowHeading.email",
                 (journeyData["email"] as PageData)["emailAddress"],
-                "/${RegisterLaUserStepId.Email.urlPathSegment}",
+                "/${JourneyType.LA_USER_REGISTRATION.urlPathSegment}/${RegisterLaUserStepId.Email.urlPathSegment}",
             ),
         )
         model.addAttribute("formData", formData)

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/pages/Page.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/pages/Page.kt
@@ -10,12 +10,12 @@ import uk.gov.communities.prsdb.webapp.models.formModels.FormModel
 import kotlin.reflect.KClass
 import kotlin.reflect.full.createInstance
 
-class Page(
+open class Page(
     private val formModel: KClass<out FormModel>,
     private val templateName: String,
     private val content: Map<String, Any>,
 ) {
-    fun populateModelAndGetTemplateName(
+    open fun populateModelAndGetTemplateName(
         validator: Validator,
         model: Model,
         pageData: Map<String, Any?>?,

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/dataModels/FormSummaryDataModel.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/dataModels/FormSummaryDataModel.kt
@@ -1,0 +1,7 @@
+package uk.gov.communities.prsdb.webapp.models.dataModels
+
+data class FormSummaryDataModel(
+    val fieldHeading: String,
+    val fieldValue: Any?,
+    val changeUrl: String?,
+)

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/formModels/CheckAnswersFormModel.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/formModels/CheckAnswersFormModel.kt
@@ -1,0 +1,3 @@
+package uk.gov.communities.prsdb.webapp.models.formModels
+
+class CheckAnswersFormModel : FormModel

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/LocalAuthorityDataService.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/LocalAuthorityDataService.kt
@@ -113,6 +113,7 @@ class LocalAuthorityDataService(
     ) {
         val oneLoginUser = oneLoginUserRepository.getReferenceById(baseUserId)
 
+        // TODO: I don't think this is modifying the date create / date modified?
         localAuthorityUserRepository.save(
             LocalAuthorityUser(
                 baseUser = oneLoginUser,

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/LocalAuthorityDataService.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/LocalAuthorityDataService.kt
@@ -10,8 +10,10 @@ import org.springframework.stereotype.Service
 import org.springframework.web.server.ResponseStatusException
 import uk.gov.communities.prsdb.webapp.constants.MAX_ENTRIES_IN_TABLE_PAGE
 import uk.gov.communities.prsdb.webapp.database.entity.LocalAuthority
+import uk.gov.communities.prsdb.webapp.database.entity.LocalAuthorityUser
 import uk.gov.communities.prsdb.webapp.database.repository.LocalAuthorityUserOrInvitationRepository
 import uk.gov.communities.prsdb.webapp.database.repository.LocalAuthorityUserRepository
+import uk.gov.communities.prsdb.webapp.database.repository.OneLoginUserRepository
 import uk.gov.communities.prsdb.webapp.models.dataModels.LocalAuthorityUserAccessLevelDataModel
 import uk.gov.communities.prsdb.webapp.models.dataModels.LocalAuthorityUserDataModel
 
@@ -19,6 +21,7 @@ import uk.gov.communities.prsdb.webapp.models.dataModels.LocalAuthorityUserDataM
 class LocalAuthorityDataService(
     val localAuthorityUserRepository: LocalAuthorityUserRepository,
     val localAuthorityUserOrInvitationRepository: LocalAuthorityUserOrInvitationRepository,
+    val oneLoginUserRepository: OneLoginUserRepository,
 ) {
     fun getUserAndLocalAuthorityIfAuthorizedUser(
         localAuthorityId: Int,
@@ -100,5 +103,24 @@ class LocalAuthorityDataService(
 
     fun deleteUser(localAuthorityUserId: Long) {
         localAuthorityUserRepository.deleteById(localAuthorityUserId)
+    }
+
+    fun registerNewUser(
+        baseUserId: String,
+        localAuthority: LocalAuthority,
+        name: String,
+        email: String,
+    ) {
+        val oneLoginUser = oneLoginUserRepository.getReferenceById(baseUserId)
+
+        localAuthorityUserRepository.save(
+            LocalAuthorityUser(
+                baseUser = oneLoginUser,
+                isManager = false,
+                localAuthority = localAuthority,
+                name = name,
+                email = email,
+            ),
+        )
     }
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/LocalAuthorityInvitationService.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/LocalAuthorityInvitationService.kt
@@ -38,6 +38,10 @@ class LocalAuthorityInvitationService(
         return invitation
     }
 
+    fun deleteInvitation(invitation: LocalAuthorityInvitation) {
+        invitationRepository.delete(invitation)
+    }
+
     fun tokenIsValid(token: String): Boolean {
         try {
             getInvitationFromToken(token)

--- a/src/main/resources/data-local.sql
+++ b/src/main/resources/data-local.sql
@@ -29,14 +29,18 @@ VALUES ('urn:fdc:gov.uk:2022:ABCDE', '07712345678', '01/01/00', '09/13/24', '09/
 INSERT INTO local_authority (name, created_date, last_modified_date)
 VALUES ('Betelgeuse', '09/13/24', '09/13/24');
 
-INSERT INTO local_authority_user (subject_identifier, is_manager, local_authority_id, created_date, last_modified_date)
-VALUES ('urn:fdc:gov.uk:2022:KLMNO', true, 1, '10/07/24', '10/07/24'),
-       ('urn:fdc:gov.uk:2022:UVWXY', true, 1, '10/14/24', '10/14/24'),
-       ('urn:fdc:gov.uk:2022:PQRST', false, 1, '10/09/24', '10/09/24'),
-       ('urn:fdc:gov.uk:2022:07lXHJeQwE0k5PZO7w_PQF425vT8T7e63MrvyPYNSoI', true, 1, '10/09/24', '10/09/24'),
-       ('urn:fdc:gov.uk:2022:mwfvbb5GgiDh0acjz9EDDQ7zwskWZzUSnWfavL70f6s', true, 1, '10/02/24', '10/02/24'),
-       ('urn:fdc:gov.uk:2022:n93slCXHsxJ9rU6-AFM0jFIctYQjYf0KN9YVuJT-cao', true, 1, '10/15/24', '10/15/24'),
-       ('urn:fdc:gov.uk:2022:cgVX2oJWKHMwzm8Gzx25CSoVXixVS0rw32Sar4Om8vQ', false, 1, '10/15/24', '10/15/24');
+INSERT INTO local_authority_user (subject_identifier, is_manager, local_authority_id, created_date, last_modified_date, name, email)
+VALUES ('urn:fdc:gov.uk:2022:KLMNO', true, 1, '10/07/24', '10/07/24', 'Ford Prefect', 'Ford.Prefect@la.com'),
+       ('urn:fdc:gov.uk:2022:UVWXY', true, 1, '10/14/24', '10/14/24','Mock User', 'test@la.com'),
+       ('urn:fdc:gov.uk:2022:PQRST', false, 1, '10/09/24', '10/09/24','Arthur Dent', 'Arthur.Dent@la.com'),
+       ('urn:fdc:gov.uk:2022:07lXHJeQwE0k5PZO7w_PQF425vT8T7e63MrvyPYNSoI', true, 1, '10/09/24', '10/09/24', 'Jasmin Conterio',
+        'jasmin.conterio@softwire.com'),
+       ('urn:fdc:gov.uk:2022:mwfvbb5GgiDh0acjz9EDDQ7zwskWZzUSnWfavL70f6s', true, 1, '10/02/24', '10/02/24', 'Isobel Ibironke',
+        'isobel.ibironke@softwire.com'),
+       ('urn:fdc:gov.uk:2022:n93slCXHsxJ9rU6-AFM0jFIctYQjYf0KN9YVuJT-cao', true, 1, '10/15/24', '10/15/24', 'PRSDB LA Admin',
+        'Team-PRSDB+laadmin@softwire.com'),
+       ('urn:fdc:gov.uk:2022:cgVX2oJWKHMwzm8Gzx25CSoVXixVS0rw32Sar4Om8vQ', false, 1, '10/15/24', '10/15/24', 'PRSDB La User',
+        'Team-PRSDB+lauser@softwire.com');
 
 INSERT INTO local_authority_invitation (invited_email, inviting_authority_id, token)
 VALUES ('invited.user@example.com', 1, gen_random_uuid()),

--- a/src/main/resources/db/migrations/V1_5_0__add_name_email_to_la_users.sql
+++ b/src/main/resources/db/migrations/V1_5_0__add_name_email_to_la_users.sql
@@ -1,0 +1,11 @@
+ALTER TABLE local_authority_user
+    ADD email VARCHAR(255);
+
+ALTER TABLE local_authority_user
+    ADD name VARCHAR(255);
+
+ALTER TABLE local_authority_user
+    ALTER COLUMN email SET NOT NULL;
+
+ALTER TABLE local_authority_user
+    ALTER COLUMN name SET NOT NULL;

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -190,6 +190,8 @@ forms.buttons.continue=Continue
 forms.buttons.back=Back
 forms.buttons.confirm=Confirm
 
+forms.links.change=Change
+
 forms.phoneNumber.fieldSetHeading=What is your phone number?
 forms.phoneNumber.fieldSetHint=We'll use this to contact you about your record.
 forms.phoneNumber.label=Enter your phone number

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -165,6 +165,14 @@ registerLaUser.checkAnswers.rowHeading.localAuthority=Local authority
 registerLaUser.checkAnswers.rowHeading.name=Name
 registerLaUser.checkAnswers.rowHeading.email=Email address
 
+registerLaUser.success.banner.title=You''ve registered as a {0,,localAuthority} user
+registerLaUser.success.whatHappensNext.paragraph.one=You now have full access to the database.
+registerLaUser.success.whatHappensNext.paragraph.two=Head to your dashboard to:
+registerLaUser.success.whatHappensNext.bullet.one=view property and landlord information
+registerLaUser.success.whatHappensNext.bullet.two=request compliance updates
+registerLaUser.success.whatHappensNext.bullet.three=view reports from the public about the database
+registerLaUser.success.goToDashboardButtonText=Go to dashboard
+
 registerAHome=Register a home to rent
 registerAHome.navLink.one=Service Link 1
 registerAHome.navLink.two=Service Link 2

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -161,6 +161,9 @@ registerLAUser.invalidLink.heading=This link is not valid
 registerLAUser.invalidLink.description=Ask you manager or your admin user for the PRS database to invite you again
 
 registerLaUser.checkAnswers.summaryName=Your details
+registerLaUser.checkAnswers.rowHeading.localAuthority=Local authority
+registerLaUser.checkAnswers.rowHeading.name=Name
+registerLaUser.checkAnswers.rowHeading.email=Email address
 
 registerAHome=Register a home to rent
 registerAHome.navLink.one=Service Link 1

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -160,6 +160,8 @@ registerLAUser.invalidLink.title=Invalid link
 registerLAUser.invalidLink.heading=This link is not valid
 registerLAUser.invalidLink.description=Ask you manager or your admin user for the PRS database to invite you again
 
+registerLaUser.checkAnswers.summaryName=Your details
+
 registerAHome=Register a home to rent
 registerAHome.navLink.one=Service Link 1
 registerAHome.navLink.two=Service Link 2
@@ -183,6 +185,7 @@ forms.buttons.startNow=Start Now
 forms.buttons.saveAndContinue=Save and continue
 forms.buttons.continue=Continue
 forms.buttons.back=Back
+forms.buttons.confirm=Confirm
 
 forms.phoneNumber.fieldSetHeading=What is your phone number?
 forms.phoneNumber.fieldSetHint=We'll use this to contact you about your record.
@@ -201,6 +204,8 @@ forms.name.fieldSetHeading=What is your full name?
 forms.name.fieldSetHint=Enter your name as it's written on your passport or driving licence.
 forms.name.label=Full name
 forms.name.error.missing=You must enter your full name
+
+forms.checkAnswers.heading=Check your answers
 
 pagination.previousText=Previous
 pagination.pageText=page

--- a/src/main/resources/templates/forms/checkAnswersForm.html
+++ b/src/main/resources/templates/forms/checkAnswersForm.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html th:replace="~{fragments/layout :: layout(#{${title}}, ~{::main}, false)}">
+    <th:block id="main-content"
+              th:replace="~{fragments/layout :: layout(${title}, ~{::#main-content/content()},false)}">
+        <a href="#" th:replace="~{fragments/forms/backLink :: backLink(${backUrl})}">Back
+            link</a>
+        <main class="govuk-main-wrapper">
+            <div id="page-content"
+                 th:replace="~{fragments/layouts/twoThirdsLayout :: twoThirdsLayout(~{::#page-content/content()})}">
+                <header>
+                    <h1 class="govuk-heading-l" th:text="#{forms.checkAnswers.heading}">forms.checkAnswers.heading</h1>
+                    <h2 class="govuk-heading-m" th:text="#{${summaryName}}"></h2>
+                </header>
+
+                <form th:action="@{''}" method="post" novalidate th:object="${formModel}">
+
+                    <button th:replace="~{fragments/buttons/primaryButton :: primaryButton(#{${submitButtonText}})}"></button>
+                </form>
+            </div>
+        </main>
+    </th:block>
+
+</html>

--- a/src/main/resources/templates/forms/checkAnswersForm.html
+++ b/src/main/resources/templates/forms/checkAnswersForm.html
@@ -1,10 +1,15 @@
+<!--/*@thymesVar id="title" type="java.lang.String"*/-->
+<!--/*@thymesVar id="formModel" type="java.lang.Object"*/-->
+<!--/*@thymesVar id="formData" type="java.lang.Object"*/-->
+<!--/*@thymesVar id="submitButtonText" type="java.lang.String"*/-->
+<!--/*@thymesVar id="backUrl" type="java.lang.String"*/-->
 <!DOCTYPE html>
-<html th:replace="~{fragments/layout :: layout(#{${title}}, ~{::main}, false)}">
+<html>
     <th:block id="main-content"
               th:replace="~{fragments/layout :: layout(${title}, ~{::#main-content/content()},false)}">
-        <a href="#" th:replace="~{fragments/forms/backLink :: backLink(${backUrl})}">Back
-            link</a>
+        <a href="#" th:replace="~{fragments/forms/backLink :: backLink(${backUrl})}">Back link</a>
         <main class="govuk-main-wrapper">
+
             <div id="page-content"
                  th:replace="~{fragments/layouts/twoThirdsLayout :: twoThirdsLayout(~{::#page-content/content()})}">
                 <header>
@@ -13,7 +18,7 @@
                 </header>
 
                 <form th:action="@{''}" method="post" novalidate th:object="${formModel}">
-
+                    <dl th:replace="~{fragments/summaryList :: summaryList(${formData})}"></dl>
                     <button th:replace="~{fragments/buttons/primaryButton :: primaryButton(#{${submitButtonText}})}"></button>
                 </form>
             </div>

--- a/src/main/resources/templates/fragments/summaryList.html
+++ b/src/main/resources/templates/fragments/summaryList.html
@@ -1,0 +1,15 @@
+<dl th:fragment="summaryList(listRows)" class="govuk-summary-list">
+    <div class="govuk-summary-list__row" th:each="row: ${listRows}">
+        <dt class="govuk-summary-list__key" th:text="#{${row.fieldHeading}}">
+            fieldHeading
+        </dt>
+        <dd class="govuk-summary-list__value" th:text="${row.fieldValue}">
+            fieldValue
+        </dd>
+        <dd class="govuk-summary-list__actions">
+            <a th:if="${row.changeUrl} != null" class="govuk-link" th:href="@{${row.changeUrl}}" th:text="#{forms.links.change}">
+                <span class="govuk-visually-hidden" th:text="#{${row.fieldHeading}}">fieldHeading</span>
+            </a>
+        </dd>
+    </div>
+</dl>

--- a/src/main/resources/templates/registerLAUserSuccess.html
+++ b/src/main/resources/templates/registerLAUserSuccess.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html th:replace="~{fragments/layout :: layout(#{registerLAUser.title}, ~{::main}, false)}">
+<main class="govuk-main-wrapper" id="main-content">
+    <div id="page-contents" th:replace="~{fragments/layouts/twoThirdsLayout :: twoThirdsLayout(~{::#page-contents/content()})}">
+        <div id="confirmation-banner" th:replace="~{fragments/confirmationPageBanner :: confirmationPageBanner(#{registerLaUser.success.banner.title(${localAuthority})}, ~{::#confirmation-banner/content()})}">
+        </div>
+        <h2 class="govuk-heading-m" th:text="#{common.confirmationPage.whatHappensNext}">common.whatHappensNext</h2>
+        <p class="govuk-body" th:text="#{registerLaUser.success.whatHappensNext.paragraph.one}">
+            registerLaUser.success.whatHappensNext.paragraph.one
+        </p>
+        <p class="govuk-body" th:text="#{registerLaUser.success.whatHappensNext.paragraph.two}">
+            registerLaUser.success.whatHappensNext.paragraph.two
+        </p>
+        <ul class="govuk-list govuk-list--bullet">
+            <li th:text="#{registerLaUser.success.whatHappensNext.bullet.one}">
+                registerLaUser.success.whatHappensNext.bullet.one
+            </li>
+            <li th:text="#{registerLaUser.success.whatHappensNext.bullet.two}">
+                registerLaUser.success.whatHappensNext.bullet.two
+            </li>
+            <li th:text="#{registerLaUser.success.whatHappensNext.bullet.three}">
+                registerLaUser.success.whatHappensNext.bullet.three
+            </li>
+        </ul>
+        <div class="govuk-button-group">
+            <!--TODO: Where should this link go? -->
+            <a th:replace="~{fragments/buttons/primaryButtonLink :: primaryButtonLink(@{/local-authority/{id}/}, #{registerLaUser.success.goToDashboardButtonText})}">
+                registerLaUser.success.goToDashboardButtonText
+            </a>
+        </div>
+    </div>
+</main>
+</html>

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/controllers/RegisterLAUserControllerTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/controllers/RegisterLAUserControllerTests.kt
@@ -17,6 +17,7 @@ import uk.gov.communities.prsdb.webapp.forms.steps.RegisterLaUserStepId
 import uk.gov.communities.prsdb.webapp.forms.steps.Step
 import uk.gov.communities.prsdb.webapp.models.formModels.EmailFormModel
 import uk.gov.communities.prsdb.webapp.services.JourneyDataService
+import uk.gov.communities.prsdb.webapp.services.LocalAuthorityDataService
 import uk.gov.communities.prsdb.webapp.services.LocalAuthorityInvitationService
 
 @WebMvcTest(RegisterLAUserController::class)
@@ -31,6 +32,9 @@ class RegisterLAUserControllerTests(
 
     @MockBean
     lateinit var journeyDataService: JourneyDataService
+
+    @MockBean
+    lateinit var localAuthorityDataService: LocalAuthorityDataService
 
     @BeforeEach
     fun setupMocks() {

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/LaUserRegistrationJourneyTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/LaUserRegistrationJourneyTests.kt
@@ -6,10 +6,10 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.whenever
 import org.springframework.boot.test.mock.mockito.MockBean
-import uk.gov.communities.prsdb.webapp.integration.pageobjects.pages.PageNotFoundPage
 import uk.gov.communities.prsdb.webapp.integration.pageobjects.pages.basePages.assertIsPage
 import uk.gov.communities.prsdb.webapp.integration.pageobjects.pages.laUserRegistrationJourneyPages.EmailFormPageLaUserRegistration
 import uk.gov.communities.prsdb.webapp.integration.pageobjects.pages.laUserRegistrationJourneyPages.NameFormPageLaUserRegistration
+import uk.gov.communities.prsdb.webapp.integration.pageobjects.pages.laUserRegistrationJourneyPages.SummaryPageLaUserRegistration
 import uk.gov.communities.prsdb.webapp.services.LocalAuthorityInvitationService
 
 class LaUserRegistrationJourneyTests : IntegrationTest() {
@@ -79,8 +79,8 @@ class LaUserRegistrationJourneyTests : IntegrationTest() {
             formPage.fillInput("test@example.com")
             // This will need to change when the "check answers" page is implemented
             val nextPage = formPage.submit()
-            val notFoundPage = assertIsPage(nextPage, PageNotFoundPage::class)
-            assertThat(notFoundPage.heading).containsText("Page not found")
+            val summaryPage = assertIsPage(nextPage, SummaryPageLaUserRegistration::class)
+            assertThat(summaryPage.bannerHeading).containsText("Check your answers")
         }
 
         @Test

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageobjects/pages/laUserRegistrationJourneyPages/SummaryPageLaUserRegistration.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageobjects/pages/laUserRegistrationJourneyPages/SummaryPageLaUserRegistration.kt
@@ -1,0 +1,10 @@
+package uk.gov.communities.prsdb.webapp.integration.pageobjects.pages.laUserRegistrationJourneyPages
+
+import com.microsoft.playwright.Page
+import uk.gov.communities.prsdb.webapp.integration.pageobjects.pages.basePages.BasePage
+
+class SummaryPageLaUserRegistration(
+    page: Page,
+) : BasePage(page) {
+    val bannerHeading = page.locator(".govuk-heading-l")
+}

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/LocalAuthorityDataServiceTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/LocalAuthorityDataServiceTests.kt
@@ -24,6 +24,7 @@ import uk.gov.communities.prsdb.webapp.database.entity.LocalAuthorityUser
 import uk.gov.communities.prsdb.webapp.database.entity.LocalAuthorityUserOrInvitation
 import uk.gov.communities.prsdb.webapp.database.repository.LocalAuthorityUserOrInvitationRepository
 import uk.gov.communities.prsdb.webapp.database.repository.LocalAuthorityUserRepository
+import uk.gov.communities.prsdb.webapp.database.repository.OneLoginUserRepository
 import uk.gov.communities.prsdb.webapp.mockObjects.MockLocalAuthorityData.Companion.DEFAULT_1L_USER_NAME
 import uk.gov.communities.prsdb.webapp.mockObjects.MockLocalAuthorityData.Companion.DEFAULT_LA_ID
 import uk.gov.communities.prsdb.webapp.mockObjects.MockLocalAuthorityData.Companion.DEFAULT_LA_USER_ID
@@ -43,6 +44,9 @@ class LocalAuthorityDataServiceTests {
 
     @Mock
     private lateinit var localAuthorityUserOrInvitationRepository: LocalAuthorityUserOrInvitationRepository
+
+    @Mock
+    private lateinit var oneLoginUserRepository: OneLoginUserRepository
 
     @InjectMocks
     private lateinit var localAuthorityDataService: LocalAuthorityDataService


### PR DESCRIPTION
This finishes the functionality for registering a new LA User.

In this PR:
- Create a "check answers" page, make this the next step after the "email" step
![image](https://github.com/user-attachments/assets/b7af6eb4-1c21-48f4-8dc7-3937d16809de)
- Create a "success" page 
![image](https://github.com/user-attachments/assets/1bd7d856-9c16-4100-895c-3fda24bcbd08)
- Add name and email columns to the local_authority_users table
- When the form is completed (by clicking the "Confirm" button on the "check your answers page")
    - Add the new user to the local_authority_users table
    - Remove the invitation from the local_authority_invitation table
    - Check - am I clearing the token from the session?
    - Render the success page

Still to look at (maybe in another PR):
- Tests
- Update the Manage Local Authority Users page so it uses the name from the local_authority_users table rather than the name from One-Login
