### PR TITLE
PRSD-562: Cache Looked-up Addresses

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/LandlordRegistrationJourney.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/LandlordRegistrationJourney.kt
@@ -22,6 +22,7 @@ import uk.gov.communities.prsdb.webapp.models.formModels.PhoneNumberFormModel
 import uk.gov.communities.prsdb.webapp.models.formModels.SelectAddressFormModel
 import uk.gov.communities.prsdb.webapp.models.viewModels.RadiosButtonViewModel
 import uk.gov.communities.prsdb.webapp.models.viewModels.SelectViewModel
+import uk.gov.communities.prsdb.webapp.services.AddressDataService
 import uk.gov.communities.prsdb.webapp.services.AddressLookupService
 import uk.gov.communities.prsdb.webapp.services.JourneyDataService
 
@@ -30,6 +31,7 @@ class LandlordRegistrationJourney(
     validator: Validator,
     journeyDataService: JourneyDataService,
     addressLookupService: AddressLookupService,
+    addressDataService: AddressDataService,
 ) : Journey<LandlordRegistrationStepId>(
         journeyType = JourneyType.LANDLORD_REGISTRATION,
         initialStepId = LandlordRegistrationStepId.Name,
@@ -179,7 +181,9 @@ class LandlordRegistrationJourney(
                             urlPathSegment = LandlordRegistrationStepId.LookupAddress.urlPathSegment,
                             journeyDataService = journeyDataService,
                             addressLookupService = addressLookupService,
+                            addressDataService = addressDataService,
                         ),
+                    isSatisfied = { _, pageData -> isSelectAddressSatisfied(pageData, addressDataService) },
                     nextAction = { journeyData, _ -> selectAddressNextAction(journeyData) },
                     saveAfterSubmit = false,
                 ),
@@ -264,7 +268,9 @@ class LandlordRegistrationJourney(
                             urlPathSegment = LandlordRegistrationStepId.LookupContactAddress.urlPathSegment,
                             journeyDataService = journeyDataService,
                             addressLookupService = addressLookupService,
+                            addressDataService = addressDataService,
                         ),
+                    isSatisfied = { _, pageData -> isSelectAddressSatisfied(pageData, addressDataService) },
                     nextAction = { journeyData, _ -> selectContactAddressNextAction(journeyData) },
                     saveAfterSubmit = false,
                 ),
@@ -331,6 +337,14 @@ class LandlordRegistrationJourney(
                 // TODO: Set nextAction to next journey step
                 Pair(LandlordRegistrationStepId.CheckAnswers, null)
             }
