### PR TITLE
Prsd 578 select licensing type

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/constants/enums/LicensingType.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/constants/enums/LicensingType.kt
@@ -1,0 +1,8 @@
+package uk.gov.communities.prsdb.webapp.constants.enums
+
+enum class LicensingType {
+    SELECTIVE_LICENCE,
+    HMO_MANDATORY_LICENCE,
+    HMO_ADDITIONAL_LICENCE,
+    NO_LICENSING,
+}

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/PropertyRegistrationJourney.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/PropertyRegistrationJourney.kt
@@ -6,6 +6,7 @@ import uk.gov.communities.prsdb.webapp.constants.LOCAL_AUTHORITIES
 import uk.gov.communities.prsdb.webapp.constants.MANUAL_ADDRESS_CHOSEN
 import uk.gov.communities.prsdb.webapp.constants.REGISTER_PROPERTY_JOURNEY_URL
 import uk.gov.communities.prsdb.webapp.constants.enums.JourneyType
+import uk.gov.communities.prsdb.webapp.constants.enums.LicensingType
 import uk.gov.communities.prsdb.webapp.constants.enums.OwnershipType
 import uk.gov.communities.prsdb.webapp.constants.enums.PropertyType
 import uk.gov.communities.prsdb.webapp.forms.pages.AlreadyRegisteredPage
@@ -13,6 +14,7 @@ import uk.gov.communities.prsdb.webapp.forms.pages.Page
 import uk.gov.communities.prsdb.webapp.forms.pages.SelectAddressPage
 import uk.gov.communities.prsdb.webapp.forms.steps.RegisterPropertyStepId
 import uk.gov.communities.prsdb.webapp.forms.steps.Step
+import uk.gov.communities.prsdb.webapp.models.formModels.LicensingTypeFormModel
 import uk.gov.communities.prsdb.webapp.models.formModels.LookupAddressFormModel
 import uk.gov.communities.prsdb.webapp.models.formModels.ManualAddressFormModel
 import uk.gov.communities.prsdb.webapp.models.formModels.NoInputFormModel
@@ -24,6 +26,7 @@ import uk.gov.communities.prsdb.webapp.models.formModels.PropertyTypeFormModel
 import uk.gov.communities.prsdb.webapp.models.formModels.SelectAddressFormModel
 import uk.gov.communities.prsdb.webapp.models.formModels.SelectLocalAuthorityFormModel
 import uk.gov.communities.prsdb.webapp.models.viewModels.RadiosButtonViewModel
+import uk.gov.communities.prsdb.webapp.models.viewModels.RadiosDividerViewModel
 import uk.gov.communities.prsdb.webapp.models.viewModels.SelectViewModel
 import uk.gov.communities.prsdb.webapp.services.AddressDataService
 import uk.gov.communities.prsdb.webapp.services.AddressLookupService
