### PR TITLE
PRSD-641: Create Landlord

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/database/entity/Address.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/database/entity/Address.kt
@@ -5,9 +5,10 @@ import jakarta.persistence.Entity
 import jakarta.persistence.GeneratedValue
 import jakarta.persistence.GenerationType
 import jakarta.persistence.Id
+import uk.gov.communities.prsdb.webapp.models.dataModels.AddressDataModel
 
 @Entity
-class Address : ModifiableAuditableEntity() {
+class Address() : ModifiableAuditableEntity() {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private val id: Long? = null
@@ -46,4 +47,20 @@ class Address : ModifiableAuditableEntity() {
 
     lateinit var custodianCode: String
         private set
+
+    constructor(addressDataModel: AddressDataModel) : this() {
+        this.uprn = addressDataModel.uprn
+        this.singleLineAddress = addressDataModel.singleLineAddress
+        if (addressDataModel.organisation != null) this.organisation = addressDataModel.organisation
+        if (addressDataModel.subBuilding != null) this.subBuilding = addressDataModel.subBuilding
+        if (addressDataModel.buildingName != null) this.buildingName = addressDataModel.buildingName
+        if (addressDataModel.buildingNumber != null) this.buildingNumber = addressDataModel.buildingNumber
+        if (addressDataModel.streetName != null) this.streetName = addressDataModel.streetName
+        if (addressDataModel.locality != null) this.locality = addressDataModel.locality
+        if (addressDataModel.townName != null) this.townName = addressDataModel.townName
+        if (addressDataModel.postcode != null) this.postcode = addressDataModel.postcode
+        if (addressDataModel.townName != null) this.townName = addressDataModel.townName
+        if (addressDataModel.postcode != null) this.postcode = addressDataModel.postcode
+        if (addressDataModel.custodianCode != null) this.custodianCode = addressDataModel.custodianCode
+    }
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/database/entity/Address.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/database/entity/Address.kt
@@ -12,6 +12,7 @@ class Address : ModifiableAuditableEntity() {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private val id: Long? = null
 
+    @Column(unique = true)
     var uprn: Long? = null
         private set
 

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/database/entity/Landlord.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/database/entity/Landlord.kt
@@ -12,7 +12,7 @@ import jakarta.persistence.OneToOne
 import java.util.Date
 
 @Entity
-class Landlord : ModifiableAuditableEntity() {
+class Landlord() : ModifiableAuditableEntity() {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private val id: Long? = null
@@ -61,4 +61,25 @@ class Landlord : ModifiableAuditableEntity() {
     @Column(nullable = false)
     var isActive: Boolean? = null
         private set
+
+    constructor(
+        baseUser: OneLoginUser,
+        name: String,
+        email: String,
+        phoneNumber: String,
+        address: Address,
+        registrationNumber: RegistrationNumber,
+        internationalAddress: String?,
+        dateOfBirth: Date?,
+    ) : this() {
+        this.baseUser = baseUser
+        this.name = name
+        this.email = email
+        this.phoneNumber = phoneNumber
+        this.address = address
+        this.registrationNumber = registrationNumber
+        this.isActive = true
+        if (internationalAddress != null) this.internationalAddress = internationalAddress
+        if (dateOfBirth != null) this.dateOfBirth = dateOfBirth
+    }
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/database/repository/AddressRepository.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/database/repository/AddressRepository.kt
@@ -1,0 +1,8 @@
+package uk.gov.communities.prsdb.webapp.database.repository
+
+import org.springframework.data.jpa.repository.JpaRepository
+import uk.gov.communities.prsdb.webapp.database.entity.Address
+
+interface AddressRepository : JpaRepository<Address, Long> {
+    fun findByUprn(uprn: Long): Address?
+}

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/dataModels/AddressDataModel.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/dataModels/AddressDataModel.kt
@@ -15,4 +15,21 @@ data class AddressDataModel(
     val locality: String? = null,
     val townName: String? = null,
     val postcode: String? = null,
-)
+) {
+    companion object {
+        fun parseAddressDataModel(
+            addressLineOne: String,
+            townOrCity: String,
+            postcode: String,
+            addressLineTwo: String? = null,
+            county: String? = null,
+        ): AddressDataModel =
+            AddressDataModel(
+                singleLineAddress =
+                    listOfNotNull(addressLineOne, addressLineTwo, townOrCity, postcode, county)
+                        .joinToString(", "),
+                townName = townOrCity,
+                postcode = postcode,
+            )
+    }
+}

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/AddressService.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/AddressService.kt
@@ -19,23 +19,4 @@ class AddressService(
 
         return addressRepository.save(Address(addressDataModel))
     }
-
-    fun createAddress(
-        addressLineOne: String,
-        townOrCity: String,
-        postcode: String,
-        addressLineTwo: String? = null,
-        county: String? = null,
-    ): Address {
-        val addressDataModel =
-            AddressDataModel(
-                singleLineAddress =
-                    listOfNotNull(addressLineOne, addressLineTwo, townOrCity, postcode, county)
-                        .joinToString(", "),
-                townName = townOrCity,
-                postcode = postcode,
-            )
-
-        return addressRepository.save(Address(addressDataModel))
-    }
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/AddressService.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/AddressService.kt
@@ -1,0 +1,41 @@
+package uk.gov.communities.prsdb.webapp.services
+
+import jakarta.transaction.Transactional
+import org.springframework.stereotype.Service
+import uk.gov.communities.prsdb.webapp.database.entity.Address
+import uk.gov.communities.prsdb.webapp.database.repository.AddressRepository
+import uk.gov.communities.prsdb.webapp.models.dataModels.AddressDataModel
+
+@Service
+class AddressService(
+    private val addressRepository: AddressRepository,
+) {
+    @Transactional
+    fun createAddress(addressDataModel: AddressDataModel): Address {
+        if (addressDataModel.uprn != null) {
+            val alreadyExistingAddress = addressRepository.findByUprn(addressDataModel.uprn)
+            if (alreadyExistingAddress != null) return alreadyExistingAddress
+        }
+
+        return addressRepository.save(Address(addressDataModel))
+    }
+
+    fun createAddress(
+        addressLineOne: String,
+        townOrCity: String,
+        postcode: String,
+        addressLineTwo: String? = null,
+        county: String? = null,
+    ): Address {
+        val addressDataModel =
+            AddressDataModel(
+                singleLineAddress =
+                    listOfNotNull(addressLineOne, addressLineTwo, townOrCity, postcode, county)
+                        .joinToString(", "),
+                townName = townOrCity,
+                postcode = postcode,
+            )
+
+        return addressRepository.save(Address(addressDataModel))
+    }
+}

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/AddressService.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/AddressService.kt
@@ -11,7 +11,7 @@ class AddressService(
     private val addressRepository: AddressRepository,
 ) {
     @Transactional
-    fun createAddress(addressDataModel: AddressDataModel): Address {
+    fun findOrCreateAddress(addressDataModel: AddressDataModel): Address {
         if (addressDataModel.uprn != null) {
             val alreadyExistingAddress = addressRepository.findByUprn(addressDataModel.uprn)
             if (alreadyExistingAddress != null) return alreadyExistingAddress

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/LandlordService.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/LandlordService.kt
@@ -4,16 +4,51 @@ import org.springframework.stereotype.Service
 import uk.gov.communities.prsdb.webapp.constants.enums.RegistrationNumberType
 import uk.gov.communities.prsdb.webapp.database.entity.Landlord
 import uk.gov.communities.prsdb.webapp.database.repository.LandlordRepository
+import uk.gov.communities.prsdb.webapp.database.repository.OneLoginUserRepository
+import uk.gov.communities.prsdb.webapp.models.dataModels.AddressDataModel
 import uk.gov.communities.prsdb.webapp.models.dataModels.RegistrationNumberDataModel
+import java.util.Date
 
 @Service
 class LandlordService(
     val landlordRepository: LandlordRepository,
+    val oneLoginUserRepository: OneLoginUserRepository,
+    val addressService: AddressService,
+    val registrationNumberService: RegistrationNumberService,
 ) {
     fun retrieveLandlordByRegNum(regNum: RegistrationNumberDataModel): Landlord? {
         if (regNum.type != RegistrationNumberType.LANDLORD) {
             throw IllegalArgumentException("Invalid registration number type")
         }
         return landlordRepository.findByRegistrationNumber_Number(regNum.number)
+    }
+
+    fun createLandlordAndReturnRegistrationNumber(
+        baseUserId: String,
+        name: String,
+        email: String,
+        phoneNumber: String,
+        addressDataModel: AddressDataModel,
+        internationalAddress: String? = null,
+        dateOfBirth: Date? = null,
+    ): String {
+        val baseUser = oneLoginUserRepository.getReferenceById(baseUserId)
+        val address = addressService.findOrCreateAddress(addressDataModel)
+        val registrationNumber = registrationNumberService.createRegistrationNumber(RegistrationNumberType.LANDLORD)
+
+        landlordRepository.save(
+            Landlord(
+                baseUser,
+                name,
+                email,
+                phoneNumber,
+                address,
+                registrationNumber,
+                internationalAddress,
+                dateOfBirth,
+            ),
+        )
+
+        return registrationNumber.toString()
     }
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/RegistrationNumberService.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/RegistrationNumberService.kt
@@ -13,9 +13,7 @@ class RegistrationNumberService(
     val regNumRepository: RegistrationNumberRepository,
 ) {
     @Transactional
-    fun createRegistrationNumber(type: RegistrationNumberType) {
-        regNumRepository.save(RegistrationNumber(type, generateUniqueRegNum()))
-    }
+    fun createRegistrationNumber(type: RegistrationNumberType) = regNumRepository.save(RegistrationNumber(type, generateUniqueRegNum()))
 
     private fun generateUniqueRegNum(): Long {
         var registrationNumber: Long

--- a/src/main/resources/db/migrations/V1_6_1__unique_address_uprn.sql
+++ b/src/main/resources/db/migrations/V1_6_1__unique_address_uprn.sql
@@ -1,0 +1,2 @@
+ALTER TABLE address
+    ADD CONSTRAINT uc_address_uprn UNIQUE (uprn);

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/models/dataModels/AddressDataModelTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/models/dataModels/AddressDataModelTests.kt
@@ -1,0 +1,79 @@
+package uk.gov.communities.prsdb.webapp.models.dataModels
+
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
+import kotlin.test.assertEquals
+
+class AddressDataModelTests {
+    companion object {
+        @JvmStatic
+        fun provideManualAddressFieldsAndAddressDataModels() =
+            listOf(
+                Arguments.of(
+                    "Flat 10",
+                    "Townville",
+                    "EG1 2AB",
+                    "1 Example Road",
+                    "Countyshire",
+                    AddressDataModel(
+                        singleLineAddress = "Flat 10, 1 Example Road, Townville, EG1 2AB, Countyshire",
+                        townName = "Townville",
+                        postcode = "EG1 2AB",
+                    ),
+                ),
+                Arguments.of(
+                    "1 Example Road",
+                    "Townville",
+                    "EG1 2AB",
+                    null,
+                    "Countyshire",
+                    AddressDataModel(
+                        singleLineAddress = "1 Example Road, Townville, EG1 2AB, Countyshire",
+                        townName = "Townville",
+                        postcode = "EG1 2AB",
+                    ),
+                ),
+                Arguments.of(
+                    "Flat 10",
+                    "Townville",
+                    "EG1 2AB",
+                    "1 Example Road",
+                    null,
+                    AddressDataModel(
+                        singleLineAddress = "Flat 10, 1 Example Road, Townville, EG1 2AB",
+                        townName = "Townville",
+                        postcode = "EG1 2AB",
+                    ),
+                ),
+                Arguments.of(
+                    "1 Example Road",
+                    "Townville",
+                    "EG1 2AB",
+                    null,
+                    null,
+                    AddressDataModel(
+                        singleLineAddress = "1 Example Road, Townville, EG1 2AB",
+                        townName = "Townville",
+                        postcode = "EG1 2AB",
+                    ),
+                ),
+            )
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideManualAddressFieldsAndAddressDataModels")
+    fun `parseAddressDataModel returns a corresponding AddressDataModel`(
+        addressLineOne: String,
+        townOrCity: String,
+        postcode: String,
+        addressLineTwo: String?,
+        county: String?,
+        expectedAddressDataModel: AddressDataModel,
+    ) {
+        assertEquals(
+            expectedAddressDataModel,
+            AddressDataModel.parseAddressDataModel(addressLineOne, townOrCity, postcode, addressLineTwo, county),
+        )
+    }
+}

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/AddressServiceTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/AddressServiceTests.kt
@@ -1,0 +1,94 @@
+package uk.gov.communities.prsdb.webapp.services
+
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.ArgumentCaptor.captor
+import org.mockito.ArgumentMatchers.any
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.Mockito.verify
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.whenever
+import uk.gov.communities.prsdb.webapp.database.entity.Address
+import uk.gov.communities.prsdb.webapp.database.repository.AddressRepository
+import uk.gov.communities.prsdb.webapp.models.dataModels.AddressDataModel
+import kotlin.test.assertEquals
+
+@ExtendWith(MockitoExtension::class)
+class AddressServiceTests {
+    @Mock
+    private lateinit var mockAddressRepository: AddressRepository
+
+    @InjectMocks
+    private lateinit var addressService: AddressService
+
+    private val mockAddress = Address()
+
+    @Test
+    fun `createAddress creates an address when given an AddressDataModel with no UPRN`() {
+        val addressDataModel = AddressDataModel("1 Example Road, EG1 2AB")
+
+        whenever(mockAddressRepository.save(any(Address::class.java))).thenReturn(mockAddress)
+
+        addressService.createAddress(addressDataModel)
+
+        val addressCaptor = captor<Address>()
+        verify(mockAddressRepository).save(addressCaptor.capture())
+        assertEquals(addressDataModel.singleLineAddress, addressCaptor.value.singleLineAddress)
+    }
+
+    @Test
+    fun `createAddress returns the corresponding address when given an AddressDataModel with an already existing UPRN`() {
+        val uprn = 123456L
+        val addressDataModel = AddressDataModel(singleLineAddress = "1 Example Road, EG1 2AB", uprn = uprn)
+        val address = Address(addressDataModel)
+
+        whenever(mockAddressRepository.findByUprn(uprn)).thenReturn(address)
+
+        val createdAddress = addressService.createAddress(addressDataModel)
+
+        assertEquals(address, createdAddress)
+    }
+
+    @Test
+    fun `createAddress creates an address when given an AddressDataModel with a new UPRN`() {
+        val uprn = 123456L
+        val addressDataModel = AddressDataModel(singleLineAddress = "1 Example Road, EG1 2AB", uprn = uprn)
+        val address = Address(addressDataModel)
+
+        whenever(mockAddressRepository.findByUprn(uprn)).thenReturn(null)
+        whenever(mockAddressRepository.save(any(Address::class.java))).thenReturn(mockAddress)
+
+        addressService.createAddress(addressDataModel)
+
+        verify(mockAddressRepository).findByUprn(uprn)
+        val addressCaptor = captor<Address>()
+        verify(mockAddressRepository).save(addressCaptor.capture())
+        assertEquals(addressDataModel.singleLineAddress, addressCaptor.value.singleLineAddress)
+    }
+
+    @Test
+    fun `createAddress creates an address when given manual address fields`() {
+        val expectedAddressDataModel =
+            AddressDataModel(
+                singleLineAddress = "1 Example Road, Townville, EG1 2AB, Countyshire",
+                townName = "Townville",
+                postcode = "EG1 2AB",
+            )
+
+        whenever(mockAddressRepository.save(any(Address::class.java))).thenReturn(Address())
+
+        addressService.createAddress(
+            addressLineOne = "1 Example Road",
+            townOrCity = "Townville",
+            postcode = "EG1 2AB",
+            county = "Countyshire",
+        )
+
+        val addressCaptor = captor<Address>()
+        verify(mockAddressRepository).save(addressCaptor.capture())
+        assertEquals(expectedAddressDataModel.singleLineAddress, addressCaptor.value.singleLineAddress)
+        assertEquals(expectedAddressDataModel.townName, addressCaptor.value.townName)
+        assertEquals(expectedAddressDataModel.postcode, addressCaptor.value.postcode)
+    }
+}

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/AddressServiceTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/AddressServiceTests.kt
@@ -25,12 +25,12 @@ class AddressServiceTests {
     private val mockAddress = Address()
 
     @Test
-    fun `createAddress creates an address when given an AddressDataModel with no UPRN`() {
+    fun `findOrCreateAddress creates an address when given an AddressDataModel with no UPRN`() {
         val addressDataModel = AddressDataModel("1 Example Road, EG1 2AB")
 
         whenever(mockAddressRepository.save(any(Address::class.java))).thenReturn(mockAddress)
 
-        addressService.createAddress(addressDataModel)
+        addressService.findOrCreateAddress(addressDataModel)
 
         val addressCaptor = captor<Address>()
         verify(mockAddressRepository).save(addressCaptor.capture())
@@ -38,27 +38,27 @@ class AddressServiceTests {
     }
 
     @Test
-    fun `createAddress returns the corresponding address when given an AddressDataModel with an already existing UPRN`() {
+    fun `findOrCreateAddress returns the corresponding address when given an AddressDataModel with an already existing UPRN`() {
         val uprn = 123456L
         val addressDataModel = AddressDataModel(singleLineAddress = "1 Example Road, EG1 2AB", uprn = uprn)
         val address = Address(addressDataModel)
 
         whenever(mockAddressRepository.findByUprn(uprn)).thenReturn(address)
 
-        val createdAddress = addressService.createAddress(addressDataModel)
+        val createdAddress = addressService.findOrCreateAddress(addressDataModel)
 
         assertEquals(address, createdAddress)
     }
 
     @Test
-    fun `createAddress creates an address when given an AddressDataModel with a new UPRN`() {
+    fun `findOrCreateAddress creates an address when given an AddressDataModel with a new UPRN`() {
         val uprn = 123456L
         val addressDataModel = AddressDataModel(singleLineAddress = "1 Example Road, EG1 2AB", uprn = uprn)
 
         whenever(mockAddressRepository.findByUprn(uprn)).thenReturn(null)
         whenever(mockAddressRepository.save(any(Address::class.java))).thenReturn(mockAddress)
 
-        addressService.createAddress(addressDataModel)
+        addressService.findOrCreateAddress(addressDataModel)
 
         verify(mockAddressRepository).findByUprn(uprn)
         val addressCaptor = captor<Address>()

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/AddressServiceTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/AddressServiceTests.kt
@@ -54,7 +54,6 @@ class AddressServiceTests {
     fun `createAddress creates an address when given an AddressDataModel with a new UPRN`() {
         val uprn = 123456L
         val addressDataModel = AddressDataModel(singleLineAddress = "1 Example Road, EG1 2AB", uprn = uprn)
-        val address = Address(addressDataModel)
 
         whenever(mockAddressRepository.findByUprn(uprn)).thenReturn(null)
         whenever(mockAddressRepository.save(any(Address::class.java))).thenReturn(mockAddress)
@@ -65,30 +64,5 @@ class AddressServiceTests {
         val addressCaptor = captor<Address>()
         verify(mockAddressRepository).save(addressCaptor.capture())
         assertEquals(addressDataModel.singleLineAddress, addressCaptor.value.singleLineAddress)
-    }
-
-    @Test
-    fun `createAddress creates an address when given manual address fields`() {
-        val expectedAddressDataModel =
-            AddressDataModel(
-                singleLineAddress = "1 Example Road, Townville, EG1 2AB, Countyshire",
-                townName = "Townville",
-                postcode = "EG1 2AB",
-            )
-
-        whenever(mockAddressRepository.save(any(Address::class.java))).thenReturn(Address())
-
-        addressService.createAddress(
-            addressLineOne = "1 Example Road",
-            townOrCity = "Townville",
-            postcode = "EG1 2AB",
-            county = "Countyshire",
-        )
-
-        val addressCaptor = captor<Address>()
-        verify(mockAddressRepository).save(addressCaptor.capture())
-        assertEquals(expectedAddressDataModel.singleLineAddress, addressCaptor.value.singleLineAddress)
-        assertEquals(expectedAddressDataModel.townName, addressCaptor.value.townName)
-        assertEquals(expectedAddressDataModel.postcode, addressCaptor.value.postcode)
     }
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/LandlordServiceTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/LandlordServiceTests.kt
@@ -1,26 +1,44 @@
 package uk.gov.communities.prsdb.webapp.services
 
 import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.ArgumentCaptor.captor
-import org.mockito.Mockito.mock
+import org.mockito.InjectMocks
+import org.mockito.Mock
 import org.mockito.Mockito.verify
+import org.mockito.internal.matchers.apachecommons.ReflectionEquals
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.whenever
 import uk.gov.communities.prsdb.webapp.constants.enums.RegistrationNumberType
+import uk.gov.communities.prsdb.webapp.database.entity.Address
+import uk.gov.communities.prsdb.webapp.database.entity.Landlord
+import uk.gov.communities.prsdb.webapp.database.entity.OneLoginUser
+import uk.gov.communities.prsdb.webapp.database.entity.RegistrationNumber
 import uk.gov.communities.prsdb.webapp.database.repository.LandlordRepository
+import uk.gov.communities.prsdb.webapp.database.repository.OneLoginUserRepository
+import uk.gov.communities.prsdb.webapp.models.dataModels.AddressDataModel
 import uk.gov.communities.prsdb.webapp.models.dataModels.RegistrationNumberDataModel
 import kotlin.test.assertNull
 
+@ExtendWith(MockitoExtension::class)
 class LandlordServiceTests {
+    @Mock
     private lateinit var mockLandlordRepository: LandlordRepository
-    private lateinit var landlordService: LandlordService
 
-    @BeforeEach
-    fun setUp() {
-        mockLandlordRepository = mock()
-        landlordService = LandlordService(mockLandlordRepository)
-    }
+    @Mock
+    private lateinit var mockOneLoginUserRepository: OneLoginUserRepository
+
+    @Mock
+    private lateinit var mockAddressService: AddressService
+
+    @Mock
+    private lateinit var mockRegistrationNumberService: RegistrationNumberService
+
+    @InjectMocks
+    private lateinit var landlordService: LandlordService
 
     @Test
     fun `retrieveLandlordByRegNum returns a landlord given its registration number`() {
@@ -49,5 +67,47 @@ class LandlordServiceTests {
                 RegistrationNumberDataModel(RegistrationNumberType.PROPERTY, 0L),
             )
         }
+    }
+
+    @Test
+    fun `createLandlordAndReturnRegistrationNumber creates a landlord and returns its registration number`() {
+        val baseUserId = "baseUserId"
+        val addressDataModel = AddressDataModel("1 Example Road, EG1 2AB")
+
+        val baseUser = OneLoginUser(baseUserId)
+        val address = Address(addressDataModel)
+        val registrationNumber = RegistrationNumber(RegistrationNumberType.LANDLORD, 1233456)
+
+        val expectedLandlord =
+            Landlord(
+                baseUser,
+                "name",
+                "example@email.com",
+                "07123456789",
+                address,
+                registrationNumber,
+                null,
+                null,
+            )
+
+        whenever(mockOneLoginUserRepository.getReferenceById(baseUserId)).thenReturn(baseUser)
+        whenever(mockAddressService.findOrCreateAddress(addressDataModel)).thenReturn(address)
+        whenever(mockRegistrationNumberService.createRegistrationNumber(RegistrationNumberType.LANDLORD)).thenReturn(
+            registrationNumber,
+        )
+
+        val registrationNumberString =
+            landlordService.createLandlordAndReturnRegistrationNumber(
+                baseUserId,
+                "name",
+                "example@email.com",
+                "07123456789",
+                addressDataModel,
+            )
+
+        val landlordCaptor = captor<Landlord>()
+        verify(mockLandlordRepository).save(landlordCaptor.capture())
+        assertTrue(ReflectionEquals(expectedLandlord, "id").matches(landlordCaptor.value))
+        assertEquals(registrationNumber.toString(), registrationNumberString)
     }
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/RegistrationNumberServiceTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/RegistrationNumberServiceTests.kt
@@ -17,6 +17,8 @@ class RegistrationNumberServiceTests {
     private lateinit var mockRegNumRepository: RegistrationNumberRepository
     private lateinit var regNumService: RegistrationNumberService
 
+    private val mockRegistrationNumber = RegistrationNumber()
+
     @BeforeEach
     fun setup() {
         mockRegNumRepository = mock()
@@ -26,6 +28,7 @@ class RegistrationNumberServiceTests {
     @Test
     fun `createRegistrationNumber creates a registration number for the given entity type`() {
         whenever(mockRegNumRepository.existsByNumber(any(Long::class.java))).thenReturn(false)
+        whenever(mockRegNumRepository.save(any(RegistrationNumber::class.java))).thenReturn(mockRegistrationNumber)
 
         regNumService.createRegistrationNumber(RegistrationNumberType.LANDLORD)
 
@@ -37,6 +40,7 @@ class RegistrationNumberServiceTests {
     @Test
     fun `createRegistrationNumber creates a unique registration number`() {
         whenever(mockRegNumRepository.existsByNumber(any(Long::class.java))).thenReturn(true, false)
+        whenever(mockRegNumRepository.save(any(RegistrationNumber::class.java))).thenReturn(mockRegistrationNumber)
 
         regNumService.createRegistrationNumber(RegistrationNumberType.LANDLORD)
 


### PR DESCRIPTION
### Features
- Creates minor migration for making `Landlord.uprn` unique
- Creates `AddressDataModel.parseAddressDataModel()` (for converting a set of manual address fields into an `AddressDataModel`)
- Creates `AddressService.findOrCreateAddress()`
- Creates `LandlordService.createLandlordAndReturnRegistrationNumber()`

### Tests
- Tests for created/updated methods in 
  - `RegistrationNumberService`
  - `AddressService`
  - `LandlordService`
  - `AddressDataModel`