### PR TITLE
PRSD-495: Add property registration check answers template

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/PropertyRegistrationJourney.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/PropertyRegistrationJourney.kt
@@ -333,7 +333,7 @@ class PropertyRegistrationJourney(
                                     "detailMainText" to "forms.selectiveLicence.detail.text",
                                 ),
                         ),
-                    nextAction = { _, _ -> Pair(RegisterPropertyStepId.CheckAnswers, null) },
+                    nextAction = { _, _ -> Pair(RegisterPropertyStepId.PlaceholderPage, null) },
                 ),
                 Step(
                     id = RegisterPropertyStepId.HmoMandatoryLicence,
@@ -356,7 +356,7 @@ class PropertyRegistrationJourney(
                                         ),
                                 ),
                         ),
-                    nextAction = { _, _ -> Pair(RegisterPropertyStepId.CheckAnswers, null) },
+                    nextAction = { _, _ -> Pair(RegisterPropertyStepId.PlaceholderPage, null) },
                 ),
                 Step(
                     id = RegisterPropertyStepId.HmoAdditionalLicence,
@@ -373,7 +373,7 @@ class PropertyRegistrationJourney(
                                     "detailMainText" to "forms.hmoAdditionalLicence.detail.text",
                                 ),
                         ),
-                    nextAction = { _, _ -> Pair(RegisterPropertyStepId.CheckAnswers, null) },
+                    nextAction = { _, _ -> Pair(RegisterPropertyStepId.PlaceholderPage, null) },
                 ),
                 Step(
                     id = RegisterPropertyStepId.CheckAnswers,

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/PropertyRegistrationJourney.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/PropertyRegistrationJourney.kt
@@ -14,6 +14,7 @@ import uk.gov.communities.prsdb.webapp.forms.pages.Page
 import uk.gov.communities.prsdb.webapp.forms.pages.SelectAddressPage
 import uk.gov.communities.prsdb.webapp.forms.steps.RegisterPropertyStepId
 import uk.gov.communities.prsdb.webapp.forms.steps.Step
+import uk.gov.communities.prsdb.webapp.models.dataModels.FormSummaryDataModel
 import uk.gov.communities.prsdb.webapp.models.formModels.HmoAdditionalLicenceFormModel
 import uk.gov.communities.prsdb.webapp.models.formModels.HmoMandatoryLicenceFormModel
 import uk.gov.communities.prsdb.webapp.models.formModels.LicensingTypeFormModel
@@ -332,7 +333,7 @@ class PropertyRegistrationJourney(
                                     "detailMainText" to "forms.selectiveLicence.detail.text",
                                 ),
                         ),
-                    nextAction = { _, _ -> Pair(RegisterPropertyStepId.PlaceholderPage, null) },
+                    nextAction = { _, _ -> Pair(RegisterPropertyStepId.CheckAnswers, null) },
                 ),
                 Step(
                     id = RegisterPropertyStepId.HmoMandatoryLicence,
@@ -355,7 +356,7 @@ class PropertyRegistrationJourney(
                                         ),
                                 ),
                         ),
