### PR TITLE
PRSD-491: Check field widths in templates

### DIFF
--- a/src/main/resources/templates/examples/exampleLandlordSearch.html
+++ b/src/main/resources/templates/examples/exampleLandlordSearch.html
@@ -5,7 +5,7 @@
     <form th:action="@{''}" class="form" id="example-landlord-search" method="post" th:object="${searchWrapper}"
           novalidate>
         <div class="govuk-form-group">
-            <div th:replace="~{fragments/forms/basicTextInput :: textInput('Search for a landlord', 'searchTerm', null, null)}"></div>
+            <div th:replace="~{fragments/forms/basicTextInput :: textInput('Search for a landlord', 'searchTerm', null)}"></div>
             <button type="submit" class="govuk-button" data-module="govuk-button">
                 Submit
             </button>

--- a/src/main/resources/templates/forms/lookupAddressForm.html
+++ b/src/main/resources/templates/forms/lookupAddressForm.html
@@ -14,8 +14,8 @@
     <th:block id="fieldset-content"
               th:replace="~{fragments/forms/fieldSet :: fieldSet(~{::#fieldset-content/content()}, 'lookupAddress',
                             #{${fieldSetHeading}}, ${fieldSetHint != null ? #messages.msg(fieldSetHint) : null})}">
-        <div th:replace="~{fragments/forms/basicTextInput :: textInput(#{${postcodeLabel}}, 'postcode', #{${postcodeHint}}, null)}"></div>
-        <div th:replace="~{fragments/forms/basicTextInput :: textInput(#{${houseNameOrNumberLabel}}, 'houseNameOrNumber', #{${houseNameOrNumberHint}}, null)}"></div>
+        <div th:replace="~{fragments/forms/basicTextInput :: textInput(#{${postcodeLabel}}, 'postcode', #{${postcodeHint}})}"></div>
+        <div th:replace="~{fragments/forms/basicTextInput :: textInput(#{${houseNameOrNumberLabel}}, 'houseNameOrNumber', #{${houseNameOrNumberHint}})}"></div>
     </th:block>
     <button th:replace="~{fragments/buttons/primaryButton :: primaryButton(#{${submitButtonText}})}"></button>
 </th:block>

--- a/src/main/resources/templates/forms/manualAddressForm.html
+++ b/src/main/resources/templates/forms/manualAddressForm.html
@@ -15,11 +15,11 @@
     <th:block id="fieldset-content"
               th:replace="~{fragments/forms/fieldSet :: fieldSet(~{::#fieldset-content/content()}, 'manualAddress',
                             #{${fieldSetHeading}}, ${fieldSetHint != null ? #messages.msg(fieldSetHint) : null})}">
-        <div th:replace="~{fragments/forms/basicTextInput :: textInput(#{${addressLineOneLabel}}, 'addressLineOne', null, null)}"></div>
-        <div th:replace="~{fragments/forms/basicTextInput :: textInput(#{${addressLineTwoLabel}}, 'addressLineTwo', null, null)}"></div>
-        <div th:replace="~{fragments/forms/basicTextInput :: textInput(#{${townOrCityLabel}}, 'townOrCity', null, 20)}"></div>
-        <div th:replace="~{fragments/forms/basicTextInput :: textInput(#{${countyLabel}}, 'county', null, 20)}"></div>
-        <div th:replace="~{fragments/forms/basicTextInput :: textInput(#{${postcodeLabel}}, 'postcode', null, 10)}"></div>
+        <div th:replace="~{fragments/forms/basicTextInput :: textInput(#{${addressLineOneLabel}}, 'addressLineOne', null)}"></div>
+        <div th:replace="~{fragments/forms/basicTextInput :: textInput(#{${addressLineTwoLabel}}, 'addressLineTwo', null)}"></div>
+        <div th:replace="~{fragments/forms/fixedWidthTextInput :: fixedWidthTextInput(#{${townOrCityLabel}}, 'townOrCity', null, 20)}"></div>
+        <div th:replace="~{fragments/forms/fixedWidthTextInput :: fixedWidthTextInput(#{${countyLabel}}, 'county', null, 20)}"></div>
+        <div th:replace="~{fragments/forms/fixedWidthTextInput :: fixedWidthTextInput(#{${postcodeLabel}}, 'postcode', null, 10)}"></div>
     </th:block>
     <button th:replace="~{fragments/buttons/primaryButton :: primaryButton(#{${submitButtonText}})}"></button>
 </th:block>

