### PR TITLE
Feat/prsd 367 use verified identity

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/config/IdVerificationSecurityConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/config/IdVerificationSecurityConfig.kt
@@ -2,7 +2,6 @@ package uk.gov.communities.prsdb.webapp.config
 
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
-import org.springframework.context.annotation.Profile
 import org.springframework.core.annotation.Order
 import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
@@ -18,7 +17,6 @@ import uk.gov.communities.prsdb.webapp.constants.OneLoginClaimKeys
 import uk.gov.communities.prsdb.webapp.constants.REGISTER_LANDLORD_JOURNEY_URL
 import uk.gov.communities.prsdb.webapp.controllers.RegisterLandlordController
 
-@Profile("!local | local-auth")
 @Configuration
 @EnableMethodSecurity
 class IdVerificationSecurityConfig(

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/config/OneLoginConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/config/OneLoginConfig.kt
@@ -88,16 +88,16 @@ class OneLoginConfig {
 
     private fun extractKeysFromJson(didJson: JSONObject): List<ECKey> {
         val keyArray = didJson.getJSONArray("assertionMethod")
+
         val publicKeysSequence =
-            sequence {
-                for (index in 0 until keyArray.length()) {
-                    yield(keyArray.getJSONObject(index))
+            keyArray
+                .map {
+                    val keyWrapper = it as JSONObject
+                    val jsonKey = keyWrapper.getJSONObject("publicKeyJwk")
+                    val keyId = keyWrapper.getString("id")
+                    jsonKey.put("kid", keyId)
+                    ECKey.parse(jsonKey.toString())
                 }
-            }.map {
-                val jsonKey = it.getJSONObject("publicKeyJwk")
-                jsonKey.put("kid", it.getString("id"))
-                ECKey.parse(jsonKey.toString())
-            }
         return publicKeysSequence.toList()
     }
 

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/config/OneLoginConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/config/OneLoginConfig.kt
@@ -35,7 +35,8 @@ class OneLoginConfig {
     @Value("\${one-login.jwt.private.key}")
     lateinit var privateKey: RSAPrivateKey
 
-    val didUri = "https://identity.integration.account.gov.uk/.well-known/did.json"
+    @Value("\${one-login.did.uri}")
+    lateinit var didUri: String
 
     @Bean
     fun oneLoginIdTokenDecoderFactory(): JwtDecoderFactory<Unit> =

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/config/OneLoginConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/config/OneLoginConfig.kt
@@ -1,7 +1,15 @@
 package uk.gov.communities.prsdb.webapp.config
 
+import com.nimbusds.jose.JWSAlgorithm
+import com.nimbusds.jose.jwk.ECKey
 import com.nimbusds.jose.jwk.JWK
+import com.nimbusds.jose.jwk.JWKSet
 import com.nimbusds.jose.jwk.RSAKey
+import com.nimbusds.jose.jwk.source.ImmutableJWKSet
+import com.nimbusds.jose.proc.JWSVerificationKeySelector
+import com.nimbusds.jose.proc.SecurityContext
+import com.nimbusds.jwt.proc.DefaultJWTProcessor
+import org.json.JSONObject
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
@@ -13,6 +21,8 @@ import org.springframework.security.oauth2.client.registration.ClientRegistratio
 import org.springframework.security.oauth2.core.ClientAuthenticationMethod
 import org.springframework.security.oauth2.jose.jws.SignatureAlgorithm
 import org.springframework.security.oauth2.jwt.JwtDecoderFactory
+import org.springframework.security.oauth2.jwt.NimbusJwtDecoder
+import org.springframework.web.client.RestClient
 import java.security.interfaces.RSAPrivateKey
 import java.security.interfaces.RSAPublicKey
 import java.util.UUID
@@ -24,6 +34,18 @@ class OneLoginConfig {
 
     @Value("\${one-login.jwt.private.key}")
     lateinit var privateKey: RSAPrivateKey
+
+    val didUri = "https://identity.integration.account.gov.uk/.well-known/did.json"
+
+    @Bean
+    fun oneLoginIdTokenDecoderFactory(): JwtDecoderFactory<Unit> =
+        JwtDecoderFactory {
+            val publicKeys = retrieveECKeys()
+            val processor = DefaultJWTProcessor<SecurityContext>()
+            val keySelector = JWSVerificationKeySelector(JWSAlgorithm.ES256, ImmutableJWKSet(JWKSet(publicKeys)))
+            processor.jwsKeySelector = keySelector
+            NimbusJwtDecoder(processor)
+        }
 
     fun oneloginJWKResolver(clientRegistration: ClientRegistration): JWK? {
         if (clientRegistration.clientAuthenticationMethod.equals(ClientAuthenticationMethod.PRIVATE_KEY_JWT)) {
@@ -56,5 +78,37 @@ class OneLoginConfig {
         val idTokenDecoderFactory = OidcIdTokenDecoderFactory()
         idTokenDecoderFactory.setJwsAlgorithmResolver { SignatureAlgorithm.ES256 }
         return idTokenDecoderFactory
+    }
+
+    private fun retrieveECKeys(): List<ECKey> {
+        val didJson = retrieveDidJsonObject()
+        return extractKeysFromJson(didJson)
+    }
+
+    private fun extractKeysFromJson(didJson: JSONObject): List<ECKey> {
+        val keyArray = didJson.getJSONArray("assertionMethod")
+        val publicKeysSequence =
+            sequence {
+                for (index in 0 until keyArray.length()) {
+                    yield(keyArray.getJSONObject(index))
+                }
+            }.map {
+                val jsonKey = it.getJSONObject("publicKeyJwk")
+                jsonKey.put("kid", it.getString("id"))
+                ECKey.parse(jsonKey.toString())
+            }
+        return publicKeysSequence.toList()
+    }
+
+    private fun retrieveDidJsonObject(): JSONObject {
+        val didResponseBody =
+            RestClient
+                .create()
+                .get()
+                .uri(didUri)
+                .retrieve()
+                .body(String::class.java)
+
+        return JSONObject(didResponseBody)
     }
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/RegisterLandlordController.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/RegisterLandlordController.kt
@@ -19,7 +19,7 @@ import java.security.Principal
 @RequestMapping("/${REGISTER_LANDLORD_JOURNEY_URL}")
 class RegisterLandlordController(
     var landlordRegistrationJourney: LandlordRegistrationJourney,
-    val myService: IdentityService,
+    val identityService: IdentityService,
 ) {
     @GetMapping
     fun index(model: Model): String {
@@ -39,7 +39,7 @@ class RegisterLandlordController(
         principal: Principal,
         @AuthenticationPrincipal oidcUser: OidcUser,
     ): String {
-        var identity = myService.getVerifiedIdentityData(oidcUser)
+        var identity = identityService.getVerifiedIdentityData(oidcUser)
 
         if (identity != null) {
             identity["verifiedIdentity"] = true

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/RegisterLandlordController.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/RegisterLandlordController.kt
@@ -12,14 +12,14 @@ import org.springframework.web.bind.annotation.RequestParam
 import uk.gov.communities.prsdb.webapp.constants.REGISTER_LANDLORD_JOURNEY_URL
 import uk.gov.communities.prsdb.webapp.forms.journeys.LandlordRegistrationJourney
 import uk.gov.communities.prsdb.webapp.forms.journeys.PageData
-import uk.gov.communities.prsdb.webapp.services.IdentityService
+import uk.gov.communities.prsdb.webapp.services.OneLoginIdentityService
 import java.security.Principal
 
 @Controller
 @RequestMapping("/${REGISTER_LANDLORD_JOURNEY_URL}")
 class RegisterLandlordController(
     var landlordRegistrationJourney: LandlordRegistrationJourney,
-    val identityService: IdentityService,
+    val identityService: OneLoginIdentityService,
 ) {
     @GetMapping
     fun index(model: Model): String {

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/RegisterLandlordController.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/RegisterLandlordController.kt
@@ -39,13 +39,7 @@ class RegisterLandlordController(
         principal: Principal,
         @AuthenticationPrincipal oidcUser: OidcUser,
     ): String {
-        var identity = identityService.getVerifiedIdentityData(oidcUser)
-
-        if (identity != null) {
-            identity["verifiedIdentity"] = true
-        } else {
-            identity = mutableMapOf("verifiedIdentity" to false)
-        }
+        var identity = identityService.getVerifiedIdentityData(oidcUser) ?: mutableMapOf()
 
         return landlordRegistrationJourney.updateJourneyDataAndGetViewNameOrRedirect(
             landlordRegistrationJourney.getStepId(IDENTITY_VERIFICATION_PATH_SEGMENT),

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/exceptions/InvalidVerifiedCredentialsException.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/exceptions/InvalidVerifiedCredentialsException.kt
@@ -1,0 +1,5 @@
+package uk.gov.communities.prsdb.webapp.exceptions
+
+class InvalidVerifiedCredentialsException(
+    message: String,
+) : Exception(message)

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/exceptions/VerifiedCredentialParsingException.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/exceptions/VerifiedCredentialParsingException.kt
@@ -1,0 +1,11 @@
+package uk.gov.communities.prsdb.webapp.exceptions
+
+class VerifiedCredentialParsingException(
+    innerException: Exception,
+) : Exception(
+        "The verifiedCredential map returned in the IdentityJWT did not match the model of a verified credential. " +
+            "See https://docs.sign-in.service.gov.uk/" +
+            "integrate-with-integration-environment/prove-users-identity/" +
+            "#understand-your-user-s-core-identity-claim",
+        innerException,
+    )

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/LandlordRegistrationJourney.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/LandlordRegistrationJourney.kt
@@ -35,8 +35,7 @@ class LandlordRegistrationJourney(
             listOf(
                 Step(
                     id = LandlordRegistrationStepId.VerifyIdentity,
-                    page =
-                        VerifyIdentityPage(),
+                    page = VerifyIdentityPage(),
                     nextAction = { journeyData, _ ->
                         if (doesJourneyDataContainVerifiedIdentity(journeyData)) {
                             Pair(LandlordRegistrationStepId.ConfirmIdentity, null)

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/local/api/controllers/MockOneLoginController.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/local/api/controllers/MockOneLoginController.kt
@@ -13,6 +13,7 @@ import com.nimbusds.jwt.JWT
 import com.nimbusds.jwt.JWTClaimsSet
 import com.nimbusds.jwt.SignedJWT
 import org.json.JSONObject
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Profile
 import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
@@ -64,7 +65,12 @@ class MockOneLoginController {
         }
 
         var userInfoFile = "src/main/kotlin/uk/gov/communities/prsdb/webapp/local/api/mockOneLoginResponses/userInfo.json"
+        const val VERIFIED_USER_FILE =
+            "src/main/kotlin/uk/gov/communities/prsdb/webapp/local/api/mockOneLoginResponses/verifiedUserInfo.json"
     }
+
+    @Value("\${local.id-verification-user-info-file:${VERIFIED_USER_FILE}}")
+    lateinit var postVerificationUserInfoFile: String
 
     private val userId = "urn:fdc:gov.uk:2022:UVWXY"
 
@@ -137,13 +143,9 @@ class MockOneLoginController {
                 .build()
                 .toUri()
 
-        userInfoFile =
-            if (vtr != null) {
-                "src/main/kotlin/uk/gov/communities/prsdb/webapp/local/api/mockOneLoginResponses/verifiedUserInfo.json"
-                // "src/main/kotlin/uk/gov/communities/prsdb/webapp/local/api/mockOneLoginResponses/unverifiedUserInfo.json"
-            } else {
-                "src/main/kotlin/uk/gov/communities/prsdb/webapp/local/api/mockOneLoginResponses/userInfo.json"
-            }
+        if (vtr != null) {
+            userInfoFile = postVerificationUserInfoFile
+        }
 
         return ResponseEntity.status(302).location(locationURI).build()
     }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/local/api/mockOneLoginResponses/did.json
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/local/api/mockOneLoginResponses/did.json
@@ -1,0 +1,14 @@
+{
+  "assertionMethod" : [ {
+    "id" : "keyId",
+    "publicKeyJwk" :
+    {
+      "kty": "EC",
+      "use": "sig",
+      "crv": "P-256",
+      "x": "publicJWK_x",
+      "y": "publicJWK_y",
+      "alg": "ES256"
+    }
+  } ]
+}

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/local/api/mockOneLoginResponses/unverifiedUserInfo.json
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/local/api/mockOneLoginResponses/unverifiedUserInfo.json
@@ -1,0 +1,8 @@
+{
+  "sub": "userId",
+  "email": "userEmail",
+  "email_verified": true,
+  "phone_number": "userNumber",
+  "phone_number_verified": true,
+  "https://vocab.account.gov.uk": ""
+}

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/local/api/mockOneLoginResponses/verifiableCredential.json
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/local/api/mockOneLoginResponses/verifiableCredential.json
@@ -1,0 +1,58 @@
+{
+  "_comment": "The identity in this file is the example used in the one login documentation at https://docs.sign-in.service.gov.uk/integrate-with-integration-environment/prove-users-identity/#understand-your-user-s-core-identity-claim",
+  "type": [
+    "VerifiableCredential",
+    "VerifiableIdentityCredential"
+  ],
+  "credentialSubject": {
+    "name": [
+      {
+        "validFrom": "2020-03-01",
+        "nameParts": [
+          {
+            "value": "Alice",
+            "type": "GivenName"
+          },
+          {
+            "value": "Jane",
+            "type": "GivenName"
+          },
+          {
+            "value": "Laura",
+            "type": "GivenName"
+          },
+          {
+            "value": "Doe",
+            "type": "FamilyName"
+          }
+        ]
+      },
+      {
+        "validUntil": "2020-03-01",
+        "nameParts": [
+          {
+            "value": "Alice",
+            "type": "GivenName"
+          },
+          {
+            "value": "Jane",
+            "type": "GivenName"
+          },
+          {
+            "value": "Laura",
+            "type": "GivenName"
+          },
+          {
+            "value": "O’Donnell",
+            "type": "FamilyName"
+          }
+        ]
+      }
+    ],
+    "birthDate": [
+      {
+        "value": "1970-01-01"
+      }
+    ]
+  }
+}

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/local/api/mockOneLoginResponses/verifiedUserInfo.json
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/local/api/mockOneLoginResponses/verifiedUserInfo.json
@@ -1,0 +1,8 @@
+{
+  "sub": "userId",
+  "email": "userEmail",
+  "email_verified": true,
+  "phone_number": "userNumber",
+  "phone_number_verified": true,
+  "https://vocab.account.gov.uk/v1/coreIdentityJWT": "coreIdentityJwt"
+}

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/dataModels/VerifiedCredentialModel.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/dataModels/VerifiedCredentialModel.kt
@@ -36,7 +36,7 @@ class CredentialSubject(
         birthDateList.singleOrNull()?.value ?: throw InvalidVerifiedCredentialsException("Not exactly one date of birth")
 
     fun getCurrentName(): String {
-        val currentName = name.singleOrNull { it.validTo == null }
+        val currentName = name.singleOrNull { it.validUntil == null }
         if (currentName == null) {
             throw InvalidVerifiedCredentialsException("Not exactly one current name")
         } else {
@@ -67,12 +67,12 @@ class BirthDate(
 class TemporalName(
     val nameParts: List<SingleName>,
     val validFrom: LocalDate? = null,
-    val validTo: LocalDate? = null,
+    val validUntil: LocalDate? = null,
 ) {
     companion object {
         fun fromJsonMap(jsonMap: Map<String, Any>): TemporalName {
             val validFromString = jsonMap["validFrom"] as? String
-            val validToString = jsonMap["validTo"] as? String
+            val validToString = jsonMap["validUntil"] as? String
             val nameParts = getListOfMaps(jsonMap, "nameParts").map { SingleName.fromJsonMap(it) }
 
             return TemporalName(

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/dataModels/VerifiedCredentialModel.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/dataModels/VerifiedCredentialModel.kt
@@ -1,0 +1,105 @@
+// If these unchecked casts cause parsing to fail, an exception will be thrown
+@file:Suppress("UNCHECKED_CAST")
+
+package uk.gov.communities.prsdb.webapp.models.dataModels
+
+import uk.gov.communities.prsdb.webapp.exceptions.InvalidVerifiedCredentialsException
+import uk.gov.communities.prsdb.webapp.exceptions.VerifiedCredentialParsingException
+import java.time.LocalDate
+
+class VerifiedCredentialModel(
+    val type: List<String>,
+    val credentialSubject: CredentialSubject,
+) {
+    companion object {
+        fun fromUnknownMap(map: Map<*, *>?): VerifiedCredentialModel {
+            try {
+                return fromJsonMap(map as Map<String, Any>)
+            } catch (e: Exception) {
+                throw VerifiedCredentialParsingException(e)
+            }
+        }
+
+        private fun fromJsonMap(jsonMap: Map<String, Any>): VerifiedCredentialModel {
+            val type = jsonMap["type"] as List<String>
+            val subject = CredentialSubject.fromJsonMap(jsonMap["credentialSubject"] as Map<String, Any>)
+            return VerifiedCredentialModel(type, subject)
+        }
+    }
+}
+
+class CredentialSubject(
+    val name: List<TemporalName>,
+    birthDateList: List<BirthDate>,
+) {
+    val birthDate: LocalDate =
+        birthDateList.singleOrNull()?.value ?: throw InvalidVerifiedCredentialsException("Not exactly one date of birth")
+
+    fun getCurrentName(): String {
+        val currentName = name.singleOrNull { it.validTo == null }
+        if (currentName == null) {
+            throw InvalidVerifiedCredentialsException("Not exactly one current name")
+        } else {
+            return currentName.nameParts.joinToString(" ")
+        }
+    }
+
+    companion object {
+        fun fromJsonMap(jsonMap: Map<String, Any>): CredentialSubject {
+            val name = getListOfMaps(jsonMap, "name").map { TemporalName.fromJsonMap(it) }
+            val birthDate = getListOfMaps(jsonMap, "birthDate").map { BirthDate.fromJsonMap(it) }
+            return CredentialSubject(name, birthDate)
+        }
+    }
+}
+
+class BirthDate(
+    val value: LocalDate,
+) {
+    companion object {
+        fun fromJsonMap(jsonMap: Map<String, Any>): BirthDate {
+            val valueString = jsonMap["value"] as String
+            return BirthDate(LocalDate.parse(valueString))
+        }
+    }
+}
+
+class TemporalName(
+    val nameParts: List<SingleName>,
+    val validFrom: LocalDate? = null,
+    val validTo: LocalDate? = null,
+) {
+    companion object {
+        fun fromJsonMap(jsonMap: Map<String, Any>): TemporalName {
+            val validFromString = jsonMap["validFrom"] as? String
+            val validToString = jsonMap["validTo"] as? String
+            val nameParts = getListOfMaps(jsonMap, "nameParts").map { SingleName.fromJsonMap(it) }
+
+            return TemporalName(
+                nameParts,
+                validFromString?.let { LocalDate.parse(it) },
+                validToString?.let { LocalDate.parse(it) },
+            )
+        }
+    }
+}
+
+class SingleName(
+    val value: String,
+    val type: String,
+) {
+    override fun toString() = value
+
+    companion object {
+        fun fromJsonMap(jsonMap: Map<String, Any>): SingleName {
+            val value = jsonMap["value"] as String
+            val type = jsonMap["type"] as String
+            return SingleName(value, type)
+        }
+    }
+}
+
+fun getListOfMaps(
+    map: Map<String, Any>,
+    key: String,
+): List<Map<String, Any>> = map[key] as List<Map<String, Any>>

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/dataModels/VerifiedCredentialModel.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/dataModels/VerifiedCredentialModel.kt
@@ -99,7 +99,7 @@ class SingleName(
     }
 }
 
-fun getListOfMaps(
+private fun getListOfMaps(
     map: Map<String, Any>,
     key: String,
 ): List<Map<String, Any>> = map[key] as List<Map<String, Any>>

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/OneLoginIdentityService.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/OneLoginIdentityService.kt
@@ -9,8 +9,8 @@ import uk.gov.communities.prsdb.webapp.models.dataModels.VerifiedCredentialModel
 @Service
 class OneLoginIdentityService(
     private val decoderFactory: JwtDecoderFactory<Unit>,
-) : IdentityService {
-    override fun getVerifiedIdentityData(user: OidcUser): MutableMap<String, Any?>? {
+) {
+    fun getVerifiedIdentityData(user: OidcUser): MutableMap<String, Any?>? {
         val idClaimString = user.claims[OneLoginClaimKeys.CORE_IDENTITY] as? String
         if (idClaimString != null) {
             val decoder = decoderFactory.createDecoder(Unit)
@@ -27,8 +27,4 @@ class OneLoginIdentityService(
 
         return null
     }
-}
-
-interface IdentityService {
-    fun getVerifiedIdentityData(user: OidcUser): MutableMap<String, Any?>?
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/OneLoginIdentityService.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/OneLoginIdentityService.kt
@@ -1,0 +1,75 @@
+package uk.gov.communities.prsdb.webapp.services
+
+import com.nimbusds.jose.JWSAlgorithm
+import com.nimbusds.jose.jwk.ECKey
+import com.nimbusds.jose.jwk.JWKSet
+import com.nimbusds.jose.jwk.source.ImmutableJWKSet
+import com.nimbusds.jose.proc.JWSVerificationKeySelector
+import com.nimbusds.jose.proc.SecurityContext
+import com.nimbusds.jwt.proc.DefaultJWTProcessor
+import org.springframework.boot.configurationprocessor.json.JSONArray
+import org.springframework.boot.configurationprocessor.json.JSONObject
+import org.springframework.security.oauth2.core.oidc.user.OidcUser
+import org.springframework.security.oauth2.jwt.JwtDecoder
+import org.springframework.security.oauth2.jwt.NimbusJwtDecoder
+import org.springframework.stereotype.Service
+import org.springframework.web.client.RestClient
+import uk.gov.communities.prsdb.webapp.constants.OneLoginClaimKeys
+import uk.gov.communities.prsdb.webapp.models.dataModels.VerifiedCredentialModel
+
+@Service
+class OneLoginIdentityService : IdentityService {
+    override fun getVerifiedIdentityData(user: OidcUser): MutableMap<String, Any?>? {
+        val idClaimString = user.claims[OneLoginClaimKeys.CORE_IDENTITY] as? String
+        if (idClaimString != null) {
+            val decoder = idTokenDecoder()
+            val idClaimJwt = decoder.decode(idClaimString)
+
+            val verifiableCredentialMap = idClaimJwt.claims["vc"] as? Map<*, *>
+            val verifiableCredential = VerifiedCredentialModel.fromUnknownMap(verifiableCredentialMap)
+
+            return mutableMapOf(
+                "name" to verifiableCredential.credentialSubject.getCurrentName(),
+                "birthDate" to verifiableCredential.credentialSubject.birthDate,
+            )
+        }
+
+        return null
+    }
+
+    private fun idTokenDecoder(): JwtDecoder {
+        val defaultClient = RestClient.create()
+        val didResponseString =
+            defaultClient
+                .get()
+                .uri(
+                    "https://identity.integration.account.gov.uk/.well-known/did.json",
+                ).retrieve()
+                .body(String::class.java)
+        val keyArray = JSONObject(didResponseString).getJSONArray("assertionMethod")
+        val ecKeyList = keyArraySequence(keyArray).toList()
+
+        val publicKeys = ecKeyList.map { mapJsonObjectToEcKey(it) }
+        val processor = DefaultJWTProcessor<SecurityContext>()
+        val keySelector = JWSVerificationKeySelector(JWSAlgorithm.ES256, ImmutableJWKSet(JWKSet(publicKeys)))
+        processor.jwsKeySelector = keySelector
+        return NimbusJwtDecoder(processor)
+    }
+
+    private fun keyArraySequence(keyArray: JSONArray) =
+        sequence {
+            for (index in 0 until keyArray.length()) {
+                yield(keyArray.getJSONObject(index))
+            }
+        }
+
+    private fun mapJsonObjectToEcKey(keyObject: JSONObject): ECKey {
+        val jsonKey = keyObject.getJSONObject("publicKeyJwk")
+        jsonKey.put("kid", keyObject.getString("id"))
+        return ECKey.parse(jsonKey.toString())
+    }
+}
+
+interface IdentityService {
+    fun getVerifiedIdentityData(user: OidcUser): MutableMap<String, Any?>?
+}

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/OneLoginIdentityService.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/OneLoginIdentityService.kt
@@ -1,28 +1,19 @@
 package uk.gov.communities.prsdb.webapp.services
 
-import com.nimbusds.jose.JWSAlgorithm
-import com.nimbusds.jose.jwk.ECKey
-import com.nimbusds.jose.jwk.JWKSet
-import com.nimbusds.jose.jwk.source.ImmutableJWKSet
-import com.nimbusds.jose.proc.JWSVerificationKeySelector
-import com.nimbusds.jose.proc.SecurityContext
-import com.nimbusds.jwt.proc.DefaultJWTProcessor
-import org.springframework.boot.configurationprocessor.json.JSONArray
-import org.springframework.boot.configurationprocessor.json.JSONObject
 import org.springframework.security.oauth2.core.oidc.user.OidcUser
-import org.springframework.security.oauth2.jwt.JwtDecoder
-import org.springframework.security.oauth2.jwt.NimbusJwtDecoder
+import org.springframework.security.oauth2.jwt.JwtDecoderFactory
 import org.springframework.stereotype.Service
-import org.springframework.web.client.RestClient
 import uk.gov.communities.prsdb.webapp.constants.OneLoginClaimKeys
 import uk.gov.communities.prsdb.webapp.models.dataModels.VerifiedCredentialModel
 
 @Service
-class OneLoginIdentityService : IdentityService {
+class OneLoginIdentityService(
+    private val decoderFactory: JwtDecoderFactory<Unit>,
+) : IdentityService {
     override fun getVerifiedIdentityData(user: OidcUser): MutableMap<String, Any?>? {
         val idClaimString = user.claims[OneLoginClaimKeys.CORE_IDENTITY] as? String
         if (idClaimString != null) {
-            val decoder = idTokenDecoder()
+            val decoder = decoderFactory.createDecoder(Unit)
             val idClaimJwt = decoder.decode(idClaimString)
 
             val verifiableCredentialMap = idClaimJwt.claims["vc"] as? Map<*, *>
@@ -35,38 +26,6 @@ class OneLoginIdentityService : IdentityService {
         }
 
         return null
-    }
-
-    private fun idTokenDecoder(): JwtDecoder {
-        val defaultClient = RestClient.create()
-        val didResponseString =
-            defaultClient
-                .get()
-                .uri(
-                    "https://identity.integration.account.gov.uk/.well-known/did.json",
-                ).retrieve()
-                .body(String::class.java)
-        val keyArray = JSONObject(didResponseString).getJSONArray("assertionMethod")
-        val ecKeyList = keyArraySequence(keyArray).toList()
-
-        val publicKeys = ecKeyList.map { mapJsonObjectToEcKey(it) }
-        val processor = DefaultJWTProcessor<SecurityContext>()
-        val keySelector = JWSVerificationKeySelector(JWSAlgorithm.ES256, ImmutableJWKSet(JWKSet(publicKeys)))
-        processor.jwsKeySelector = keySelector
-        return NimbusJwtDecoder(processor)
-    }
-
-    private fun keyArraySequence(keyArray: JSONArray) =
-        sequence {
-            for (index in 0 until keyArray.length()) {
-                yield(keyArray.getJSONObject(index))
-            }
-        }
-
-    private fun mapJsonObjectToEcKey(keyObject: JSONObject): ECKey {
-        val jsonKey = keyObject.getJSONObject("publicKeyJwk")
-        jsonKey.put("kid", keyObject.getString("id"))
-        return ECKey.parse(jsonKey.toString())
     }
 }
 

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -43,6 +43,7 @@ one-login:
     public.key: ${ONE_LOGIN_PUBLIC_KEY:classpath:public_key.pem}
     private.key: ${ONE_LOGIN_PRIVATE_KEY:classpath:private_key.pem}
 
+
 notify:
   api-key: ${EMAILNOTIFICATIONS_APIKEY}
 
@@ -79,6 +80,7 @@ spring:
             jwk-set-uri: http://localhost:8080/local/one-login/.well-known/jwks.json
             user-info-uri: http://localhost:8080/local/one-login/userinfo
             userNameAttribute: "sub"
+one-login.did.uri: http://localhost:8080/local/one-login/.well-known/did.json
 
 ---
 

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -87,6 +87,16 @@ one-login.did.uri: http://localhost:8080/local/one-login/.well-known/did.json
 spring:
   config:
     activate:
+      on-profile: local-no-auth-unverified
+
+local:
+  id-verification-user-info-file: src/main/kotlin/uk/gov/communities/prsdb/webapp/local/api/mockOneLoginResponses/unverifiedUserInfo.json
+
+---
+
+spring:
+  config:
+    activate:
       on-profile: local-auth
 
   security:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -29,6 +29,7 @@ one-login:
   jwt:
     public.key: ${ONE_LOGIN_PUBLIC_KEY}
     private.key: ${ONE_LOGIN_PRIVATE_KEY}
+  did.uri: https://identity.integration.account.gov.uk/.well-known/did.json
 
 notify:
   api-key: ${EMAILNOTIFICATIONS_APIKEY}

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/PrsdbWebappApplicationTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/PrsdbWebappApplicationTests.kt
@@ -12,7 +12,7 @@ import uk.gov.communities.prsdb.webapp.clients.OSPlacesClient
 import uk.gov.communities.prsdb.webapp.config.NotifyConfig
 import uk.gov.communities.prsdb.webapp.config.OSPlacesConfig
 import uk.gov.communities.prsdb.webapp.config.OneLoginConfig
-import uk.gov.communities.prsdb.webapp.services.IdentityService
+import uk.gov.communities.prsdb.webapp.services.OneLoginIdentityService
 import uk.gov.service.notify.NotificationClient
 
 @Import(TestcontainersConfiguration::class)
@@ -47,5 +47,5 @@ class PrsdbWebappApplicationTests {
     lateinit var osPlacesClient: OSPlacesClient
 
     @MockBean
-    lateinit var identityService: IdentityService
+    lateinit var identityService: OneLoginIdentityService
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/PrsdbWebappApplicationTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/PrsdbWebappApplicationTests.kt
@@ -12,6 +12,7 @@ import uk.gov.communities.prsdb.webapp.clients.OSPlacesClient
 import uk.gov.communities.prsdb.webapp.config.NotifyConfig
 import uk.gov.communities.prsdb.webapp.config.OSPlacesConfig
 import uk.gov.communities.prsdb.webapp.config.OneLoginConfig
+import uk.gov.communities.prsdb.webapp.services.IdentityService
 import uk.gov.service.notify.NotificationClient
 
 @Import(TestcontainersConfiguration::class)
@@ -44,4 +45,7 @@ class PrsdbWebappApplicationTests {
 
     @MockBean
     lateinit var osPlacesClient: OSPlacesClient
+
+    @MockBean
+    lateinit var identityService: IdentityService
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/controllers/RegisterLandlordControllerTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/controllers/RegisterLandlordControllerTests.kt
@@ -10,7 +10,7 @@ import org.springframework.test.web.servlet.get
 import org.springframework.web.context.WebApplicationContext
 import uk.gov.communities.prsdb.webapp.forms.journeys.LandlordRegistrationJourney
 import uk.gov.communities.prsdb.webapp.forms.steps.LandlordRegistrationStepId
-import uk.gov.communities.prsdb.webapp.services.IdentityService
+import uk.gov.communities.prsdb.webapp.services.OneLoginIdentityService
 
 @WebMvcTest(RegisterLandlordController::class)
 class RegisterLandlordControllerTests(
@@ -20,7 +20,7 @@ class RegisterLandlordControllerTests(
     lateinit var mockLandlordRegistrationJourney: LandlordRegistrationJourney
 
     @MockBean
-    lateinit var identityService: IdentityService
+    lateinit var identityService: OneLoginIdentityService
 
     @BeforeEach
     fun steup() {

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/controllers/RegisterLandlordControllerTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/controllers/RegisterLandlordControllerTests.kt
@@ -10,6 +10,7 @@ import org.springframework.test.web.servlet.get
 import org.springframework.web.context.WebApplicationContext
 import uk.gov.communities.prsdb.webapp.forms.journeys.LandlordRegistrationJourney
 import uk.gov.communities.prsdb.webapp.forms.steps.LandlordRegistrationStepId
+import uk.gov.communities.prsdb.webapp.services.IdentityService
 
 @WebMvcTest(RegisterLandlordController::class)
 class RegisterLandlordControllerTests(
@@ -17,6 +18,9 @@ class RegisterLandlordControllerTests(
 ) : ControllerTest(webContext) {
     @MockBean
     lateinit var mockLandlordRegistrationJourney: LandlordRegistrationJourney
+
+    @MockBean
+    lateinit var identityService: IdentityService
 
     @BeforeEach
     fun steup() {

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/IntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/IntegrationTest.kt
@@ -21,7 +21,7 @@ import uk.gov.communities.prsdb.webapp.clients.OSPlacesClient
 import uk.gov.communities.prsdb.webapp.config.NotifyConfig
 import uk.gov.communities.prsdb.webapp.config.OSPlacesConfig
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.Navigator
-import uk.gov.communities.prsdb.webapp.services.IdentityService
+import uk.gov.communities.prsdb.webapp.services.OneLoginIdentityService
 import uk.gov.service.notify.NotificationClient
 
 @Import(TestcontainersConfiguration::class)
@@ -48,7 +48,7 @@ abstract class IntegrationTest {
     lateinit var osPlacesClient: OSPlacesClient
 
     @MockBean
-    lateinit var identityService: IdentityService
+    lateinit var identityService: OneLoginIdentityService
 
     @SpyBean
     lateinit var clientRegistrationRepository: ClientRegistrationRepository

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/IntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/IntegrationTest.kt
@@ -21,6 +21,7 @@ import uk.gov.communities.prsdb.webapp.clients.OSPlacesClient
 import uk.gov.communities.prsdb.webapp.config.NotifyConfig
 import uk.gov.communities.prsdb.webapp.config.OSPlacesConfig
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.Navigator
+import uk.gov.communities.prsdb.webapp.services.IdentityService
 import uk.gov.service.notify.NotificationClient
 
 @Import(TestcontainersConfiguration::class)
@@ -45,6 +46,9 @@ abstract class IntegrationTest {
 
     @MockBean
     lateinit var osPlacesClient: OSPlacesClient
+
+    @MockBean
+    lateinit var identityService: IdentityService
 
     @SpyBean
     lateinit var clientRegistrationRepository: ClientRegistrationRepository

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/LandlordRegistrationJourneyTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/LandlordRegistrationJourneyTests.kt
@@ -3,10 +3,13 @@ package uk.gov.communities.prsdb.webapp.integration
 import com.google.i18n.phonenumbers.PhoneNumberUtil
 import com.microsoft.playwright.Page
 import com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
+import org.mockito.kotlin.any
+import org.mockito.kotlin.whenever
 import org.springframework.test.context.jdbc.Sql
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages.BasePage.Companion.assertPageIs
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.landlordRegistrationJourneyPages.CountryOfResidenceFormPageLandlordRegistration
@@ -16,6 +19,11 @@ import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.landlordReg
 @Sql("/data-local.sql")
 class LandlordRegistrationJourneyTests : IntegrationTest() {
     private val phoneNumberUtil = PhoneNumberUtil.getInstance()
+
+    @BeforeEach
+    fun setup() {
+        whenever(identityService.getVerifiedIdentityData(any())).thenReturn(null)
+    }
 
     @Nested
     inner class LandlordRegistrationStepName {

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/RegisterLandlordPageTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/RegisterLandlordPageTests.kt
@@ -5,8 +5,12 @@ import com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat
 import com.microsoft.playwright.options.AriaRole
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.whenever
 import org.springframework.test.context.jdbc.Sql
+import uk.gov.communities.prsdb.webapp.models.formModels.VerifiedIdentityModel
 import java.net.URI
+import java.time.LocalDate
 
 @Sql("/data-local.sql")
 class RegisterLandlordPageTests : IntegrationTest() {
@@ -17,7 +21,23 @@ class RegisterLandlordPageTests : IntegrationTest() {
     }
 
     @Test
-    fun `the 'Start Now' button directs a user to the landlord registration email page`(page: Page) {
+    fun `the 'Start Now' button directs an unverified user to the landlord registration email page`(page: Page) {
+        whenever(identityService.getVerifiedIdentityData(any())).thenReturn(null)
+
+        page.navigate("http://localhost:$port/register-as-a-landlord")
+        page.getByRole(AriaRole.BUTTON, Page.GetByRoleOptions().setName("Start Now")).click()
+        assertEquals("/register-as-a-landlord/name", URI(page.url()).path)
+    }
+
+    @Test
+    fun `the 'Start Now' button directs a verified user to the identity confirmation page`(page: Page) {
+        val verifiedIdentityMap =
+            mutableMapOf<String, Any?>(
+                VerifiedIdentityModel.NAME_KEY to "name",
+                VerifiedIdentityModel.BIRTH_DATE_KEY to LocalDate.now(),
+            )
+        whenever(identityService.getVerifiedIdentityData(any())).thenReturn(verifiedIdentityMap)
+
         page.navigate("http://localhost:$port/register-as-a-landlord")
         page.getByRole(AriaRole.BUTTON, Page.GetByRoleOptions().setName("Start Now")).click()
         assertEquals("/register-as-a-landlord/name", URI(page.url()).path)

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/RegisterLandlordPageTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/RegisterLandlordPageTests.kt
@@ -40,6 +40,6 @@ class RegisterLandlordPageTests : IntegrationTest() {
 
         page.navigate("http://localhost:$port/register-as-a-landlord")
         page.getByRole(AriaRole.BUTTON, Page.GetByRoleOptions().setName("Start Now")).click()
-        assertEquals("/register-as-a-landlord/name", URI(page.url()).path)
+        assertEquals("/register-as-a-landlord/confirm-identity", URI(page.url()).path)
     }
 }


### PR DESCRIPTION
This PR is for pulling the verifiedIdentity creation into a separate service, as well as a quick and dirty local configurable implementation of verified identity to remove the need to connect to One Login. 