-                    nextAction = { _, _ -> Pair(RegisterPropertyStepId.PlaceholderPage, null) },
+                    nextAction = { _, _ -> Pair(RegisterPropertyStepId.CheckAnswers, null) },
                 ),
                 Step(
                     id = RegisterPropertyStepId.HmoAdditionalLicence,
@@ -370,6 +371,49 @@ class PropertyRegistrationJourney(
                                     "label" to "forms.hmoAdditionalLicence.label",
                                     "detailSummary" to "forms.hmoAdditionalLicence.detail.summary",
                                     "detailMainText" to "forms.hmoAdditionalLicence.detail.text",
+                                ),
+                        ),
+                    nextAction = { _, _ -> Pair(RegisterPropertyStepId.CheckAnswers, null) },
+                ),
+                Step(
+                    id = RegisterPropertyStepId.CheckAnswers,
+                    page =
+                        Page(
+                            formModel = NoInputFormModel::class,
+                            templateName = "forms/propertyRegistrationCheckAnswersForm",
+                            content =
+                                mapOf(
+                                    "title" to "registerProperty.title",
+                                    "propertyName" to "1 example road EX4 PL3",
+                                    "submitButtonText" to "forms.buttons.saveAndContinue",
+                                    "propertyDetails" to
+                                        listOf(
+                                            FormSummaryDataModel(
+                                                "forms.checkPropertyAnswers.propertyDetails.address",
+                                                "1 example road EX4 PL3",
+                                                null,
+                                            ),
+                                            FormSummaryDataModel(
+                                                "forms.checkPropertyAnswers.propertyDetails.uprn",
+                                                "100023584755",
+                                                null,
+                                            ),
+                                            FormSummaryDataModel(
+                                                "forms.checkPropertyAnswers.propertyDetails.type",
+                                                "Flat",
+                                                null,
+                                            ),
+                                            FormSummaryDataModel(
+                                                "forms.checkPropertyAnswers.propertyDetails.ownership",
+                                                "Freehold",
+                                                null,
+                                            ),
+                                            FormSummaryDataModel(
+                                                "forms.checkPropertyAnswers.propertyDetails.landlordType",
+                                                "Individual",
+                                                null,
+                                            ),
+                                        ),
                                 ),
                         ),
                     nextAction = { _, _ -> Pair(RegisterPropertyStepId.PlaceholderPage, null) },

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/steps/RegisterPropertyStepId.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/steps/RegisterPropertyStepId.kt
@@ -18,4 +18,5 @@ enum class RegisterPropertyStepId(
     SelectiveLicence("selective-licence"),
     HmoMandatoryLicence("hmo-mandatory-licence"),
     HmoAdditionalLicence("hmo-additional-licence"),
+    CheckAnswers("check-answers"),
 }

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -442,6 +442,19 @@ forms.hmoAdditionalLicence.label=Enter the HMO additional licence number
 forms.hmoAdditionalLicence.detail.summary=What's a HMO additional licence?
 forms.hmoAdditionalLicence.detail.text=A HMO must have a licence if it is occupied by 5 or more people. A council can also include other types of HMOs for licensing.
 
+forms.checkPropertyAnswers.headingPrefix=Check your answers for:
+forms.checkPropertyAnswers.propertyDetails.heading=Property details
+forms.checkPropertyAnswers.propertyDetails.hint=Check the property address is correct
+forms.checkPropertyAnswers.propertyDetails.detail.summary=What is a UPRN?
+forms.checkPropertyAnswers.propertyDetails.detail.text=Unique property reference numbers (UPRNs) are unique identifiers for every address in Great Britain.
+forms.checkPropertyAnswers.propertyDetails.address=Property address
+forms.checkPropertyAnswers.propertyDetails.uprn=UPRN
+forms.checkPropertyAnswers.propertyDetails.type=Property type
+forms.checkPropertyAnswers.propertyDetails.ownership=Ownership type
+forms.checkPropertyAnswers.propertyDetails.landlordType=Landlord type
+forms.checkPropertyAnswers.additionalLandlords.heading=Additional landlords
+forms.checkPropertyAnswers.interestedParties.heading=Interested parties
+
 pagination.previousText=Previous
 pagination.pageText=page
 pagination.nextText=Next

--- a/src/main/resources/templates/forms/propertyRegistrationCheckAnswersForm.html
+++ b/src/main/resources/templates/forms/propertyRegistrationCheckAnswersForm.html
@@ -15,43 +15,44 @@
             <span th:text="${propertyName}"></span>
         </h1>
     </legend>
-    <div class="govuk-tabs" data-module="govuk-tabs">
-        <ul class="govuk-tabs__list">
-            <li class="govuk-tabs__list-item govuk-tabs__list-item--selected">
-                <a class="govuk-tabs__tab" href="#property-details" th:text="#{forms.checkPropertyAnswers.propertyDetails.heading}">
-                    forms.checkPropertyAnswers.propertyDetails.heading
-                </a>
-            </li>
-            <li class="govuk-tabs__list-item">
-                <a class="govuk-tabs__tab" href="#additional-landlords" th:text="#{forms.checkPropertyAnswers.additionalLandlords.heading}">
-                    forms.checkPropertyAnswers.additionalLandlords.heading
-                </a>
-            </li>
-            <li class="govuk-tabs__list-item">
-                <a class="govuk-tabs__tab" href="#interested-parties" th:text="#{forms.checkPropertyAnswers.interestedParties.heading}">
-                    forms.checkPropertyAnswers.interestedParties.heading
-                </a>
-            </li>
-        </ul>
-        <div class="govuk-tabs__panel" id="property-details">
-            <div id="my-hint" class="govuk-hint" th:text="#{forms.checkPropertyAnswers.propertyDetails.hint}">
-                forms.checkPropertyAnswers.propertyDetails.hint
+    <div th:replace="~{fragments/tabs/tabs :: tabs(~{:: #tabs-content})}" >
+        <th:block id="tabs-content">
+            <ul th:replace="~{fragments/tabs/tabsHeadingList :: tabsHeadingList(~{:: #tab-headings})}">
+                <th:block id="tab-headings">
+                    <li th:replace="~{fragments/tabs/tabsListItem :: tabsListItem('property-details', #{forms.checkPropertyAnswers.propertyDetails.heading})}">
+                    </li>
+                    <li th:replace="~{fragments/tabs/tabsListItem :: tabsListItem('additional-landlords', #{forms.checkPropertyAnswers.additionalLandlords.heading})}">
+                    </li>
+                    <li th:replace="~{fragments/tabs/tabsListItem :: tabsListItem('interested-parties', #{forms.checkPropertyAnswers.interestedParties.heading})}">
+                    </li>
+                </th:block>
+            </ul>
+            <div th:replace="~{fragments/tabs/tabsPanel :: tabsPanel('property-details', ~{:: #property-details-panel-content})}">
+                <th:block id="property-details-panel-content">
+                    <div class="govuk-hint" th:text="#{forms.checkPropertyAnswers.propertyDetails.hint}">
+                        forms.checkPropertyAnswers.propertyDetails.hint
+                    </div>
+                    <dl th:replace="~{fragments/summaryList :: summaryList(${propertyDetails})}"></dl>
+                    <details id="details-content" th:replace="~{fragments/details :: details(#{forms.checkPropertyAnswers.propertyDetails.detail.summary},~{::#details-content/content()})}">
+                        <div class="govuk-details__text" th:text="#{forms.checkPropertyAnswers.propertyDetails.detail.text}">
+                            forms.checkPropertyAnswers.propertyDetails.detail.text
+                        </div>
+                    </details>
+                </th:block>
             </div>
-            <dl th:replace="~{fragments/summaryList :: summaryList(${propertyDetails})}"></dl>
-            <details id="details-content" th:replace="~{fragments/details :: details(#{forms.checkPropertyAnswers.propertyDetails.detail.summary},~{::#details-content/content()})}">
-                <div class="govuk-details__text" th:text="#{forms.checkPropertyAnswers.propertyDetails.detail.text}">
-                    forms.checkPropertyAnswers.propertyDetails.detail.text
-                </div>
-            </details>
-        </div>
-        <div class="govuk-tabs__panel govuk-tabs__panel--hidden" id="additional-landlords">
-            <h2 class="govuk-heading-m">TODO: PRSD-584</h2>
-            <p class="govuk-body">This tab will show details of additional landlords, and will be implemented as part of PRSD-584</p>
-        </div>
-        <div class="govuk-tabs__panel govuk-tabs__panel--hidden" id="interested-parties">
-            <h2 class="govuk-heading-m">TODO: PRSD-585</h2>
-            <p class="govuk-body">This tab will show details of interested parties, and will be implemented as part of PRSD-585</p>
-        </div>
+            <div th:replace="~{fragments/tabs/tabsPanel :: tabsPanel('additional-landlords', ~{:: #additional-landlords-panel-content})}">
+                <th:block id="additional-landlords-panel-content">
+                    <h2 class="govuk-heading-m">TODO: PRSD-584</h2>
+                    <p class="govuk-body">This tab will show details of additional landlords, and will be implemented as part of PRSD-584</p>
+                </th:block>
+            </div>
+            <div th:replace="~{fragments/tabs/tabsPanel :: tabsPanel('interested-parties', ~{:: #interested-parties-panel-content})}">
+                <th:block id="interested-parties-panel-content">
+                    <h2 class="govuk-heading-m">TODO: PRSD-585</h2>
+                    <p class="govuk-body">This tab will show details of interested parties, and will be implemented as part of PRSD-585</p>
+                </th:block>
+            </div>
+        </th:block>
     </div>
     <button th:replace="~{fragments/buttons/primaryButton :: primaryButton(#{${submitButtonText}})}"></button>
 </th:block>

--- a/src/main/resources/templates/forms/propertyRegistrationCheckAnswersForm.html
+++ b/src/main/resources/templates/forms/propertyRegistrationCheckAnswersForm.html
@@ -5,68 +5,54 @@
 <!--/*@thymesVar id="propertyName" type="java.lang.String"*/-->
 <!--/*@thymesVar id="backUrl" type="java.lang.String"*/-->
 <!DOCTYPE html>
-<html>
-<th:block id="main-content"
-          th:replace="~{fragments/layout :: layout(#{${title}}, ~{::#main-content/content()},false)}">
-    <a href="#" th:replace="~{fragments/forms/backLink :: backLink(${backUrl})}">Back link</a>
-    <main class="govuk-main-wrapper">
 
-        <div id="page-content"
-             th:replace="~{fragments/layouts/twoThirdsLayout :: twoThirdsLayout(~{::#page-content/content()})}">
-            <header>
-                <h1 class="govuk-heading-l">
-                    <span th:text="#{forms.checkPropertyAnswers.headingPrefix}"></span>
-                    <br>
-                    <span th:text="${propertyName}"></span>
-                </h1>
-            </header>
-
-            <form th:action="@{''}" method="post" novalidate th:object="${formModel}">
-
-                <div class="govuk-tabs" data-module="govuk-tabs">
-                    <h2 class="govuk-tabs__title">
-                        Contents
-                    </h2>
-                    <ul class="govuk-tabs__list">
-                        <li class="govuk-tabs__list-item govuk-tabs__list-item--selected">
-                            <a class="govuk-tabs__tab" href="#property-details" th:text="#{forms.checkPropertyAnswers.propertyDetails.heading}">
-                                forms.checkPropertyAnswers.propertyDetails.heading
-                            </a>
-                        </li>
-                        <li class="govuk-tabs__list-item">
-                            <a class="govuk-tabs__tab" href="#additional-landlords" th:text="#{forms.checkPropertyAnswers.additionalLandlords.heading}">
-                                forms.checkPropertyAnswers.additionalLandlords.heading
-                            </a>
-                        </li>
-                        <li class="govuk-tabs__list-item">
-                            <a class="govuk-tabs__tab" href="#interested-parties" th:text="#{forms.checkPropertyAnswers.interestedParties.heading}">
-                                forms.checkPropertyAnswers.interestedParties.heading
-                            </a>
-                        </li>
-                    </ul>
-                    <div class="govuk-tabs__panel" id="property-details">
-                        <div id="my-hint" class="govuk-hint" th:text="#{forms.checkPropertyAnswers.propertyDetails.hint}">
-                            forms.checkPropertyAnswers.propertyDetails.hint
-                        </div>
-                        <dl th:replace="~{fragments/summaryList :: summaryList(${propertyDetails})}"></dl>
-                        <details id="details-content" th:replace="~{fragments/details :: details(#{forms.checkPropertyAnswers.propertyDetails.detail.summary},~{::#details-content/content()})}">
-                            <div class="govuk-details__text" th:text="#{forms.checkPropertyAnswers.propertyDetails.detail.text}">
-                                forms.checkPropertyAnswers.propertyDetails.detail.text
-                            </div>
-                        </details>
-                    </div>
-                    <div class="govuk-tabs__panel govuk-tabs__panel--hidden" id="additional-landlords">
-                        <h2 class="govuk-heading-l">TODO: PRSD-584</h2>
-                        <p class="govuk-body">This tab will show details of additional landlords, and will be implemented as part of PRSD-584</p>
-                    </div>
-                    <div class="govuk-tabs__panel govuk-tabs__panel--hidden" id="interested-parties">
-                        <h2 class="govuk-heading-l">TODO: PRSD-585</h2>
-                        <p class="govuk-body">This tab will show details of interested parties, and will be implemented as part of PRSD-585</p>
-                    </div>
+<html th:replace="~{fragments/forms/questionPage :: questionPage(#{${title}}, ${formModel}, ~{::#form-content}, ${backUrl})}">
+<th:block id="form-content">
+    <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+        <h1 class="govuk-fieldset__heading">
+            <span th:text="#{forms.checkPropertyAnswers.headingPrefix}"></span>
+            <br>
+            <span th:text="${propertyName}"></span>
+        </h1>
+    </legend>
+    <div class="govuk-tabs" data-module="govuk-tabs">
+        <ul class="govuk-tabs__list">
+            <li class="govuk-tabs__list-item govuk-tabs__list-item--selected">
+                <a class="govuk-tabs__tab" href="#property-details" th:text="#{forms.checkPropertyAnswers.propertyDetails.heading}">
+                    forms.checkPropertyAnswers.propertyDetails.heading
+                </a>
+            </li>
+            <li class="govuk-tabs__list-item">
+                <a class="govuk-tabs__tab" href="#additional-landlords" th:text="#{forms.checkPropertyAnswers.additionalLandlords.heading}">
+                    forms.checkPropertyAnswers.additionalLandlords.heading
+                </a>
+            </li>
+            <li class="govuk-tabs__list-item">
+                <a class="govuk-tabs__tab" href="#interested-parties" th:text="#{forms.checkPropertyAnswers.interestedParties.heading}">
+                    forms.checkPropertyAnswers.interestedParties.heading
+                </a>
+            </li>
+        </ul>
+        <div class="govuk-tabs__panel" id="property-details">
+            <div id="my-hint" class="govuk-hint" th:text="#{forms.checkPropertyAnswers.propertyDetails.hint}">
+                forms.checkPropertyAnswers.propertyDetails.hint
             </div>
-                <button th:replace="~{fragments/buttons/primaryButton :: primaryButton(#{${submitButtonText}})}"></button>
-            </form>
+            <dl th:replace="~{fragments/summaryList :: summaryList(${propertyDetails})}"></dl>
+            <details id="details-content" th:replace="~{fragments/details :: details(#{forms.checkPropertyAnswers.propertyDetails.detail.summary},~{::#details-content/content()})}">
+                <div class="govuk-details__text" th:text="#{forms.checkPropertyAnswers.propertyDetails.detail.text}">
+                    forms.checkPropertyAnswers.propertyDetails.detail.text
+                </div>
+            </details>
         </div>
-    </main>
+        <div class="govuk-tabs__panel govuk-tabs__panel--hidden" id="additional-landlords">
+            <h2 class="govuk-heading-m">TODO: PRSD-584</h2>
+            <p class="govuk-body">This tab will show details of additional landlords, and will be implemented as part of PRSD-584</p>
+        </div>
+        <div class="govuk-tabs__panel govuk-tabs__panel--hidden" id="interested-parties">
+            <h2 class="govuk-heading-m">TODO: PRSD-585</h2>
+            <p class="govuk-body">This tab will show details of interested parties, and will be implemented as part of PRSD-585</p>
+        </div>
+    </div>
+    <button th:replace="~{fragments/buttons/primaryButton :: primaryButton(#{${submitButtonText}})}"></button>
 </th:block>
 </html>

--- a/src/main/resources/templates/forms/propertyRegistrationCheckAnswersForm.html
+++ b/src/main/resources/templates/forms/propertyRegistrationCheckAnswersForm.html
@@ -1,0 +1,72 @@
+<!--/*@thymesVar id="title" type="java.lang.String"*/-->
+<!--/*@thymesVar id="formModel" type="java.lang.Object"*/-->
+<!--/*@thymesVar id="propertyDetails" type="java.lang.Object"*/-->
+<!--/*@thymesVar id="submitButtonText" type="java.lang.String"*/-->
+<!--/*@thymesVar id="propertyName" type="java.lang.String"*/-->
+<!--/*@thymesVar id="backUrl" type="java.lang.String"*/-->
+<!DOCTYPE html>
+<html>
+<th:block id="main-content"
+          th:replace="~{fragments/layout :: layout(#{${title}}, ~{::#main-content/content()},false)}">
+    <a href="#" th:replace="~{fragments/forms/backLink :: backLink(${backUrl})}">Back link</a>
+    <main class="govuk-main-wrapper">
+
+        <div id="page-content"
+             th:replace="~{fragments/layouts/twoThirdsLayout :: twoThirdsLayout(~{::#page-content/content()})}">
+            <header>
+                <h1 class="govuk-heading-l">
+                    <span th:text="#{forms.checkPropertyAnswers.headingPrefix}"></span>
+                    <br>
+                    <span th:text="${propertyName}"></span>
+                </h1>
+            </header>
+
+            <form th:action="@{''}" method="post" novalidate th:object="${formModel}">
+
+                <div class="govuk-tabs" data-module="govuk-tabs">
+                    <h2 class="govuk-tabs__title">
+                        Contents
+                    </h2>
+                    <ul class="govuk-tabs__list">
+                        <li class="govuk-tabs__list-item govuk-tabs__list-item--selected">
+                            <a class="govuk-tabs__tab" href="#property-details" th:text="#{forms.checkPropertyAnswers.propertyDetails.heading}">
+                                forms.checkPropertyAnswers.propertyDetails.heading
+                            </a>
+                        </li>
+                        <li class="govuk-tabs__list-item">
+                            <a class="govuk-tabs__tab" href="#additional-landlords" th:text="#{forms.checkPropertyAnswers.additionalLandlords.heading}">
+                                forms.checkPropertyAnswers.additionalLandlords.heading
+                            </a>
+                        </li>
+                        <li class="govuk-tabs__list-item">
+                            <a class="govuk-tabs__tab" href="#interested-parties" th:text="#{forms.checkPropertyAnswers.interestedParties.heading}">
+                                forms.checkPropertyAnswers.interestedParties.heading
+                            </a>
+                        </li>
+                    </ul>
+                    <div class="govuk-tabs__panel" id="property-details">
+                        <div id="my-hint" class="govuk-hint" th:text="#{forms.checkPropertyAnswers.propertyDetails.hint}">
+                            forms.checkPropertyAnswers.propertyDetails.hint
+                        </div>
+                        <dl th:replace="~{fragments/summaryList :: summaryList(${propertyDetails})}"></dl>
+                        <details id="details-content" th:replace="~{fragments/details :: details(#{forms.checkPropertyAnswers.propertyDetails.detail.summary},~{::#details-content/content()})}">
+                            <div class="govuk-details__text" th:text="#{forms.checkPropertyAnswers.propertyDetails.detail.text}">
+                                forms.checkPropertyAnswers.propertyDetails.detail.text
+                            </div>
+                        </details>
+                    </div>
+                    <div class="govuk-tabs__panel govuk-tabs__panel--hidden" id="additional-landlords">
+                        <h2 class="govuk-heading-l">TODO: PRSD-584</h2>
+                        <p class="govuk-body">This tab will show details of additional landlords, and will be implemented as part of PRSD-584</p>
+                    </div>
+                    <div class="govuk-tabs__panel govuk-tabs__panel--hidden" id="interested-parties">
+                        <h2 class="govuk-heading-l">TODO: PRSD-585</h2>
+                        <p class="govuk-body">This tab will show details of interested parties, and will be implemented as part of PRSD-585</p>
+                    </div>
+            </div>
+                <button th:replace="~{fragments/buttons/primaryButton :: primaryButton(#{${submitButtonText}})}"></button>
+            </form>
+        </div>
+    </main>
+</th:block>
+</html>

--- a/src/main/resources/templates/fragments/tabs/tabs.html
+++ b/src/main/resources/templates/fragments/tabs/tabs.html
@@ -1,0 +1,3 @@
+<div th:fragment="tabs(content)" class="govuk-tabs" data-module="govuk-tabs">
+    <div th:replace="${content}"></div>
+</div>

--- a/src/main/resources/templates/fragments/tabs/tabsHeadingList.html
+++ b/src/main/resources/templates/fragments/tabs/tabsHeadingList.html
@@ -1,0 +1,3 @@
+<ul th:fragment="tabsHeadingList(content)" class="govuk-tabs__list">
+    <li th:replace="${content}"></li>
+</ul>

--- a/src/main/resources/templates/fragments/tabs/tabsListItem.html
+++ b/src/main/resources/templates/fragments/tabs/tabsListItem.html
@@ -1,0 +1,5 @@
+<li th:fragment="tabsListItem(sectiondId, headingText)"  class="govuk-tabs__list-item">
+    <a class="govuk-tabs__tab" th:href="'#'+${sectiondId}" th:text="${headingText}">
+        headingText
+    </a>
+</li>

--- a/src/main/resources/templates/fragments/tabs/tabsPanel.html
+++ b/src/main/resources/templates/fragments/tabs/tabsPanel.html
@@ -1,0 +1,3 @@
+<div th:fragment="tabsPanel(sectionId, content)" class="govuk-tabs__panel" th:id="${sectionId}">
+    <div th:replace="${content}"></div>
+</div>


### PR DESCRIPTION
Create the template for the register-property check answers page, with placeholder text for the additional landlords and interested parties tabs. The rest of this ticket will involve modifying the "propertyDetails" `List` returned from the `Journey` to have the correct list of details in all circumstances and ensuring the journey flows correctly. This ticket is explictly just for the UI.

![image](https://github.com/user-attachments/assets/b9086f5a-c4ce-4871-b332-ef578c53ad4b)

![image](https://github.com/user-attachments/assets/b24c44ea-e4d1-4fe5-aedd-725627bc1cb2)

![image](https://github.com/user-attachments/assets/f54bc43d-9ff7-49cd-9909-ebe5f47250fa)

![image](https://github.com/user-attachments/assets/5cb5adc4-da7f-4eb6-b7b5-9e2b830dfa03)
