### PR TITLE
Feat/prsd 494 property registration occupancy

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/PropertyRegistrationJourney.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/PropertyRegistrationJourney.kt
@@ -123,7 +123,7 @@ class PropertyRegistrationJourney(
                                         ),
                                 ),
                         ),
-                    nextAction = { _, _ -> Pair(RegisterPropertyStepId.NumberOfHouseholds, null) },
+                    nextAction = { journeyData, subpage -> occupancyNextAction(journeyData, subpage) },
                 ),
                 Step(
                     id = RegisterPropertyStepId.NumberOfHouseholds,
@@ -170,4 +170,24 @@ class PropertyRegistrationJourney(
                         ),
                 ),
             ),
-    )
+    ) {
+    companion object {
+        private fun occupancyNextAction(
+            journeyData: JourneyData,
+            subPage: Int?,
+        ): Pair<RegisterPropertyStepId, Int?> =
+            when (
+                val propertyIsOccupied =
+                    objectToStringKeyedMap(journeyData[RegisterPropertyStepId.Occupancy.urlPathSegment])
+                        ?.get("occupied")
+                        .toString()
+            ) {
+                "true" -> Pair(RegisterPropertyStepId.NumberOfHouseholds, subPage)
+                "false" -> Pair(RegisterPropertyStepId.PlaceholderPage, null)
+                else -> throw IllegalArgumentException(
+                    "Invalid value for journeyData[\"${RegisterPropertyStepId.Occupancy.urlPathSegment}\"][\"occupied\"]:" +
+                        propertyIsOccupied,
+                )
+            }
+    }
+}

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/PropertyRegistrationJourney.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/PropertyRegistrationJourney.kt
@@ -9,6 +9,7 @@ import uk.gov.communities.prsdb.webapp.forms.pages.Page
 import uk.gov.communities.prsdb.webapp.forms.steps.RegisterPropertyStepId
 import uk.gov.communities.prsdb.webapp.forms.steps.Step
 import uk.gov.communities.prsdb.webapp.models.formModels.LandingPageFormModel
+import uk.gov.communities.prsdb.webapp.models.formModels.NumberOfHouseholdsFormModel
 import uk.gov.communities.prsdb.webapp.models.formModels.OccupancyFormModel
 import uk.gov.communities.prsdb.webapp.models.formModels.OwnershipTypeFormModel
 import uk.gov.communities.prsdb.webapp.models.formModels.PropertyTypeFormModel
@@ -121,6 +122,22 @@ class PropertyRegistrationJourney(
                                         ),
                                 ),
                         ),
+                    nextAction = { _, _ -> Pair(RegisterPropertyStepId.NumberOfHouseholds, null) },
+                ),
+                Step(
+                    id = RegisterPropertyStepId.NumberOfHouseholds,
+                    page =
+                        Page(
+                            formModel = NumberOfHouseholdsFormModel::class,
+                            templateName = "forms/numberOfHouseholdsForm",
+                            content =
+                                mapOf(
+                                    "title" to "registerProperty.title",
+                                    "fieldSetHeading" to "forms.numberOfHouseholds.fieldSetHeading",
+                                    "fieldSetHint" to "forms.numberOfHouseholds.label",
+                                    "label" to "forms.numberOfHouseholds.label",
+                                ),
+                        ),
                     nextAction = { _, _ -> Pair(RegisterPropertyStepId.PlaceholderPage, null) },
                 ),
                 Step(
@@ -132,6 +149,7 @@ class PropertyRegistrationJourney(
                             content =
                                 mapOf(
                                     "title" to "registerProperty.title",
+                                    "fieldSetHeading" to "forms.numberOfHouseholds.fieldSetHeading",
                                 ),
                         ),
                 ),

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/PropertyRegistrationJourney.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/PropertyRegistrationJourney.kt
@@ -123,7 +123,7 @@ class PropertyRegistrationJourney(
                                         ),
                                 ),
                         ),
