### PR TITLE
Feat/prsd 579 selective licence

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/PropertyRegistrationJourney.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/PropertyRegistrationJourney.kt
@@ -25,6 +25,7 @@ import uk.gov.communities.prsdb.webapp.models.formModels.OwnershipTypeFormModel
 import uk.gov.communities.prsdb.webapp.models.formModels.PropertyTypeFormModel
 import uk.gov.communities.prsdb.webapp.models.formModels.SelectAddressFormModel
 import uk.gov.communities.prsdb.webapp.models.formModels.SelectLocalAuthorityFormModel
+import uk.gov.communities.prsdb.webapp.models.formModels.SelectiveLicenceFormModel
 import uk.gov.communities.prsdb.webapp.models.viewModels.RadiosButtonViewModel
 import uk.gov.communities.prsdb.webapp.models.viewModels.RadiosDividerViewModel
 import uk.gov.communities.prsdb.webapp.models.viewModels.SelectViewModel
@@ -312,6 +313,21 @@ class PropertyRegistrationJourney(
                                         ),
                                 ),
                         ),
+                    nextAction = { journeyData, _ -> licensingTypeNextAction(journeyData) },
+                ),
+                Step(
+                    id = RegisterPropertyStepId.SelectiveLicence,
+                    page =
+                        Page(
+                            formModel = SelectiveLicenceFormModel::class,
+                            templateName = "forms/selectiveLicenceForm",
+                            content =
+                                mapOf(
+                                    "title" to "registerProperty.title",
+                                    "fieldSetHeading" to "forms.selectiveLicence.fieldSetHeading",
+                                    "label" to "forms.selectiveLicence.label",
+                                ),
+                        ),
                     nextAction = { _, _ -> Pair(RegisterPropertyStepId.PlaceholderPage, null) },
                 ),
                 Step(
@@ -362,6 +378,20 @@ class PropertyRegistrationJourney(
                 return Pair(RegisterPropertyStepId.PropertyType, null)
             }
         }
+
+        private fun licensingTypeNextAction(journeyData: JourneyData): Pair<RegisterPropertyStepId, Int?> =
+            when (
+                LicensingType.valueOf(
+                    objectToStringKeyedMap(journeyData[RegisterPropertyStepId.LicensingType.urlPathSegment])
+                        ?.get("licensingType")
+                        .toString(),
+                )
+            ) {
+                LicensingType.SELECTIVE_LICENCE -> Pair(RegisterPropertyStepId.SelectiveLicence, null)
+                LicensingType.HMO_MANDATORY_LICENCE -> Pair(RegisterPropertyStepId.PlaceholderPage, null)
+                LicensingType.HMO_ADDITIONAL_LICENCE -> Pair(RegisterPropertyStepId.PlaceholderPage, null)
+                LicensingType.NO_LICENSING -> Pair(RegisterPropertyStepId.PlaceholderPage, null)
+            }
 
         // TODO PRSD-637: Check the database to see if this property is registered.
         private fun addressAlreadyRegistered(uprn: Long): Boolean = uprn == 1123456.toLong()

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/PropertyRegistrationJourney.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/PropertyRegistrationJourney.kt
@@ -379,19 +379,17 @@ class PropertyRegistrationJourney(
             }
         }
 
