### PR TITLE
PRSD-495: Hide UPRN detail when no UPRN

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/pages/PropertyRegistrationCheckAnswersPage.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/pages/PropertyRegistrationCheckAnswersPage.kt
@@ -38,6 +38,7 @@ class PropertyRegistrationCheckAnswersPage(
 
         model.addAttribute("propertyDetails", propertyDetails)
         model.addAttribute("propertyName", propertyName)
+        model.addAttribute("showUprnDetail", !DataHelper.isManualAddressChosen(journeyDataService, journeyData))
         return super.populateModelAndGetTemplateName(validator, model, pageData, prevStepUrl, journeyData)
     }
 

--- a/src/main/resources/templates/forms/propertyRegistrationCheckAnswersForm.html
+++ b/src/main/resources/templates/forms/propertyRegistrationCheckAnswersForm.html
@@ -4,6 +4,7 @@
 <!--/*@thymesVar id="submitButtonText" type="java.lang.String"*/-->
 <!--/*@thymesVar id="propertyName" type="java.lang.String"*/-->
 <!--/*@thymesVar id="backUrl" type="java.lang.String"*/-->
+<!--/*@thymesVar id="showUprnDetail" type="java.lang.Boolean"*/-->
 <!DOCTYPE html>
 
 <html th:replace="~{fragments/forms/questionPage :: questionPage(#{${title}}, ${formModel}, ~{::#form-content}, ${backUrl})}">
@@ -33,11 +34,13 @@
                         forms.checkPropertyAnswers.propertyDetails.hint
                     </div>
                     <dl th:replace="~{fragments/summaryList :: summaryList(${propertyDetails})}"></dl>
-                    <details id="details-content" th:replace="~{fragments/details :: details(#{forms.checkPropertyAnswers.propertyDetails.detail.summary},~{::#details-content/content()})}">
-                        <div class="govuk-details__text" th:text="#{forms.checkPropertyAnswers.propertyDetails.detail.text}">
-                            forms.checkPropertyAnswers.propertyDetails.detail.text
-                        </div>
-                    </details>
+                    <th:block th:if="${showUprnDetail}">
+                        <details id="details-content"  th:replace="~{fragments/details :: details(#{forms.checkPropertyAnswers.propertyDetails.detail.summary},~{::#details-content/content()})}">
+                            <div class="govuk-details__text" th:text="#{forms.checkPropertyAnswers.propertyDetails.detail.text}">
+                                forms.checkPropertyAnswers.propertyDetails.detail.text
+                            </div>
+                        </details>
+                    </th:block>
                 </th:block>
             </div>
             <div th:replace="~{fragments/tabs/tabsPanel :: tabsPanel('additional-landlords', ~{:: #additional-landlords-panel-content})}">


### PR DESCRIPTION
The hint for UPRN detail should only appear when the UPRN is shown in the check answers page (i.e. the address has been selected).

![image](https://github.com/user-attachments/assets/994a10b7-3722-4862-9030-6d51e224a701)

![image](https://github.com/user-attachments/assets/3b68f134-40e7-4e75-8f6d-3530d4cbcff6)