-                    nextAction = { journeyData, subpage -> occupancyNextAction(journeyData, subpage) },
+                    nextAction = { journeyData, _ -> occupancyNextAction(journeyData) },
                 ),
                 Step(
                     id = RegisterPropertyStepId.NumberOfHouseholds,
@@ -171,17 +171,14 @@ class PropertyRegistrationJourney(
             ),
     ) {
     companion object {
-        private fun occupancyNextAction(
-            journeyData: JourneyData,
-            subPage: Int?,
-        ): Pair<RegisterPropertyStepId, Int?> =
+        private fun occupancyNextAction(journeyData: JourneyData): Pair<RegisterPropertyStepId, Int?> =
             when (
                 val propertyIsOccupied =
                     objectToStringKeyedMap(journeyData[RegisterPropertyStepId.Occupancy.urlPathSegment])
                         ?.get("occupied")
                         .toString()
             ) {
-                "true" -> Pair(RegisterPropertyStepId.NumberOfHouseholds, subPage)
+                "true" -> Pair(RegisterPropertyStepId.NumberOfHouseholds, null)
                 "false" -> Pair(RegisterPropertyStepId.PlaceholderPage, null)
                 else -> throw IllegalArgumentException(
                     "Invalid value for journeyData[\"${RegisterPropertyStepId.Occupancy.urlPathSegment}\"][\"occupied\"]:" +

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/PropertyRegistrationJourney.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/PropertyRegistrationJourney.kt
@@ -10,6 +10,7 @@ import uk.gov.communities.prsdb.webapp.forms.steps.RegisterPropertyStepId
 import uk.gov.communities.prsdb.webapp.forms.steps.Step
 import uk.gov.communities.prsdb.webapp.models.formModels.LandingPageFormModel
 import uk.gov.communities.prsdb.webapp.models.formModels.NumberOfHouseholdsFormModel
+import uk.gov.communities.prsdb.webapp.models.formModels.NumberOfPeopleFormModel
 import uk.gov.communities.prsdb.webapp.models.formModels.OccupancyFormModel
 import uk.gov.communities.prsdb.webapp.models.formModels.OwnershipTypeFormModel
 import uk.gov.communities.prsdb.webapp.models.formModels.PropertyTypeFormModel
@@ -134,8 +135,23 @@ class PropertyRegistrationJourney(
                                 mapOf(
                                     "title" to "registerProperty.title",
                                     "fieldSetHeading" to "forms.numberOfHouseholds.fieldSetHeading",
-                                    "fieldSetHint" to "forms.numberOfHouseholds.label",
                                     "label" to "forms.numberOfHouseholds.label",
+                                ),
+                        ),
+                    nextAction = { _, _ -> Pair(RegisterPropertyStepId.NumberOfPeople, null) },
+                ),
+                Step(
+                    id = RegisterPropertyStepId.NumberOfPeople,
+                    page =
+                        Page(
+                            formModel = NumberOfPeopleFormModel::class,
+                            templateName = "forms/numberOfPeopleForm",
+                            content =
+                                mapOf(
+                                    "title" to "registerProperty.title",
+                                    "fieldSetHeading" to "forms.numberOfPeople.fieldSetHeading",
+                                    "fieldSetHint" to "forms.numberOfPeople.fieldSetHint",
+                                    "label" to "forms.numberOfPeople.label",
                                 ),
                         ),
                     nextAction = { _, _ -> Pair(RegisterPropertyStepId.PlaceholderPage, null) },

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/PropertyRegistrationJourney.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/PropertyRegistrationJourney.kt
@@ -165,7 +165,6 @@ class PropertyRegistrationJourney(
                             content =
                                 mapOf(
                                     "title" to "registerProperty.title",
-                                    "fieldSetHeading" to "forms.numberOfHouseholds.fieldSetHeading",
                                 ),
                         ),
                 ),

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/PropertyRegistrationJourney.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/PropertyRegistrationJourney.kt
@@ -9,6 +9,7 @@ import uk.gov.communities.prsdb.webapp.forms.pages.Page
 import uk.gov.communities.prsdb.webapp.forms.steps.RegisterPropertyStepId
 import uk.gov.communities.prsdb.webapp.forms.steps.Step
 import uk.gov.communities.prsdb.webapp.models.formModels.LandingPageFormModel
+import uk.gov.communities.prsdb.webapp.models.formModels.OccupancyFormModel
 import uk.gov.communities.prsdb.webapp.models.formModels.OwnershipTypeFormModel
 import uk.gov.communities.prsdb.webapp.models.formModels.PropertyTypeFormModel
 import uk.gov.communities.prsdb.webapp.models.viewModels.RadiosButtonViewModel
@@ -89,6 +90,33 @@ class PropertyRegistrationJourney(
                                                 value = OwnershipType.LEASEHOLD,
                                                 labelMsgKey = "forms.ownershipType.radios.option.leasehold.label",
                                                 hintMsgKey = "forms.ownershipType.radios.option.leasehold.hint",
+                                            ),
+                                        ),
+                                ),
+                        ),
+                    nextAction = { _, _ -> Pair(RegisterPropertyStepId.Occupancy, null) },
+                ),
+                Step(
+                    id = RegisterPropertyStepId.Occupancy,
+                    page =
+                        Page(
+                            formModel = OccupancyFormModel::class,
+                            templateName = "forms/propertyOccupancyForm",
+                            content =
+                                mapOf(
+                                    "title" to "registerProperty.title",
+                                    "fieldSetHeading" to "forms.occupancy.fieldSetHeading",
+                                    "radioOptions" to
+                                        listOf(
+                                            RadiosButtonViewModel(
+                                                value = true,
+                                                labelMsgKey = "forms.occupancy.radios.option.yes.label",
+                                                hintMsgKey = "forms.occupancy.radios.option.yes.hint",
+                                            ),
+                                            RadiosButtonViewModel(
+                                                value = false,
+                                                labelMsgKey = "forms.occupancy.radios.option.no.label",
+                                                hintMsgKey = "forms.occupancy.radios.option.no.hint",
                                             ),
                                         ),
                                 ),

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/steps/RegisterPropertyStepId.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/steps/RegisterPropertyStepId.kt
@@ -7,6 +7,6 @@ enum class RegisterPropertyStepId(
     PropertyType("property-type"),
     OwnershipType("ownership-type"),
     Occupancy("occupancy"),
-    NumberOfHouseholds("households"),
-    NumberOfPeople("people"),
+    NumberOfHouseholds("number-of-households"),
+    NumberOfPeople("number-of-people"),
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/steps/RegisterPropertyStepId.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/steps/RegisterPropertyStepId.kt
@@ -6,4 +6,7 @@ enum class RegisterPropertyStepId(
     PlaceholderPage("placeholder"),
     PropertyType("property-type"),
     OwnershipType("ownership-type"),
+    Occupancy("occupancy"),
+    NumberOfHouseholds("households"),
+    NumberOfPeople("people"),
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/formModels/NumberOfHouseholdsFormModel.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/formModels/NumberOfHouseholdsFormModel.kt
@@ -2,7 +2,7 @@ package uk.gov.communities.prsdb.webapp.models.formModels
 
 import uk.gov.communities.prsdb.webapp.validation.ConstraintDescriptor
 import uk.gov.communities.prsdb.webapp.validation.IsValidPrioritised
-import uk.gov.communities.prsdb.webapp.validation.NotNullConstraintValidator
+import uk.gov.communities.prsdb.webapp.validation.NotBlankConstraintValidator
 import uk.gov.communities.prsdb.webapp.validation.PositiveOrZeroIntegerValidator
 import uk.gov.communities.prsdb.webapp.validation.ValidatedBy
 
@@ -12,7 +12,7 @@ class NumberOfHouseholdsFormModel : FormModel {
         constraints = [
             ConstraintDescriptor(
                 messageKey = "forms.numberOfHouseholds.input.error.missing",
-                validatorType = NotNullConstraintValidator::class,
+                validatorType = NotBlankConstraintValidator::class,
             ),
             ConstraintDescriptor(
                 messageKey = "forms.numberOfHouseholds.input.error.invalidFormat",
@@ -20,5 +20,5 @@ class NumberOfHouseholdsFormModel : FormModel {
             ),
         ],
     )
-    var numberOfHouseholds: Int? = null
+    var numberOfHouseholds: String = ""
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/formModels/NumberOfHouseholdsFormModel.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/formModels/NumberOfHouseholdsFormModel.kt
@@ -1,0 +1,24 @@
+package uk.gov.communities.prsdb.webapp.models.formModels
+
+import uk.gov.communities.prsdb.webapp.validation.ConstraintDescriptor
+import uk.gov.communities.prsdb.webapp.validation.IsValidPrioritised
+import uk.gov.communities.prsdb.webapp.validation.NotNullConstraintValidator
+import uk.gov.communities.prsdb.webapp.validation.PositiveOrZeroIntegerValidator
+import uk.gov.communities.prsdb.webapp.validation.ValidatedBy
+
+@IsValidPrioritised
+class NumberOfHouseholdsFormModel : FormModel {
+    @ValidatedBy(
+        constraints = [
+            ConstraintDescriptor(
+                messageKey = "forms.numberOfHouseholds.input.error.missing",
+                validatorType = NotNullConstraintValidator::class,
+            ),
+            ConstraintDescriptor(
+                messageKey = "forms.numberOfHouseholds.input.error.invalidFormat",
+                validatorType = PositiveOrZeroIntegerValidator::class,
+            ),
+        ],
+    )
+    var numberOfHouseholds: Int? = null
+}

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/formModels/NumberOfPeopleFormModel.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/formModels/NumberOfPeopleFormModel.kt
@@ -1,0 +1,24 @@
+package uk.gov.communities.prsdb.webapp.models.formModels
+
+import uk.gov.communities.prsdb.webapp.validation.ConstraintDescriptor
+import uk.gov.communities.prsdb.webapp.validation.IsValidPrioritised
+import uk.gov.communities.prsdb.webapp.validation.NotNullConstraintValidator
+import uk.gov.communities.prsdb.webapp.validation.PositiveOrZeroIntegerValidator
+import uk.gov.communities.prsdb.webapp.validation.ValidatedBy
+
+@IsValidPrioritised
+class NumberOfPeopleFormModel : FormModel {
+    @ValidatedBy(
+        constraints = [
+            ConstraintDescriptor(
+                messageKey = "forms.numberOfPeople.input.error.missing",
+                validatorType = NotNullConstraintValidator::class,
+            ),
+            ConstraintDescriptor(
+                messageKey = "forms.numberOfPeople.input.error.invalidFormat",
+                validatorType = PositiveOrZeroIntegerValidator::class,
+            ),
+        ],
+    )
+    var numberOfPeople: Int? = null
+}

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/formModels/NumberOfPeopleFormModel.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/formModels/NumberOfPeopleFormModel.kt
@@ -2,7 +2,7 @@ package uk.gov.communities.prsdb.webapp.models.formModels
 
 import uk.gov.communities.prsdb.webapp.validation.ConstraintDescriptor
 import uk.gov.communities.prsdb.webapp.validation.IsValidPrioritised
-import uk.gov.communities.prsdb.webapp.validation.NotNullConstraintValidator
+import uk.gov.communities.prsdb.webapp.validation.NotBlankConstraintValidator
 import uk.gov.communities.prsdb.webapp.validation.PositiveOrZeroIntegerValidator
 import uk.gov.communities.prsdb.webapp.validation.ValidatedBy
 
@@ -12,7 +12,7 @@ class NumberOfPeopleFormModel : FormModel {
         constraints = [
             ConstraintDescriptor(
                 messageKey = "forms.numberOfPeople.input.error.missing",
-                validatorType = NotNullConstraintValidator::class,
+                validatorType = NotBlankConstraintValidator::class,
             ),
             ConstraintDescriptor(
                 messageKey = "forms.numberOfPeople.input.error.invalidFormat",
@@ -20,5 +20,5 @@ class NumberOfPeopleFormModel : FormModel {
             ),
         ],
     )
-    var numberOfPeople: Int? = null
+    var numberOfPeople: String = ""
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/formModels/OccupancyFormModel.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/formModels/OccupancyFormModel.kt
@@ -1,0 +1,19 @@
+package uk.gov.communities.prsdb.webapp.models.formModels
+
+import uk.gov.communities.prsdb.webapp.validation.ConstraintDescriptor
+import uk.gov.communities.prsdb.webapp.validation.IsValidPrioritised
+import uk.gov.communities.prsdb.webapp.validation.NotNullConstraintValidator
+import uk.gov.communities.prsdb.webapp.validation.ValidatedBy
+
+@IsValidPrioritised
+class OccupancyFormModel : FormModel {
+    @ValidatedBy(
+        constraints = [
+            ConstraintDescriptor(
+                messageKey = "forms.occupancy.radios.error.missing",
+                validatorType = NotNullConstraintValidator::class,
+            ),
+        ],
+    )
+    var occupied: Boolean? = null
+}

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/validation/PositiveOrZeroIntegerValidator.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/validation/PositiveOrZeroIntegerValidator.kt
@@ -3,5 +3,12 @@ package uk.gov.communities.prsdb.webapp.validation
 import org.hibernate.validator.internal.constraintvalidators.bv.number.sign.PositiveOrZeroValidatorForInteger
 
 class PositiveOrZeroIntegerValidator : PropertyConstraintValidator {
-    override fun isValid(value: Any?): Boolean = PositiveOrZeroValidatorForInteger().isValid(value as Int, null)
+    override fun isValid(value: Any?): Boolean {
+        try {
+            val integerValue = value.toString().toInt()
+            return PositiveOrZeroValidatorForInteger().isValid(integerValue, null)
+        } catch (e: NumberFormatException) {
+            return false
+        }
+    }
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/validation/PositiveOrZeroIntegerValidator.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/validation/PositiveOrZeroIntegerValidator.kt
@@ -1,0 +1,7 @@
+package uk.gov.communities.prsdb.webapp.validation
+
+import org.hibernate.validator.internal.constraintvalidators.bv.number.sign.PositiveOrZeroValidatorForInteger
+
+class PositiveOrZeroIntegerValidator : PropertyConstraintValidator {
+    override fun isValid(value: Any?): Boolean = PositiveOrZeroValidatorForInteger().isValid(value as Int, null)
+}

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -356,6 +356,8 @@ forms.numberOfHouseholds.details.text.paragraph.two=Unrelated adults who are not
 forms.numberOfPeople.input.error.missing=Enter the number of people living in your property
 forms.numberOfPeople.input.error.invalidFormat=Number of people in your property must be a number, like 3
 forms.numberOfPeople.fieldSetHeading=How many people live in your property?
+forms.numberOfPeople.fieldSetHint=Do not include family members only staying temporarily or babies under 1 year old.
+forms.numberOfPeople.label=Enter the number of people living in your property
 
 pagination.previousText=Previous
 pagination.pageText=page

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -346,7 +346,7 @@ forms.occupancy.details.summary.text=Why do I need to declare this?
 forms.occupancy.details.text=This decides what kind of health and safety or compliance information is needed for the property.
 
 forms.numberOfHouseholds.input.error.missing=Enter the number of households living in your property
-forms.numberOfHouseholds.input.error.invalidFormat=Number of households in your property must be a number, like 3
+forms.numberOfHouseholds.input.error.invalidFormat=Number of households in your property must be a positive, whole number, like 3
 forms.numberOfHouseholds.fieldSetHeading=How many households live in your property?
 forms.numberOfHouseholds.label=Enter the number of households living in your property
 forms.numberOfHouseholds.details.summary.text=What is a household?
@@ -354,7 +354,7 @@ forms.numberOfHouseholds.details.text.paragraph.one=A household consists of eith
 forms.numberOfHouseholds.details.text.paragraph.two=Unrelated adults who are not a couple of part of a family are separate households.
 
 forms.numberOfPeople.input.error.missing=Enter the number of people living in your property
-forms.numberOfPeople.input.error.invalidFormat=Number of people in your property must be a number, like 3
+forms.numberOfPeople.input.error.invalidFormat=Number of people in your property must be a positive, whole number, like 3
 forms.numberOfPeople.fieldSetHeading=How many people live in your property?
 forms.numberOfPeople.fieldSetHint=Do not include family members only staying temporarily or babies under 1 year old.
 forms.numberOfPeople.label=Enter the number of people living in your property

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -336,6 +336,16 @@ forms.ownershipType.radios.error.missing=Select the ownership type
 forms.ownershipType.details.summary.text=Why do I need to select the type of ownership?
 forms.ownershipType.details.text=This helps local authorities know who is responsible for repair work on the property.
 
+forms.occupancy.radios.error.missing=Select whether the property is occupied
+forms.occupancy.fieldSetHeading=Is your property occupied by tenants?
+forms.occupancy.radios.option.yes.label=Yes
+forms.occupancy.radios.option.yes.hint=One or more person lives in the property
+forms.occupancy.radios.option.no.label=No
+forms.occupancy.radios.option.no.hint=The property is empty
+forms.occupancy.details.summary.text=Why do I need to declare this?
+forms.occupancy.details.text=This decides what kind of health and safety or compliance information is needed for the property.
+
+
 pagination.previousText=Previous
 pagination.pageText=page
 pagination.nextText=Next

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -345,6 +345,17 @@ forms.occupancy.radios.option.no.hint=The property is empty
 forms.occupancy.details.summary.text=Why do I need to declare this?
 forms.occupancy.details.text=This decides what kind of health and safety or compliance information is needed for the property.
 
+forms.numberOfHouseholds.input.error.missing=Enter the number of households living in your property
+forms.numberOfHouseholds.input.error.invalidFormat=Number of households in your property must be a number, like 3
+forms.numberOfHouseholds.fieldSetHeading=How many households live in your property?
+forms.numberOfHouseholds.label=Enter the number of households living in your property
+forms.numberOfHouseholds.details.summary.text=What is a household?
+forms.numberOfHouseholds.details.text.paragraph.one=A household consists of either a single person or members of the same family who live together. It includes people who are married or living together and people in same-sex relationships.
+forms.numberOfHouseholds.details.text.paragraph.two=Unrelated adults who are not a couple of part of a family are separate households.
+
+forms.numberOfPeople.input.error.missing=Enter the number of people living in your property
+forms.numberOfPeople.input.error.invalidFormat=Number of people in your property must be a number, like 3
+forms.numberOfPeople.fieldSetHeading=How many people live in your property?
 
 pagination.previousText=Previous
 pagination.pageText=page

--- a/src/main/resources/templates/forms/numberOfHouseholdsForm.html
+++ b/src/main/resources/templates/forms/numberOfHouseholdsForm.html
@@ -1,0 +1,29 @@
+<!--/*@thymesVar id="title" type="java.lang.String"*/-->
+<!--/*@thymesVar id="formModel" type="java.lang.Object"*/-->
+<!--/*@thymesVar id="fieldSetHeading" type="java.lang.String"*/-->
+<!--/*@thymesVar id="fieldSetHint" type="java.lang.String"*/-->
+<!--/*@thymesVar id="label" type="java.lang.String"*/-->
+<!--/*@thymesVar id="backUrl" type="java.lang.String"*/-->
+<!--/*@thymesVar id="hint" type="java.lang.String"*/-->
+<!--/*@thymesVar id="submitButtonText" type="java.lang.String"*/-->
+<!DOCTYPE html>
+<html th:replace="~{fragments/forms/questionPage :: questionPage(#{${title}}, ${formModel}, ~{::#form-content}, ${backUrl})}">
+<th:block id="form-content">
+    <th:block id="fieldset-content"
+              th:replace="~{fragments/forms/fieldSet :: fieldSet(~{::#fieldset-content/content()}, 'numberOfHouseholds', #{${fieldSetHeading}}, null)}">
+        <div th:replace="~{fragments/forms/numericalInput :: numericalInput(#{${label}}, 'numberOfHouseholds', null, 4)}">
+        </div>
+    </th:block>
+    <details id="details-content" th:replace="~{fragments/details :: details(#{'forms.numberOfHouseholds.details.summary.text'},~{::#details-content/content()})}">
+        <div class="govuk-details__text">
+            <p  th:text="#{'forms.numberOfHouseholds.details.text.paragraph.one'}">
+                forms.numberOfHouseholds.details.text.paragraph.one
+            </p>
+            <p th:text="#{'forms.numberOfHouseholds.details.text.paragraph.two'}">
+                forms.numberOfHouseholds.details.text.paragraph.two
+            </p>
+        </div>
+    </details>
+    <button th:replace="~{fragments/buttons/primaryButton :: primaryButton(#{forms.buttons.continue})}"></button>
+</th:block>
+</html>

--- a/src/main/resources/templates/forms/numberOfHouseholdsForm.html
+++ b/src/main/resources/templates/forms/numberOfHouseholdsForm.html
@@ -21,6 +21,6 @@
             </p>
         </div>
     </details>
-    <button th:replace="~{fragments/buttons/primaryButton :: primaryButton(#{forms.buttons.continue})}"></button>
+    <button th:replace="~{fragments/buttons/primaryButton :: primaryButton(#{forms.buttons.saveAndContinue})}"></button>
 </th:block>
 </html>

--- a/src/main/resources/templates/forms/numberOfHouseholdsForm.html
+++ b/src/main/resources/templates/forms/numberOfHouseholdsForm.html
@@ -1,17 +1,14 @@
 <!--/*@thymesVar id="title" type="java.lang.String"*/-->
 <!--/*@thymesVar id="formModel" type="java.lang.Object"*/-->
 <!--/*@thymesVar id="fieldSetHeading" type="java.lang.String"*/-->
-<!--/*@thymesVar id="fieldSetHint" type="java.lang.String"*/-->
 <!--/*@thymesVar id="label" type="java.lang.String"*/-->
 <!--/*@thymesVar id="backUrl" type="java.lang.String"*/-->
-<!--/*@thymesVar id="hint" type="java.lang.String"*/-->
-<!--/*@thymesVar id="submitButtonText" type="java.lang.String"*/-->
 <!DOCTYPE html>
 <html th:replace="~{fragments/forms/questionPage :: questionPage(#{${title}}, ${formModel}, ~{::#form-content}, ${backUrl})}">
 <th:block id="form-content">
     <th:block id="fieldset-content"
               th:replace="~{fragments/forms/fieldSet :: fieldSet(~{::#fieldset-content/content()}, 'numberOfHouseholds', #{${fieldSetHeading}}, null)}">
-        <div th:replace="~{fragments/forms/numericalInput :: numericalInput(#{${label}}, 'numberOfHouseholds', null, 4)}">
+        <div th:replace="~{fragments/forms/numericalInput :: numericalInput(#{${label}}, 'numberOfHouseholds', null, 2)}">
         </div>
     </th:block>
     <details id="details-content" th:replace="~{fragments/details :: details(#{'forms.numberOfHouseholds.details.summary.text'},~{::#details-content/content()})}">

--- a/src/main/resources/templates/forms/numberOfPeopleForm.html
+++ b/src/main/resources/templates/forms/numberOfPeopleForm.html
@@ -12,6 +12,6 @@
     <div th:replace="~{fragments/forms/numericalInput :: numericalInput(#{${label}}, 'numberOfPeople', null, 2)}">
     </div>
   </th:block>
-  <button th:replace="~{fragments/buttons/primaryButton :: primaryButton(#{forms.buttons.continue})}"></button>
+  <button th:replace="~{fragments/buttons/primaryButton :: primaryButton(#{forms.buttons.saveAndContinue})}"></button>
 </th:block>
 </html>

--- a/src/main/resources/templates/forms/numberOfPeopleForm.html
+++ b/src/main/resources/templates/forms/numberOfPeopleForm.html
@@ -1,0 +1,17 @@
+<!--/*@thymesVar id="title" type="java.lang.String"*/-->
+<!--/*@thymesVar id="formModel" type="java.lang.Object"*/-->
+<!--/*@thymesVar id="fieldSetHeading" type="java.lang.String"*/-->
+<!--/*@thymesVar id="fieldSetHint" type="java.lang.String"*/-->
+<!--/*@thymesVar id="label" type="java.lang.String"*/-->
+<!--/*@thymesVar id="backUrl" type="java.lang.String"*/-->
+<!DOCTYPE html>
+<html th:replace="~{fragments/forms/questionPage :: questionPage(#{${title}}, ${formModel}, ~{::#form-content}, ${backUrl})}">
+<th:block id="form-content">
+  <th:block id="fieldset-content"
+            th:replace="~{fragments/forms/fieldSet :: fieldSet(~{::#fieldset-content/content()}, 'numberOfPeople', #{${fieldSetHeading}}, #{${fieldSetHint}})}">
+    <div th:replace="~{fragments/forms/numericalInput :: numericalInput(#{${label}}, 'numberOfPeople', null, 2)}">
+    </div>
+  </th:block>
+  <button th:replace="~{fragments/buttons/primaryButton :: primaryButton(#{forms.buttons.continue})}"></button>
+</th:block>
+</html>

--- a/src/main/resources/templates/forms/ownershipTypeForm.html
+++ b/src/main/resources/templates/forms/ownershipTypeForm.html
@@ -10,8 +10,9 @@
               th:replace="~{fragments/forms/fieldSet :: fieldSet(~{::#fieldset-content/content()}, 'ownershipType', #{${fieldSetHeading}}, null)}">
         <th:block th:replace="~{fragments/forms/radios :: radios(null,'ownershipType',null, ${radioOptions})}"></th:block>
     </th:block>
-    <details
-            th:replace="~{fragments/details :: details(#{forms.ownershipType.details.summary.text}, #{forms.ownershipType.details.text})}"></details>
+    <details id="details-content" th:replace="~{fragments/details :: details(#{'forms.ownershipType.details.summary.text'},~{::#details-content/content()})}">
+        <div class="govuk-details__text" th:text="#{'forms.ownershipType.details.text'}">detailsText</div>
+    </details>
     <button th:replace="~{fragments/buttons/primaryButton :: primaryButton(#{forms.buttons.continue})}"></button>
 </th:block>
 </html>

--- a/src/main/resources/templates/forms/ownershipTypeForm.html
+++ b/src/main/resources/templates/forms/ownershipTypeForm.html
@@ -13,6 +13,6 @@
     <details id="details-content" th:replace="~{fragments/details :: details(#{'forms.ownershipType.details.summary.text'},~{::#details-content/content()})}">
         <div class="govuk-details__text" th:text="#{'forms.ownershipType.details.text'}">detailsText</div>
     </details>
-    <button th:replace="~{fragments/buttons/primaryButton :: primaryButton(#{forms.buttons.continue})}"></button>
+    <button th:replace="~{fragments/buttons/primaryButton :: primaryButton(#{forms.buttons.saveAndContinue})}"></button>
 </th:block>
 </html>

--- a/src/main/resources/templates/forms/propertyOccupancyForm.html
+++ b/src/main/resources/templates/forms/propertyOccupancyForm.html
@@ -13,6 +13,6 @@
     <details id="details-content" th:replace="~{fragments/details :: details(#{'forms.occupancy.details.summary.text'},~{::#details-content/content()})}">
         <div class="govuk-details__text" th:text="#{'forms.occupancy.details.text'}">detailsText</div>
     </details>
-    <button th:replace="~{fragments/buttons/primaryButton :: primaryButton(#{forms.buttons.continue})}"></button>
+    <button th:replace="~{fragments/buttons/primaryButton :: primaryButton(#{forms.buttons.saveAndContinue})}"></button>
 </th:block>
 </html>

--- a/src/main/resources/templates/forms/propertyOccupancyForm.html
+++ b/src/main/resources/templates/forms/propertyOccupancyForm.html
@@ -10,8 +10,9 @@
               th:replace="~{fragments/forms/fieldSet :: fieldSet(~{::#fieldset-content/content()}, 'occupied', #{${fieldSetHeading}}, null)}">
         <th:block th:replace="~{fragments/forms/radios :: radios(null,'occupied',null, ${radioOptions})}"></th:block>
     </th:block>
-    <details
-            th:replace="~{fragments/details :: details(#{forms.occupancy.details.summary.text}, #{forms.occupancy.details.text})}"></details>
+    <details id="details-content" th:replace="~{fragments/details :: details(#{'forms.occupancy.details.summary.text'},~{::#details-content/content()})}">
+        <div class="govuk-details__text" th:text="#{'forms.occupancy.details.text'}">detailsText</div>
+    </details>
     <button th:replace="~{fragments/buttons/primaryButton :: primaryButton(#{forms.buttons.continue})}"></button>
 </th:block>
 </html>

--- a/src/main/resources/templates/forms/propertyOccupancyForm.html
+++ b/src/main/resources/templates/forms/propertyOccupancyForm.html
@@ -1,0 +1,17 @@
+<!--/*@thymesVar id="title" type="java.lang.String"*/-->
+<!--/*@thymesVar id="formModel" type="java.lang.Object"*/-->
+<!--/*@thymesVar id="fieldSetHeading" type="java.lang.String"*/-->
+<!--/*@thymesVar id="backUrl" type="java.lang.String"*/-->
+<!--/*@thymesVar id="radioOptions" type="java.lang.Object"*/-->
+<!DOCTYPE html>
+<html th:replace="~{fragments/forms/questionPage :: questionPage(#{${title}}, ${formModel}, ~{::#form-content}, ${backUrl})}">
+<th:block id="form-content">
+    <th:block id="fieldset-content"
+              th:replace="~{fragments/forms/fieldSet :: fieldSet(~{::#fieldset-content/content()}, 'occupied', #{${fieldSetHeading}}, null)}">
+        <th:block th:replace="~{fragments/forms/radios :: radios(null,'occupied',null, ${radioOptions})}"></th:block>
+    </th:block>
+    <details
+            th:replace="~{fragments/details :: details(#{forms.occupancy.details.summary.text}, #{forms.occupancy.details.text})}"></details>
+    <button th:replace="~{fragments/buttons/primaryButton :: primaryButton(#{forms.buttons.continue})}"></button>
+</th:block>
+</html>

--- a/src/main/resources/templates/forms/propertyTypeForm.html
+++ b/src/main/resources/templates/forms/propertyTypeForm.html
@@ -10,6 +10,6 @@
               th:replace="~{fragments/forms/fieldSet :: fieldSet(~{::#fieldset-content/content()}, 'propertyType', #{${fieldSetHeading}}, null)}">
         <th:block th:replace="~{fragments/forms/radios :: radios(null,'propertyType',null, ${radioOptions})}"></th:block>
     </th:block>
-    <button th:replace="~{fragments/buttons/primaryButton :: primaryButton(#{forms.buttons.continue})}"></button>
+    <button th:replace="~{fragments/buttons/primaryButton :: primaryButton(#{forms.buttons.saveAndContinue})}"></button>
 </th:block>
 </html>

--- a/src/main/resources/templates/fragments/details.html
+++ b/src/main/resources/templates/fragments/details.html
@@ -1,10 +1,10 @@
-<details th:fragment="details(summaryText, detailsText)" class="govuk-details">
+<details th:fragment="details(summaryText, content)" class="govuk-details">
     <summary class="govuk-details__summary">
         <span class="govuk-details__summary-text" th:text="${summaryText}">
             summaryText
         </span>
     </summary>
-    <div class="govuk-details__text" th:text="${detailsText}">
-        detailsText
+    <div class="govuk-details__text" th:replace="${content}">
+        content
     </div>
 </details>

--- a/src/main/resources/templates/fragments/forms/numericalInput.html
+++ b/src/main/resources/templates/fragments/forms/numericalInput.html
@@ -1,0 +1,11 @@
+<!--The width input should be 2, 3, 4, 5, 10, 20, 30-->
+<th:block th:fragment="numericalInput(label, fieldName, hint, fieldWidth)"
+          th:replace="~{fragments/forms/inputGroup :: inputGroup(${label}, ${fieldName}, ~{::input}, ${hint})}">
+    <input class="govuk-input"
+           th:with="width=${fieldWidth ?: 10} "
+           th:classappend='${#fields.hasErrors(fieldName) ? "govuk-input--error" : ""} + ${" govuk-input--width-"+width}'
+           type="text"
+           inputmode="numeric"
+           th:field="*{__${fieldName}__}"
+           th:attrappend="aria-describedby=${hint != null} ? ${fieldName}+'-details-hint'">
+</th:block>

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/PropertyRegistrationJourneyTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/PropertyRegistrationJourneyTests.kt
@@ -134,7 +134,8 @@ class PropertyRegistrationJourneyTests : IntegrationTest() {
             val householdsPage = navigator.goToPropertyRegistrationHouseholdsPage()
             householdsPage.householdsInput.fill("not-a-number")
             householdsPage.form.submit()
-            assertThat(householdsPage.form.getErrorMessage()).containsText("Number of households in your property must be a number, like 3")
+            assertThat(householdsPage.form.getErrorMessage())
+                .containsText("Number of households in your property must be a positive, whole number, like 3")
         }
 
         @Test
@@ -142,7 +143,8 @@ class PropertyRegistrationJourneyTests : IntegrationTest() {
             val householdsPage = navigator.goToPropertyRegistrationHouseholdsPage()
             householdsPage.householdsInput.fill("2.3")
             householdsPage.form.submit()
-            assertThat(householdsPage.form.getErrorMessage()).containsText("Number of households in your property must be a number, like 3")
+            assertThat(householdsPage.form.getErrorMessage())
+                .containsText("Number of households in your property must be a positive, whole number, like 3")
         }
 
         @Test
@@ -150,7 +152,8 @@ class PropertyRegistrationJourneyTests : IntegrationTest() {
             val householdsPage = navigator.goToPropertyRegistrationHouseholdsPage()
             householdsPage.householdsInput.fill("-2")
             householdsPage.form.submit()
-            assertThat(householdsPage.form.getErrorMessage()).containsText("Number of households in your property must be a number, like 3")
+            assertThat(householdsPage.form.getErrorMessage())
+                .containsText("Number of households in your property must be a positive, whole number, like 3")
         }
     }
 
@@ -168,7 +171,8 @@ class PropertyRegistrationJourneyTests : IntegrationTest() {
             val peoplePage = navigator.goToPropertyRegistrationPeoplePage()
             peoplePage.peopleInput.fill("not-a-number")
             peoplePage.form.submit()
-            assertThat(peoplePage.form.getErrorMessage()).containsText("Number of people in your property must be a number, like 3")
+            assertThat(peoplePage.form.getErrorMessage())
+                .containsText("Number of people in your property must be a positive, whole number, like 3")
         }
 
         @Test
@@ -176,7 +180,8 @@ class PropertyRegistrationJourneyTests : IntegrationTest() {
             val peoplePage = navigator.goToPropertyRegistrationPeoplePage()
             peoplePage.peopleInput.fill("2.3")
             peoplePage.form.submit()
-            assertThat(peoplePage.form.getErrorMessage()).containsText("Number of people in your property must be a number, like 3")
+            assertThat(peoplePage.form.getErrorMessage())
+                .containsText("Number of people in your property must be a positive, whole number, like 3")
         }
 
         @Test
@@ -184,7 +189,8 @@ class PropertyRegistrationJourneyTests : IntegrationTest() {
             val peoplePage = navigator.goToPropertyRegistrationPeoplePage()
             peoplePage.peopleInput.fill("-2")
             peoplePage.form.submit()
-            assertThat(peoplePage.form.getErrorMessage()).containsText("Number of people in your property must be a number, like 3")
+            assertThat(peoplePage.form.getErrorMessage())
+                .containsText("Number of people in your property must be a positive, whole number, like 3")
         }
     }
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/Navigator.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/Navigator.kt
@@ -2,6 +2,7 @@ package uk.gov.communities.prsdb.webapp.integration.pageObjects
 
 import com.microsoft.playwright.Page
 import com.microsoft.playwright.Response
+import uk.gov.communities.prsdb.webapp.constants.enums.OwnershipType
 import uk.gov.communities.prsdb.webapp.constants.enums.PropertyType
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.InviteNewLaUserPage
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.ManageLaUsersPage
@@ -15,7 +16,10 @@ import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.landlordReg
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.landlordRegistrationJourneyPages.EmailFormPageLandlordRegistration
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.landlordRegistrationJourneyPages.NameFormPageLandlordRegistration
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.landlordRegistrationJourneyPages.PhoneNumberFormPageLandlordRegistration
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyRegistrationJourneyPages.HouseholdsFormPagePropertyRegistration
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyRegistrationJourneyPages.OccupancyFormPagePropertyRegistration
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyRegistrationJourneyPages.OwnershipTypeFormPagePropertyRegistration
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyRegistrationJourneyPages.PeopleFormPagePropertyRegistration
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyRegistrationJourneyPages.PropertyTypeFormPagePropertyRegistration
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyRegistrationJourneyPages.RegisterPropertyStartPage
 
@@ -119,6 +123,27 @@ class Navigator(
         propertyTypePage.form.getRadios().selectValue(PropertyType.DETACHED_HOUSE)
         propertyTypePage.form.submit()
         return createValidPage(page, OwnershipTypeFormPagePropertyRegistration::class)
+    }
+
+    fun goToPropertyRegistrationOccupancyPage(): OccupancyFormPagePropertyRegistration {
+        val ownershipTypePage = goToPropertyRegistrationOwnershipTypePage()
+        ownershipTypePage.form.getRadios().selectValue(OwnershipType.FREEHOLD)
+        ownershipTypePage.form.submit()
+        return createValidPage(page, OccupancyFormPagePropertyRegistration::class)
+    }
+
+    fun goToPropertyRegistrationHouseholdsPage(): HouseholdsFormPagePropertyRegistration {
+        val occupancyPage = goToPropertyRegistrationOccupancyPage()
+        occupancyPage.form.getRadios().selectValue("true")
+        occupancyPage.form.submit()
+        return createValidPage(page, HouseholdsFormPagePropertyRegistration::class)
+    }
+
+    fun goToPropertyRegistrationPeoplePage(): PeopleFormPagePropertyRegistration {
+        val householdsPage = goToPropertyRegistrationHouseholdsPage()
+        householdsPage.householdsInput.fill("2")
+        householdsPage.form.submit()
+        return createValidPage(page, PeopleFormPagePropertyRegistration::class)
     }
 
     private fun navigate(path: String): Response? = page.navigate("http://localhost:$port/$path")

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/propertyRegistrationJourneyPages/HouseholdsFormPagePropertyRegistration.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/propertyRegistrationJourneyPages/HouseholdsFormPagePropertyRegistration.kt
@@ -1,0 +1,15 @@
+package uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyRegistrationJourneyPages
+
+import com.microsoft.playwright.Page
+import uk.gov.communities.prsdb.webapp.constants.REGISTER_PROPERTY_JOURNEY_URL
+import uk.gov.communities.prsdb.webapp.forms.steps.RegisterPropertyStepId
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages.FormBasePage
+
+class HouseholdsFormPagePropertyRegistration(
+    page: Page,
+) : FormBasePage(
+        page,
+        "/$REGISTER_PROPERTY_JOURNEY_URL/${RegisterPropertyStepId.NumberOfHouseholds.urlPathSegment}",
+    ) {
+    val householdsInput = form.getTextInput("numberOfHouseholds")
+}

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/propertyRegistrationJourneyPages/OccupancyFormPagePropertyRegistration.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/propertyRegistrationJourneyPages/OccupancyFormPagePropertyRegistration.kt
@@ -1,0 +1,10 @@
+package uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyRegistrationJourneyPages
+
+import com.microsoft.playwright.Page
+import uk.gov.communities.prsdb.webapp.constants.REGISTER_PROPERTY_JOURNEY_URL
+import uk.gov.communities.prsdb.webapp.forms.steps.RegisterPropertyStepId
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages.FormBasePage
+
+class OccupancyFormPagePropertyRegistration(
+    page: Page,
+) : FormBasePage(page, "/$REGISTER_PROPERTY_JOURNEY_URL/${RegisterPropertyStepId.Occupancy.urlPathSegment}")

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/propertyRegistrationJourneyPages/PeopleFormPagePropertyRegistration.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/propertyRegistrationJourneyPages/PeopleFormPagePropertyRegistration.kt
@@ -1,0 +1,15 @@
+package uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyRegistrationJourneyPages
+
+import com.microsoft.playwright.Page
+import uk.gov.communities.prsdb.webapp.constants.REGISTER_PROPERTY_JOURNEY_URL
+import uk.gov.communities.prsdb.webapp.forms.steps.RegisterPropertyStepId
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages.FormBasePage
+
+class PeopleFormPagePropertyRegistration(
+    page: Page,
+) : FormBasePage(
+        page,
+        "/$REGISTER_PROPERTY_JOURNEY_URL/${RegisterPropertyStepId.NumberOfPeople.urlPathSegment}",
+    ) {
+    val peopleInput = form.getTextInput("numberOfPeople")
+}


### PR DESCRIPTION
Occupancy page:
- If this is not filled in, the user sees an error "Select whether the property is occupied"
- If the "yes" option is ticked, the user is taken to the "number-of-households" page
- If the "no" option is ticked, the user is taken to the next step (currently a placeholder page)
![image](https://github.com/user-attachments/assets/4a865e53-c529-44a5-8845-84558651c159)

Households page:
- If this is not filled in, the user should see an error "Enter the number of households living in your property"
- If this is filled in but not with an integer, the use should see an error "Number of households in your property must be a number, like 3"
- If this is filled in with an integer, the user should be taken to the "number-of-people" step
![image](https://github.com/user-attachments/assets/9f537512-6bac-4c82-b421-2b8ed199936e)

People page:
- If this is not filled in, the user should see an error "Enter the number of people living in your property"
- If this is filled in but not with an integer, the use should see an error "Number of people in your property must be a number, like 3"
- If this is filled in with an integer, the user should be taken to the next step (currently a placeholder page - should be the same as the "no" option from the occupancy page)
![image](https://github.com/user-attachments/assets/3284954b-c352-4099-a7ca-4fdd51f20b03)

Tests:
- The path for an occupied property is included in the `User can navigate the whole journey if pages are correctly filled in` test
- The path for an unoccupied property is in the OccupancyStep nested class
- Errors are tested in nested classes for each step