-        private fun licensingTypeNextAction(journeyData: JourneyData): Pair<RegisterPropertyStepId, Int?> =
-            when (
-                LicensingType.valueOf(
-                    objectToStringKeyedMap(journeyData[RegisterPropertyStepId.LicensingType.urlPathSegment])
-                        ?.get("licensingType")
-                        .toString(),
-                )
-            ) {
+        private fun licensingTypeNextAction(journeyData: JourneyData): Pair<RegisterPropertyStepId, Int?> {
+            val licensingTypePageData = objectToStringKeyedMap(journeyData[RegisterPropertyStepId.LicensingType.urlPathSegment])
+            val licensingType = LicensingType.valueOf(licensingTypePageData?.get("licensingType") as String)
+
+            return when (licensingType) {
                 LicensingType.SELECTIVE_LICENCE -> Pair(RegisterPropertyStepId.SelectiveLicence, null)
                 LicensingType.HMO_MANDATORY_LICENCE -> Pair(RegisterPropertyStepId.PlaceholderPage, null)
                 LicensingType.HMO_ADDITIONAL_LICENCE -> Pair(RegisterPropertyStepId.PlaceholderPage, null)
                 LicensingType.NO_LICENSING -> Pair(RegisterPropertyStepId.PlaceholderPage, null)
             }
+        }
 
         // TODO PRSD-637: Check the database to see if this property is registered.
         private fun addressAlreadyRegistered(uprn: Long): Boolean = uprn == 1123456.toLong()

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/steps/RegisterPropertyStepId.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/steps/RegisterPropertyStepId.kt
@@ -15,4 +15,5 @@ enum class RegisterPropertyStepId(
     NumberOfHouseholds("number-of-households"),
     NumberOfPeople("number-of-people"),
     LicensingType("licensing-type"),
+    SelectiveLicence("selective-licence"),
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/formModels/SelectiveLicenceFormModel.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/formModels/SelectiveLicenceFormModel.kt
@@ -17,7 +17,7 @@ class SelectiveLicenceFormModel : FormModel {
             ConstraintDescriptor(
                 messageKey = "forms.selectiveLicence.error.invalid",
                 validatorType = LengthConstraintValidator::class,
-                validatorArgs = arrayOf("0", "50"),
+                validatorArgs = arrayOf("0", "20"),
             ),
         ],
     )

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/formModels/SelectiveLicenceFormModel.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/formModels/SelectiveLicenceFormModel.kt
@@ -17,7 +17,7 @@ class SelectiveLicenceFormModel : FormModel {
             ConstraintDescriptor(
                 messageKey = "forms.selectiveLicence.error.invalid",
                 validatorType = LengthConstraintValidator::class,
-                validatorArgs = arrayOf("0", "20"),
+                validatorArgs = arrayOf("0", "255"),
             ),
         ],
     )

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/formModels/SelectiveLicenceFormModel.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/formModels/SelectiveLicenceFormModel.kt
@@ -1,0 +1,25 @@
+package uk.gov.communities.prsdb.webapp.models.formModels
+
+import uk.gov.communities.prsdb.webapp.validation.ConstraintDescriptor
+import uk.gov.communities.prsdb.webapp.validation.IsValidPrioritised
+import uk.gov.communities.prsdb.webapp.validation.LengthConstraintValidator
+import uk.gov.communities.prsdb.webapp.validation.NotBlankConstraintValidator
+import uk.gov.communities.prsdb.webapp.validation.ValidatedBy
+
+@IsValidPrioritised
+class SelectiveLicenceFormModel : FormModel {
+    @ValidatedBy(
+        constraints = [
+            ConstraintDescriptor(
+                messageKey = "forms.selectiveLicence.error.missing",
+                validatorType = NotBlankConstraintValidator::class,
+            ),
+            ConstraintDescriptor(
+                messageKey = "forms.selectiveLicence.error.invalid",
+                validatorType = LengthConstraintValidator::class,
+                validatorArgs = arrayOf("0", "50"),
+            ),
+        ],
+    )
+    var licenceNumber: String? = null
+}

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -419,7 +419,7 @@ forms.licensingType.radios.option.hmoAdditional.hint=A local authority can also 
 forms.licensingType.radios.option.noLicensing.label=I don't have any licensing for my property
 
 forms.selectiveLicence.error.missing=Enter the selective licence number
-forms.selectiveLicence.error.invalid=Enter a valid selective licence number
+forms.selectiveLicence.error.invalid=The licensing number is too long
 forms.selectiveLicence.fieldSetHeading=What is your selective licence number?
 forms.selectiveLicence.label=Enter the selective licence number
 forms.selectiveLicence.detail.summary=What is selective licensing?

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -418,6 +418,13 @@ forms.licensingType.radios.option.hmoAdditional.label=HMO additional licence
 forms.licensingType.radios.option.hmoAdditional.hint=A local authority can also include other types of HMOs for licensing.
 forms.licensingType.radios.option.noLicensing.label=I don't have any licensing for my property
 
+forms.selectiveLicence.error.missing=Enter the selective licence number
+forms.selectiveLicence.error.invalid=Enter a valid selective licence number
+forms.selectiveLicence.fieldSetHeading=What is your selective licence number?
+forms.selectiveLicence.label=Enter the selective licence number
+forms.selectiveLicence.detail.summary=What is selective licensing?
+forms.selectiveLicence.detail.text=Some local authorities issue a selective licensing number for privately rented housing in a local area.
+
 pagination.previousText=Previous
 pagination.pageText=page
 pagination.nextText=Next

