### PR TITLE
Feat/prsd 493 select ownership type page

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/constants/enums/OwnershipType.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/constants/enums/OwnershipType.kt
@@ -1,0 +1,6 @@
+package uk.gov.communities.prsdb.webapp.constants.enums
+
+enum class OwnershipType {
+    FREEHOLD,
+    LEASEHOLD,
+}

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/PropertyRegistrationJourney.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/PropertyRegistrationJourney.kt
@@ -3,11 +3,13 @@ package uk.gov.communities.prsdb.webapp.forms.journeys
 import org.springframework.stereotype.Component
 import org.springframework.validation.Validator
 import uk.gov.communities.prsdb.webapp.constants.enums.JourneyType
+import uk.gov.communities.prsdb.webapp.constants.enums.OwnershipType
 import uk.gov.communities.prsdb.webapp.constants.enums.PropertyType
 import uk.gov.communities.prsdb.webapp.forms.pages.Page
 import uk.gov.communities.prsdb.webapp.forms.steps.RegisterPropertyStepId
 import uk.gov.communities.prsdb.webapp.forms.steps.Step
 import uk.gov.communities.prsdb.webapp.models.formModels.LandingPageFormModel
+import uk.gov.communities.prsdb.webapp.models.formModels.OwnershipTypeFormModel
 import uk.gov.communities.prsdb.webapp.models.formModels.PropertyTypeFormModel
 import uk.gov.communities.prsdb.webapp.models.viewModels.RadiosViewModel
 import uk.gov.communities.prsdb.webapp.services.JourneyDataService
