### PR TITLE
PRSD-537: Fix getNowAsLocalDate

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/helpers/DateTimeHelper.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/helpers/DateTimeHelper.kt
@@ -1,15 +1,16 @@
 package uk.gov.communities.prsdb.webapp.helpers
 
-import kotlinx.datetime.Clock
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.TimeZone
+import kotlinx.datetime.toKotlinInstant
 import kotlinx.datetime.toLocalDateTime
+import java.time.Clock
 
-class DateTimeHelper {
-    val clock: Clock = Clock.System
-
+class DateTimeHelper(
+    private val clock: Clock = Clock.systemUTC(),
+) {
     fun getNowAsLocalDate(): LocalDate {
-        val instant = clock.now().toLocalDateTime(TimeZone.of("UTC"))
+        val instant = clock.instant().toKotlinInstant().toLocalDateTime(TimeZone.of("Europe/London"))
         return LocalDate(instant.year, instant.month.value, instant.dayOfMonth)
     }
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/helpers/DateTimeHelperTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/helpers/DateTimeHelperTests.kt
@@ -1,8 +1,10 @@
 package uk.gov.communities.prsdb.webapp.helpers
 
 import kotlinx.datetime.LocalDate
+import kotlinx.datetime.LocalDateTime
+import kotlinx.datetime.LocalTime
 import kotlinx.datetime.TimeZone
-import kotlinx.datetime.atStartOfDayIn
+import kotlinx.datetime.toInstant
 import kotlinx.datetime.toJavaInstant
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.CsvSource
@@ -13,22 +15,30 @@ import kotlin.test.assertEquals
 class DateTimeHelperTests {
     @ParameterizedTest
     @CsvSource(
-        // Winter
-        "2023,12,1",
-        // Summer
-        "2023,6,1",
+        // Winter morning
+        "2023,12,1,0,0,0",
+        // Winter night
+        "2023,12,1,23,59,59",
+        // Summer morning
+        "2023,6,1,0,0,0",
+        // Summer evening
+        "2023,6,1,23,59,59",
     )
     fun `getNowAsLocalDate returns the correct local date`(
         year: Int,
         month: Int,
         dayOfMonth: Int,
+        hour: Int,
+        minute: Int,
+        second: Int,
     ) {
         val expectedDate = LocalDate(year, month, dayOfMonth)
+        val expectedDateTime = LocalDateTime(expectedDate, LocalTime(hour, minute, second))
 
         val dateTimeHelper =
             DateTimeHelper(
                 Clock.fixed(
-                    expectedDate.atStartOfDayIn(TimeZone.of("Europe/London")).toJavaInstant(),
+                    expectedDateTime.toInstant(TimeZone.of("Europe/London")).toJavaInstant(),
                     ZoneId.of("UTC"),
                 ),
             )

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/helpers/DateTimeHelperTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/helpers/DateTimeHelperTests.kt
@@ -1,0 +1,38 @@
+package uk.gov.communities.prsdb.webapp.helpers
+
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.atStartOfDayIn
+import kotlinx.datetime.toJavaInstant
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.CsvSource
+import java.time.Clock
+import java.time.ZoneId
+import kotlin.test.assertEquals
+
+class DateTimeHelperTests {
+    @ParameterizedTest
+    @CsvSource(
+        // Winter
+        "2023,12,1",
+        // Summer
+        "2023,6,1",
+    )
+    fun `getNowAsLocalDate returns the correct local date`(
+        year: Int,
+        month: Int,
+        dayOfMonth: Int,
+    ) {
+        val expectedDate = LocalDate(year, month, dayOfMonth)
+
+        val dateTimeHelper =
+            DateTimeHelper(
+                Clock.fixed(
+                    expectedDate.atStartOfDayIn(TimeZone.of("Europe/London")).toJavaInstant(),
+                    ZoneId.of("UTC"),
+                ),
+            )
+
+        assertEquals(expectedDate, dateTimeHelper.getNowAsLocalDate())
+    }
+}


### PR DESCRIPTION
Sets timezone to London in and adds tests for `DateTimeHelper.getNowAsLocalDate`