--- a/src/main/resources/templates/forms/selectiveLicenceForm.html
+++ b/src/main/resources/templates/forms/selectiveLicenceForm.html
@@ -1,0 +1,18 @@
+<!--/*@thymesVar id="title" type="java.lang.String"*/-->
+<!--/*@thymesVar id="formModel" type="java.lang.Object"*/-->
+<!--/*@thymesVar id="fieldSetHeading" type="java.lang.String"*/-->
+<!--/*@thymesVar id="label" type="java.lang.String"*/-->
+<!--/*@thymesVar id="backUrl" type="java.lang.String"*/-->
+<!DOCTYPE html>
+<html th:replace="~{fragments/forms/questionPage :: questionPage(#{${title}}, ${formModel}, ~{::#form-content}, ${backUrl})}">
+<form id="form-content" th:remove="tag">
+    <fieldset id="fieldset-content"
+              th:replace="~{fragments/forms/fieldSet :: fieldSet(~{::#fieldset-content/content()}, 'licenceNumber', #{${fieldSetHeading}}, null)}">
+        <input th:replace="~{fragments/forms/basicTextInput :: textInput(#{${label}}, 'licenceNumber', null)}">
+    </fieldset>
+    <details id="details-content" th:replace="~{fragments/details :: details(#{'forms.selectiveLicence.detail.summary'},~{::#details-content/content()})}">
+        <div class="govuk-details__text" th:text="#{'forms.selectiveLicence.detail.text'}">detailsText</div>
+    </details>
+    <button th:replace="~{fragments/buttons/primaryButton :: primaryButton(#{'forms.buttons.continue'})}"></button>
+</form>
+</html>

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/PropertyRegistrationJourneyTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/PropertyRegistrationJourneyTests.kt
@@ -393,10 +393,13 @@ class PropertyRegistrationJourneyTests : IntegrationTest() {
             val selectiveLicencePage = navigator.goToPropertyRegistrationSelectiveLicencePage()
             val aVeryLongString =
                 "This string is very long, so long that it is not feasible that it is a real licence number " +
-                    "- therefore if it is submitted there will in fact be an error rather than a successful submission"
+                    "- therefore if it is submitted there will in fact be an error rather than a successful submission." +
+                    " It is actually quite difficult for a string to be long enough to trigger this error, because the" +
+                    " maximum length has been selected to be permissive of id numbers we do not expect while still having " +
+                    "a cap reachable with a little effort."
             selectiveLicencePage.licenceNumberInput.fill(aVeryLongString)
             selectiveLicencePage.form.submit()
-            assertThat(selectiveLicencePage.form.getErrorMessage()).containsText("forms.selectiveLicence.error.invalid")
+            assertThat(selectiveLicencePage.form.getErrorMessage()).containsText("The licensing number is too long")
         }
     }
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/Navigator.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/Navigator.kt
@@ -3,6 +3,7 @@ package uk.gov.communities.prsdb.webapp.integration.pageObjects
 import com.microsoft.playwright.Page
 import com.microsoft.playwright.Response
 import uk.gov.communities.prsdb.webapp.constants.MANUAL_ADDRESS_CHOSEN
+import uk.gov.communities.prsdb.webapp.constants.enums.LicensingType
 import uk.gov.communities.prsdb.webapp.constants.enums.OwnershipType
 import uk.gov.communities.prsdb.webapp.constants.enums.PropertyType
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.InviteNewLaUserPage
@@ -39,6 +40,7 @@ import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyReg
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyRegistrationJourneyPages.RegisterPropertyStartPage
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyRegistrationJourneyPages.SelectAddressFormPagePropertyRegistration
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyRegistrationJourneyPages.SelectLocalAuthorityFormPagePropertyRegistration
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyRegistrationJourneyPages.SelectiveLicenceFormPagePropertyRegistration
 
 class Navigator(
     private val page: Page,
@@ -277,6 +279,13 @@ class Navigator(
         peoplePage.peopleInput.fill("4")
         peoplePage.form.submit()
         return createValidPage(page, LicensingTypeFormPagePropertyRegistration::class)
+    }
+
+    fun goToPropertyRegistrationSelectiveLicencePage(): SelectiveLicenceFormPagePropertyRegistration {
+        val licensingTypePage = goToPropertyRegistrationLicensingTypePage()
+        licensingTypePage.form.getRadios().selectValue(LicensingType.SELECTIVE_LICENCE)
+        licensingTypePage.form.submit()
+        return createValidPage(page, SelectiveLicenceFormPagePropertyRegistration::class)
     }
 
     private fun navigate(path: String): Response? = page.navigate("http://localhost:$port/$path")

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/propertyRegistrationJourneyPages/SelectiveLicenceFormPagePropertyRegistration.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/propertyRegistrationJourneyPages/SelectiveLicenceFormPagePropertyRegistration.kt
@@ -1,0 +1,15 @@
+package uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyRegistrationJourneyPages
+
+import com.microsoft.playwright.Page
+import uk.gov.communities.prsdb.webapp.constants.REGISTER_PROPERTY_JOURNEY_URL
+import uk.gov.communities.prsdb.webapp.forms.steps.RegisterPropertyStepId
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages.FormBasePage
+
+class SelectiveLicenceFormPagePropertyRegistration(
+    page: Page,
+) : FormBasePage(
+        page,
+        "/$REGISTER_PROPERTY_JOURNEY_URL/${RegisterPropertyStepId.SelectiveLicence.urlPathSegment}",
+    ) {
+    val licenceNumberInput = form.getTextInput("licenceNumber")
+}


### PR DESCRIPTION
Adding the selective licence page if the landlord selects "selective licence" on the licensing page. I've decided to make this the "main line" through the form for journey integration test because I'm doing it first, so I've added the tests for all the other selections as dummy tests (i.e. testing that they reach the placeholder page) so they're easy to populate later. 


Page:
![image](https://github.com/user-attachments/assets/051046b2-fb69-43f2-994b-6e4fbacc5039)

No number submitted:
![image](https://github.com/user-attachments/assets/aa352121-faee-4723-8984-2b7285d02a34)

Licence number too long:
![image](https://github.com/user-attachments/assets/706ae4a1-c330-4b8a-bbf5-e4790dfa2569)