--- a/src/main/resources/templates/forms/nameForm.html
+++ b/src/main/resources/templates/forms/nameForm.html
@@ -10,7 +10,7 @@
 <!--/*/ <th:block id="form-content"> /*/-->
 <!--/*/    <th:block id="fieldset-content"
               th:replace="~{fragments/forms/fieldSet :: fieldSet(~{::#fieldset-content/content()}, 'name', #{${fieldSetHeading}}, #{${fieldSetHint}})}"> /*/-->
-        <div th:replace="~{fragments/forms/basicTextInput :: textInput(#{${label}}, 'name', null, null)}">
+        <div th:replace="~{fragments/forms/basicTextInput :: textInput(#{${label}}, 'name', null)}">
         </div>
 <!--/*/    </th:block> /*/-->
     <button th:replace="~{fragments/buttons/primaryButton :: primaryButton(#{${submitButtonText}})}"></button>

--- a/src/main/resources/templates/forms/selectiveLicenceForm.html
+++ b/src/main/resources/templates/forms/selectiveLicenceForm.html
@@ -8,7 +8,7 @@
 <form id="form-content" th:remove="tag">
     <fieldset id="fieldset-content"
               th:replace="~{fragments/forms/fieldSet :: fieldSet(~{::#fieldset-content/content()}, 'licenceNumber', #{${fieldSetHeading}}, null)}">
-        <input th:replace="~{fragments/forms/basicTextInput :: textInput(#{${label}}, 'licenceNumber', null, null)}">
+        <input th:replace="~{fragments/forms/basicTextInput :: textInput(#{${label}}, 'licenceNumber', null)}">
     </fieldset>
     <details id="details-content" th:replace="~{fragments/details :: details(#{'forms.selectiveLicence.detail.summary'},~{::#details-content/content()})}">
         <div class="govuk-details__text" th:text="#{'forms.selectiveLicence.detail.text'}">detailsText</div>

--- a/src/main/resources/templates/fragments/conditional/customPropertyTypeInput.html
+++ b/src/main/resources/templates/fragments/conditional/customPropertyTypeInput.html
@@ -1,3 +1,3 @@
 <th:block th:fragment="customPropertyTypeInput" th:replace="~{fragments/forms/basicTextInput ::