+
+        private fun isSelectAddressSatisfied(
+            pageData: PageData,
+            addressDataService: AddressDataService,
+        ): Boolean {
+            val selectedAddress = pageData["address"].toString()
+            return selectedAddress == MANUAL_ADDRESS_CHOSEN || addressDataService.getAddressData(selectedAddress) != null
+        }
 
         private fun getSelectedAddress(
             journeyData: JourneyData,

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/pages/SelectAddressPage.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/pages/SelectAddressPage.kt
@@ -8,6 +8,7 @@ import uk.gov.communities.prsdb.webapp.models.formModels.FormModel
 import uk.gov.communities.prsdb.webapp.models.viewModels.RadiosButtonViewModel
 import uk.gov.communities.prsdb.webapp.models.viewModels.RadiosDividerViewModel
 import uk.gov.communities.prsdb.webapp.models.viewModels.RadiosViewModel
+import uk.gov.communities.prsdb.webapp.services.AddressDataService
 import uk.gov.communities.prsdb.webapp.services.AddressLookupService
 import uk.gov.communities.prsdb.webapp.services.JourneyDataService
 import kotlin.reflect.KClass
@@ -19,6 +20,7 @@ class SelectAddressPage(
     private val urlPathSegment: String,
     private val journeyDataService: JourneyDataService,
     private val addressLookupService: AddressLookupService,
+    private val addressDataService: AddressDataService,
 ) : Page(formModel, templateName, content) {
     override fun populateModelAndGetTemplateName(
         validator: Validator,
@@ -32,11 +34,12 @@ class SelectAddressPage(
         val postcode = objectToStringKeyedMap(journeyData[urlPathSegment])?.get("postcode").toString()
 
         val addressLookupResults = addressLookupService.search(houseNameOrNumber, postcode)
+        addressDataService.setAddressData(addressLookupResults)
 
         var addressRadiosViewModel: List<RadiosViewModel> =
             addressLookupResults.mapIndexed { index, address ->
                 RadiosButtonViewModel(
-                    value = address.address,
+                    value = address.singleLineAddress,
                     valueStr = (index + 1).toString(),
                 )
             }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/local/api/controllers/OSPlacesAPIStubController.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/local/api/controllers/OSPlacesAPIStubController.kt
@@ -25,11 +25,15 @@ class OSPlacesAPIStubController {
                     ",",
                     "{'results':[",
                     "]}",
-                ) { "{'DPA':{'ADDRESS':'$it, Example Road, EG','POSTCODE':'EG','BUILDING_NUMBER':$it}}" }
+                ) {
+                    "{'DPA':{'ADDRESS':'$it, Example Road, EG'," +
+                        "'LOCAL_CUSTODIAN_CODE':${it}00,'UPRN':'','BUILDING_NUMBER':$it,'POSTCODE':'EG'}}"
+                }
             }
         } catch (exception: Exception) {
             println(exception.message)
-            return "{'results':[{'DPA':{'ADDRESS':'1, Example Road, EG','POSTCODE':'EG','BUILDING_NUMBER':1}}]}"
+            return "{'results':[{'DPA':{'ADDRESS':'1, Example Road, EG'," +
+                "'LOCAL_CUSTODIAN_CODE':100,'UPRN':'','BUILDING_NUMBER':1,'POSTCODE':'EG'}}]}"
         }
     }
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/dataModels/AddressDataModel.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/dataModels/AddressDataModel.kt
@@ -1,9 +1,15 @@
 package uk.gov.communities.prsdb.webapp.models.dataModels
 
 data class AddressDataModel(
-    val address: String,
-    val postcode: String,
-    val houseNumber: Int? = null,
-    val houseName: String? = null,
-    val poBoxNumber: String? = null,
+    val singleLineAddress: String,
+    val custodianCode: String,
+    val uprn: Int? = null,
+    val organisation: String? = null,
+    val subBuilding: String? = null,
+    val buildingName: String? = null,
+    val buildingNumber: String? = null,
+    val streetName: String? = null,
+    val locality: String? = null,
+    val townName: String? = null,
+    val postcode: String? = null,
 )

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/dataModels/AddressDataModel.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/dataModels/AddressDataModel.kt
@@ -1,5 +1,8 @@
 package uk.gov.communities.prsdb.webapp.models.dataModels
 
