### PR TITLE
Feat/prsd 372 landlord registration check answers

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/LandlordRegistrationJourney.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/LandlordRegistrationJourney.kt
@@ -402,19 +402,7 @@ class LandlordRegistrationJourney(
             addressDataService: AddressDataService,
         ) = Step(
             id = LandlordRegistrationStepId.CheckAnswers,
-            page =
-                LandlordRegistrationCheckAnswersPage(
-                    formModel = CheckAnswersFormModel::class,
-                    templateName = "forms/checkAnswersForm",
-                    content =
-                        mapOf(
-                            "title" to "registerAsALandlord.title",
-                            "summaryName" to "registerAsALandlord.checkAnswers.summaryName",
-                            "submitButtonText" to "forms.buttons.confirmAndContinue",
-                        ),
-                    journeyDataService = journeyDataService,
-                    addressDataService = addressDataService,
-                ),
+            page = LandlordRegistrationCheckAnswersPage(journeyDataService, addressDataService),
             nextAction = { _, _ -> Pair(LandlordRegistrationStepId.Declaration, null) },
             saveAfterSubmit = false,
         )

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/LandlordRegistrationJourney.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/LandlordRegistrationJourney.kt
@@ -63,7 +63,7 @@ class LandlordRegistrationJourney(
                 lookupContactAddressStep(),
                 selectContactAddressStep(journeyDataService, addressLookupService, addressDataService),
                 manualContactAddressStep(),
-                checkAnswersStep(),
+                checkAnswersStep(journeyDataService, addressDataService),
                 declarationStep(journeyDataService, landlordService, addressDataService),
             ),
     ) {
@@ -397,24 +397,27 @@ class LandlordRegistrationJourney(
                 saveAfterSubmit = false,
             )
 
-        private fun checkAnswersStep() =
-            Step(
-                // TODO PRSD-372 update message value(s)
-                id = LandlordRegistrationStepId.CheckAnswers,
-                page =
-                    LandlordRegistrationCheckAnswersPage(
-                        formModel = CheckAnswersFormModel::class,
-                        templateName = "forms/checkAnswersForm",
-                        content =
-                            mapOf(
-                                "title" to "registerAsALandlord.title",
-                                "summaryName" to "registerAsALandlord.title",
-                                "submitButtonText" to "forms.buttons.confirmAndContinue",
-                            ),
-                    ),
-                nextAction = { _, _ -> Pair(LandlordRegistrationStepId.Declaration, null) },
-                saveAfterSubmit = false,
-            )
+        private fun checkAnswersStep(
+            journeyDataService: JourneyDataService,
+            addressDataService: AddressDataService,
+        ) = Step(
+            id = LandlordRegistrationStepId.CheckAnswers,
+            page =
+                LandlordRegistrationCheckAnswersPage(
+                    formModel = CheckAnswersFormModel::class,
+                    templateName = "forms/checkAnswersForm",
+                    content =
+                        mapOf(
+                            "title" to "registerAsALandlord.title",
+                            "summaryName" to "registerAsALandlord.checkAnswers.summaryName",
+                            "submitButtonText" to "forms.buttons.confirmAndContinue",
+                        ),
+                    journeyDataService = journeyDataService,
+                    addressDataService = addressDataService,
+                ),
+            nextAction = { _, _ -> Pair(LandlordRegistrationStepId.Declaration, null) },
+            saveAfterSubmit = false,
+        )
 
         private fun declarationStep(
             journeyDataService: JourneyDataService,

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/pages/LandlordRegistrationCheckAnswersPage.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/pages/LandlordRegistrationCheckAnswersPage.kt
@@ -2,18 +2,23 @@ package uk.gov.communities.prsdb.webapp.forms.pages
 
 import org.springframework.ui.Model
 import org.springframework.validation.Validator
+import uk.gov.communities.prsdb.webapp.constants.LOCAL_AUTHORITIES
 import uk.gov.communities.prsdb.webapp.constants.enums.JourneyType
 import uk.gov.communities.prsdb.webapp.forms.journeys.JourneyData
-import uk.gov.communities.prsdb.webapp.forms.journeys.objectToStringKeyedMap
-import uk.gov.communities.prsdb.webapp.forms.steps.RegisterLaUserStepId
+import uk.gov.communities.prsdb.webapp.forms.steps.LandlordRegistrationStepId
+import uk.gov.communities.prsdb.webapp.helpers.LandlordJourneyDataHelper
 import uk.gov.communities.prsdb.webapp.models.formModels.FormModel
 import uk.gov.communities.prsdb.webapp.models.viewModels.FormSummaryViewModel
+import uk.gov.communities.prsdb.webapp.services.AddressDataService
+import uk.gov.communities.prsdb.webapp.services.JourneyDataService
 import kotlin.reflect.KClass
 
 class LandlordRegistrationCheckAnswersPage(
     formModel: KClass<out FormModel>,
     templateName: String,
     content: Map<String, Any>,
+    private val journeyDataService: JourneyDataService,
+    private val addressDataService: AddressDataService,
 ) : Page(formModel, templateName, content) {
     override fun populateModelAndGetTemplateName(
         validator: Validator,
@@ -22,26 +27,130 @@ class LandlordRegistrationCheckAnswersPage(
         prevStepUrl: String?,
         journeyData: JourneyData?,
     ): String {
-        val formData = mutableListOf<FormSummaryViewModel>()
+        journeyData!!
 
-        // TODO PRSD-372 update the formData below
+        val formData =
+            getIdentityFormData(journeyData) +
+                getEmailAndPhoneFormData(journeyData) +
+                getAddressFormData(journeyData)
 
-        formData.addAll(
-            listOf(
-                FormSummaryViewModel(
-                    "registerLaUser.checkAnswers.rowHeading.name",
-                    objectToStringKeyedMap(journeyData?.get("name"))?.get("name"),
-                    "/${JourneyType.LA_USER_REGISTRATION.urlPathSegment}/${RegisterLaUserStepId.Name.urlPathSegment}",
-                ),
-                FormSummaryViewModel(
-                    "registerLaUser.checkAnswers.rowHeading.email",
-                    objectToStringKeyedMap(journeyData?.get("email"))?.get("emailAddress"),
-                    "/${JourneyType.LA_USER_REGISTRATION.urlPathSegment}/${RegisterLaUserStepId.Email.urlPathSegment}",
-                ),
+        model.addAttribute("formData", formData)
+        return super.populateModelAndGetTemplateName(validator, model, pageData, prevStepUrl)
+    }
+
+    private fun getIdentityFormData(journeyData: JourneyData): List<FormSummaryViewModel> {
+        val isIdentityVerified = LandlordJourneyDataHelper.isIdentityVerified(journeyDataService, journeyData)
+
+        return listOf(
+            FormSummaryViewModel(
+                "registerAsALandlord.checkAnswers.rowHeading.name",
+                LandlordJourneyDataHelper.getName(journeyDataService, journeyData)!!,
+                if (isIdentityVerified) null else "/${BASE_CHANGE_URL}/${LandlordRegistrationStepId.Name.urlPathSegment}",
+            ),
+            FormSummaryViewModel(
+                "registerAsALandlord.checkAnswers.rowHeading.dateOfBirth",
+                LandlordJourneyDataHelper.getDOB(journeyDataService, journeyData)!!,
+                if (isIdentityVerified) null else "/${BASE_CHANGE_URL}/${LandlordRegistrationStepId.DateOfBirth.urlPathSegment}",
+            ),
+        )
+    }
+
+    private fun getEmailAndPhoneFormData(journeyData: JourneyData): List<FormSummaryViewModel> =
+        listOf(
+            FormSummaryViewModel(
+                "registerAsALandlord.checkAnswers.rowHeading.email",
+                LandlordJourneyDataHelper.getEmail(journeyDataService, journeyData)!!,
+                "/${BASE_CHANGE_URL}/${LandlordRegistrationStepId.Email.urlPathSegment}",
+            ),
+            FormSummaryViewModel(
+                "registerAsALandlord.checkAnswers.rowHeading.telephoneNumber",
+                LandlordJourneyDataHelper.getPhoneNumber(journeyDataService, journeyData)!!,
+                "/${BASE_CHANGE_URL}/${LandlordRegistrationStepId.PhoneNumber.urlPathSegment}",
             ),
         )
 
-        model.addAttribute("formData", formData)
-        return super.populateModelAndGetTemplateName(validator, model, pageData, prevStepUrl, journeyData)
+    private fun getAddressFormData(journeyData: JourneyData): List<FormSummaryViewModel> {
+        val livesInUK = LandlordJourneyDataHelper.getLivesInUK(journeyDataService, journeyData)!!
+
+        return getLivesInUKFormData(livesInUK) +
+            (if (!livesInUK) getInternationalAddressFormData(journeyData) else emptyList()) +
+            getContactAddressFormData(journeyData, addressDataService, livesInUK)
+    }
+
+    private fun getLivesInUKFormData(livesInUK: Boolean): List<FormSummaryViewModel> =
+        listOf(
+            FormSummaryViewModel(
+                "registerAsALandlord.checkAnswers.rowHeading.ukResident",
+                if (livesInUK) "commonText.yes" else "commonText.no",
+                "/${BASE_CHANGE_URL}/${LandlordRegistrationStepId.CountryOfResidence.urlPathSegment}",
+            ),
+        )
+
+    private fun getInternationalAddressFormData(journeyData: JourneyData): List<FormSummaryViewModel> =
+        listOf(
+            FormSummaryViewModel(
+                "registerAsALandlord.checkAnswers.rowHeading.countryOfResidence",
+                LandlordJourneyDataHelper.getNonUKCountryOfResidence(journeyDataService, journeyData)!!,
+                "/${BASE_CHANGE_URL}/${LandlordRegistrationStepId.CountryOfResidence.urlPathSegment}",
+            ),
+            FormSummaryViewModel(
+                "registerAsALandlord.checkAnswers.rowHeading.contactAddressOutsideUK",
+                LandlordJourneyDataHelper.getInternationalAddress(journeyDataService, journeyData)!!,
+                "/${BASE_CHANGE_URL}/${LandlordRegistrationStepId.InternationalAddress.urlPathSegment}",
+            ),
+        )
+
+    private fun getContactAddressFormData(
+        journeyData: JourneyData,
+        addressDataService: AddressDataService,
+        livesInUK: Boolean,
+    ): List<FormSummaryViewModel> {
+        val address = LandlordJourneyDataHelper.getAddress(journeyDataService, journeyData, addressDataService)!!
+        val localAuthority = LOCAL_AUTHORITIES.find { it.custodianCode == address.custodianCode }?.displayName
+
+        return listOfNotNull(
+            FormSummaryViewModel(
+                if (livesInUK) {
+                    "registerAsALandlord.checkAnswers.rowHeading.contactAddress"
+                } else {
+                    "registerAsALandlord.checkAnswers.rowHeading.ukContactAddress"
+                },
+                address.singleLineAddress,
+                getContactAddressChangeURLPathSegment(journeyData, livesInUK),
+            ),
+            if (localAuthority == null) {
+                null
+            } else {
+                FormSummaryViewModel(
+                    "registerAsALandlord.checkAnswers.rowHeading.localAuthority",
+                    localAuthority,
+                    null,
+                )
+            },
+        )
+    }
+
+    private fun getContactAddressChangeURLPathSegment(
+        journeyData: JourneyData,
+        livesInUK: Boolean,
+    ): String =
+        if (livesInUK) {
+            if (LandlordJourneyDataHelper.isManualAddressChosen(journeyDataService, journeyData)) {
+                LandlordRegistrationStepId.ManualAddress.urlPathSegment
+            } else {
+                LandlordRegistrationStepId.LookupAddress.urlPathSegment
+            }
+        } else {
+            val isContactAddress = true
+            if (LandlordJourneyDataHelper.isManualAddressChosen(journeyDataService, journeyData, isContactAddress)
+            ) {
+                LandlordRegistrationStepId.ManualContactAddress.urlPathSegment
+            } else {
+                LandlordRegistrationStepId.LookupContactAddress.urlPathSegment
+            }
+        }
+
+    companion object {
+        private val BASE_CHANGE_URL = JourneyType.LANDLORD_REGISTRATION.urlPathSegment
     }
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/pages/LandlordRegistrationCheckAnswersPage.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/pages/LandlordRegistrationCheckAnswersPage.kt
@@ -2,7 +2,6 @@ package uk.gov.communities.prsdb.webapp.forms.pages
 
 import org.springframework.ui.Model
 import org.springframework.validation.Validator
-import uk.gov.communities.prsdb.webapp.constants.LOCAL_AUTHORITIES
 import uk.gov.communities.prsdb.webapp.forms.journeys.JourneyData
 import uk.gov.communities.prsdb.webapp.forms.steps.LandlordRegistrationStepId
 import uk.gov.communities.prsdb.webapp.helpers.LandlordJourneyDataHelper
@@ -108,29 +107,22 @@ class LandlordRegistrationCheckAnswersPage(
         journeyData: JourneyData,
         addressDataService: AddressDataService,
         livesInUK: Boolean,
-    ): List<FormSummaryViewModel> {
-        val address = LandlordJourneyDataHelper.getAddress(journeyDataService, journeyData, addressDataService)!!
-        val localAuthority = LOCAL_AUTHORITIES.find { it.custodianCode == address.custodianCode }?.displayName
-
-        return listOfNotNull(
-            FormSummaryViewModel(
-                if (livesInUK) {
-                    "registerAsALandlord.checkAnswers.rowHeading.contactAddress"
-                } else {
-                    "registerAsALandlord.checkAnswers.rowHeading.ukContactAddress"
-                },
-                address.singleLineAddress,
-                getContactAddressChangeURLPathSegment(journeyData, livesInUK),
-            ),
-            localAuthority?.let {
-                FormSummaryViewModel(
-                    "registerAsALandlord.checkAnswers.rowHeading.localAuthority",
-                    localAuthority,
-                    null,
-                )
+    ): FormSummaryViewModel =
+        FormSummaryViewModel(
+            if (livesInUK) {
+                "registerAsALandlord.checkAnswers.rowHeading.contactAddress"
+            } else {
+                "registerAsALandlord.checkAnswers.rowHeading.ukContactAddress"
             },
+            LandlordJourneyDataHelper
+                .getAddress(
+                    journeyDataService,
+                    journeyData,
+                    addressDataService,
+                )!!
+                .singleLineAddress,
+            getContactAddressChangeURLPathSegment(journeyData, livesInUK),
         )
-    }
 
     private fun getContactAddressChangeURLPathSegment(
         journeyData: JourneyData,

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/pages/LandlordRegistrationCheckAnswersPage.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/pages/LandlordRegistrationCheckAnswersPage.kt
@@ -3,23 +3,27 @@ package uk.gov.communities.prsdb.webapp.forms.pages
 import org.springframework.ui.Model
 import org.springframework.validation.Validator
 import uk.gov.communities.prsdb.webapp.constants.LOCAL_AUTHORITIES
-import uk.gov.communities.prsdb.webapp.constants.enums.JourneyType
 import uk.gov.communities.prsdb.webapp.forms.journeys.JourneyData
 import uk.gov.communities.prsdb.webapp.forms.steps.LandlordRegistrationStepId
 import uk.gov.communities.prsdb.webapp.helpers.LandlordJourneyDataHelper
-import uk.gov.communities.prsdb.webapp.models.formModels.FormModel
+import uk.gov.communities.prsdb.webapp.models.formModels.CheckAnswersFormModel
 import uk.gov.communities.prsdb.webapp.models.viewModels.FormSummaryViewModel
 import uk.gov.communities.prsdb.webapp.services.AddressDataService
 import uk.gov.communities.prsdb.webapp.services.JourneyDataService
-import kotlin.reflect.KClass
 
 class LandlordRegistrationCheckAnswersPage(
-    formModel: KClass<out FormModel>,
-    templateName: String,
-    content: Map<String, Any>,
     private val journeyDataService: JourneyDataService,
     private val addressDataService: AddressDataService,
-) : Page(formModel, templateName, content) {
+) : Page(
+        formModel = CheckAnswersFormModel::class,
+        templateName = "forms/checkAnswersForm",
+        content =
+            mapOf(
+                "title" to "registerAsALandlord.title",
+                "summaryName" to "registerAsALandlord.checkAnswers.summaryName",
+                "submitButtonText" to "forms.buttons.confirmAndContinue",
+            ),
+    ) {
     override fun populateModelAndGetTemplateName(
         validator: Validator,
         model: Model,
@@ -45,12 +49,12 @@ class LandlordRegistrationCheckAnswersPage(
             FormSummaryViewModel(
                 "registerAsALandlord.checkAnswers.rowHeading.name",
                 LandlordJourneyDataHelper.getName(journeyDataService, journeyData)!!,
-                if (isIdentityVerified) null else "/${BASE_CHANGE_URL}/${LandlordRegistrationStepId.Name.urlPathSegment}",
+                if (isIdentityVerified) null else LandlordRegistrationStepId.Name.urlPathSegment,
             ),
             FormSummaryViewModel(
                 "registerAsALandlord.checkAnswers.rowHeading.dateOfBirth",
                 LandlordJourneyDataHelper.getDOB(journeyDataService, journeyData)!!,
-                if (isIdentityVerified) null else "/${BASE_CHANGE_URL}/${LandlordRegistrationStepId.DateOfBirth.urlPathSegment}",
+                if (isIdentityVerified) null else LandlordRegistrationStepId.DateOfBirth.urlPathSegment,
             ),
         )
     }
@@ -60,12 +64,12 @@ class LandlordRegistrationCheckAnswersPage(
             FormSummaryViewModel(
                 "registerAsALandlord.checkAnswers.rowHeading.email",
                 LandlordJourneyDataHelper.getEmail(journeyDataService, journeyData)!!,
-                "/${BASE_CHANGE_URL}/${LandlordRegistrationStepId.Email.urlPathSegment}",
+                LandlordRegistrationStepId.Email.urlPathSegment,
             ),
             FormSummaryViewModel(
                 "registerAsALandlord.checkAnswers.rowHeading.telephoneNumber",
                 LandlordJourneyDataHelper.getPhoneNumber(journeyDataService, journeyData)!!,
-                "/${BASE_CHANGE_URL}/${LandlordRegistrationStepId.PhoneNumber.urlPathSegment}",
+                LandlordRegistrationStepId.PhoneNumber.urlPathSegment,
             ),
         )
 
@@ -82,7 +86,7 @@ class LandlordRegistrationCheckAnswersPage(
             FormSummaryViewModel(
                 "registerAsALandlord.checkAnswers.rowHeading.ukResident",
                 if (livesInUK) "commonText.yes" else "commonText.no",
-                "/${BASE_CHANGE_URL}/${LandlordRegistrationStepId.CountryOfResidence.urlPathSegment}",
+                LandlordRegistrationStepId.CountryOfResidence.urlPathSegment,
             ),
         )
 
@@ -91,12 +95,12 @@ class LandlordRegistrationCheckAnswersPage(
             FormSummaryViewModel(
                 "registerAsALandlord.checkAnswers.rowHeading.countryOfResidence",
                 LandlordJourneyDataHelper.getNonUKCountryOfResidence(journeyDataService, journeyData)!!,
-                "/${BASE_CHANGE_URL}/${LandlordRegistrationStepId.CountryOfResidence.urlPathSegment}",
+                LandlordRegistrationStepId.CountryOfResidence.urlPathSegment,
             ),
             FormSummaryViewModel(
                 "registerAsALandlord.checkAnswers.rowHeading.contactAddressOutsideUK",
                 LandlordJourneyDataHelper.getInternationalAddress(journeyDataService, journeyData)!!,
-                "/${BASE_CHANGE_URL}/${LandlordRegistrationStepId.InternationalAddress.urlPathSegment}",
+                LandlordRegistrationStepId.InternationalAddress.urlPathSegment,
             ),
         )
 
@@ -118,9 +122,7 @@ class LandlordRegistrationCheckAnswersPage(
                 address.singleLineAddress,
                 getContactAddressChangeURLPathSegment(journeyData, livesInUK),
             ),
-            if (localAuthority == null) {
-                null
-            } else {
+            localAuthority?.let {
                 FormSummaryViewModel(
                     "registerAsALandlord.checkAnswers.rowHeading.localAuthority",
                     localAuthority,
@@ -149,8 +151,4 @@ class LandlordRegistrationCheckAnswersPage(
                 LandlordRegistrationStepId.LookupContactAddress.urlPathSegment
             }
         }
-
-    companion object {
-        private val BASE_CHANGE_URL = JourneyType.LANDLORD_REGISTRATION.urlPathSegment
-    }
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/pages/LandlordRegistrationCheckAnswersPage.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/pages/LandlordRegistrationCheckAnswersPage.kt
@@ -84,7 +84,7 @@ class LandlordRegistrationCheckAnswersPage(
         listOf(
             FormSummaryViewModel(
                 "registerAsALandlord.checkAnswers.rowHeading.ukResident",
-                if (livesInUK) "commonText.yes" else "commonText.no",
+                livesInUK,
                 LandlordRegistrationStepId.CountryOfResidence.urlPathSegment,
             ),
         )

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/helpers/LandlordJourneyDataHelper.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/helpers/LandlordJourneyDataHelper.kt
@@ -103,14 +103,18 @@ class LandlordJourneyDataHelper {
             "livesInUK",
         )
 
-        fun getCountryOfResidence(
+        fun getNonUKCountryOfResidence(
             journeyDataService: JourneyDataService,
             journeyData: JourneyData,
-        ) = journeyDataService.getFieldStringValue(
-            journeyData,
-            LandlordRegistrationStepId.CountryOfResidence.urlPathSegment,
-            "countryOfResidence",
-        )
+        ) = if (getLivesInUK(journeyDataService, journeyData) == true) {
+            null
+        } else {
+            journeyDataService.getFieldStringValue(
+                journeyData,
+                LandlordRegistrationStepId.CountryOfResidence.urlPathSegment,
+                "countryOfResidence",
+            )
+        }
 
         fun getAddress(
             journeyDataService: JourneyDataService,

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -84,6 +84,17 @@ registerAsALandlord.byEmail.paragraph.one.afterLink=.
 registerAsALandlord.byEmail.paragraph.two.beforeLink=You can email the completed form to
 registerAsALandlord.byEmail.paragraph.two.link=landlordregistration@uk.gov.uk
 registerAsALandlord.byEmail.paragraph.two.afterLink=.
+registerAsALandlord.checkAnswers.summaryName=Your details
+registerAsALandlord.checkAnswers.rowHeading.name=Name
+registerAsALandlord.checkAnswers.rowHeading.dateOfBirth=Date of birth
+registerAsALandlord.checkAnswers.rowHeading.email=Email address
+registerAsALandlord.checkAnswers.rowHeading.telephoneNumber=Telephone number
+registerAsALandlord.checkAnswers.rowHeading.ukResident=UK resident
+registerAsALandlord.checkAnswers.rowHeading.contactAddress=Contact address
+registerAsALandlord.checkAnswers.rowHeading.countryOfResidence=Country of residence
+registerAsALandlord.checkAnswers.rowHeading.contactAddressOutsideUK=Contact address (outside UK)
+registerAsALandlord.checkAnswers.rowHeading.ukContactAddress=UK contact address
+registerAsALandlord.checkAnswers.rowHeading.localAuthority=Local Authority
 
 registerAsALandlord.confirmation.banner.heading=We've saved your personal details
 registerAsALandlord.confirmation.banner.body.beforeRegistrationNumber=Your landlord registration number is

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/forms/pages/LandlordRegistrationCheckAnswersPageTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/forms/pages/LandlordRegistrationCheckAnswersPageTests.kt
@@ -13,10 +13,6 @@ import org.springframework.validation.Validator
 import uk.gov.communities.prsdb.webapp.forms.steps.LandlordRegistrationStepId
 import uk.gov.communities.prsdb.webapp.mockObjects.JourneyDataBuilder
 import uk.gov.communities.prsdb.webapp.mockObjects.JourneyDataBuilder.Companion.DEFAULT_ADDRESS
-import uk.gov.communities.prsdb.webapp.mockObjects.JourneyDataBuilder.Companion.DEFAULT_DOB
-import uk.gov.communities.prsdb.webapp.mockObjects.JourneyDataBuilder.Companion.DEFAULT_EMAIL_ADDRESS
-import uk.gov.communities.prsdb.webapp.mockObjects.JourneyDataBuilder.Companion.DEFAULT_NAME
-import uk.gov.communities.prsdb.webapp.mockObjects.JourneyDataBuilder.Companion.DEFAULT_PHONE_NUMBER
 import uk.gov.communities.prsdb.webapp.models.dataModels.AddressDataModel
 import uk.gov.communities.prsdb.webapp.models.viewModels.FormSummaryViewModel
 import uk.gov.communities.prsdb.webapp.services.AddressDataService
@@ -83,14 +79,16 @@ class LandlordRegistrationCheckAnswersPageTests {
 
     @Test
     fun `formData has the correct name and DOB (unverified)`() {
-        val journeyData = journeyDataBuilder.build()
+        val name = "Arthur Dent"
+        val dob = LocalDate.of(200, 1, 1)
+        val journeyData = journeyDataBuilder.withUnverifiedUser(name, dob).build()
 
         val formData = getFormData(journeyData)
 
         assertEquals(
             FormSummaryViewModel(
                 "registerAsALandlord.checkAnswers.rowHeading.name",
-                DEFAULT_NAME,
+                name,
                 LandlordRegistrationStepId.Name.urlPathSegment,
             ),
             formData.single {
@@ -100,7 +98,7 @@ class LandlordRegistrationCheckAnswersPageTests {
         assertEquals(
             FormSummaryViewModel(
                 "registerAsALandlord.checkAnswers.rowHeading.dateOfBirth",
-                DEFAULT_DOB,
+                dob,
                 LandlordRegistrationStepId.DateOfBirth.urlPathSegment,
             ),
             formData.single {
@@ -111,14 +109,16 @@ class LandlordRegistrationCheckAnswersPageTests {
 
     @Test
     fun `formData has the correct email and phone number`() {
-        val journeyData = journeyDataBuilder.build()
+        val emailAddress = "example@email.com"
+        val phoneNumber = "07123456789"
+        val journeyData = journeyDataBuilder.withEmailAddress(emailAddress).withPhoneNumber(phoneNumber).build()
 
         val formData = getFormData(journeyData)
 
         assertEquals(
             FormSummaryViewModel(
                 "registerAsALandlord.checkAnswers.rowHeading.email",
-                DEFAULT_EMAIL_ADDRESS,
+                emailAddress,
                 LandlordRegistrationStepId.Email.urlPathSegment,
             ),
             formData.single {
@@ -128,7 +128,7 @@ class LandlordRegistrationCheckAnswersPageTests {
         assertEquals(
             FormSummaryViewModel(
                 "registerAsALandlord.checkAnswers.rowHeading.telephoneNumber",
-                DEFAULT_PHONE_NUMBER,
+                phoneNumber,
                 LandlordRegistrationStepId.PhoneNumber.urlPathSegment,
             ),
             formData.single {

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/forms/pages/LandlordRegistrationCheckAnswersPageTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/forms/pages/LandlordRegistrationCheckAnswersPageTests.kt
@@ -1,0 +1,306 @@
+package uk.gov.communities.prsdb.webapp.forms.pages
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import org.springframework.ui.ExtendedModelMap
+import org.springframework.ui.Model
+import org.springframework.validation.Validator
+import uk.gov.communities.prsdb.webapp.forms.steps.LandlordRegistrationStepId
+import uk.gov.communities.prsdb.webapp.mockObjects.JourneyDataBuilder
+import uk.gov.communities.prsdb.webapp.mockObjects.JourneyDataBuilder.Companion.DEFAULT_ADDRESS
+import uk.gov.communities.prsdb.webapp.mockObjects.JourneyDataBuilder.Companion.DEFAULT_DOB
+import uk.gov.communities.prsdb.webapp.mockObjects.JourneyDataBuilder.Companion.DEFAULT_EMAIL_ADDRESS
+import uk.gov.communities.prsdb.webapp.mockObjects.JourneyDataBuilder.Companion.DEFAULT_NAME
+import uk.gov.communities.prsdb.webapp.mockObjects.JourneyDataBuilder.Companion.DEFAULT_PHONE_NUMBER
+import uk.gov.communities.prsdb.webapp.models.dataModels.AddressDataModel
+import uk.gov.communities.prsdb.webapp.models.viewModels.FormSummaryViewModel
+import uk.gov.communities.prsdb.webapp.services.AddressDataService
+import uk.gov.communities.prsdb.webapp.services.JourneyDataService
+import java.time.LocalDate
+
+class LandlordRegistrationCheckAnswersPageTests {
+    private lateinit var page: LandlordRegistrationCheckAnswersPage
+    private lateinit var addressService: AddressDataService
+    private lateinit var validator: Validator
+    private lateinit var model: Model
+    private lateinit var pageData: Map<String, Any?>
+    private lateinit var prevStepUrl: String
+    private lateinit var journeyDataBuilder: JourneyDataBuilder
+
+    @BeforeEach
+    fun setup() {
+        addressService = mock()
+        page = LandlordRegistrationCheckAnswersPage(JourneyDataService(mock(), mock(), mock(), mock()), addressService)
+        validator = mock()
+        whenever(validator.supports(any<Class<*>>())).thenReturn(true)
+        model = ExtendedModelMap()
+        pageData = mock()
+        prevStepUrl = "mock"
+        journeyDataBuilder = JourneyDataBuilder.landlordDefault(addressService)
+    }
+
+    private fun getFormData(journeyData: MutableMap<String, Any?>): List<FormSummaryViewModel> {
+        page.populateModelAndGetTemplateName(validator, model, pageData, prevStepUrl, journeyData)
+
+        val formData = model.asMap()["formData"] as List<*>
+        return formData.filterIsInstance<FormSummaryViewModel>()
+    }
+
+    @Test
+    fun `formData has the correct name and DOB (verified)`() {
+        val name = "Arthur Dent"
+        val dob = LocalDate.of(2001, 1, 1)
+        val journeyData = journeyDataBuilder.withVerifiedUser(name, dob).build()
+
+        val formData = getFormData(journeyData)
+
+        assertEquals(
+            FormSummaryViewModel(
+                "registerAsALandlord.checkAnswers.rowHeading.name",
+                name,
+                null,
+            ),
+            formData.single {
+                it.fieldHeading == "registerAsALandlord.checkAnswers.rowHeading.name"
+            },
+        )
+        assertEquals(
+            FormSummaryViewModel(
+                "registerAsALandlord.checkAnswers.rowHeading.dateOfBirth",
+                dob,
+                null,
+            ),
+            formData.single {
+                it.fieldHeading == "registerAsALandlord.checkAnswers.rowHeading.dateOfBirth"
+            },
+        )
+    }
+
+    @Test
+    fun `formData has the correct name and DOB (unverified)`() {
+        val journeyData = journeyDataBuilder.build()
+
+        val formData = getFormData(journeyData)
+
+        assertEquals(
+            FormSummaryViewModel(
+                "registerAsALandlord.checkAnswers.rowHeading.name",
+                DEFAULT_NAME,
+                LandlordRegistrationStepId.Name.urlPathSegment,
+            ),
+            formData.single {
+                it.fieldHeading == "registerAsALandlord.checkAnswers.rowHeading.name"
+            },
+        )
+        assertEquals(
+            FormSummaryViewModel(
+                "registerAsALandlord.checkAnswers.rowHeading.dateOfBirth",
+                DEFAULT_DOB,
+                LandlordRegistrationStepId.DateOfBirth.urlPathSegment,
+            ),
+            formData.single {
+                it.fieldHeading == "registerAsALandlord.checkAnswers.rowHeading.dateOfBirth"
+            },
+        )
+    }
+
+    @Test
+    fun `formData has the correct email and phone number`() {
+        val journeyData = journeyDataBuilder.build()
+
+        val formData = getFormData(journeyData)
+
+        assertEquals(
+            FormSummaryViewModel(
+                "registerAsALandlord.checkAnswers.rowHeading.email",
+                DEFAULT_EMAIL_ADDRESS,
+                LandlordRegistrationStepId.Email.urlPathSegment,
+            ),
+            formData.single {
+                it.fieldHeading == "registerAsALandlord.checkAnswers.rowHeading.email"
+            },
+        )
+        assertEquals(
+            FormSummaryViewModel(
+                "registerAsALandlord.checkAnswers.rowHeading.telephoneNumber",
+                DEFAULT_PHONE_NUMBER,
+                LandlordRegistrationStepId.PhoneNumber.urlPathSegment,
+            ),
+            formData.single {
+                it.fieldHeading == "registerAsALandlord.checkAnswers.rowHeading.telephoneNumber"
+            },
+        )
+    }
+
+    @Test
+    fun `formData has the correct lives in UK status`() {
+        val journeyData = journeyDataBuilder.build()
+
+        val formData = getFormData(journeyData)
+
+        assertEquals(
+            FormSummaryViewModel(
+                "registerAsALandlord.checkAnswers.rowHeading.ukResident",
+                true,
+                LandlordRegistrationStepId.CountryOfResidence.urlPathSegment,
+            ),
+            formData.single {
+                it.fieldHeading == "registerAsALandlord.checkAnswers.rowHeading.ukResident"
+            },
+        )
+    }
+
+    @Test
+    fun `formData has the correct selected address`() {
+        val journeyData = journeyDataBuilder.build()
+
+        val formData = getFormData(journeyData)
+
+        assertEquals(
+            FormSummaryViewModel(
+                "registerAsALandlord.checkAnswers.rowHeading.contactAddress",
+                DEFAULT_ADDRESS,
+                LandlordRegistrationStepId.LookupAddress.urlPathSegment,
+            ),
+            formData.single {
+                it.fieldHeading == "registerAsALandlord.checkAnswers.rowHeading.contactAddress"
+            },
+        )
+    }
+
+    @Test
+    fun `formData has the correct manual  address`() {
+        val addressLineOne = "1 Example Road"
+        val townOrCity = "Townville"
+        val postcode = "EG1 2BA"
+        val journeyData =
+            journeyDataBuilder
+                .withManualAddress(addressLineOne, townOrCity, postcode)
+                .build()
+
+        val formData = getFormData(journeyData)
+
+        assertEquals(
+            FormSummaryViewModel(
+                "registerAsALandlord.checkAnswers.rowHeading.contactAddress",
+                AddressDataModel.fromManualAddressData(addressLineOne, townOrCity, postcode).singleLineAddress,
+                LandlordRegistrationStepId.ManualAddress.urlPathSegment,
+            ),
+            formData.single {
+                it.fieldHeading == "registerAsALandlord.checkAnswers.rowHeading.contactAddress"
+            },
+        )
+    }
+
+    @Test
+    fun `formData has the correct international and selected contact addresses`() {
+        val countryOfResidence = "Germany"
+        val internationalAddress = "international address"
+        val selectedAddress = "1 Example Road"
+        val journeyData =
+            journeyDataBuilder
+                .withInternationalAndSelectedContactAddress(
+                    countryOfResidence,
+                    internationalAddress,
+                    selectedAddress,
+                ).build()
+
+        val formData = getFormData(journeyData)
+
+        assertEquals(
+            FormSummaryViewModel(
+                "registerAsALandlord.checkAnswers.rowHeading.countryOfResidence",
+                countryOfResidence,
+                LandlordRegistrationStepId.CountryOfResidence.urlPathSegment,
+            ),
+            formData.single {
+                it.fieldHeading == "registerAsALandlord.checkAnswers.rowHeading.countryOfResidence"
+            },
+        )
+        assertEquals(
+            FormSummaryViewModel(
+                "registerAsALandlord.checkAnswers.rowHeading.contactAddressOutsideUK",
+                internationalAddress,
+                LandlordRegistrationStepId.InternationalAddress.urlPathSegment,
+            ),
+            formData.single {
+                it.fieldHeading == "registerAsALandlord.checkAnswers.rowHeading.contactAddressOutsideUK"
+            },
+        )
+        assertEquals(
+            FormSummaryViewModel(
+                "registerAsALandlord.checkAnswers.rowHeading.ukContactAddress",
+                selectedAddress,
+                LandlordRegistrationStepId.LookupContactAddress.urlPathSegment,
+            ),
+            formData.single {
+                it.fieldHeading == "registerAsALandlord.checkAnswers.rowHeading.ukContactAddress"
+            },
+        )
+    }
+
+    @Test
+    fun `formData has the correct international and manual contact addresses`() {
+        val countryOfResidence = "Germany"
+        val internationalAddress = "international address"
+        val addressLineOne = "1 Example Road"
+        val townOrCity = "Townville"
+        val postcode = "EG1 2BA"
+        val journeyData =
+            journeyDataBuilder
+                .withInternationalAndManualContactAddress(
+                    countryOfResidence,
+                    internationalAddress,
+                    addressLineOne,
+                    townOrCity,
+                    postcode,
+                ).build()
+
+        val formData = getFormData(journeyData)
+
+        assertEquals(
+            FormSummaryViewModel(
+                "registerAsALandlord.checkAnswers.rowHeading.countryOfResidence",
+                countryOfResidence,
+                LandlordRegistrationStepId.CountryOfResidence.urlPathSegment,
+            ),
+            formData.single {
+                it.fieldHeading == "registerAsALandlord.checkAnswers.rowHeading.countryOfResidence"
+            },
+        )
+        assertEquals(
+            FormSummaryViewModel(
+                "registerAsALandlord.checkAnswers.rowHeading.contactAddressOutsideUK",
+                internationalAddress,
+                LandlordRegistrationStepId.InternationalAddress.urlPathSegment,
+            ),
+            formData.single {
+                it.fieldHeading == "registerAsALandlord.checkAnswers.rowHeading.contactAddressOutsideUK"
+            },
+        )
+        assertEquals(
+            FormSummaryViewModel(
+                "registerAsALandlord.checkAnswers.rowHeading.ukContactAddress",
+                AddressDataModel.fromManualAddressData(addressLineOne, townOrCity, postcode).singleLineAddress,
+                LandlordRegistrationStepId.ManualContactAddress.urlPathSegment,
+            ),
+            formData.single {
+                it.fieldHeading == "registerAsALandlord.checkAnswers.rowHeading.ukContactAddress"
+            },
+        )
+    }
+
+    @Test
+    fun `formData does not contain country of residence for national landlords`() {
+        val journeyData = journeyDataBuilder.build()
+
+        val formData = getFormData(journeyData)
+
+        assertTrue(formData.none { it.fieldHeading == "registerAsALandlord.checkAnswers.rowHeading.contactAddressOutsideUK" })
+    }
+}

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/forms/pages/PropertyRegistrationCheckAnswersPageTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/forms/pages/PropertyRegistrationCheckAnswersPageTests.kt
@@ -17,6 +17,7 @@ import uk.gov.communities.prsdb.webapp.constants.enums.OwnershipType
 import uk.gov.communities.prsdb.webapp.constants.enums.PropertyType
 import uk.gov.communities.prsdb.webapp.forms.steps.RegisterPropertyStepId
 import uk.gov.communities.prsdb.webapp.mockObjects.JourneyDataBuilder
+import uk.gov.communities.prsdb.webapp.models.dataModels.AddressDataModel
 import uk.gov.communities.prsdb.webapp.models.viewModels.FormSummaryViewModel
 import uk.gov.communities.prsdb.webapp.services.AddressDataService
 import uk.gov.communities.prsdb.webapp.services.JourneyDataService
@@ -95,16 +96,11 @@ class PropertyRegistrationCheckAnswersPageTests {
     @Test
     fun `propertyDetails has the correct address summary rows for a manual address`() {
         // Arrange
-        val manualAddressMap =
-            mutableMapOf(
-                "addressLineOne" to "Flat B",
-                "addressLineTwo" to "3 Example Road",
-                "townOrCity" to "Exampleton",
-                "county" to "Exampleshire",
-                "postcode" to "EG",
-            )
+        val manualAddress = AddressDataModel.fromManualAddressData("3 Example Road", "Townville", "EG")
+
         val localAuthorityIndex = 19
-        val journeyData = journeyDataBuilder.withManualAddress(manualAddressMap, localAuthorityIndex).build()
+        val journeyData =
+            journeyDataBuilder.withManualAddress("3 Example Road", "Townville", "EG", localAuthorityIndex).build()
 
         // Act
         val propertyDetails = getPropertyDetails(journeyData)
@@ -112,7 +108,7 @@ class PropertyRegistrationCheckAnswersPageTests {
         assertEquals(
             FormSummaryViewModel(
                 "forms.checkPropertyAnswers.propertyDetails.address",
-                manualAddressMap.values.joinToString(", "),
+                manualAddress.singleLineAddress,
                 RegisterPropertyStepId.ManualAddress.urlPathSegment,
             ),
             propertyDetails.single {

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/forms/pages/PropertyRegistrationCheckAnswersPageTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/forms/pages/PropertyRegistrationCheckAnswersPageTests.kt
@@ -39,7 +39,7 @@ class PropertyRegistrationCheckAnswersPageTests {
         model = ExtendedModelMap()
         pageData = mock()
         prevStepUrl = "mock"
-        journeyDataBuilder = JourneyDataBuilder.default(addressService)
+        journeyDataBuilder = JourneyDataBuilder.propertyDefault(addressService)
     }
 
     private fun getPropertyDetails(journeyData: MutableMap<String, Any?>): List<FormSummaryViewModel> {

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/forms/pages/PropertyRegistrationCheckAnswersPageTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/forms/pages/PropertyRegistrationCheckAnswersPageTests.kt
@@ -96,11 +96,14 @@ class PropertyRegistrationCheckAnswersPageTests {
     @Test
     fun `propertyDetails has the correct address summary rows for a manual address`() {
         // Arrange
-        val manualAddress = AddressDataModel.fromManualAddressData("3 Example Road", "Townville", "EG")
+        val addressLineOne = "3 Example Road"
+        val townOrCity = "Townville"
+        val postcode = "EG1 2AB"
+        val manualAddress = AddressDataModel.fromManualAddressData(addressLineOne, townOrCity, postcode)
 
         val localAuthorityIndex = 19
         val journeyData =
-            journeyDataBuilder.withManualAddress("3 Example Road", "Townville", "EG", localAuthorityIndex).build()
+            journeyDataBuilder.withManualAddress(addressLineOne, townOrCity, postcode, localAuthorityIndex).build()
 
         // Act
         val propertyDetails = getPropertyDetails(journeyData)

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/helpers/LandlordJourneyDataHelperTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/helpers/LandlordJourneyDataHelperTests.kt
@@ -3,7 +3,9 @@ package uk.gov.communities.prsdb.webapp.helpers
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
-import org.junit.jupiter.params.provider.CsvSource
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
+import org.junit.jupiter.params.provider.ValueSource
 import org.mockito.Mockito.mock
 import org.mockito.kotlin.whenever
 import uk.gov.communities.prsdb.webapp.constants.MANUAL_ADDRESS_CHOSEN
@@ -23,6 +25,13 @@ class LandlordJourneyDataHelperTests {
 
     companion object {
         private const val COUNTRY_OF_RESIDENCE = "France"
+
+        @JvmStatic
+        private fun provideCountryOfResidenceFormInputs() =
+            listOf(
+                Arguments.of(true, null),
+                Arguments.of(false, COUNTRY_OF_RESIDENCE),
+            )
     }
 
     @BeforeEach
@@ -116,7 +125,7 @@ class LandlordJourneyDataHelperTests {
     }
 
     @ParameterizedTest(name = "when livesInUK = {0}")
-    @CsvSource("true,", "false,$COUNTRY_OF_RESIDENCE")
+    @MethodSource("provideCountryOfResidenceFormInputs")
     fun `getNonUKCountryOfResidence returns the corresponding country or null`(
         livesInUK: Boolean,
         expectedNonUKCountryOfResidence: String?,
@@ -144,7 +153,7 @@ class LandlordJourneyDataHelperTests {
     }
 
     @ParameterizedTest(name = "when livesInUK = {0}")
-    @CsvSource("true", "false")
+    @ValueSource(booleans = [true, false])
     fun `getAddress returns the corresponding selected address`(livesInUK: Boolean) {
         val selectAddressPathSegment =
             if (livesInUK) {
@@ -184,7 +193,7 @@ class LandlordJourneyDataHelperTests {
     }
 
     @ParameterizedTest(name = "when livesInUK = {0}")
-    @CsvSource("true", "false")
+    @ValueSource(booleans = [true, false])
     fun `getAddress returns the corresponding manual address`(livesInUK: Boolean) {
         val selectAddressPathSegment =
             if (livesInUK) {

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/helpers/LandlordJourneyDataHelperTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/helpers/LandlordJourneyDataHelperTests.kt
@@ -21,6 +21,10 @@ class LandlordJourneyDataHelperTests {
 
     private val mockJourneyData: JourneyData = mutableMapOf()
 
+    companion object {
+        private const val COUNTRY_OF_RESIDENCE = "France"
+    }
+
     @BeforeEach
     fun setup() {
         mockJourneyDataService = mock()
@@ -109,6 +113,34 @@ class LandlordJourneyDataHelperTests {
         val manualDOB = LandlordJourneyDataHelper.getDOB(mockJourneyDataService, mockJourneyData)
 
         assertEquals(expectedManualDOB, manualDOB)
+    }
+
+    @ParameterizedTest(name = "when livesInUK = {0}")
+    @CsvSource("true,", "false,$COUNTRY_OF_RESIDENCE")
+    fun `getNonUKCountryOfResidence returns the corresponding country or null`(
+        livesInUK: Boolean,
+        expectedNonUKCountryOfResidence: String?,
+    ) {
+        whenever(
+            mockJourneyDataService.getFieldBooleanValue(
+                mockJourneyData,
+                LandlordRegistrationStepId.CountryOfResidence.urlPathSegment,
+                "livesInUK",
+            ),
+        ).thenReturn(livesInUK)
+
+        whenever(
+            mockJourneyDataService.getFieldStringValue(
+                mockJourneyData,
+                LandlordRegistrationStepId.CountryOfResidence.urlPathSegment,
+                "countryOfResidence",
+            ),
+        ).thenReturn(COUNTRY_OF_RESIDENCE)
+
+        val nonUKCountryOfResidence =
+            LandlordJourneyDataHelper.getNonUKCountryOfResidence(mockJourneyDataService, mockJourneyData)
+
+        assertEquals(expectedNonUKCountryOfResidence, nonUKCountryOfResidence)
     }
 
     @ParameterizedTest(name = "when livesInUK = {0}")

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/LandlordRegistrationJourneyTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/LandlordRegistrationJourneyTests.kt
@@ -32,7 +32,6 @@ import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.landlordReg
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.landlordRegistrationJourneyPages.LookupContactAddressFormPageLandlordRegistration
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.landlordRegistrationJourneyPages.ManualAddressFormPageLandlordRegistration
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.landlordRegistrationJourneyPages.ManualContactAddressFormPageLandlordRegistration
-import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.landlordRegistrationJourneyPages.NameFormPageLandlordRegistration
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.landlordRegistrationJourneyPages.PhoneNumberFormPageLandlordRegistration
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.landlordRegistrationJourneyPages.SelectAddressFormPageLandlordRegistration
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.landlordRegistrationJourneyPages.SelectContactAddressFormPageLandlordRegistration
@@ -85,31 +84,6 @@ class LandlordRegistrationJourneyTests : IntegrationTest() {
         selectAddressPage.form.submit()
 
         val checkAnswersPage = assertPageIs(page, CheckAnswersPageLandlordRegistration::class)
-
-        assertThat(checkAnswersPage.summaryList.getRowKey(0)).containsText("Name")
-        assertThat(checkAnswersPage.summaryList.getRowValue(0)).containsText("Arthur Dent")
-        assertThat(checkAnswersPage.summaryList.getRowAction(0)).isEmpty()
-
-        assertThat(checkAnswersPage.summaryList.getRowKey(1)).containsText("Date of birth")
-        assertThat(checkAnswersPage.summaryList.getRowValue(1)).containsText("8 June 2000")
-        assertThat(checkAnswersPage.summaryList.getRowAction(1)).isEmpty()
-
-        assertThat(checkAnswersPage.summaryList.getRowKey(2)).containsText("Email address")
-        assertThat(checkAnswersPage.summaryList.getRowValue(2)).containsText("test@example.com")
-        assertThat(checkAnswersPage.summaryList.getRowAction(2)).containsText("Change")
-
-        assertThat(checkAnswersPage.summaryList.getRowKey(3)).containsText("Telephone number")
-        assertThat(checkAnswersPage.summaryList.getRowValue(3)).containsText("07123456789")
-        assertThat(checkAnswersPage.summaryList.getRowAction(3)).containsText("Change")
-
-        assertThat(checkAnswersPage.summaryList.getRowKey(4)).containsText("UK resident")
-        assertThat(checkAnswersPage.summaryList.getRowValue(4)).containsText("Yes")
-        assertThat(checkAnswersPage.summaryList.getRowAction(4)).containsText("Change")
-
-        assertThat(checkAnswersPage.summaryList.getRowKey(5)).containsText("Contact address")
-        assertThat(checkAnswersPage.summaryList.getRowValue(5)).containsText("1, Example Road, EG1 2AB")
-        assertThat(checkAnswersPage.summaryList.getRowAction(5)).containsText("Change")
-
         checkAnswersPage.form.submit()
 
         val declarationPage = assertPageIs(page, DeclarationFormPageLandlordRegistration::class)
@@ -162,31 +136,6 @@ class LandlordRegistrationJourneyTests : IntegrationTest() {
         manualAddressPage.form.submit()
 
         val checkAnswersPage = assertPageIs(page, CheckAnswersPageLandlordRegistration::class)
-
-        assertThat(checkAnswersPage.summaryList.getRowKey(0)).containsText("Name")
-        assertThat(checkAnswersPage.summaryList.getRowValue(0)).containsText("Arthur Dent")
-        assertThat(checkAnswersPage.summaryList.getRowAction(0)).isEmpty()
-
-        assertThat(checkAnswersPage.summaryList.getRowKey(1)).containsText("Date of birth")
-        assertThat(checkAnswersPage.summaryList.getRowValue(1)).containsText("8 June 2000")
-        assertThat(checkAnswersPage.summaryList.getRowAction(1)).isEmpty()
-
-        assertThat(checkAnswersPage.summaryList.getRowKey(2)).containsText("Email address")
-        assertThat(checkAnswersPage.summaryList.getRowValue(2)).containsText("test@example.com")
-        assertThat(checkAnswersPage.summaryList.getRowAction(2)).containsText("Change")
-
-        assertThat(checkAnswersPage.summaryList.getRowKey(3)).containsText("Telephone number")
-        assertThat(checkAnswersPage.summaryList.getRowValue(3)).containsText(formattedNumber)
-        assertThat(checkAnswersPage.summaryList.getRowAction(3)).containsText("Change")
-
-        assertThat(checkAnswersPage.summaryList.getRowKey(4)).containsText("UK resident")
-        assertThat(checkAnswersPage.summaryList.getRowValue(4)).containsText("Yes")
-        assertThat(checkAnswersPage.summaryList.getRowAction(4)).containsText("Change")
-
-        assertThat(checkAnswersPage.summaryList.getRowKey(5)).containsText("Contact address")
-        assertThat(checkAnswersPage.summaryList.getRowValue(5)).containsText("1 Example Road, Townville, EG1 2AB")
-        assertThat(checkAnswersPage.summaryList.getRowAction(5)).containsText("Change")
-
         checkAnswersPage.form.submit()
 
         val declarationPage = assertPageIs(page, DeclarationFormPageLandlordRegistration::class)
@@ -246,39 +195,6 @@ class LandlordRegistrationJourneyTests : IntegrationTest() {
         selectContactAddressPage.form.submit()
 
         val checkAnswersPage = assertPageIs(page, CheckAnswersPageLandlordRegistration::class)
-
-        assertThat(checkAnswersPage.summaryList.getRowKey(0)).containsText("Name")
-        assertThat(checkAnswersPage.summaryList.getRowValue(0)).containsText("landlord name")
-        assertThat(checkAnswersPage.summaryList.getRowAction(0)).containsText("Change")
-
-        assertThat(checkAnswersPage.summaryList.getRowKey(1)).containsText("Date of birth")
-        assertThat(checkAnswersPage.summaryList.getRowValue(1)).containsText("12 November 1990")
-        assertThat(checkAnswersPage.summaryList.getRowAction(1)).containsText("Change")
-
-        assertThat(checkAnswersPage.summaryList.getRowKey(2)).containsText("Email address")
-        assertThat(checkAnswersPage.summaryList.getRowValue(2)).containsText("test@example.com")
-        assertThat(checkAnswersPage.summaryList.getRowAction(2)).containsText("Change")
-
-        assertThat(checkAnswersPage.summaryList.getRowKey(3)).containsText("Telephone number")
-        assertThat(checkAnswersPage.summaryList.getRowValue(3)).containsText(formattedNumber)
-        assertThat(checkAnswersPage.summaryList.getRowAction(3)).containsText("Change")
-
-        assertThat(checkAnswersPage.summaryList.getRowKey(4)).containsText("UK resident")
-        assertThat(checkAnswersPage.summaryList.getRowValue(4)).containsText("No")
-        assertThat(checkAnswersPage.summaryList.getRowAction(4)).containsText("Change")
-
-        assertThat(checkAnswersPage.summaryList.getRowKey(5)).containsText("Country of residence")
-        assertThat(checkAnswersPage.summaryList.getRowValue(5)).containsText("France")
-        assertThat(checkAnswersPage.summaryList.getRowAction(5)).containsText("Change")
-
-        assertThat(checkAnswersPage.summaryList.getRowKey(6)).containsText("Contact address (outside UK)")
-        assertThat(checkAnswersPage.summaryList.getRowValue(6)).containsText("international address")
-        assertThat(checkAnswersPage.summaryList.getRowAction(6)).containsText("Change")
-
-        assertThat(checkAnswersPage.summaryList.getRowKey(7)).containsText("UK contact address")
-        assertThat(checkAnswersPage.summaryList.getRowValue(7)).containsText("1, Example Road, EG1 2AB")
-        assertThat(checkAnswersPage.summaryList.getRowAction(7)).containsText("Change")
-
         checkAnswersPage.form.submit()
 
         val declarationPage = assertPageIs(page, DeclarationFormPageLandlordRegistration::class)
@@ -344,39 +260,6 @@ class LandlordRegistrationJourneyTests : IntegrationTest() {
         manualContactAddressPage.form.submit()
 
         val checkAnswersPage = assertPageIs(page, CheckAnswersPageLandlordRegistration::class)
-
-        assertThat(checkAnswersPage.summaryList.getRowKey(0)).containsText("Name")
-        assertThat(checkAnswersPage.summaryList.getRowValue(0)).containsText("landlord name")
-        assertThat(checkAnswersPage.summaryList.getRowAction(0)).containsText("Change")
-
-        assertThat(checkAnswersPage.summaryList.getRowKey(1)).containsText("Date of birth")
-        assertThat(checkAnswersPage.summaryList.getRowValue(1)).containsText("12 November 1990")
-        assertThat(checkAnswersPage.summaryList.getRowAction(1)).containsText("Change")
-
-        assertThat(checkAnswersPage.summaryList.getRowKey(2)).containsText("Email address")
-        assertThat(checkAnswersPage.summaryList.getRowValue(2)).containsText("test@example.com")
-        assertThat(checkAnswersPage.summaryList.getRowAction(2)).containsText("Change")
-
-        assertThat(checkAnswersPage.summaryList.getRowKey(3)).containsText("Telephone number")
-        assertThat(checkAnswersPage.summaryList.getRowValue(3)).containsText(formattedNumber)
-        assertThat(checkAnswersPage.summaryList.getRowAction(3)).containsText("Change")
-
-        assertThat(checkAnswersPage.summaryList.getRowKey(4)).containsText("UK resident")
-        assertThat(checkAnswersPage.summaryList.getRowValue(4)).containsText("No")
-        assertThat(checkAnswersPage.summaryList.getRowAction(4)).containsText("Change")
-
-        assertThat(checkAnswersPage.summaryList.getRowKey(5)).containsText("Country of residence")
-        assertThat(checkAnswersPage.summaryList.getRowValue(5)).containsText("France")
-        assertThat(checkAnswersPage.summaryList.getRowAction(5)).containsText("Change")
-
-        assertThat(checkAnswersPage.summaryList.getRowKey(6)).containsText("Contact address (outside UK)")
-        assertThat(checkAnswersPage.summaryList.getRowValue(6)).containsText("international address")
-        assertThat(checkAnswersPage.summaryList.getRowAction(6)).containsText("Change")
-
-        assertThat(checkAnswersPage.summaryList.getRowKey(7)).containsText("UK contact address")
-        assertThat(checkAnswersPage.summaryList.getRowValue(7)).containsText("1 Example Road, Townville, EG1 2AB")
-        assertThat(checkAnswersPage.summaryList.getRowAction(7)).containsText("Change")
-
         checkAnswersPage.form.submit()
 
         val declarationPage = assertPageIs(page, DeclarationFormPageLandlordRegistration::class)
@@ -703,109 +586,6 @@ class LandlordRegistrationJourneyTests : IntegrationTest() {
                 .containsText("Enter the first line of an address, typically the building and street")
             assertThat(manualContactAddressPage.form.getErrorMessage("townOrCity")).containsText("Enter town or city")
             assertThat(manualContactAddressPage.form.getErrorMessage("postcode")).containsText("Enter postcode")
-        }
-    }
-
-    @Nested
-    inner class LandlordRegistrationStepCheckAnswers {
-        @Nested
-        inner class CheckNonAddressDetails {
-            private lateinit var checkAnswersPage: CheckAnswersPageLandlordRegistration
-
-            @BeforeEach
-            fun setup() {
-                checkAnswersPage = navigator.goToLandlordRegistrationCheckAnswersPage()
-            }
-
-            @Test
-            fun `Change Name link navigates to the correct step`(page: Page) {
-                val changeNameLink = checkAnswersPage.summaryList.getRowActionLink(0)
-                changeNameLink.click()
-                assertPageIs(page, NameFormPageLandlordRegistration::class)
-            }
-
-            @Test
-            fun `Change Date of Birth link navigates to the correct step`(page: Page) {
-                val changeDateOfBirthLink = checkAnswersPage.summaryList.getRowActionLink(1)
-                changeDateOfBirthLink.click()
-                assertPageIs(page, DateOfBirthFormPageLandlordRegistration::class)
-            }
-
-            @Test
-            fun `Change Email link navigates to the correct step`(page: Page) {
-                val changeEmailLink = checkAnswersPage.summaryList.getRowActionLink(2)
-                changeEmailLink.click()
-                assertPageIs(page, EmailFormPageLandlordRegistration::class)
-            }
-
-            @Test
-            fun `Change Phone number link navigates to the correct step`(page: Page) {
-                val changePhoneNumberLink = checkAnswersPage.summaryList.getRowActionLink(3)
-                changePhoneNumberLink.click()
-                assertPageIs(page, PhoneNumberFormPageLandlordRegistration::class)
-            }
-
-            @Test
-            fun `Change UK Resident link navigates to the correct step`(page: Page) {
-                val changeUKResidentLink = checkAnswersPage.summaryList.getRowActionLink(4)
-                changeUKResidentLink.click()
-                assertPageIs(page, CountryOfResidenceFormPageLandlordRegistration::class)
-            }
-        }
-
-        @Nested
-        inner class CheckAddressDetails {
-            @Test
-            fun `Change selected address link navigates to the correct step`(page: Page) {
-                val checkAnswersPage = navigator.goToLandlordRegistrationCheckAnswersPage()
-                val changeSelectedAddressLink = checkAnswersPage.summaryList.getRowActionLink(5)
-                changeSelectedAddressLink.click()
-                assertPageIs(page, LookupAddressFormPageLandlordRegistration::class)
-            }
-
-            @Test
-            fun `Change manual address link navigates to the correct step`(page: Page) {
-                val checkAnswersPage = navigator.goToLandlordRegistrationCheckAnswersPage(isManualAddressChosen = true)
-                val changeManualAddressLink = checkAnswersPage.summaryList.getRowActionLink(5)
-                changeManualAddressLink.click()
-                assertPageIs(page, ManualAddressFormPageLandlordRegistration::class)
-            }
-        }
-
-        @Nested
-        inner class CheckInternationalAddressDetails {
-            @Test
-            fun `Change country of residence link navigates to the correct step`(page: Page) {
-                val checkAnswersPage = navigator.goToLandlordRegistrationCheckAnswersPage(livesInUK = false)
-                val changeCountryOfResidenceLink = checkAnswersPage.summaryList.getRowActionLink(5)
-                changeCountryOfResidenceLink.click()
-                assertPageIs(page, CountryOfResidenceFormPageLandlordRegistration::class)
-            }
-
-            @Test
-            fun `Change international address link navigates to the correct step`(page: Page) {
-                val checkAnswersPage = navigator.goToLandlordRegistrationCheckAnswersPage(livesInUK = false)
-                val changeInternationalAddressLink = checkAnswersPage.summaryList.getRowActionLink(6)
-                changeInternationalAddressLink.click()
-                assertPageIs(page, InternationalAddressFormPageLandlordRegistration::class)
-            }
-
-            @Test
-            fun `Change selected address link navigates to the correct step`(page: Page) {
-                val checkAnswersPage = navigator.goToLandlordRegistrationCheckAnswersPage(livesInUK = false)
-                val changeSelectedContactAddressLink = checkAnswersPage.summaryList.getRowActionLink(7)
-                changeSelectedContactAddressLink.click()
-                assertPageIs(page, LookupContactAddressFormPageLandlordRegistration::class)
-            }
-
-            @Test
-            fun `Change manual address link navigates to the correct step`(page: Page) {
-                val checkAnswersPage =
-                    navigator.goToLandlordRegistrationCheckAnswersPage(livesInUK = false, isManualAddressChosen = true)
-                val changeManualContactAddressLink = checkAnswersPage.summaryList.getRowActionLink(7)
-                changeManualContactAddressLink.click()
-                assertPageIs(page, ManualContactAddressFormPageLandlordRegistration::class)
-            }
         }
     }
 

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/LandlordRegistrationJourneyTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/LandlordRegistrationJourneyTests.kt
@@ -9,7 +9,6 @@ import kotlinx.datetime.number
 import kotlinx.datetime.plus
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
@@ -33,6 +32,7 @@ import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.landlordReg
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.landlordRegistrationJourneyPages.LookupContactAddressFormPageLandlordRegistration
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.landlordRegistrationJourneyPages.ManualAddressFormPageLandlordRegistration
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.landlordRegistrationJourneyPages.ManualContactAddressFormPageLandlordRegistration
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.landlordRegistrationJourneyPages.NameFormPageLandlordRegistration
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.landlordRegistrationJourneyPages.PhoneNumberFormPageLandlordRegistration
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.landlordRegistrationJourneyPages.SelectAddressFormPageLandlordRegistration
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.landlordRegistrationJourneyPages.SelectContactAddressFormPageLandlordRegistration
@@ -50,7 +50,6 @@ class LandlordRegistrationJourneyTests : IntegrationTest() {
 
     @BeforeEach
     fun setup() {
-        whenever(identityService.getVerifiedIdentityData(any())).thenReturn(null)
         whenever(
             osPlacesClient.search(any(), any()),
         ).thenReturn(
@@ -59,8 +58,6 @@ class LandlordRegistrationJourneyTests : IntegrationTest() {
         )
     }
 
-    // TODO PRSD-622: Add the steps before and after the address section of the journey
-    @Disabled("TODO: PRSD-372 - Check answer page cannot return null values")
     @Test
     fun `User can navigate the whole journey if pages are correctly filled in (verified, UK resident, selected address)`(page: Page) {
         val confirmIdentityPage = navigator.goToLandlordRegistrationConfirmIdentityFormPage()
@@ -88,6 +85,31 @@ class LandlordRegistrationJourneyTests : IntegrationTest() {
         selectAddressPage.form.submit()
 
         val checkAnswersPage = assertPageIs(page, CheckAnswersPageLandlordRegistration::class)
+
+        assertThat(checkAnswersPage.summaryList.getRowKey(0)).containsText("Name")
+        assertThat(checkAnswersPage.summaryList.getRowValue(0)).containsText("Arthur Dent")
+        assertThat(checkAnswersPage.summaryList.getRowAction(0)).isEmpty()
+
+        assertThat(checkAnswersPage.summaryList.getRowKey(1)).containsText("Date of birth")
+        assertThat(checkAnswersPage.summaryList.getRowValue(1)).containsText("8 June 2000")
+        assertThat(checkAnswersPage.summaryList.getRowAction(1)).isEmpty()
+
+        assertThat(checkAnswersPage.summaryList.getRowKey(2)).containsText("Email address")
+        assertThat(checkAnswersPage.summaryList.getRowValue(2)).containsText("test@example.com")
+        assertThat(checkAnswersPage.summaryList.getRowAction(2)).containsText("Change")
+
+        assertThat(checkAnswersPage.summaryList.getRowKey(3)).containsText("Telephone number")
+        assertThat(checkAnswersPage.summaryList.getRowValue(3)).containsText("07123456789")
+        assertThat(checkAnswersPage.summaryList.getRowAction(3)).containsText("Change")
+
+        assertThat(checkAnswersPage.summaryList.getRowKey(4)).containsText("UK resident")
+        assertThat(checkAnswersPage.summaryList.getRowValue(4)).containsText("Yes")
+        assertThat(checkAnswersPage.summaryList.getRowAction(4)).containsText("Change")
+
+        assertThat(checkAnswersPage.summaryList.getRowKey(5)).containsText("Contact address")
+        assertThat(checkAnswersPage.summaryList.getRowValue(5)).containsText("1, Example Road, EG1 2AB")
+        assertThat(checkAnswersPage.summaryList.getRowAction(5)).containsText("Change")
+
         checkAnswersPage.form.submit()
 
         val declarationPage = assertPageIs(page, DeclarationFormPageLandlordRegistration::class)
@@ -105,7 +127,6 @@ class LandlordRegistrationJourneyTests : IntegrationTest() {
         assertEquals("/", URI(page.url()).path)
     }
 
-    @Disabled("TODO: PRSD-372 - Check answer page cannot return null values")
     @Test
     fun `User can navigate the whole journey if pages are correctly filled in (verified, UK resident, manual address)`(page: Page) {
         val confirmIdentityPage = navigator.goToLandlordRegistrationConfirmIdentityFormPage()
@@ -117,7 +138,8 @@ class LandlordRegistrationJourneyTests : IntegrationTest() {
 
         val phoneNumPage = assertPageIs(page, PhoneNumberFormPageLandlordRegistration::class)
         val number = phoneNumberUtil.getExampleNumber("GB")
-        phoneNumPage.phoneNumberInput.fill("${number.countryCode}${number.nationalNumber}")
+        val formattedNumber = "${number.countryCode}${number.nationalNumber}"
+        phoneNumPage.phoneNumberInput.fill(formattedNumber)
         phoneNumPage.form.submit()
 
         val countryOfResidencePage = assertPageIs(page, CountryOfResidenceFormPageLandlordRegistration::class)
@@ -134,14 +156,37 @@ class LandlordRegistrationJourneyTests : IntegrationTest() {
         selectAddressPage.form.submit()
 
         val manualAddressPage = assertPageIs(page, ManualAddressFormPageLandlordRegistration::class)
-        manualAddressPage.addressLineOneInput.fill("address line one")
-        manualAddressPage.addressLineTwoInput.fill("address line two")
-        manualAddressPage.townOrCityInput.fill("town")
-        manualAddressPage.countyInput.fill("county")
+        manualAddressPage.addressLineOneInput.fill("1 Example Road")
+        manualAddressPage.townOrCityInput.fill("Townville")
         manualAddressPage.postcodeInput.fill("EG1 2AB")
         manualAddressPage.form.submit()
 
         val checkAnswersPage = assertPageIs(page, CheckAnswersPageLandlordRegistration::class)
+
+        assertThat(checkAnswersPage.summaryList.getRowKey(0)).containsText("Name")
+        assertThat(checkAnswersPage.summaryList.getRowValue(0)).containsText("Arthur Dent")
+        assertThat(checkAnswersPage.summaryList.getRowAction(0)).isEmpty()
+
+        assertThat(checkAnswersPage.summaryList.getRowKey(1)).containsText("Date of birth")
+        assertThat(checkAnswersPage.summaryList.getRowValue(1)).containsText("8 June 2000")
+        assertThat(checkAnswersPage.summaryList.getRowAction(1)).isEmpty()
+
+        assertThat(checkAnswersPage.summaryList.getRowKey(2)).containsText("Email address")
+        assertThat(checkAnswersPage.summaryList.getRowValue(2)).containsText("test@example.com")
+        assertThat(checkAnswersPage.summaryList.getRowAction(2)).containsText("Change")
+
+        assertThat(checkAnswersPage.summaryList.getRowKey(3)).containsText("Telephone number")
+        assertThat(checkAnswersPage.summaryList.getRowValue(3)).containsText(formattedNumber)
+        assertThat(checkAnswersPage.summaryList.getRowAction(3)).containsText("Change")
+
+        assertThat(checkAnswersPage.summaryList.getRowKey(4)).containsText("UK resident")
+        assertThat(checkAnswersPage.summaryList.getRowValue(4)).containsText("Yes")
+        assertThat(checkAnswersPage.summaryList.getRowAction(4)).containsText("Change")
+
+        assertThat(checkAnswersPage.summaryList.getRowKey(5)).containsText("Contact address")
+        assertThat(checkAnswersPage.summaryList.getRowValue(5)).containsText("1 Example Road, Townville, EG1 2AB")
+        assertThat(checkAnswersPage.summaryList.getRowAction(5)).containsText("Change")
+
         checkAnswersPage.form.submit()
 
         val declarationPage = assertPageIs(page, DeclarationFormPageLandlordRegistration::class)
@@ -162,7 +207,7 @@ class LandlordRegistrationJourneyTests : IntegrationTest() {
     @Test
     fun `User can navigate the whole journey if pages are correctly filled in (unverified, international, selected address)`(page: Page) {
         val namePage = navigator.goToLandlordRegistrationNameFormPage()
-        namePage.nameInput.fill("name")
+        namePage.nameInput.fill("landlord name")
         namePage.form.submit()
 
         val dateOfBirthPage = assertPageIs(page, DateOfBirthFormPageLandlordRegistration::class)
@@ -177,7 +222,8 @@ class LandlordRegistrationJourneyTests : IntegrationTest() {
 
         val phoneNumPage = assertPageIs(page, PhoneNumberFormPageLandlordRegistration::class)
         val number = phoneNumberUtil.getExampleNumber("GB")
-        phoneNumPage.phoneNumberInput.fill("${number.countryCode}${number.nationalNumber}")
+        val formattedNumber = "${number.countryCode}${number.nationalNumber}"
+        phoneNumPage.phoneNumberInput.fill(formattedNumber)
         phoneNumPage.form.submit()
 
         val countryOfResidencePage = assertPageIs(page, CountryOfResidenceFormPageLandlordRegistration::class)
@@ -200,6 +246,39 @@ class LandlordRegistrationJourneyTests : IntegrationTest() {
         selectContactAddressPage.form.submit()
 
         val checkAnswersPage = assertPageIs(page, CheckAnswersPageLandlordRegistration::class)
+
+        assertThat(checkAnswersPage.summaryList.getRowKey(0)).containsText("Name")
+        assertThat(checkAnswersPage.summaryList.getRowValue(0)).containsText("landlord name")
+        assertThat(checkAnswersPage.summaryList.getRowAction(0)).containsText("Change")
+
+        assertThat(checkAnswersPage.summaryList.getRowKey(1)).containsText("Date of birth")
+        assertThat(checkAnswersPage.summaryList.getRowValue(1)).containsText("12 November 1990")
+        assertThat(checkAnswersPage.summaryList.getRowAction(1)).containsText("Change")
+
+        assertThat(checkAnswersPage.summaryList.getRowKey(2)).containsText("Email address")
+        assertThat(checkAnswersPage.summaryList.getRowValue(2)).containsText("test@example.com")
+        assertThat(checkAnswersPage.summaryList.getRowAction(2)).containsText("Change")
+
+        assertThat(checkAnswersPage.summaryList.getRowKey(3)).containsText("Telephone number")
+        assertThat(checkAnswersPage.summaryList.getRowValue(3)).containsText(formattedNumber)
+        assertThat(checkAnswersPage.summaryList.getRowAction(3)).containsText("Change")
+
+        assertThat(checkAnswersPage.summaryList.getRowKey(4)).containsText("UK resident")
+        assertThat(checkAnswersPage.summaryList.getRowValue(4)).containsText("No")
+        assertThat(checkAnswersPage.summaryList.getRowAction(4)).containsText("Change")
+
+        assertThat(checkAnswersPage.summaryList.getRowKey(5)).containsText("Country of residence")
+        assertThat(checkAnswersPage.summaryList.getRowValue(5)).containsText("France")
+        assertThat(checkAnswersPage.summaryList.getRowAction(5)).containsText("Change")
+
+        assertThat(checkAnswersPage.summaryList.getRowKey(6)).containsText("Contact address (outside UK)")
+        assertThat(checkAnswersPage.summaryList.getRowValue(6)).containsText("international address")
+        assertThat(checkAnswersPage.summaryList.getRowAction(6)).containsText("Change")
+
+        assertThat(checkAnswersPage.summaryList.getRowKey(7)).containsText("UK contact address")
+        assertThat(checkAnswersPage.summaryList.getRowValue(7)).containsText("1, Example Road, EG1 2AB")
+        assertThat(checkAnswersPage.summaryList.getRowAction(7)).containsText("Change")
+
         checkAnswersPage.form.submit()
 
         val declarationPage = assertPageIs(page, DeclarationFormPageLandlordRegistration::class)
@@ -220,7 +299,7 @@ class LandlordRegistrationJourneyTests : IntegrationTest() {
     @Test
     fun `User can navigate the whole journey if pages are correctly filled in (unverified, international, manual address)`(page: Page) {
         val namePage = navigator.goToLandlordRegistrationNameFormPage()
-        namePage.nameInput.fill("name")
+        namePage.nameInput.fill("landlord name")
         namePage.form.submit()
 
         val dateOfBirthPage = assertPageIs(page, DateOfBirthFormPageLandlordRegistration::class)
@@ -235,7 +314,8 @@ class LandlordRegistrationJourneyTests : IntegrationTest() {
 
         val phoneNumPage = assertPageIs(page, PhoneNumberFormPageLandlordRegistration::class)
         val number = phoneNumberUtil.getExampleNumber("GB")
-        phoneNumPage.phoneNumberInput.fill("${number.countryCode}${number.nationalNumber}")
+        val formattedNumber = "${number.countryCode}${number.nationalNumber}"
+        phoneNumPage.phoneNumberInput.fill(formattedNumber)
         phoneNumPage.form.submit()
 
         val countryOfResidencePage = assertPageIs(page, CountryOfResidenceFormPageLandlordRegistration::class)
@@ -258,14 +338,45 @@ class LandlordRegistrationJourneyTests : IntegrationTest() {
         selectContactAddressPage.form.submit()
 
         val manualContactAddressPage = assertPageIs(page, ManualContactAddressFormPageLandlordRegistration::class)
-        manualContactAddressPage.addressLineOneInput.fill("address line one")
-        manualContactAddressPage.addressLineTwoInput.fill("address line two")
-        manualContactAddressPage.townOrCityInput.fill("town")
-        manualContactAddressPage.countyInput.fill("county")
+        manualContactAddressPage.addressLineOneInput.fill("1 Example Road")
+        manualContactAddressPage.townOrCityInput.fill("Townville")
         manualContactAddressPage.postcodeInput.fill("EG1 2AB")
         manualContactAddressPage.form.submit()
 
         val checkAnswersPage = assertPageIs(page, CheckAnswersPageLandlordRegistration::class)
+
+        assertThat(checkAnswersPage.summaryList.getRowKey(0)).containsText("Name")
+        assertThat(checkAnswersPage.summaryList.getRowValue(0)).containsText("landlord name")
+        assertThat(checkAnswersPage.summaryList.getRowAction(0)).containsText("Change")
+
+        assertThat(checkAnswersPage.summaryList.getRowKey(1)).containsText("Date of birth")
+        assertThat(checkAnswersPage.summaryList.getRowValue(1)).containsText("12 November 1990")
+        assertThat(checkAnswersPage.summaryList.getRowAction(1)).containsText("Change")
+
+        assertThat(checkAnswersPage.summaryList.getRowKey(2)).containsText("Email address")
+        assertThat(checkAnswersPage.summaryList.getRowValue(2)).containsText("test@example.com")
+        assertThat(checkAnswersPage.summaryList.getRowAction(2)).containsText("Change")
+
+        assertThat(checkAnswersPage.summaryList.getRowKey(3)).containsText("Telephone number")
+        assertThat(checkAnswersPage.summaryList.getRowValue(3)).containsText(formattedNumber)
+        assertThat(checkAnswersPage.summaryList.getRowAction(3)).containsText("Change")
+
+        assertThat(checkAnswersPage.summaryList.getRowKey(4)).containsText("UK resident")
+        assertThat(checkAnswersPage.summaryList.getRowValue(4)).containsText("No")
+        assertThat(checkAnswersPage.summaryList.getRowAction(4)).containsText("Change")
+
+        assertThat(checkAnswersPage.summaryList.getRowKey(5)).containsText("Country of residence")
+        assertThat(checkAnswersPage.summaryList.getRowValue(5)).containsText("France")
+        assertThat(checkAnswersPage.summaryList.getRowAction(5)).containsText("Change")
+
+        assertThat(checkAnswersPage.summaryList.getRowKey(6)).containsText("Contact address (outside UK)")
+        assertThat(checkAnswersPage.summaryList.getRowValue(6)).containsText("international address")
+        assertThat(checkAnswersPage.summaryList.getRowAction(6)).containsText("Change")
+
+        assertThat(checkAnswersPage.summaryList.getRowKey(7)).containsText("UK contact address")
+        assertThat(checkAnswersPage.summaryList.getRowValue(7)).containsText("1 Example Road, Townville, EG1 2AB")
+        assertThat(checkAnswersPage.summaryList.getRowAction(7)).containsText("Change")
+
         checkAnswersPage.form.submit()
 
         val declarationPage = assertPageIs(page, DeclarationFormPageLandlordRegistration::class)
@@ -592,6 +703,109 @@ class LandlordRegistrationJourneyTests : IntegrationTest() {
                 .containsText("Enter the first line of an address, typically the building and street")
             assertThat(manualContactAddressPage.form.getErrorMessage("townOrCity")).containsText("Enter town or city")
             assertThat(manualContactAddressPage.form.getErrorMessage("postcode")).containsText("Enter postcode")
+        }
+    }
+
+    @Nested
+    inner class LandlordRegistrationStepCheckAnswers {
+        @Nested
+        inner class CheckNonAddressDetails {
+            private lateinit var checkAnswersPage: CheckAnswersPageLandlordRegistration
+
+            @BeforeEach
+            fun setup() {
+                checkAnswersPage = navigator.goToLandlordRegistrationCheckAnswersPage()
+            }
+
+            @Test
+            fun `Change Name link navigates to the correct step`(page: Page) {
+                val changeNameLink = checkAnswersPage.summaryList.getRowActionLink(0)
+                changeNameLink.click()
+                assertPageIs(page, NameFormPageLandlordRegistration::class)
+            }
+
+            @Test
+            fun `Change Date of Birth link navigates to the correct step`(page: Page) {
+                val changeDateOfBirthLink = checkAnswersPage.summaryList.getRowActionLink(1)
+                changeDateOfBirthLink.click()
+                assertPageIs(page, DateOfBirthFormPageLandlordRegistration::class)
+            }
+
+            @Test
+            fun `Change Email link navigates to the correct step`(page: Page) {
+                val changeEmailLink = checkAnswersPage.summaryList.getRowActionLink(2)
+                changeEmailLink.click()
+                assertPageIs(page, EmailFormPageLandlordRegistration::class)
+            }
+
+            @Test
+            fun `Change Phone number link navigates to the correct step`(page: Page) {
+                val changePhoneNumberLink = checkAnswersPage.summaryList.getRowActionLink(3)
+                changePhoneNumberLink.click()
+                assertPageIs(page, PhoneNumberFormPageLandlordRegistration::class)
+            }
+
+            @Test
+            fun `Change UK Resident link navigates to the correct step`(page: Page) {
+                val changeUKResidentLink = checkAnswersPage.summaryList.getRowActionLink(4)
+                changeUKResidentLink.click()
+                assertPageIs(page, CountryOfResidenceFormPageLandlordRegistration::class)
+            }
+        }
+
+        @Nested
+        inner class CheckAddressDetails {
+            @Test
+            fun `Change selected address link navigates to the correct step`(page: Page) {
+                val checkAnswersPage = navigator.goToLandlordRegistrationCheckAnswersPage()
+                val changeSelectedAddressLink = checkAnswersPage.summaryList.getRowActionLink(5)
+                changeSelectedAddressLink.click()
+                assertPageIs(page, LookupAddressFormPageLandlordRegistration::class)
+            }
+
+            @Test
+            fun `Change manual address link navigates to the correct step`(page: Page) {
+                val checkAnswersPage = navigator.goToLandlordRegistrationCheckAnswersPage(isManualAddressChosen = true)
+                val changeManualAddressLink = checkAnswersPage.summaryList.getRowActionLink(5)
+                changeManualAddressLink.click()
+                assertPageIs(page, ManualAddressFormPageLandlordRegistration::class)
+            }
+        }
+
+        @Nested
+        inner class CheckInternationalAddressDetails {
+            @Test
+            fun `Change country of residence link navigates to the correct step`(page: Page) {
+                val checkAnswersPage = navigator.goToLandlordRegistrationCheckAnswersPage(livesInUK = false)
+                val changeCountryOfResidenceLink = checkAnswersPage.summaryList.getRowActionLink(5)
+                changeCountryOfResidenceLink.click()
+                assertPageIs(page, CountryOfResidenceFormPageLandlordRegistration::class)
+            }
+
+            @Test
+            fun `Change international address link navigates to the correct step`(page: Page) {
+                val checkAnswersPage = navigator.goToLandlordRegistrationCheckAnswersPage(livesInUK = false)
+                val changeInternationalAddressLink = checkAnswersPage.summaryList.getRowActionLink(6)
+                changeInternationalAddressLink.click()
+                assertPageIs(page, InternationalAddressFormPageLandlordRegistration::class)
+            }
+
+            @Test
+            fun `Change selected address link navigates to the correct step`(page: Page) {
+                val checkAnswersPage = navigator.goToLandlordRegistrationCheckAnswersPage(livesInUK = false)
+                val changeSelectedContactAddressLink = checkAnswersPage.summaryList.getRowActionLink(7)
+                changeSelectedContactAddressLink.click()
+                assertPageIs(page, LookupContactAddressFormPageLandlordRegistration::class)
+            }
+
+            @Test
+            fun `Change manual address link navigates to the correct step`(page: Page) {
+                val checkAnswersPage =
+                    navigator.goToLandlordRegistrationCheckAnswersPage(livesInUK = false, isManualAddressChosen = true)
+                val changeManualContactAddressLink = checkAnswersPage.summaryList.getRowActionLink(7)
+                changeManualContactAddressLink.click()
+                assertPageIs(page, ManualContactAddressFormPageLandlordRegistration::class)
+            }
         }
     }
 

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/Navigator.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/Navigator.kt
@@ -132,7 +132,7 @@ class Navigator(
     fun goToLandlordRegistrationSelectAddressPage(): SelectAddressFormPageLandlordRegistration {
         val lookupAddressPage = goToLandlordRegistrationLookupAddressPage()
         lookupAddressPage.postcodeInput.fill("EG")
-        lookupAddressPage.houseNameOrNumberInput.fill("5")
+        lookupAddressPage.houseNameOrNumberInput.fill("1")
         lookupAddressPage.form.submit()
         return createValidPage(page, SelectAddressFormPageLandlordRegistration::class)
     }
@@ -155,7 +155,7 @@ class Navigator(
 
     fun goToLandlordRegistrationLookupContactAddressPage(): LookupContactAddressFormPageLandlordRegistration {
         val internationalAddressPage = goToLandlordRegistrationInternationalAddressPage()
-        internationalAddressPage.textAreaInput.fill("address")
+        internationalAddressPage.textAreaInput.fill("international address")
         internationalAddressPage.form.submit()
         return createValidPage(page, LookupContactAddressFormPageLandlordRegistration::class)
     }
@@ -175,11 +175,25 @@ class Navigator(
         return createValidPage(page, ManualContactAddressFormPageLandlordRegistration::class)
     }
 
-    fun goToLandlordRegistrationCheckAnswersPage(): CheckAnswersPageLandlordRegistration {
-        val selectAddressPage = goToLandlordRegistrationSelectContactAddressPage()
-        selectAddressPage.radios.selectValue("1, Example Road, EG1 2AB")
-        selectAddressPage.form.submit()
-        return createValidPage(page, CheckAnswersPageLandlordRegistration::class)
+    fun goToLandlordRegistrationCheckAnswersPage(
+        livesInUK: Boolean = true,
+        isManualAddressChosen: Boolean = false,
+    ): CheckAnswersPageLandlordRegistration {
+        if (isManualAddressChosen) {
+            val manualAddressPage =
+                if (livesInUK) goToLandlordRegistrationManualAddressPage() else goToLandlordRegistrationManualContactAddressPage()
+            manualAddressPage.addressLineOneInput.fill("1 Example Road")
+            manualAddressPage.townOrCityInput.fill("Townville")
+            manualAddressPage.postcodeInput.fill("EG1 2AB")
+            manualAddressPage.form.submit()
+            return createValidPage(page, CheckAnswersPageLandlordRegistration::class)
+        } else {
+            val selectAddressPage =
+                if (livesInUK) goToLandlordRegistrationSelectAddressPage() else goToLandlordRegistrationSelectContactAddressPage()
+            selectAddressPage.radios.selectValue("1, Example Road, EG1 2AB")
+            selectAddressPage.form.submit()
+            return createValidPage(page, CheckAnswersPageLandlordRegistration::class)
+        }
     }
 
     fun goToLandlordRegistrationDeclarationPage(): DeclarationFormPageLandlordRegistration {

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/landlordRegistrationJourneyPages/CheckAnswersPageLandlordRegistration.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/landlordRegistrationJourneyPages/CheckAnswersPageLandlordRegistration.kt
@@ -3,11 +3,8 @@ package uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.landlordRe
 import com.microsoft.playwright.Page
 import uk.gov.communities.prsdb.webapp.constants.REGISTER_LANDLORD_JOURNEY_URL
 import uk.gov.communities.prsdb.webapp.forms.steps.RegisterLaUserStepId
-import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.SummaryList
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages.FormBasePage
 
 class CheckAnswersPageLandlordRegistration(
     page: Page,
-) : FormBasePage(page, "/$REGISTER_LANDLORD_JOURNEY_URL/${RegisterLaUserStepId.CheckAnswers.urlPathSegment}") {
-    val summaryList = SummaryList(page)
-}
+) : FormBasePage(page, "/$REGISTER_LANDLORD_JOURNEY_URL/${RegisterLaUserStepId.CheckAnswers.urlPathSegment}")

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/landlordRegistrationJourneyPages/CheckAnswersPageLandlordRegistration.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/landlordRegistrationJourneyPages/CheckAnswersPageLandlordRegistration.kt
@@ -3,8 +3,11 @@ package uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.landlordRe
 import com.microsoft.playwright.Page
 import uk.gov.communities.prsdb.webapp.constants.REGISTER_LANDLORD_JOURNEY_URL
 import uk.gov.communities.prsdb.webapp.forms.steps.RegisterLaUserStepId
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.SummaryList
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages.FormBasePage
 
 class CheckAnswersPageLandlordRegistration(
     page: Page,
-) : FormBasePage(page, "/$REGISTER_LANDLORD_JOURNEY_URL/${RegisterLaUserStepId.CheckAnswers.urlPathSegment}")
+) : FormBasePage(page, "/$REGISTER_LANDLORD_JOURNEY_URL/${RegisterLaUserStepId.CheckAnswers.urlPathSegment}") {
+    val summaryList = SummaryList(page)
+}

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/mockObjects/JourneyDataBuilder.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/mockObjects/JourneyDataBuilder.kt
@@ -21,15 +21,7 @@ class JourneyDataBuilder(
     fun build() = journeyData
 
     companion object {
-        const val DEFAULT_NAME = "Arthur Dent"
-
-        val DEFAULT_DOB = LocalDate.of(2000, 6, 8)
-
         const val DEFAULT_ADDRESS = "4, Example Road, EG"
-
-        const val DEFAULT_PHONE_NUMBER = "07123456789"
-
-        const val DEFAULT_EMAIL_ADDRESS = "test@example.com"
 
         private val defaultPropertyJourneyData: Map<String, Any?> =
             mapOf(
@@ -84,18 +76,17 @@ class JourneyDataBuilder(
                 22,
             )
 
-        // Unverified, National, Selected Address
         private val defaultLandlordJourneyData: Map<String, Any?> =
             mapOf(
-                LandlordRegistrationStepId.Name.urlPathSegment to mutableMapOf("name" to DEFAULT_NAME),
+                LandlordRegistrationStepId.Name.urlPathSegment to mutableMapOf("name" to "Arthur Dent"),
                 LandlordRegistrationStepId.DateOfBirth.urlPathSegment to
                     mutableMapOf(
-                        "day" to DEFAULT_DOB.dayOfMonth,
-                        "month" to DEFAULT_DOB.monthValue,
-                        "year" to DEFAULT_DOB.year,
+                        "day" to 6,
+                        "month" to 8,
+                        "year" to 2000,
                     ),
-                LandlordRegistrationStepId.Email.urlPathSegment to mutableMapOf("emailAddress" to DEFAULT_EMAIL_ADDRESS),
-                LandlordRegistrationStepId.PhoneNumber.urlPathSegment to mutableMapOf("phoneNumber" to DEFAULT_PHONE_NUMBER),
+                LandlordRegistrationStepId.Email.urlPathSegment to mutableMapOf("emailAddress" to "test@example.com"),
+                LandlordRegistrationStepId.PhoneNumber.urlPathSegment to mutableMapOf("phoneNumber" to "07123456789"),
                 LandlordRegistrationStepId.CountryOfResidence.urlPathSegment to mutableMapOf("livesInUK" to true),
                 LandlordRegistrationStepId.SelectAddress.urlPathSegment to mutableMapOf("address" to DEFAULT_ADDRESS),
             )
@@ -239,6 +230,26 @@ class JourneyDataBuilder(
                 "name" to name,
                 "birthDate" to dob,
             )
+        return this
+    }
+
+    fun withUnverifiedUser(
+        name: String,
+        dob: LocalDate,
+    ): JourneyDataBuilder {
+        journeyData[LandlordRegistrationStepId.Name.urlPathSegment] = mutableMapOf("name" to name)
+        journeyData[LandlordRegistrationStepId.DateOfBirth.urlPathSegment] =
+            mutableMapOf("day" to dob.dayOfMonth, "month" to dob.monthValue, "year" to dob.year)
+        return this
+    }
+
+    fun withEmailAddress(emailAddress: String): JourneyDataBuilder {
+        journeyData[LandlordRegistrationStepId.Email.urlPathSegment] = mutableMapOf("emailAddress" to emailAddress)
+        return this
+    }
+
+    fun withPhoneNumber(phoneNumber: String): JourneyDataBuilder {
+        journeyData[LandlordRegistrationStepId.PhoneNumber.urlPathSegment] = mutableMapOf("phoneNumber" to phoneNumber)
         return this
     }
 

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/mockObjects/JourneyDataBuilder.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/mockObjects/JourneyDataBuilder.kt
@@ -18,8 +18,9 @@ class JourneyDataBuilder(
     fun build() = journeyData
 
     companion object {
-        private val defaultAddress = "4, Example Road, EG"
-        private val defaultJourneyData: Map<String, Any?> =
+        private const val DEFAULT_ADDRESS = "4, Example Road, EG"
+
+        private val defaultPropertyJourneyData: Map<String, Any?> =
             mapOf(
                 "lookup-address" to
                     mutableMapOf(
@@ -28,7 +29,7 @@ class JourneyDataBuilder(
                     ),
                 "select-address" to
                     mutableMapOf(
-                        "address" to defaultAddress,
+                        "address" to DEFAULT_ADDRESS,
                     ),
                 "property-type" to
                     mutableMapOf(
@@ -65,8 +66,12 @@ class JourneyDataBuilder(
                     ),
             )
 
-        fun default(addressService: AddressDataService) =
-            JourneyDataBuilder(addressService, defaultJourneyData).withSelectedAddress(defaultAddress, 709902, 22)
+        fun propertyDefault(addressService: AddressDataService) =
+            JourneyDataBuilder(addressService, defaultPropertyJourneyData).withSelectedAddress(
+                DEFAULT_ADDRESS,
+                709902,
+                22,
+            )
     }
 
     fun withSelectedAddress(
@@ -123,9 +128,18 @@ class JourneyDataBuilder(
     ): JourneyDataBuilder {
         journeyData["licensing-type"] = mutableMapOf("licensingType" to licensingType.name)
         when (licensingType) {
-            LicensingType.SELECTIVE_LICENCE -> journeyData["selective-licence"] = mutableMapOf("licenceNumber" to licenseNumber)
-            LicensingType.HMO_MANDATORY_LICENCE -> journeyData["hmo-mandatory-licence"] = mutableMapOf("licenceNumber" to licenseNumber)
-            LicensingType.HMO_ADDITIONAL_LICENCE -> journeyData["hmo-additional-licence"] = mutableMapOf("licenceNumber" to licenseNumber)
+            LicensingType.SELECTIVE_LICENCE ->
+                journeyData["selective-licence"] =
+                    mutableMapOf("licenceNumber" to licenseNumber)
+
+            LicensingType.HMO_MANDATORY_LICENCE ->
+                journeyData["hmo-mandatory-licence"] =
+                    mutableMapOf("licenceNumber" to licenseNumber)
+
+            LicensingType.HMO_ADDITIONAL_LICENCE ->
+                journeyData["hmo-additional-licence"] =
+                    mutableMapOf("licenceNumber" to licenseNumber)
+
             LicensingType.NO_LICENSING -> {}
         }
         return this
@@ -153,7 +167,7 @@ class JourneyDataBuilder(
             mutableMapOf(
                 "numberOfHouseholds" to households.toString(),
             )
-        journeyData[ "number-of-people" ] =
+        journeyData["number-of-people"] =
             mutableMapOf(
                 "numberOfPeople" to people.toString(),
             )

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,7 +1,12 @@
 spring:
   application:
     name: 'prsdb-webapp'
+  mvc:
+    format:
+      date: "d MMMM yyyy"
+
 notify:
   api-key: ${EMAILNOTIFICATIONS_APIKEY}
+
 os-places:
   api-key: ${OS_PLACES_API_KEY}


### PR DESCRIPTION
- created the check answers journey step
- created the `LandlordRegistrationCheckAnswersPage` to to populate the model that should be returned for this page
- ensured the page renders the correct data and links according to users input
- ensured that data is persisted through each journey flow (so if a user changes from being a UK resident and back again the data they input from that flow prepopulates when they return to the pages)
- updated existing tests and created new ones

Notes:
- There are not yet integration tests to check the page when a user has had their ID verified by one login - they were proving tricky and I felt it was better to get the PR in while I worked on them. - These have now been pushed to the PR
- Some references to the check answers page were using `CheckAnswersPage` in their name and some were using `SummaryPage` I have changed them all to `CheckAnswersPage` for consistency.