### PR TITLE
Chore/prsd none add filtered journey data to step details

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/Journey.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/Journey.kt
@@ -129,9 +129,7 @@ abstract class Journey<T : StepId>(
             // This stores journeyData for only the journey path the user is on
             // and excludes user data for pages in the journey that belong to a different path
             val stepData = journeyDataService.getPageData(journeyData, currentStep.name, null)
-            if (stepData != null && currentStep.isSatisfied(validator, stepData)) {
-                filteredJourneyData[currentStep.name] = stepData
-            }
+            filteredJourneyData[currentStep.name] = stepData
 
             val (nextStepId, nextSubPageNumber) =
                 currentStep.nextAction(journeyData, currentSubPageNumber)

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/Journey.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/Journey.kt
@@ -125,10 +125,14 @@ abstract class Journey<T : StepId>(
         while (!(currentStep.id == targetStep.id && currentSubPageNumber == targetSubPageNumber)) {
             val pageData = journeyDataService.getPageData(journeyData, currentStep.name, currentSubPageNumber)
             if (pageData == null || !currentStep.isSatisfied(validator, pageData)) return null
+
+            // This stores journeyData for only the journey path the user is on
+            // and excludes user data for pages in the journey that belong to a different path
             val stepData = journeyDataService.getPageData(journeyData, currentStep.name, null)
             if (stepData != null && currentStep.isSatisfied(validator, stepData)) {
                 filteredJourneyData[currentStep.name] = stepData
             }
+
             val (nextStepId, nextSubPageNumber) =
                 currentStep.nextAction(journeyData, currentSubPageNumber)
             val nextStep = steps.singleOrNull { step -> step.id == nextStepId } ?: return null

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/Journey.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/Journey.kt
@@ -55,6 +55,7 @@ abstract class Journey<T : StepId>(
             model,
             pageData,
             prevStepUrl,
+            prevStepDetails?.filteredJourneyData,
         )
     }
 
@@ -120,6 +121,7 @@ abstract class Journey<T : StepId>(
         var prevStep: Step<T>? = null
         var prevSubPageNumber: Int? = null
         var currentSubPageNumber: Int? = null
+        var filteredJourneyData: JourneyData? = null
         while (!(currentStep.id == targetStep.id && currentSubPageNumber == targetSubPageNumber)) {
             val pageData = journeyDataService.getPageData(journeyData, currentStep.name, currentSubPageNumber)
             if (pageData == null || !currentStep.isSatisfied(validator, pageData)) return null
@@ -130,8 +132,13 @@ abstract class Journey<T : StepId>(
             prevSubPageNumber = currentSubPageNumber
             currentStep = nextStep
             currentSubPageNumber = nextSubPageNumber
+            if (filteredJourneyData == null) {
+                filteredJourneyData = pageData
+            } else {
+                filteredJourneyData.plus(pageData)
+            }
         }
-        return StepDetails(prevStep, prevSubPageNumber)
+        return StepDetails(prevStep, prevSubPageNumber, filteredJourneyData)
     }
 
     private fun getPrevStepUrl(

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/LandlordRegistrationJourney.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/LandlordRegistrationJourney.kt
@@ -8,6 +8,7 @@ import uk.gov.communities.prsdb.webapp.constants.PLACE_NAMES
 import uk.gov.communities.prsdb.webapp.constants.REGISTER_LANDLORD_JOURNEY_URL
 import uk.gov.communities.prsdb.webapp.constants.enums.JourneyType
 import uk.gov.communities.prsdb.webapp.forms.pages.ConfirmIdentityPage
+import uk.gov.communities.prsdb.webapp.forms.pages.LandlordRegistrationSummaryPage
 import uk.gov.communities.prsdb.webapp.forms.pages.Page
 import uk.gov.communities.prsdb.webapp.forms.pages.SelectAddressPage
 import uk.gov.communities.prsdb.webapp.forms.pages.VerifyIdentityPage
@@ -332,6 +333,23 @@ class LandlordRegistrationJourney(
                         ),
                     // TODO: Set nextAction to next journey step
                     nextAction = { _, _ -> Pair(LandlordRegistrationStepId.CheckAnswers, null) },
+                    saveAfterSubmit = false,
+                ),
+                Step(
+                    // TODO PRSD-372 update message value(s)
+                    id = LandlordRegistrationStepId.CheckAnswers,
+                    page =
+                        LandlordRegistrationSummaryPage(
+                            formModel = CheckAnswersFormModel::class,
+                            templateName = "forms/checkAnswersForm",
+                            content =
+                                mapOf(
+                                    "title" to "registerAsALandlord.title",
+                                    "summaryName" to "registerAsALandlord.title",
+                                    "submitButtonText" to "forms.buttons.confirmAndContinue",
+                                ),
+                        ),
+                    nextAction = { _, _ -> Pair(LandlordRegistrationStepId.Declaration, null) },
                     saveAfterSubmit = false,
                 ),
             ),

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/pages/LandlordRegistrationSummaryPage.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/pages/LandlordRegistrationSummaryPage.kt
@@ -1,0 +1,47 @@
+package uk.gov.communities.prsdb.webapp.forms.pages
+
+import org.springframework.ui.Model
+import org.springframework.validation.Validator
+import uk.gov.communities.prsdb.webapp.constants.enums.JourneyType
+import uk.gov.communities.prsdb.webapp.forms.journeys.JourneyData
+import uk.gov.communities.prsdb.webapp.forms.journeys.objectToStringKeyedMap
+import uk.gov.communities.prsdb.webapp.forms.steps.RegisterLaUserStepId
+import uk.gov.communities.prsdb.webapp.models.dataModels.FormSummaryDataModel
+import uk.gov.communities.prsdb.webapp.models.formModels.FormModel
+import kotlin.reflect.KClass
+
+class LandlordRegistrationSummaryPage(
+    formModel: KClass<out FormModel>,
+    templateName: String,
+    content: Map<String, Any>,
+) : Page(formModel, templateName, content) {
+    override fun populateModelAndGetTemplateName(
+        validator: Validator,
+        model: Model,
+        pageData: Map<String, Any?>?,
+        prevStepUrl: String?,
+        journeyData: JourneyData?,
+    ): String {
+        val formData = mutableListOf<FormSummaryDataModel>()
+
+        // TODO PRSD-372 update the formData below
+
+        formData.addAll(
+            listOf(
+                FormSummaryDataModel(
+                    "registerLaUser.checkAnswers.rowHeading.name",
+                    objectToStringKeyedMap(journeyData?.get("name"))?.get("name"),
+                    "/${JourneyType.LA_USER_REGISTRATION.urlPathSegment}/${RegisterLaUserStepId.Name.urlPathSegment}",
+                ),
+                FormSummaryDataModel(
+                    "registerLaUser.checkAnswers.rowHeading.email",
+                    objectToStringKeyedMap(journeyData?.get("email"))?.get("emailAddress"),
+                    "/${JourneyType.LA_USER_REGISTRATION.urlPathSegment}/${RegisterLaUserStepId.Email.urlPathSegment}",
+                ),
+            ),
+        )
+
+        model.addAttribute("formData", formData)
+        return super.populateModelAndGetTemplateName(validator, model, pageData, prevStepUrl, journeyData)
+    }
+}

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/pages/Page.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/pages/Page.kt
@@ -6,6 +6,7 @@ import org.springframework.validation.BindingResult
 import org.springframework.validation.Validator
 import org.springframework.web.bind.WebDataBinder
 import uk.gov.communities.prsdb.webapp.constants.BACK_URL_ATTR_NAME
+import uk.gov.communities.prsdb.webapp.forms.journeys.JourneyData
 import uk.gov.communities.prsdb.webapp.models.formModels.FormModel
 import kotlin.reflect.KClass
 import kotlin.reflect.full.createInstance
@@ -31,6 +32,14 @@ open class Page(
         }
         return templateName
     }
+
+    open fun populateModelAndGetTemplateName(
+        validator: Validator,
+        model: Model,
+        pageData: Map<String, Any?>?,
+        prevStepUrl: String?,
+        journeyData: JourneyData?,
+    ): String = populateModelAndGetTemplateName(validator, model, pageData, prevStepUrl)
 
     fun isSatisfied(
         validator: Validator,

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/steps/LandlordRegistrationStepId.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/steps/LandlordRegistrationStepId.kt
@@ -20,4 +20,5 @@ enum class LandlordRegistrationStepId(
     ManualContactAddress("manual-contact-address"),
     CheckAnswers("check-answers"),
     DateOfBirth("date-of-birth"),
+    Declaration("declaration"),
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/steps/StepDetails.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/steps/StepDetails.kt
@@ -1,6 +1,9 @@
 package uk.gov.communities.prsdb.webapp.forms.steps
 
+import uk.gov.communities.prsdb.webapp.forms.journeys.JourneyData
+
 data class StepDetails<T : StepId>(
     val step: Step<T>?,
     val subPageNumber: Int?,
+    val filteredJourneyData: JourneyData?,
 )

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/forms/JourneyTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/forms/JourneyTests.kt
@@ -16,7 +16,6 @@ import org.mockito.Mockito.mock
 import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.eq
-import org.mockito.kotlin.spy
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
@@ -360,100 +359,6 @@ class JourneyTests {
             val propertyValue = bindingResult.getRawFieldValue("testProperty")
             assertEquals("testPropertyValue", propertyValue)
             assertEquals("templateName", result)
-        }
-
-        @Test
-        fun `calls populateModelAndGetTemplateName() from page with filteredJourneyData as a parameter when is present`() {
-            // Arrange
-            val page =
-                Page(
-                    TestFormModel::class,
-                    "templateName",
-                    mutableMapOf("testKey" to "testValue"),
-                )
-            val spiedOnPage = spy(page)
-
-            val testJourney =
-                TestJourney(
-                    JourneyType.LANDLORD_REGISTRATION,
-                    initialStepId = TestStepId.StepOne,
-                    journeyDataService = mockJourneyDataService,
-                    validator = validator,
-                    steps =
-                        listOf(
-                            Step(
-                                TestStepId.StepOne,
-                                page =
-                                    Page(
-                                        TestFormModel::class,
-                                        "index",
-                                        mutableMapOf(),
-                                    ),
-                                nextAction = { _, _ -> Pair(TestStepId.StepThree, null) },
-                            ),
-                            Step(
-                                TestStepId.StepTwo,
-                                page =
-                                    Page(
-                                        TestFormModel::class,
-                                        "templateName",
-                                        mutableMapOf("testKey" to "testValue"),
-                                    ),
-                            ),
-                            Step(
-                                TestStepId.StepThree,
-                                page =
-                                    Page(
-                                        TestFormModel::class,
-                                        "index",
-                                        mutableMapOf("testKey" to "testValue"),
-                                    ),
-                                nextAction = { _, _ -> Pair(TestStepId.StepFour, null) },
-                            ),
-                            Step(
-                                TestStepId.StepFour,
-                                page = spiedOnPage,
-                            ),
-                        ),
-                )
-            val model = BindingAwareModelMap()
-            val pageDataStepOne: PageData = mutableMapOf("testProperty" to "testProperty")
-            val pageDataStepTwo: PageData = mutableMapOf("testPropertyTwo" to "testProperty")
-            val pageDataStepThree: PageData = mutableMapOf("testProperty" to "testProperty")
-            val pageDataStepFour: PageData = mutableMapOf("testProperty" to "testProperty")
-            val journeyData: JourneyData =
-                mutableMapOf(
-                    TestStepId.StepOne.urlPathSegment to pageDataStepOne,
-                    TestStepId.StepTwo.urlPathSegment to pageDataStepTwo,
-                    TestStepId.StepThree.urlPathSegment to pageDataStepThree,
-                )
-            val filteredJourneyData: JourneyData =
-                mutableMapOf(
-                    TestStepId.StepOne.urlPathSegment to pageDataStepOne,
-                    TestStepId.StepThree.urlPathSegment to pageDataStepThree,
-                )
-            whenever(
-                mockJourneyDataService.getPageData(
-                    anyMap(),
-                    anyString(),
-                    anyOrNull(),
-                ),
-            ).thenReturn(
-                pageDataStepFour,
-            )
-            whenever(mockJourneyDataService.getJourneyDataFromSession()).thenReturn(journeyData)
-
-            // Act
-            testJourney.populateModelAndGetViewName(TestStepId.StepFour, model, null, null)
-
-            // Assert
-            verify(spiedOnPage).populateModelAndGetTemplateName(
-                testJourney.validator,
-                model,
-                pageDataStepFour,
-                TestStepId.StepThree.urlPathSegment,
-                filteredJourneyData,
-            )
         }
     }
 

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/forms/JourneyTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/forms/JourneyTests.kt
@@ -364,6 +364,7 @@ class JourneyTests {
 
         @Test
         fun `calls populateModelAndGetTemplateName() from page with filteredJourneyData as a parameter when is present`() {
+            // Arrange
             val page =
                 Page(
                     TestFormModel::class,
@@ -371,7 +372,7 @@ class JourneyTests {
                     mutableMapOf("testKey" to "testValue"),
                 )
             val spiedOnPage = spy(page)
-            // Arrange
+
             val testJourney =
                 TestJourney(
                     JourneyType.LANDLORD_REGISTRATION,
@@ -416,11 +417,10 @@ class JourneyTests {
                         ),
                 )
             val model = BindingAwareModelMap()
-            val pageDataStepOne: PageData = mutableMapOf("testPropertyStepOne" to "testPropertyValueStepOne")
-            val pageDataStepTwo: PageData = mutableMapOf("testPropertyTwo" to "testPropertyValueTwo")
-            val pageDataStepThree: PageData = mutableMapOf("testPropertyThree" to "testPropertyValueThree")
-            val pageDataStepFour: PageData = mutableMapOf("testPropertyFour" to "testPropertyValueFour")
-            val stepFour: Step<TestStepId> = testJourney.steps.singleOrNull { step -> step.id == TestStepId.StepFour }!!
+            val pageDataStepOne: PageData = mutableMapOf("testProperty" to "testProperty")
+            val pageDataStepTwo: PageData = mutableMapOf("testPropertyTwo" to "testProperty")
+            val pageDataStepThree: PageData = mutableMapOf("testProperty" to "testProperty")
+            val pageDataStepFour: PageData = mutableMapOf("testProperty" to "testProperty")
             val journeyData: JourneyData =
                 mutableMapOf(
                     TestStepId.StepOne.urlPathSegment to pageDataStepOne,

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/forms/JourneyTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/forms/JourneyTests.kt
@@ -16,7 +16,6 @@ import org.mockito.Mockito.mock
 import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.eq
-import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.springframework.http.HttpStatus
@@ -52,7 +51,6 @@ class JourneyTests {
         StepOne("step1"),
         StepTwo("step2"),
         StepThree("step3"),
-        StepFour("step4"),
     }
 
     class TestJourney(

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/forms/JourneyTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/forms/JourneyTests.kt
@@ -16,6 +16,8 @@ import org.mockito.Mockito.mock
 import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.eq
+import org.mockito.kotlin.spy
+import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.springframework.http.HttpStatus
@@ -51,6 +53,7 @@ class JourneyTests {
         StepOne("step1"),
         StepTwo("step2"),
         StepThree("step3"),
+        StepFour("step4"),
     }
 
     class TestJourney(
@@ -357,6 +360,100 @@ class JourneyTests {
             val propertyValue = bindingResult.getRawFieldValue("testProperty")
             assertEquals("testPropertyValue", propertyValue)
             assertEquals("templateName", result)
+        }
+
+        @Test
+        fun `calls populateModelAndGetTemplateName() from page with filteredJourneyData as a parameter when is present`() {
+            val page =
+                Page(
+                    TestFormModel::class,
+                    "templateName",
+                    mutableMapOf("testKey" to "testValue"),
+                )
+            val spiedOnPage = spy(page)
+            // Arrange
+            val testJourney =
+                TestJourney(
+                    JourneyType.LANDLORD_REGISTRATION,
+                    initialStepId = TestStepId.StepOne,
+                    journeyDataService = mockJourneyDataService,
+                    validator = validator,
+                    steps =
+                        listOf(
+                            Step(
+                                TestStepId.StepOne,
+                                page =
+                                    Page(
+                                        TestFormModel::class,
+                                        "index",
+                                        mutableMapOf(),
+                                    ),
+                                nextAction = { _, _ -> Pair(TestStepId.StepThree, null) },
+                            ),
+                            Step(
+                                TestStepId.StepTwo,
+                                page =
+                                    Page(
+                                        TestFormModel::class,
+                                        "templateName",
+                                        mutableMapOf("testKey" to "testValue"),
+                                    ),
+                            ),
+                            Step(
+                                TestStepId.StepThree,
+                                page =
+                                    Page(
+                                        TestFormModel::class,
+                                        "index",
+                                        mutableMapOf("testKey" to "testValue"),
+                                    ),
+                                nextAction = { _, _ -> Pair(TestStepId.StepFour, null) },
+                            ),
+                            Step(
+                                TestStepId.StepFour,
+                                page = spiedOnPage,
+                            ),
+                        ),
+                )
+            val model = BindingAwareModelMap()
+            val pageDataStepOne: PageData = mutableMapOf("testPropertyStepOne" to "testPropertyValueStepOne")
+            val pageDataStepTwo: PageData = mutableMapOf("testPropertyTwo" to "testPropertyValueTwo")
+            val pageDataStepThree: PageData = mutableMapOf("testPropertyThree" to "testPropertyValueThree")
+            val pageDataStepFour: PageData = mutableMapOf("testPropertyFour" to "testPropertyValueFour")
+            val stepFour: Step<TestStepId> = testJourney.steps.singleOrNull { step -> step.id == TestStepId.StepFour }!!
+            val journeyData: JourneyData =
+                mutableMapOf(
+                    TestStepId.StepOne.urlPathSegment to pageDataStepOne,
+                    TestStepId.StepTwo.urlPathSegment to pageDataStepTwo,
+                    TestStepId.StepThree.urlPathSegment to pageDataStepThree,
+                )
+            val filteredJourneyData: JourneyData =
+                mutableMapOf(
+                    TestStepId.StepOne.urlPathSegment to pageDataStepOne,
+                    TestStepId.StepThree.urlPathSegment to pageDataStepThree,
+                )
+            whenever(
+                mockJourneyDataService.getPageData(
+                    anyMap(),
+                    anyString(),
+                    anyOrNull(),
+                ),
+            ).thenReturn(
+                pageDataStepFour,
+            )
+            whenever(mockJourneyDataService.getJourneyDataFromSession()).thenReturn(journeyData)
+
+            // Act
+            testJourney.populateModelAndGetViewName(TestStepId.StepFour, model, null, null)
+
+            // Assert
+            verify(spiedOnPage).populateModelAndGetTemplateName(
+                testJourney.validator,
+                model,
+                pageDataStepFour,
+                TestStepId.StepThree.urlPathSegment,
+                filteredJourneyData,
+            )
         }
     }
 


### PR DESCRIPTION
Added `filteredJourneyData` to `StepDetails` that are returned by `journey.getPrevStep` so we can use the journey data for the journey path a user is currently on separate from all the data they may have input on pages that are no longer part of their journey path