+import kotlinx.serialization.Serializable
+
+@Serializable
 data class AddressDataModel(
     val singleLineAddress: String,
     val custodianCode: String,

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/AddressDataService.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/AddressDataService.kt
@@ -1,0 +1,27 @@
+package uk.gov.communities.prsdb.webapp.services
+
+import jakarta.servlet.http.HttpSession
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import org.springframework.context.annotation.Scope
+import org.springframework.context.annotation.ScopedProxyMode
+import org.springframework.stereotype.Service
+import org.springframework.web.context.WebApplicationContext
+import uk.gov.communities.prsdb.webapp.models.dataModels.AddressDataModel
+
+@Service
+@Scope(value = WebApplicationContext.SCOPE_REQUEST, proxyMode = ScopedProxyMode.TARGET_CLASS)
+class AddressDataService(
+    private val session: HttpSession,
+) {
+    fun getAddressData(singleLineAddress: String): AddressDataModel? =
+        Json.decodeFromString<Map<String, AddressDataModel>>(
+            session.getAttribute("addressData").toString(),
+        )[singleLineAddress]
+
+    fun setAddressData(addressDataList: List<AddressDataModel>) =
+        session.setAttribute(
+            "addressData",
+            Json.encodeToString(addressDataList.associateBy { it.singleLineAddress }),
+        )
+}

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/OSPlacesAddressLookupService.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/OSPlacesAddressLookupService.kt
@@ -27,11 +27,22 @@ class OSPlacesAddressLookupService(
             val dataset = results.getJSONObject(i).getJSONObject("DPA")
             addresses.add(
                 AddressDataModel(
-                    dataset.getString("ADDRESS"),
-                    dataset.getString("POSTCODE"),
-                    if (dataset.has("BUILDING_NUMBER")) dataset.getInt("BUILDING_NUMBER") else null,
-                    dataset.optString("BUILDING_NAME", null),
-                    dataset.optString("PO_BOX_NUMBER", null),
+                    singleLineAddress = dataset.getString("ADDRESS"),
+                    custodianCode = dataset.getInt("LOCAL_CUSTODIAN_CODE").toString(),
+                    uprn = if (dataset.getString("UPRN").isEmpty()) null else dataset.getString("UPRN").toInt(),
+                    organisation = dataset.optString("ORGANISATION_NAME", null),
+                    subBuilding = dataset.optString("SUB_BUILDING_NAME", null),
+                    buildingName = dataset.optString("BUILDING_NAME", null),
+                    buildingNumber =
+                        if (dataset.has("BUILDING_NUMBER")) {
+                            dataset.getInt("BUILDING_NUMBER").toString()
+                        } else {
+                            null
+                        },
+                    streetName = dataset.optString("THOROUGHFARE_NAME", null),
+                    locality = dataset.optString("DEPENDENT_LOCALITY", null),
+                    townName = dataset.optString("POST_TOWN", null),
+                    postcode = dataset.optString("POSTCODE", null),
                 ),
             )
         }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/AddressDataServiceTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/AddressDataServiceTests.kt
@@ -1,0 +1,86 @@
+package uk.gov.communities.prsdb.webapp.services
+
+import jakarta.servlet.http.HttpSession
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.ArgumentCaptor.captor
+import org.mockito.Mock
+import org.mockito.Mockito.verify
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.whenever
+import uk.gov.communities.prsdb.webapp.models.dataModels.AddressDataModel
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+@ExtendWith(MockitoExtension::class)
+class AddressDataServiceTests {
+    @Mock
+    private lateinit var mockHttpSession: HttpSession
+
+    private lateinit var addressDataService: AddressDataService
+
+    @BeforeEach
+    fun setup() {
+        addressDataService = AddressDataService(mockHttpSession)
+    }
+
+    @Test
+    fun `getAddressData returns the AddressDataModel that corresponds with the given address`() {
+        val addressDataJSON =
+            Json.encodeToString(
+                listOf(
+                    AddressDataModel("1, Example Road, EG", "100", 1234, buildingNumber = "1", postcode = "EG"),
+                    AddressDataModel("2, Example Road, EG", "101", buildingNumber = "2", postcode = "EG"),
+                    AddressDataModel("Main, Example Road, EG", "102", buildingName = "Main", postcode = "EG"),
+                ).associateBy { it.singleLineAddress },
+            )
+        val expectedAddressData =
+            AddressDataModel("1, Example Road, EG", "100", 1234, buildingNumber = "1", postcode = "EG")
+
+        whenever(mockHttpSession.getAttribute("addressData")).thenReturn(addressDataJSON)
+
+        val addressData = addressDataService.getAddressData("1, Example Road, EG")
+
+        assertEquals(expectedAddressData, addressData)
+    }
+
+    @Test
+    fun `getAddressData returns null when given an invalid address`() {
+        val addressDataJSON =
+            Json.encodeToString(
+                listOf(
+                    AddressDataModel("1, Example Road, EG", "100", 1234, buildingNumber = "1", postcode = "EG"),
+                    AddressDataModel("2, Example Road, EG", "101", buildingNumber = "2", postcode = "EG"),
+                    AddressDataModel("Main, Example Road, EG", "102", buildingName = "Main", postcode = "EG"),
+                ).associateBy { it.singleLineAddress },
+            )
+
+        whenever(mockHttpSession.getAttribute("addressData")).thenReturn(addressDataJSON)
+
+        val addressData = addressDataService.getAddressData("invalid address")
+
+        assertNull(addressData)
+    }
+
+    @Test
+    fun `setAddressData stores the given address data as a serialized map`() {
+        val addressDataList =
+            listOf(
+                AddressDataModel("1, Example Road, EG", "100", 1234, buildingNumber = "1", postcode = "EG"),
+                AddressDataModel("2, Example Road, EG", "101", buildingNumber = "2", postcode = "EG"),
+                AddressDataModel("Main, Example Road, EG", "102", buildingName = "Main", postcode = "EG"),
+            )
+        val expectedAddressDataString = Json.encodeToString(addressDataList.associateBy { it.singleLineAddress })
+
+        addressDataService.setAddressData(addressDataList)
+
+        val addressDataStringCaptor = captor<String>()
+        verify(mockHttpSession).setAttribute(eq("addressData"), addressDataStringCaptor.capture())
+        Assertions.assertEquals(expectedAddressDataString, addressDataStringCaptor.value)
+    }
+}

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/OSPlacesAddressLookupServiceTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/OSPlacesAddressLookupServiceTests.kt
@@ -26,22 +26,22 @@ class OSPlacesAddressLookupServiceTests {
     fun `searchByPostcode returns a corresponding list of addresses given a valid postcode`() {
         val addressesJSON =
             "{'results':[" +
-                "{'DPA':{'ADDRESS':'1, Example Road, EG','POSTCODE':'EG','BUILDING_NUMBER':1}}," +
-                "{'DPA':{'ADDRESS':'Main Building, Example Road, EG','POSTCODE':'EG','BUILDING_NAME':'Main Building'}}," +
-                "{'DPA':{'ADDRESS':'PO1, Example Road, EG','POSTCODE':'EG','PO_BOX_NUMBER':'PO1'}}," +
+                "{'DPA':{'ADDRESS':'1, Example Road, EG','LOCAL_CUSTODIAN_CODE':100,'UPRN':'1234','BUILDING_NUMBER':1,'POSTCODE':'EG'}}," +
+                "{'DPA':{'ADDRESS':'2, Example Road, EG','LOCAL_CUSTODIAN_CODE':101,'UPRN':'','BUILDING_NUMBER':2,'POSTCODE':'EG'}}," +
+                "{'DPA':{'ADDRESS':'Main, Example Road, EG','LOCAL_CUSTODIAN_CODE':102,'UPRN':'','BUILDING_NAME':'Main','POSTCODE':'EG'}}" +
                 "]}"
         val expectedAddresses =
             listOf(
-                AddressDataModel("1, Example Road, EG", "EG", 1),
-                AddressDataModel("Main Building, Example Road, EG", "EG", houseName = "Main Building"),
-                AddressDataModel("PO1, Example Road, EG", "EG", poBoxNumber = "PO1"),
+                AddressDataModel("1, Example Road, EG", "100", 1234, buildingNumber = "1", postcode = "EG"),
+                AddressDataModel("2, Example Road, EG", "101", buildingNumber = "2", postcode = "EG"),
+                AddressDataModel("Main, Example Road, EG", "102", buildingName = "Main", postcode = "EG"),
             )
 
         whenever(
             mockOSPlacesClient.search(anyString(), anyString()),
         ).thenReturn(addressesJSON)
 
-        val addresses = addressLookupService.search("", "EG")
+        val addresses = addressLookupService.search("", "")
 
         assertEquals(expectedAddresses, addresses)
     }


### PR DESCRIPTION
- Matches `AddressDataModel` to the MVP Address data model
- Creates and tests `AddressDataService`, which handles address caching
- Caches looked-up addresses in after retrieving them in `SelectAddressPage`
- Overrides `isSatisfied` on landlord registration select address steps to check that the submitted value matches a cached address