@@ -269,6 +272,43 @@ class PropertyRegistrationJourney(
                                     "fieldSetHeading" to "forms.numberOfPeople.fieldSetHeading",
                                     "fieldSetHint" to "forms.numberOfPeople.fieldSetHint",
                                     "label" to "forms.numberOfPeople.label",
+                                ),
+                        ),
+                    nextAction = { _, _ -> Pair(RegisterPropertyStepId.LicensingType, null) },
+                ),
+                Step(
+                    id = RegisterPropertyStepId.LicensingType,
+                    page =
+                        Page(
+                            formModel = LicensingTypeFormModel::class,
+                            templateName = "forms/licensingTypeForm",
+                            content =
+                                mapOf(
+                                    "title" to "registerProperty.title",
+                                    "fieldSetHeading" to "forms.licensingType.fieldSetHeading",
+                                    "radioOptions" to
+                                        listOf(
+                                            RadiosButtonViewModel(
+                                                value = LicensingType.SELECTIVE_LICENCE,
+                                                labelMsgKey = "forms.licensingType.radios.option.selectiveLicence.label",
+                                                hintMsgKey = "forms.licensingType.radios.option.selectiveLicence.hint",
+                                            ),
+                                            RadiosButtonViewModel(
+                                                value = LicensingType.HMO_MANDATORY_LICENCE,
+                                                labelMsgKey = "forms.licensingType.radios.option.hmoMandatory.label",
+                                                hintMsgKey = "forms.licensingType.radios.option.hmoMandatory.hint",
+                                            ),
+                                            RadiosButtonViewModel(
+                                                value = LicensingType.HMO_ADDITIONAL_LICENCE,
+                                                labelMsgKey = "forms.licensingType.radios.option.hmoAdditional.label",
+                                                hintMsgKey = "forms.licensingType.radios.option.hmoAdditional.hint",
+                                            ),
+                                            RadiosDividerViewModel("forms.radios.dividerText"),
+                                            RadiosButtonViewModel(
+                                                value = LicensingType.NO_LICENSING,
+                                                labelMsgKey = "forms.licensingType.radios.option.noLicensing.label",
+                                            ),
+                                        ),
                                 ),
                         ),
                     nextAction = { _, _ -> Pair(RegisterPropertyStepId.PlaceholderPage, null) },

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/PropertyRegistrationJourney.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/PropertyRegistrationJourney.kt
@@ -286,6 +286,7 @@ class PropertyRegistrationJourney(
                                 mapOf(
                                     "title" to "registerProperty.title",
                                     "fieldSetHeading" to "forms.licensingType.fieldSetHeading",
+                                    "fieldSetHint" to "forms.licensingType.fieldSetHint",
                                     "radioOptions" to
                                         listOf(
                                             RadiosButtonViewModel(

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/steps/RegisterPropertyStepId.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/steps/RegisterPropertyStepId.kt
@@ -14,4 +14,5 @@ enum class RegisterPropertyStepId(
     Occupancy("occupancy"),
     NumberOfHouseholds("number-of-households"),
     NumberOfPeople("number-of-people"),
+    LicensingType("licensing-type"),
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/formModels/LicensingTypeFormModel.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/formModels/LicensingTypeFormModel.kt
@@ -1,0 +1,20 @@
+package uk.gov.communities.prsdb.webapp.models.formModels
+
+import uk.gov.communities.prsdb.webapp.constants.enums.LicensingType
+import uk.gov.communities.prsdb.webapp.validation.ConstraintDescriptor
+import uk.gov.communities.prsdb.webapp.validation.IsValidPrioritised
+import uk.gov.communities.prsdb.webapp.validation.NotNullConstraintValidator
+import uk.gov.communities.prsdb.webapp.validation.ValidatedBy
+
+@IsValidPrioritised
+class LicensingTypeFormModel : FormModel {
+    @ValidatedBy(
+        constraints = [
+            ConstraintDescriptor(
+                messageKey = "forms.licensingType.radios.error.missing",
+                validatorType = NotNullConstraintValidator::class,
+            ),
+        ],
+    )
+    var licensingType: LicensingType? = null
+}

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -407,6 +407,7 @@ forms.declaration.checkbox.label=I agree
 forms.declaration.checkbox.error.missing=You must agree to the declaration to continue
 
 forms.licensingType.fieldSetHeading=Select the type of licensing you have for your property
+forms.licensingType.fieldSetHint=Select if your property is part of a licensing scheme. You must provide the licensing number.
 forms.licensingType.radios.error.missing=Select the type of licensing for the property
 forms.licensingType.radios.option.selectiveLicence.label=Selective licence
 forms.licensingType.radios.option.selectiveLicence.hint=Some local authorities issue a selective licence for privately rented housing in a local area.

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -416,8 +416,6 @@ forms.licensingType.radios.option.hmoAdditional.label=HMO additional licence
 forms.licensingType.radios.option.hmoAdditional.hint=A local authority can also include other types of HMOs for licensing.
 forms.licensingType.radios.option.noLicensing.label=I don't have any licensing for my property
 
-
-
 pagination.previousText=Previous
 pagination.pageText=page
 pagination.nextText=Next

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -406,6 +406,18 @@ forms.declaration.confirm.bullet.two=I understand I may be fined if I provide fa
 forms.declaration.checkbox.label=I agree
 forms.declaration.checkbox.error.missing=You must agree to the declaration to continue
 
+forms.licensingType.fieldSetHeading=Select the type of licensing you have for your property
+forms.licensingType.radios.error.missing=Select the type of licensing for the property
+forms.licensingType.radios.option.selectiveLicence.label=Selective licence
+forms.licensingType.radios.option.selectiveLicence.hint=Some local authorities issue a selective licence for privately rented housing in a local area.
+forms.licensingType.radios.option.hmoMandatory.label=HMO mandatory licence
+forms.licensingType.radios.option.hmoMandatory.hint=A House in Multiple Occupation (HMO) must have a licence if it's occupied by 5 or more people.
+forms.licensingType.radios.option.hmoAdditional.label=HMO additional licence
+forms.licensingType.radios.option.hmoAdditional.hint=A local authority can also include other types of HMOs for licensing.
+forms.licensingType.radios.option.noLicensing.label=I don't have any licensing for my property
+
+
+
 pagination.previousText=Previous
 pagination.pageText=page
 pagination.nextText=Next

--- a/src/main/resources/templates/forms/licensingTypeForm.html
+++ b/src/main/resources/templates/forms/licensingTypeForm.html
@@ -1,6 +1,7 @@
 <!--/*@thymesVar id="title" type="java.lang.String"*/-->
 <!--/*@thymesVar id="formModel" type="java.lang.Object"*/-->
 <!--/*@thymesVar id="fieldSetHeading" type="java.lang.String"*/-->
+<!--/*@thymesVar id="fieldSetHint" type="java.lang.String"*/-->
 <!--/*@thymesVar id="backUrl" type="java.lang.String"*/-->
 <!--/*@thymesVar id="radioOptions" type="java.lang.Object"*/-->
 <!DOCTYPE html>
@@ -9,7 +10,7 @@
 using a `form` element with `th:remove="tag" instead of a `th:block` means this page is a form as a prototype -->
 <form id="form-content" th:remove="tag">
     <fieldset id="fieldset-content"
-              th:replace="~{fragments/forms/fieldSet :: fieldSet(~{::#fieldset-content/content()}, 'licensingType', #{${fieldSetHeading}}, null)}">
+              th:replace="~{fragments/forms/fieldSet :: fieldSet(~{::#fieldset-content/content()}, 'licensingType', #{${fieldSetHeading}}, #{${fieldSetHint}})}">
         <input th:replace="~{fragments/forms/radios :: radios(null,'licensingType',null, ${radioOptions})}">
     </fieldset>
     <button th:replace="~{fragments/buttons/primaryButton :: primaryButton(#{forms.buttons.continue})}"></button>

--- a/src/main/resources/templates/forms/licensingTypeForm.html
+++ b/src/main/resources/templates/forms/licensingTypeForm.html
@@ -5,6 +5,8 @@
 <!--/*@thymesVar id="radioOptions" type="java.lang.Object"*/-->
 <!DOCTYPE html>
 <html th:replace="~{fragments/forms/questionPage :: questionPage(#{${title}}, ${formModel}, ~{::#form-content}, ${backUrl})}">
+<!-- The `questionPage` fragment places this content in a `form` element inside an `html` element;
+using a `form` element with `th:remove="tag" instead of a `th:block` means this page is a form as a prototype -->
 <form id="form-content" th:remove="tag">
     <fieldset id="fieldset-content"
               th:replace="~{fragments/forms/fieldSet :: fieldSet(~{::#fieldset-content/content()}, 'licensingType', #{${fieldSetHeading}}, null)}">

--- a/src/main/resources/templates/forms/licensingTypeForm.html
+++ b/src/main/resources/templates/forms/licensingTypeForm.html
@@ -6,13 +6,11 @@
 <!--/*@thymesVar id="radioOptions" type="java.lang.Object"*/-->
 <!DOCTYPE html>
 <html th:replace="~{fragments/forms/questionPage :: questionPage(#{${title}}, ${formModel}, ~{::#form-content}, ${backUrl})}">
-<!-- The `questionPage` fragment places this content in a `form` element inside an `html` element;
-using a `form` element with `th:remove="tag" instead of a `th:block` means this page is a form as a prototype -->
-<form id="form-content" th:remove="tag">
+<th:block id="form-content">
     <fieldset id="fieldset-content"
               th:replace="~{fragments/forms/fieldSet :: fieldSet(~{::#fieldset-content/content()}, 'licensingType', #{${fieldSetHeading}}, #{${fieldSetHint}})}">
         <input th:replace="~{fragments/forms/radios :: radios(null,'licensingType',null, ${radioOptions})}">
     </fieldset>
     <button th:replace="~{fragments/buttons/primaryButton :: primaryButton(#{forms.buttons.continue})}"></button>
-</form>
+</th:block>
 </html>

--- a/src/main/resources/templates/forms/licensingTypeForm.html
+++ b/src/main/resources/templates/forms/licensingTypeForm.html
@@ -1,0 +1,15 @@
+<!--/*@thymesVar id="title" type="java.lang.String"*/-->
+<!--/*@thymesVar id="formModel" type="java.lang.Object"*/-->
+<!--/*@thymesVar id="fieldSetHeading" type="java.lang.String"*/-->
+<!--/*@thymesVar id="backUrl" type="java.lang.String"*/-->
+<!--/*@thymesVar id="radioOptions" type="java.lang.Object"*/-->
+<!DOCTYPE html>
+<html th:replace="~{fragments/forms/questionPage :: questionPage(#{${title}}, ${formModel}, ~{::#form-content}, ${backUrl})}">
+<form id="form-content" th:remove="tag">
+    <fieldset id="fieldset-content"
+              th:replace="~{fragments/forms/fieldSet :: fieldSet(~{::#fieldset-content/content()}, 'licensingType', #{${fieldSetHeading}}, null)}">
+        <input th:replace="~{fragments/forms/radios :: radios(null,'licensingType',null, ${radioOptions})}">
+    </fieldset>
+    <button th:replace="~{fragments/buttons/primaryButton :: primaryButton(#{forms.buttons.continue})}"></button>
+</form>
+</html>

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/PropertyRegistrationJourneyTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/PropertyRegistrationJourneyTests.kt
@@ -10,6 +10,7 @@ import org.mockito.kotlin.any
 import org.mockito.kotlin.whenever
 import org.springframework.test.context.jdbc.Sql
 import uk.gov.communities.prsdb.webapp.constants.MANUAL_ADDRESS_CHOSEN
+import uk.gov.communities.prsdb.webapp.constants.enums.LicensingType
 import uk.gov.communities.prsdb.webapp.constants.enums.OwnershipType
 import uk.gov.communities.prsdb.webapp.constants.enums.PropertyType
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages.BasePage.Companion.assertPageIs
@@ -97,6 +98,13 @@ class PropertyRegistrationJourneyTests : IntegrationTest() {
         // fill in and submit
         peoplePage.peopleInput.fill("2")
         peoplePage.form.submit()
+
+        // Licensing type - render page
+        assertThat(propertyTypePage.form.getFieldsetHeading()).containsText("Select the type of licensing you have for your property")
+        // fill in and submit
+        propertyTypePage.form.getRadios().selectValue(LicensingType.HMO_ADDITIONAL_LICENCE)
+        propertyTypePage.form.submit()
+
         assertEquals("/register-property/placeholder", URI(page.url()).path)
     }
 
@@ -324,6 +332,16 @@ class PropertyRegistrationJourneyTests : IntegrationTest() {
             peoplePage.form.submit()
             assertThat(peoplePage.form.getErrorMessage())
                 .containsText("Number of people in your property must be a positive, whole number, like 3")
+        }
+    }
+
+    @Nested
+    inner class LicensingTypeStep {
+        @Test
+        fun `Submitting with no propertyType selected returns an error`(page: Page) {
+            val propertyTypePage = navigator.goToPropertyRegistrationLicensingTypePage()
+            propertyTypePage.form.submit()
+            assertThat(propertyTypePage.form.getErrorMessage()).containsText("Select the type of licensing for the property")
         }
     }
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/PropertyRegistrationJourneyTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/PropertyRegistrationJourneyTests.kt
@@ -341,9 +341,9 @@ class PropertyRegistrationJourneyTests : IntegrationTest() {
     inner class LicensingTypeStep {
         @Test
         fun `Submitting with no licensingType selected returns an error`(page: Page) {
-            val propertyTypePage = navigator.goToPropertyRegistrationLicensingTypePage()
-            propertyTypePage.form.submit()
-            assertThat(propertyTypePage.form.getErrorMessage()).containsText("Select the type of licensing for the property")
+            val licensingTypePage = navigator.goToPropertyRegistrationLicensingTypePage()
+            licensingTypePage.form.submit()
+            assertThat(licensingTypePage.form.getErrorMessage()).containsText("Select the type of licensing for the property")
         }
     }
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/PropertyRegistrationJourneyTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/PropertyRegistrationJourneyTests.kt
@@ -16,6 +16,7 @@ import uk.gov.communities.prsdb.webapp.constants.enums.PropertyType
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages.BasePage.Companion.assertPageIs
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyRegistrationJourneyPages.AlreadyRegisteredFormPagePropertyRegistration
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyRegistrationJourneyPages.HouseholdsFormPagePropertyRegistration
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyRegistrationJourneyPages.LicensingTypeFormPagePropertyRegistration
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyRegistrationJourneyPages.LookupAddressFormPagePropertyRegistration
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyRegistrationJourneyPages.ManualAddressFormPagePropertyRegistration
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyRegistrationJourneyPages.OccupancyFormPagePropertyRegistration
@@ -76,7 +77,7 @@ class PropertyRegistrationJourneyTests : IntegrationTest() {
         assertThat(ownershipTypePage.form.getFieldsetHeading()).containsText("Select the ownership type for your property")
         // fill in and submit
         ownershipTypePage.form.getRadios().selectValue(OwnershipType.FREEHOLD)
-        propertyTypePage.form.submit()
+        ownershipTypePage.form.submit()
         val occupancyPage = assertPageIs(page, OccupancyFormPagePropertyRegistration::class)
 
         // Occupancy - render page
@@ -98,12 +99,13 @@ class PropertyRegistrationJourneyTests : IntegrationTest() {
         // fill in and submit
         peoplePage.peopleInput.fill("2")
         peoplePage.form.submit()
+        val licensingTypePage = assertPageIs(page, LicensingTypeFormPagePropertyRegistration::class)
 
         // Licensing type - render page
-        assertThat(propertyTypePage.form.getFieldsetHeading()).containsText("Select the type of licensing you have for your property")
+        assertThat(licensingTypePage.form.getFieldsetHeading()).containsText("Select the type of licensing you have for your property")
         // fill in and submit
-        propertyTypePage.form.getRadios().selectValue(LicensingType.HMO_ADDITIONAL_LICENCE)
-        propertyTypePage.form.submit()
+        licensingTypePage.form.getRadios().selectValue(LicensingType.HMO_ADDITIONAL_LICENCE)
+        licensingTypePage.form.submit()
 
         assertEquals("/register-property/placeholder", URI(page.url()).path)
     }
@@ -338,7 +340,7 @@ class PropertyRegistrationJourneyTests : IntegrationTest() {
     @Nested
     inner class LicensingTypeStep {
         @Test
-        fun `Submitting with no propertyType selected returns an error`(page: Page) {
+        fun `Submitting with no licensingType selected returns an error`(page: Page) {
             val propertyTypePage = navigator.goToPropertyRegistrationLicensingTypePage()
             propertyTypePage.form.submit()
             assertThat(propertyTypePage.form.getErrorMessage()).containsText("Select the type of licensing for the property")

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/Navigator.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/Navigator.kt
@@ -29,6 +29,7 @@ import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.landlordReg
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.landlordRegistrationJourneyPages.SelectContactAddressFormPageLandlordRegistration
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.landlordRegistrationJourneyPages.SummaryPageLandlordRegistration
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyRegistrationJourneyPages.HouseholdsFormPagePropertyRegistration
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyRegistrationJourneyPages.LicensingTypeFormPagePropertyRegistration
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyRegistrationJourneyPages.LookupAddressFormPagePropertyRegistration
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyRegistrationJourneyPages.ManualAddressFormPagePropertyRegistration
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyRegistrationJourneyPages.OccupancyFormPagePropertyRegistration
@@ -269,6 +270,13 @@ class Navigator(
         householdsPage.householdsInput.fill("2")
         householdsPage.form.submit()
         return createValidPage(page, PeopleFormPagePropertyRegistration::class)
+    }
+
+    fun goToPropertyRegistrationLicensingTypePage(): LicensingTypeFormPagePropertyRegistration {
+        val peoplePage = goToPropertyRegistrationPeoplePage()
+        peoplePage.peopleInput.fill("4")
+        peoplePage.form.submit()
+        return createValidPage(page, LicensingTypeFormPagePropertyRegistration::class)
     }
 
     private fun navigate(path: String): Response? = page.navigate("http://localhost:$port/$path")

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/propertyRegistrationJourneyPages/LicensingTypeFormPagePropertyRegistration.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/propertyRegistrationJourneyPages/LicensingTypeFormPagePropertyRegistration.kt
@@ -1,0 +1,13 @@
+package uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyRegistrationJourneyPages
+
+import com.microsoft.playwright.Page
+import uk.gov.communities.prsdb.webapp.constants.REGISTER_PROPERTY_JOURNEY_URL
+import uk.gov.communities.prsdb.webapp.forms.steps.RegisterPropertyStepId
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages.FormBasePage
+
+class LicensingTypeFormPagePropertyRegistration(
+    page: Page,
+) : FormBasePage(
+        page,
+        "/$REGISTER_PROPERTY_JOURNEY_URL/${RegisterPropertyStepId.LicensingType.urlPathSegment}",
+    )


### PR DESCRIPTION
Added the lincensing type page and integration tests. I'm not sure if I've added this in exactly the correct place in the journey but updating the `nextAction`s later once the all the pages exist should be relatively easy (and means we're not blocked on previous steps now!)