### PR TITLE
PRSD-579: Fix fixed input widths

### DIFF
--- a/src/main/resources/templates/forms/licenceNumberForm.html
+++ b/src/main/resources/templates/forms/licenceNumberForm.html
@@ -11,7 +11,7 @@
 <form id="form-content" th:remove="tag">
     <fieldset id="fieldset-content"
               th:replace="~{fragments/forms/fieldSet :: fieldSet(~{::#fieldset-content/content()}, 'licenceNumber', #{${fieldSetHeading}}, null)}">
-        <input th:replace="~{fragments/forms/basicTextInput :: textInput(#{${label}}, 'licenceNumber', null)}">
+        <input th:replace="~{fragments/forms/fixedWidthTextInput :: fixedWidthTextInput(#{${label}}, 'licenceNumber', null, 20)}">
     </fieldset>
     <details id="details-content" th:replace="~{fragments/details :: details(#{${detailSummary}},~{::#details-content/content()})}">
         <div class="govuk-details__text">

--- a/src/main/resources/templates/fragments/forms/numericalInput.html
+++ b/src/main/resources/templates/fragments/forms/numericalInput.html
@@ -4,7 +4,7 @@
           th:assert="${fieldWidth == 2 || fieldWidth == 3 || fieldWidth == 4 || fieldWidth ==  5 || fieldWidth ==  10 || fieldWidth ==  20 || fieldWidth ==  30}">
     <th:block th:replace="~{fragments/forms/inputGroup :: inputGroup(${label}, ${fieldName}, ~{::input}, ${hint})}">
         <input class="govuk-input"
-           th:classappend='${#fields.hasErrors(fieldName) ? "govuk-input--error" : ""} + ${" govuk-input--width-"+width}'
+           th:classappend='${#fields.hasErrors(fieldName) ? "govuk-input--error" : ""} + ${" govuk-input--width-"+fieldWidth}'
            type="text"
            inputmode="numeric"
            th:field="*{__${fieldName}__}"


### PR DESCRIPTION
Two minor changes:
* Use a fixed width input for licence number input to better match the designs
* Fix an issue with the numerical input that was causing them to ignore the input value

The width I've selected on the licensing page is a little wider than [the designs](https://www.figma.com/design/ka4URNl45NiQO0LoY8XNe4/MHCLG---Private-Rented-Sector-Database?node-id=8457-364445&t=ly8OKk6KyQV37biw-0) but the designs are between 10 and 20 width and I thought this looked better that the 10 width option (see bottom)

Twenty width:
![image](https://github.com/user-attachments/assets/6ffbace4-59f7-4017-914e-275bb30e2629)

Ten width:
![image](https://github.com/user-attachments/assets/f26445a9-a597-4b7b-89cd-6912af770b6b)