-    textInput(#{forms.propertyType.radios.option.other.input.label}, 'customPropertyType', null, null)}">
+    textInput(#{forms.propertyType.radios.option.other.input.label}, 'customPropertyType', null)}">
 </th:block>

--- a/src/main/resources/templates/fragments/forms/basicTextInput.html
+++ b/src/main/resources/templates/fragments/forms/basicTextInput.html
@@ -1,10 +1,3 @@
-<!--The fieldWidth input can be 2, 3, 4, 5, 10, 20, 30-->
-<th:block th:fragment="textInput(label, fieldName, hint, fieldWidth)"
-          th:replace="~{fragments/forms/inputGroup :: inputGroup(${label}, ${fieldName}, ~{::input}, ${hint})}">
-    <input class="govuk-input"
-           th:with='widthClass=${fieldWidth != null ? " govuk-input--width-"+fieldWidth : ""}'
-           th:classappend='${#fields.hasErrors(fieldName) ? "govuk-input--error" : ""} + ${widthClass}'
-           type="text"
-           th:field="*{__${fieldName}__}"
-           th:attrappend="aria-describedby=${hint != null} ? ${fieldName}+'-details-hint'">
+<th:block th:fragment="textInput(label, fieldName, hint)"
+          th:replace="~{fragments/forms/innerTextInput :: innerTextInput(${label}, ${fieldName}, ${hint}, null)}">
 </th:block>

--- a/src/main/resources/templates/fragments/forms/fixedWidthTextInput.html
+++ b/src/main/resources/templates/fragments/forms/fixedWidthTextInput.html
@@ -1,0 +1,5 @@
+<!--The fieldWidth input can be 2, 3, 4, 5, 10, 20, 30-->
+<th:block th:fragment="fixedWidthTextInput(label, fieldName, hint, fieldWidth)"
+          th:assert="${fieldWidth == 2 || fieldWidth == 3 || fieldWidth == 4 || fieldWidth ==  5 || fieldWidth ==  10 || fieldWidth ==  20 || fieldWidth ==  30}">
+    <th:block th:replace="~{fragments/forms/innerTextInput :: innerTextInput(${label}, ${fieldName}, ${hint}, ${fieldWidth})}"></th:block>
+</th:block>

--- a/src/main/resources/templates/fragments/forms/fixedWidthTextInput.html
+++ b/src/main/resources/templates/fragments/forms/fixedWidthTextInput.html
@@ -1,4 +1,5 @@
 <!--The fieldWidth input can be 2, 3, 4, 5, 10, 20, 30-->
+<!--See https://design-system.service.gov.uk/components/text-input/#fixed-width-inputs -->
 <th:block th:fragment="fixedWidthTextInput(label, fieldName, hint, fieldWidth)"
           th:assert="${fieldWidth == 2 || fieldWidth == 3 || fieldWidth == 4 || fieldWidth ==  5 || fieldWidth ==  10 || fieldWidth ==  20 || fieldWidth ==  30}">
     <th:block th:replace="~{fragments/forms/innerTextInput :: innerTextInput(${label}, ${fieldName}, ${hint}, ${fieldWidth})}"></th:block>

--- a/src/main/resources/templates/fragments/forms/innerTextInput.html
+++ b/src/main/resources/templates/fragments/forms/innerTextInput.html
@@ -1,0 +1,13 @@
+<!--The fieldWidth input can be 2, 3, 4, 5, 10, 20, 30-->
+<!--Do not call directly, use basicTextInput or fixedWidthInput-->
+<th:block th:fragment="innerTextInput(label, fieldName, hint, fieldWidth)"
+          th:replace="~{fragments/forms/inputGroup :: inputGroup(${label}, ${fieldName}, ~{:: input}, ${hint})}">
+
+    <input class="govuk-input"
+           th:with='widthClass=${fieldWidth != null ? " govuk-input--width-"+fieldWidth : ""}'
+           th:classappend='${#fields.hasErrors(fieldName) ? "govuk-input--error" : ""} + ${widthClass}'
+           type="text"
+           th:field="*{__${fieldName}__}"
+           th:attrappend="aria-describedby=${hint != null} ? ${fieldName}+'-details-hint'">
+
+</th:block>

--- a/src/main/resources/templates/fragments/forms/numericalInput.html
+++ b/src/main/resources/templates/fragments/forms/numericalInput.html
@@ -1,11 +1,13 @@
 <!--The width input should be 2, 3, 4, 5, 10, 20, 30-->
+<!--See https://design-system.service.gov.uk/components/text-input/#fixed-width-inputs -->
 <th:block th:fragment="numericalInput(label, fieldName, hint, fieldWidth)"
-          th:replace="~{fragments/forms/inputGroup :: inputGroup(${label}, ${fieldName}, ~{::input}, ${hint})}">
-    <input class="govuk-input"
-           th:with="width=${fieldWidth ?: 10} "
+          th:assert="${fieldWidth == 2 || fieldWidth == 3 || fieldWidth == 4 || fieldWidth ==  5 || fieldWidth ==  10 || fieldWidth ==  20 || fieldWidth ==  30}">
+    <th:block th:replace="~{fragments/forms/inputGroup :: inputGroup(${label}, ${fieldName}, ~{::input}, ${hint})}">
+        <input class="govuk-input"
            th:classappend='${#fields.hasErrors(fieldName) ? "govuk-input--error" : ""} + ${" govuk-input--width-"+width}'
            type="text"
            inputmode="numeric"
            th:field="*{__${fieldName}__}"
            th:attrappend="aria-describedby=${hint != null} ? ${fieldName}+'-details-hint'">
+    </th:block>
 </th:block>


### PR DESCRIPTION
Two main changes here:
* Make separate fragments for a fluid width and fixed width text input to avoid passing lots of nulls.
* Assert that a valid width is being passed as the width parameter to protect against future mistakes.

I dont want to mess up Jasmin's otherwise good PR with this set of changes while she's away but since it's related I'm setting this as a draft merging into that PR.

@Travis-Softwire - if you like this approach I can do the same for the numerical input.