@@ -60,6 +62,33 @@ class PropertyRegistrationJourney(
                                                 labelMsgKey = "forms.propertyType.radios.option.other.label",
                                                 hintMsgKey = "forms.propertyType.radios.option.other.hint",
                                                 conditionalFragment = "customPropertyTypeInput",
+                                            ),
+                                        ),
+                                ),
+                        ),
+                    nextAction = { _, _ -> Pair(RegisterPropertyStepId.OwnershipType, null) },
+                ),
+                Step(
+                    id = RegisterPropertyStepId.OwnershipType,
+                    page =
+                        Page(
+                            formModel = OwnershipTypeFormModel::class,
+                            templateName = "forms/ownershipTypeForm.html",
+                            content =
+                                mapOf(
+                                    "title" to "registerProperty.title",
+                                    "fieldSetHeading" to "forms.ownershipType.fieldSetHeading",
+                                    "radioOptions" to
+                                        listOf(
+                                            RadiosViewModel(
+                                                value = OwnershipType.FREEHOLD,
+                                                labelMsgKey = "forms.ownershipType.radios.option.freehold.label",
+                                                hintMsgKey = "forms.ownershipType.radios.option.freehold.hint",
+                                            ),
+                                            RadiosViewModel(
+                                                value = OwnershipType.LEASEHOLD,
+                                                labelMsgKey = "forms.ownershipType.radios.option.leasehold.label",
+                                                hintMsgKey = "forms.ownershipType.radios.option.leasehold.hint",
                                             ),
                                         ),
                                 ),

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/steps/RegisterPropertyStepId.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/steps/RegisterPropertyStepId.kt
@@ -5,4 +5,5 @@ enum class RegisterPropertyStepId(
 ) : StepId {
     PlaceholderPage("placeholder"),
     PropertyType("property-type"),
+    OwnershipType("ownership-type"),
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/formModels/OwnershipTypeFormModel.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/formModels/OwnershipTypeFormModel.kt
@@ -1,0 +1,20 @@
+package uk.gov.communities.prsdb.webapp.models.formModels
+
+import uk.gov.communities.prsdb.webapp.constants.enums.OwnershipType
+import uk.gov.communities.prsdb.webapp.validation.ConstraintDescriptor
+import uk.gov.communities.prsdb.webapp.validation.IsValidPrioritised
+import uk.gov.communities.prsdb.webapp.validation.NotNullConstraintValidator
+import uk.gov.communities.prsdb.webapp.validation.ValidatedBy
+
+@IsValidPrioritised
+class OwnershipTypeFormModel : FormModel {
+    @ValidatedBy(
+        constraints = [
+            ConstraintDescriptor(
+                messageKey = "forms.ownershipType.radios.error.missing",
+                validatorType = NotNullConstraintValidator::class,
+            ),
+        ],
+    )
+    var ownershipType: OwnershipType? = null
+}

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -321,7 +321,6 @@ forms.ownershipType.radios.option.leasehold.hint=You'll have a legal agreement w
 forms.ownershipType.radios.error.missing=Select the ownership type
 forms.ownershipType.details.summary.text=Why do I need to select the type of ownership?
 forms.ownershipType.details.text=This helps local authorities know who is responsible for repair work on the property.
-forms.ownershipType.section.hint=Section 1 of 2 &mdash; Property details
 
 pagination.previousText=Previous
 pagination.pageText=page

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -313,6 +313,14 @@ forms.dateOfBirth.error.invalidFormat=You must enter a real date
 forms.dateOfBirth.error.invalidDateOfBirth=You must enter a valid date of birth
 forms.dateOfBirth.error.invalidAge=The minimum age to register as a landlord is 18
 
+forms.ownershipType.fieldSetHeading=Select the ownership type for your property
+forms.ownershipType.radios.option.freehold.label=Freehold
+forms.ownershipType.radios.option.freehold.hint=You'll have ownership of a property for an indefinite time, without payment of rent.
+forms.ownershipType.radios.option.leasehold.label=Leasehold
+forms.ownershipType.radios.option.leasehold.hint=You'll have a legal agreement with the landlord called a "lease". Most flats are leasehold.
+forms.ownershipType.radios.error.missing=Select the ownership type
+forms.ownershipType.section.hint=Section 1 of 2 &mdash; Property details
+
 pagination.previousText=Previous
 pagination.pageText=page
 pagination.nextText=Next

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -319,6 +319,8 @@ forms.ownershipType.radios.option.freehold.hint=You'll have ownership of a prope
 forms.ownershipType.radios.option.leasehold.label=Leasehold
 forms.ownershipType.radios.option.leasehold.hint=You'll have a legal agreement with the landlord called a "lease". Most flats are leasehold.
 forms.ownershipType.radios.error.missing=Select the ownership type
+forms.ownershipType.details.summary.text=Why do I need to select the type of ownership?
+forms.ownershipType.details.text=This helps local authorities know who is responsible for repair work on the property.
 forms.ownershipType.section.hint=Section 1 of 2 &mdash; Property details
 
 pagination.previousText=Previous

--- a/src/main/resources/templates/forms/ownershipTypeForm.html
+++ b/src/main/resources/templates/forms/ownershipTypeForm.html
@@ -6,7 +6,6 @@
 <!DOCTYPE html>
 <html th:replace="~{fragments/forms/questionPage :: questionPage(#{${title}}, ${formModel}, ~{::#form-content}, ${backUrl})}">
 <th:block id="form-content">
-    <div class="govuk-hint" th:utext="#{forms.ownershipType.section.hint}">forms.ownershipType.section.hint</div>
     <th:block id="fieldset-content"
               th:replace="~{fragments/forms/fieldSet :: fieldSet(~{::#fieldset-content/content()}, 'ownershipType', #{${fieldSetHeading}}, null)}">
         <th:block th:replace="~{fragments/forms/radios :: radios(null,'ownershipType',null, ${radioOptions})}"></th:block>

--- a/src/main/resources/templates/forms/ownershipTypeForm.html
+++ b/src/main/resources/templates/forms/ownershipTypeForm.html
@@ -1,0 +1,16 @@
+<!--/*@thymesVar id="title" type="java.lang.String"*/-->
+<!--/*@thymesVar id="formModel" type="java.lang.Object"*/-->
+<!--/*@thymesVar id="fieldSetHeading" type="java.lang.String"*/-->
+<!--/*@thymesVar id="backUrl" type="java.lang.String"*/-->
+<!--/*@thymesVar id="radioOptions" type="java.lang.Object"*/-->
+<!DOCTYPE html>
+<html th:replace="~{fragments/forms/questionPage :: questionPage(#{${title}}, ${formModel}, ~{::#form-content}, ${backUrl})}">
+<th:block id="form-content">
+    <div class="govuk-hint" th:utext="#{forms.ownershipType.section.hint}">forms.ownershipType.section.hint</div>
+    <th:block id="fieldset-content"
+              th:replace="~{fragments/forms/fieldSet :: fieldSet(~{::#fieldset-content/content()}, 'ownershipType', #{${fieldSetHeading}}, null)}">
+        <th:block th:replace="~{fragments/forms/radios :: radios(null,'ownershipType',null, ${radioOptions})}"></th:block>
+    </th:block>
+    <button th:replace="~{fragments/buttons/primaryButton :: primaryButton(#{forms.buttons.continue})}"></button>
+</th:block>
+</html>

--- a/src/main/resources/templates/forms/ownershipTypeForm.html
+++ b/src/main/resources/templates/forms/ownershipTypeForm.html
@@ -11,6 +11,8 @@
               th:replace="~{fragments/forms/fieldSet :: fieldSet(~{::#fieldset-content/content()}, 'ownershipType', #{${fieldSetHeading}}, null)}">
         <th:block th:replace="~{fragments/forms/radios :: radios(null,'ownershipType',null, ${radioOptions})}"></th:block>
     </th:block>
+    <details
+            th:replace="~{fragments/details :: details(#{forms.ownershipType.details.summary.text}, #{forms.ownershipType.details.text})}"></details>
     <button th:replace="~{fragments/buttons/primaryButton :: primaryButton(#{forms.buttons.continue})}"></button>
 </th:block>
 </html>

--- a/src/main/resources/templates/fragments/details.html
+++ b/src/main/resources/templates/fragments/details.html
@@ -1,0 +1,10 @@
+<details th:fragment="details(summaryText, detailsText)" class="govuk-details">
+    <summary class="govuk-details__summary">
+        <span class="govuk-details__summary-text" th:text="${summaryText}">
+            summaryText
+        </span>
+    </summary>
+    <div class="govuk-details__text" th:text="${detailsText}">
+        detailsText
+    </div>
+</details>

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/EditLAUserTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/EditLAUserTests.kt
@@ -31,7 +31,7 @@ class EditLAUserTests : IntegrationTest() {
         assertEquals("false", editUserPage.isManagerRadios.getSelectedValue())
 
         // Update the user's access level to admin
-        editUserPage.isManagerRadios.getRadio("true").click()
+        editUserPage.isManagerRadios.selectValue("true")
         editUserPage.form.submit()
         manageUsersPage = assertPageIs(page, ManageLaUsersPage::class)
 

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/PropertyRegistrationJourneyTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/PropertyRegistrationJourneyTests.kt
@@ -6,8 +6,10 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.springframework.test.context.jdbc.Sql
+import uk.gov.communities.prsdb.webapp.constants.enums.OwnershipType
 import uk.gov.communities.prsdb.webapp.constants.enums.PropertyType
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages.BasePage.Companion.assertPageIs
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyRegistrationJourneyPages.OwnershipTypeFormPagePropertyRegistration
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyRegistrationJourneyPages.PropertyTypeFormPagePropertyRegistration
 import java.net.URI
 
@@ -26,9 +28,16 @@ class PropertyRegistrationJourneyTests : IntegrationTest() {
         // Property type selection step - render page
         assertThat(propertyTypePage.form.getFieldsetHeading()).containsText("What type of property are you registering?")
         // fill in and submit
-        propertyTypePage.setRadioValue(PropertyType.DETACHED_HOUSE)
+        propertyTypePage.form.getRadios().selectValue(PropertyType.DETACHED_HOUSE)
         propertyTypePage.form.submit()
         // goes to the next page
+        val ownershipTypePage = assertPageIs(page, OwnershipTypeFormPagePropertyRegistration::class)
+
+        // Ownership type selection step - render page
+        assertThat(ownershipTypePage.form.getFieldsetHeading()).containsText("Select the ownership type for your property")
+        // fill in and submit
+        ownershipTypePage.form.getRadios().selectValue(OwnershipType.FREEHOLD)
+        propertyTypePage.form.submit()
         assertEquals("/register-property/placeholder", URI(page.url()).path)
     }
 
@@ -37,10 +46,10 @@ class PropertyRegistrationJourneyTests : IntegrationTest() {
         @Test
         fun `Submitting with other selected and the input filled in redirects to the next step`(page: Page) {
             val propertyTypePage = navigator.goToPropertyRegistrationPropertyTypePage()
-            propertyTypePage.setRadioValue(PropertyType.OTHER)
+            propertyTypePage.form.getRadios().selectValue(PropertyType.OTHER)
             propertyTypePage.customPropertyTypeInput.fill("End terrace house")
             propertyTypePage.form.submit()
-            assertEquals("/register-property/placeholder", URI(page.url()).path)
+            assertPageIs(page, OwnershipTypeFormPagePropertyRegistration::class)
         }
 
         @Test
@@ -53,9 +62,19 @@ class PropertyRegistrationJourneyTests : IntegrationTest() {
         @Test
         fun `Submitting with the Other propertyType selected but an empty customPropertyType field returns an error`(page: Page) {
             val propertyTypePage = navigator.goToPropertyRegistrationPropertyTypePage()
-            propertyTypePage.setRadioValue(PropertyType.OTHER)
+            propertyTypePage.form.getRadios().selectValue(PropertyType.OTHER)
             propertyTypePage.form.submit()
             assertThat(propertyTypePage.form.getErrorMessage()).containsText("Enter the property type")
+        }
+    }
+
+    @Nested
+    inner class OwnershipTypeStep {
+        @Test
+        fun `Submitting with no ownershipType selected returns an error`(page: Page) {
+            val ownershipTypePage = navigator.goToPropertyRegistrationOwnershipTypePage()
+            ownershipTypePage.form.submit()
+            assertThat(ownershipTypePage.form.getErrorMessage()).containsText("Select the ownership type")
         }
     }
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/Navigator.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/Navigator.kt
@@ -2,6 +2,7 @@ package uk.gov.communities.prsdb.webapp.integration.pageObjects
 
 import com.microsoft.playwright.Page
 import com.microsoft.playwright.Response
+import uk.gov.communities.prsdb.webapp.constants.enums.PropertyType
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.InviteNewLaUserPage
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.ManageLaUsersPage
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages.BasePage.Companion.createValidPage
@@ -14,6 +15,7 @@ import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.landlordReg
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.landlordRegistrationJourneyPages.EmailFormPageLandlordRegistration
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.landlordRegistrationJourneyPages.NameFormPageLandlordRegistration
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.landlordRegistrationJourneyPages.PhoneNumberFormPageLandlordRegistration
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyRegistrationJourneyPages.OwnershipTypeFormPagePropertyRegistration
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyRegistrationJourneyPages.PropertyTypeFormPagePropertyRegistration
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyRegistrationJourneyPages.RegisterPropertyStartPage
 
@@ -110,6 +112,13 @@ class Navigator(
     fun goToPropertyRegistrationPropertyTypePage(): PropertyTypeFormPagePropertyRegistration {
         navigate("register-property/property-type")
         return createValidPage(page, PropertyTypeFormPagePropertyRegistration::class)
+    }
+
+    fun goToPropertyRegistrationOwnershipTypePage(): OwnershipTypeFormPagePropertyRegistration {
+        val propertyTypePage = goToPropertyRegistrationPropertyTypePage()
+        propertyTypePage.form.getRadios().selectValue(PropertyType.DETACHED_HOUSE)
+        propertyTypePage.form.submit()
+        return createValidPage(page, OwnershipTypeFormPagePropertyRegistration::class)
     }
 
     private fun navigate(path: String): Response? = page.navigate("http://localhost:$port/$path")

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/components/Radios.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/components/Radios.kt
@@ -10,4 +10,9 @@ class Radios(
     fun getRadio(value: String) = getChildComponent("input[value='$value']")
 
     fun getSelectedValue(): String = getChildComponent("input:checked").getAttribute("value")
+
+    fun <E : Enum<E>> selectValue(value: E) {
+        val radio = getRadio(value.name)
+        radio.check()
+    }
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/components/Radios.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/components/Radios.kt
@@ -15,4 +15,8 @@ class Radios(
         val radio = getRadio(value.name)
         radio.check()
     }
+
+    fun selectValue(value: String) {
+        getRadio(value).check()
+    }
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/propertyRegistrationJourneyPages/OwnershipTypeFormPagePropertyRegistration.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/propertyRegistrationJourneyPages/OwnershipTypeFormPagePropertyRegistration.kt
@@ -5,11 +5,9 @@ import uk.gov.communities.prsdb.webapp.constants.REGISTER_PROPERTY_JOURNEY_URL
 import uk.gov.communities.prsdb.webapp.forms.steps.RegisterPropertyStepId
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages.FormBasePage
 
-class PropertyTypeFormPagePropertyRegistration(
+class OwnershipTypeFormPagePropertyRegistration(
     page: Page,
 ) : FormBasePage(
         page,
-        "/$REGISTER_PROPERTY_JOURNEY_URL/${RegisterPropertyStepId.PropertyType.urlPathSegment}",
-    ) {
-    val customPropertyTypeInput = form.getTextInput("customPropertyType")
-}
+        "/$REGISTER_PROPERTY_JOURNEY_URL/${RegisterPropertyStepId.OwnershipType.urlPathSegment}",
+    )


### PR DESCRIPTION
Note this is branching off PRSD-492, so comments on https://github.com/communitiesuk/prsdb-webapp/pull/76 might also be application to this PR!

In this PR:
- Add the ownership type step to the property registration journey
- Add a GDS "details" fragment
- Add some tests. Add a function to the "Radios.kt" object that selects a radio button - this function requires the radio value to be an enum (so it works for PropertyType and OwnershipType)

In this PR:
![image](https://github.com/user-attachments/assets/1787561e-945d-4d75-9475-a76c090bd4df)
![image](https://github.com/user-attachments/assets/be58b85a-901a-4e54-902e-543845cab601)