### PR TITLE
Feat/prsd 701 view landlord details

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/LandlordDetailsController.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/LandlordDetailsController.kt
@@ -7,7 +7,6 @@ import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import uk.gov.communities.prsdb.webapp.exceptions.PrsdbWebException
 import uk.gov.communities.prsdb.webapp.helpers.converters.MessageKeyConverter
-import uk.gov.communities.prsdb.webapp.models.dataModels.RegistrationNumberDataModel
 import uk.gov.communities.prsdb.webapp.services.AddressDataService
 import uk.gov.communities.prsdb.webapp.services.LandlordService
 import java.security.Principal
@@ -15,8 +14,8 @@ import java.time.LocalDate
 
 @PreAuthorize("hasRole('LANDLORD')")
 @Controller
-@RequestMapping("/landlord-user")
-class LandlordUserController(
+@RequestMapping("/landlord-details")
+class LandlordDetailsController(
     val landlordService: LandlordService,
     val addressDataService: AddressDataService,
 ) {
@@ -32,20 +31,18 @@ class LandlordUserController(
 
         // TODO PRSD-747 to pass Id verification status to model with verified label and message key
         model.addAttribute("name", landlord.name)
-        model.addAttribute("registrationNumber", RegistrationNumberDataModel.fromRegistrationNumber(landlord.registrationNumber))
         model.addAttribute("registrationDate", registeredDate)
         model.addAttribute("dateOfBirth", landlord.dateOfBirth)
         model.addAttribute("email", landlord.email)
         model.addAttribute("phoneNumber", landlord.phoneNumber)
-        // TODO PRSD-742 to update this check
         model.addAttribute("isUKResident", MessageKeyConverter.convert(landlord.internationalAddress == null))
-        model.addAttribute("internationalAddress", landlord.internationalAddress)
+        // TODO PRSD-742 will make country of residence available and should be displayed alongside the international address
         model.addAttribute("internationalAddress", landlord.internationalAddress)
         model.addAttribute("ukAddress", landlord.address.singleLineAddress)
         // TODO PRSD-670: Replace with link to dashboard
         model.addAttribute("backUrl", "/")
 
-        // TODO
+        // TODO PRSD-746 - add user consent information to this page once it is captured.
 
         return "landlordDetailsView"
     }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/LandlordDetailsController.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/LandlordDetailsController.kt
@@ -29,6 +29,7 @@ class LandlordDetailsController(
                 ?: throw PrsdbWebException("User ${principal.name} is not registered as a landlord")
         val registeredDate = LocalDate.of(landlord.createdDate.year, landlord.createdDate.monthValue, landlord.createdDate.dayOfMonth)
 
+        // Add personal details to model
         // TODO PRSD-747 to pass Id verification status to model with verified label and message key
         model.addAttribute("name", landlord.name)
         model.addAttribute("registrationDate", registeredDate)
@@ -43,6 +44,9 @@ class LandlordDetailsController(
         model.addAttribute("backUrl", "/")
 
         // TODO PRSD-746 - add user consent information to this page once it is captured.
+
+        // Add properties to model
+        // TODO PRSD-702 add properties to model
 
         return "landlordDetailsView"
     }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/LandlordUserController.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/LandlordUserController.kt
@@ -6,6 +6,8 @@ import org.springframework.ui.Model
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import uk.gov.communities.prsdb.webapp.exceptions.PrsdbWebException
+import uk.gov.communities.prsdb.webapp.helpers.converters.MessageKeyConverter
+import uk.gov.communities.prsdb.webapp.models.dataModels.RegistrationNumberDataModel
 import uk.gov.communities.prsdb.webapp.services.AddressDataService
 import uk.gov.communities.prsdb.webapp.services.LandlordService
 import java.security.Principal
@@ -30,13 +32,14 @@ class LandlordUserController(
 
         // TODO PRSD-747 to pass Id verification status to model with verified label and message key
         model.addAttribute("name", landlord.name)
-        model.addAttribute("registrationNumber", landlord.registrationNumber)
+        model.addAttribute("registrationNumber", RegistrationNumberDataModel.fromRegistrationNumber(landlord.registrationNumber))
         model.addAttribute("registrationDate", registeredDate)
         model.addAttribute("dateOfBirth", landlord.dateOfBirth)
         model.addAttribute("email", landlord.email)
         model.addAttribute("phoneNumber", landlord.phoneNumber)
         // TODO PRSD-742 to update this check
-        model.addAttribute("isUKResident", landlord.internationalAddress == null)
+        model.addAttribute("isUKResident", MessageKeyConverter.convert(landlord.internationalAddress == null))
+        model.addAttribute("internationalAddress", landlord.internationalAddress)
         model.addAttribute("internationalAddress", landlord.internationalAddress)
         model.addAttribute("ukAddress", landlord.address.singleLineAddress)
         // TODO PRSD-670: Replace with link to dashboard

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/LandlordUserController.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/LandlordUserController.kt
@@ -1,0 +1,49 @@
+package uk.gov.communities.prsdb.webapp.controllers
+
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.stereotype.Controller
+import org.springframework.ui.Model
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import uk.gov.communities.prsdb.webapp.exceptions.PrsdbWebException
+import uk.gov.communities.prsdb.webapp.services.AddressDataService
+import uk.gov.communities.prsdb.webapp.services.LandlordService
+import java.security.Principal
+import java.time.LocalDate
+
+@PreAuthorize("hasRole('LANDLORD')")
+@Controller
+@RequestMapping("/landlord-user")
+class LandlordUserController(
+    val landlordService: LandlordService,
+    val addressDataService: AddressDataService,
+) {
+    @GetMapping
+    fun index(
+        model: Model,
+        principal: Principal,
+    ): String {
+        val landlord =
+            landlordService.retrieveLandlordByBaseUserId(principal.name)
+                ?: throw PrsdbWebException("User ${principal.name} is not registered as a landlord")
+        val registeredDate = LocalDate.of(landlord.createdDate.year, landlord.createdDate.monthValue, landlord.createdDate.dayOfMonth)
+
+        // TODO PRSD-747 to pass Id verification status to model with verified label and message key
+        model.addAttribute("name", landlord.name)
+        model.addAttribute("registrationNumber", landlord.registrationNumber)
+        model.addAttribute("registrationDate", registeredDate)
+        model.addAttribute("dateOfBirth", landlord.dateOfBirth)
+        model.addAttribute("email", landlord.email)
+        model.addAttribute("phoneNumber", landlord.phoneNumber)
+        // TODO PRSD-742 to update this check
+        model.addAttribute("isUKResident", landlord.internationalAddress == null)
+        model.addAttribute("internationalAddress", landlord.internationalAddress)
+        model.addAttribute("ukAddress", landlord.address.singleLineAddress)
+        // TODO PRSD-670: Replace with link to dashboard
+        model.addAttribute("backUrl", "/")
+
+        // TODO
+
+        return "landlordDetailsView"
+    }
+}

--- a/src/main/resources/data-local.sql
+++ b/src/main/resources/data-local.sql
@@ -89,9 +89,8 @@ VALUES (1, '09/13/24', '09/13/24', 1, 1, '09/13/2000', true, 07111111111, 'urn:f
        (5, '09/13/24', '09/13/24', 5, 5, '05/13/1950', true, 07111111111,
         'urn:fdc:gov.uk:2022:mwfvbb5GgiDh0acjz9EDDQ7zwskWZzUSnWfavL70f6s', 'Margaret Mary Smith',
         'mm.smith@importantco.com'),
-       (6, '12/19/24', '12/19/24', 7, 5, '06/13/1989', true, 07111111111,
-        'urn:fdc:gov.uk:2022:mGHDySEVfCsvfvc6lVWf6Qt9Dv0ZxPQWKoEzcjnBlUo', 'PRSDB Landlord',
-        'Team-PRSDB+landlord@softwire.com');
+        (6, '12/19/24', '12/19/24', 7,5,'06/13/1989',true,07111111111,
+         'urn:fdc:gov.uk:2022:mGHDySEVfCsvfvc6lVWf6Qt9Dv0ZxPQWKoEzcjnBlUo','PRSDB Landlord', 'Team-PRSDB+landlord@softwire.com');
 
 SELECT setval(pg_get_serial_sequence('landlord', 'id'), (SELECT MAX(id) FROM landlord));
 

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -253,6 +253,24 @@ invitation.header=The local authority issuing that token was: {0,,token}
 
 search=Search for Private Rented Sector information
 
+landlordDetails.title=Landlord record
+landlordDetails.heading=Landlord record
+landlordDetails.lrn=Landlord registration number (LRN):
+landlordDetails.personalDetails.heading=Personal details
+landlordDetails.personalDetails.registrationDate=Database registration date
+landlordDetails.personalDetails.name=Name
+landlordDetails.personalDetails.dateOfBirth=Date of birth
+landlordDetails.personalDetails.verified=Verified
+landlordDetails.personalDetails.fromOneLogin=From your GOV.UK One Login
+landlordDetails.personalDetails.emailAddress=Email address
+landlordDetails.personalDetails.telephoneNumber=Telephone number
+landlordDetails.personalDetails.ukResident=UK resident
+landlordDetails.personalDetails.contactAddress=Contact address
+landlordDetails.personalDetails.optionalChoices.heading=Optional choices
+landlordDetails.personalDetails.optionalChoices.hint=Your privacy choices during landlord registration
+landlordDetails.personalDetails.optionalChoices.legalChanges=I agree for MHCLG to contact me about any changes to my legal responsibilities on the database
+landlordDetails.personalDetails.optionalChoices.research=I give permission for MHCLG to contact me for research related to the database
+
 forms.errorSummary.heading=There is a problem
 forms.errorMessage.prefix=Error: 
 

--- a/src/main/resources/templates/fragments/summaryList.html
+++ b/src/main/resources/templates/fragments/summaryList.html
@@ -1,18 +1,5 @@
 <dl th:fragment="summaryList(listRows)" class="govuk-summary-list">
-    <div class="govuk-summary-list__row" th:each="row: ${listRows}">
-        <dt class="govuk-summary-list__key" th:text="#{${row.fieldHeading}}">
-            fieldHeading
-        </dt>
-        <dd  class="govuk-summary-list__value" >
-                <!--/* If and only if there is a single value (as opposed to a list) we should th:remove the p tag to avoid unnecessary nesting */-->
-                <p th:remove="${iteratorStatus.size == 1} ? tag : none"
-                   th:each="value, iteratorStatus: ${row.convertedFieldValue}" class="govuk-body"
-                   th:text="${#messages.msgOrNull(value)} ?: ${{value}}">row.convertedFieldValue</p>
-        </dd>
-        <dd class="govuk-summary-list__actions">
-            <a th:if="${row.changeUrl} != null" class="govuk-link" th:href="@{${row.changeUrl}}" th:text="#{forms.links.change}">
-                <span class="govuk-visually-hidden" th:text="#{${row.fieldHeading}}">fieldHeading</span>
-            </a>
-        </dd>
-    </div>
+    <th:block th:each="row: ${listRows}">
+        <div th:replace="~{fragments/summaryRow :: summaryRow(${row.fieldHeading}, ${row.convertedFieldValue}, ${row.changeUrl})}" ></div>
+    </th:block>
 </dl>

--- a/src/main/resources/templates/fragments/summaryRow.html
+++ b/src/main/resources/templates/fragments/summaryRow.html
@@ -1,0 +1,15 @@
+<div th:fragment="summaryRow(heading, values, changeUrl)" class="govuk-summary-list__row">
+    <dt class="govuk-summary-list__key" th:text="#{${heading}}">
+    </dt>
+    <dd  class="govuk-summary-list__value" >
+        <!--/* If and only if there is a single value (as opposed to a list) we should th:remove the p tag to avoid unnecessary nesting */-->
+        <p th:remove="${iteratorStatus.size == 1} ? tag : none"
+           th:each="value, iteratorStatus: ${values}" class="govuk-body"
+           th:text="${#messages.msgOrNull(value)} ?: ${{value}}">row.convertedFieldValue</p>
+    </dd>
+    <dd class="govuk-summary-list__actions">
+        <a th:if="${changeUrl} != null" class="govuk-link" th:href="@{${changeUrl}}" th:text="#{forms.links.change}">
+            <span class="govuk-visually-hidden" th:text="#{${heading}}">fieldHeading</span>
+        </a>
+    </dd>
+</div>

--- a/src/main/resources/templates/landlordDetailsView.html
+++ b/src/main/resources/templates/landlordDetailsView.html
@@ -21,31 +21,31 @@
                             <div th:replace="~{fragments/summaryRow :: summaryRow('landlordDetails.personalDetails.registrationDate', ${registrationDate}, null)}" ></div>
                             <div th:replace="~{fragments/summaryRow :: summaryRow('landlordDetails.personalDetails.name', ${name}, null)}" ></div>
                             <div th:replace="~{fragments/summaryRow :: summaryRow('landlordDetails.personalDetails.dateOfBirth', ${dateOfBirth}, null)}" ></div>
-                            <div th:replace="~{fragments/summaryRow :: summaryRow('landlordDetails.personalDetails.emailAddress', ${email}, 'https://www.google.com')}" ></div>
-                            <div th:replace="~{fragments/summaryRow :: summaryRow('landlordDetails.personalDetails.telephoneNumber', ${phoneNumber}, 'https://www.google.com')}" ></div>
-                            <div th:replace="~{fragments/summaryRow :: summaryRow('landlordDetails.personalDetails.ukResident', ${isUKResident}, 'https://www.google.com')}" ></div>
+                            <div th:replace="~{fragments/summaryRow :: summaryRow('landlordDetails.personalDetails.emailAddress', ${email}, null)}" ></div>
+                            <div th:replace="~{fragments/summaryRow :: summaryRow('landlordDetails.personalDetails.telephoneNumber', ${phoneNumber}, null)}" ></div>
+                            <div th:replace="~{fragments/summaryRow :: summaryRow('landlordDetails.personalDetails.ukResident', ${isUKResident}, null)}" ></div>
                             <th:block th:if="${isUKResident}">
-                                <div th:replace="~{fragments/summaryRow :: summaryRow('landlordDetails.personalDetails.contactAddress', ${ukAddress}, 'https://www.google.com')}" ></div>
+                                <div th:replace="~{fragments/summaryRow :: summaryRow('landlordDetails.personalDetails.contactAddress', ${ukAddress}, null)}" ></div>
                             </th:block>
                             <th:block th:unless="${isUKResident}">
-                                <div th:replace="~{fragments/summaryRow :: summaryRow('landlordDetails.personalDetails.country', ${ukAddress}, 'https://www.google.com')}" ></div>
-                                <div th:replace="~{fragments/summaryRow :: summaryRow('landlordDetails.personalDetails.homeCountryAddress', ${internationalAddress}, 'https://www.google.com')}" ></div>
-                                <div th:replace="~{fragments/summaryRow :: summaryRow('landlordDetails.personalDetails.ukAddress', ${ukAddress}, 'https://www.google.com')}" ></div>
+                                <div th:replace="~{fragments/summaryRow :: summaryRow('landlordDetails.personalDetails.country', ${ukAddress}, null)}" ></div>
+                                <div th:replace="~{fragments/summaryRow :: summaryRow('landlordDetails.personalDetails.homeCountryAddress', ${internationalAddress}, null)}" ></div>
+                                <div th:replace="~{fragments/summaryRow :: summaryRow('landlordDetails.personalDetails.ukAddress', ${ukAddress}, null)}" ></div>
                             </th:block>
                         </dl>
                         <h2 class="govuk-heading-m" th:text="#{landlordDetails.personalDetails.optionalChoices.heading}">landlordDetails.personalDetails.optionalChoices.heading</h2>
                         <p class="govuk-hint" th:text="#{landlordDetails.personalDetails.optionalChoices.hint}">landlordDetails.personalDetails.optionalChoices.hint</p>
                         <dl class="govuk-summary-list">
-                            <div th:replace="~{fragments/summaryRow :: summaryRow('landlordDetails.personalDetails.optionalChoices.legalChanges', 'commonText.yes', 'https://www.google.com')}" ></div>
-                            <div th:replace="~{fragments/summaryRow :: summaryRow('landlordDetails.personalDetails.optionalChoices.research', 'commonText.no', 'https://www.google.com')}" ></div>
+                            <div th:replace="~{fragments/summaryRow :: summaryRow('landlordDetails.personalDetails.optionalChoices.legalChanges', 'TODO PRSD-746', null)}" ></div>
+                            <div th:replace="~{fragments/summaryRow :: summaryRow('landlordDetails.personalDetails.optionalChoices.research', 'TODO PRSD-746', null)}" ></div>
                         </dl>
                     </th:block>
                 </div>
 
                 <div th:replace="~{fragments/tabs/tabsPanel :: tabsPanel('registered-properties', ~{:: #registered-properties-panel-content})}">
                     <th:block id="registered-properties-panel-content">
-                        <h2 class="govuk-heading-m">TODO: PRSD-701</h2>
-                        <p class="govuk-body">This tab will show details of registered properties, and will be implemented as part of PRSD-701</p>
+                        <h2 class="govuk-heading-m">TODO: PRSD-702</h2>
+                        <p class="govuk-body">This tab will show details of registered properties, and will be implemented as part of PRSD-702</p>
                     </th:block>
                 </div>
             </th:block>

--- a/src/main/resources/templates/landlordDetailsView.html
+++ b/src/main/resources/templates/landlordDetailsView.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html th:replace="~{fragments/layout :: layout(#{landlordDetails.title}, ~{::main}, false)}">
+<main class="govuk-main-wrapper" id="main-content">
+    <div id="page-contents">
+        <h2 class="govuk-heading-m" th:text="#{landlordDetails.heading}">landlordDetails.heading</h2>
+        <h1 class="govuk-heading-l" th:text="${name}">landlord.name</h1>
+        <div th:replace="~{fragments/tabs/tabs :: tabs(~{:: #tabs-content})}" >
+            <th:block id="tabs-content">
+                <ul th:replace="~{fragments/tabs/tabsHeadingList :: tabsHeadingList(~{:: #tab-headings})}">
+                    <th:block id="tab-headings">
+                        <li th:replace="~{fragments/tabs/tabsListItem :: tabsListItem('personal-details', #{landlordDetails.personalDetails.heading})}">
+                        </li>
+                        <li th:replace="~{fragments/tabs/tabsListItem :: tabsListItem('registered-properties', 'Registered properties')}">
+                        </li>
+                    </th:block>
+                </ul>
+
+                <div th:replace="~{fragments/tabs/tabsPanel :: tabsPanel('personal-details', ~{:: #personal-details-panel-content})}">
+                    <th:block id="personal-details-panel-content">
+                        <dl class="govuk-summary-list">
+                            <div th:replace="~{fragments/summaryRow :: summaryRow('landlordDetails.personalDetails.registrationDate', ${registrationDate}, null)}" ></div>
+                            <div th:replace="~{fragments/summaryRow :: summaryRow('landlordDetails.personalDetails.name', ${name}, null)}" ></div>
+                            <div th:replace="~{fragments/summaryRow :: summaryRow('landlordDetails.personalDetails.dateOfBirth', ${dateOfBirth}, null)}" ></div>
+                            <div th:replace="~{fragments/summaryRow :: summaryRow('landlordDetails.personalDetails.emailAddress', ${email}, 'https://www.google.com')}" ></div>
+                            <div th:replace="~{fragments/summaryRow :: summaryRow('landlordDetails.personalDetails.telephoneNumber', ${phoneNumber}, 'https://www.google.com')}" ></div>
+                            <div th:replace="~{fragments/summaryRow :: summaryRow('landlordDetails.personalDetails.ukResident', ${isUKResident}, 'https://www.google.com')}" ></div>
+                            <th:block th:if="${isUKResident}">
+                                <div th:replace="~{fragments/summaryRow :: summaryRow('landlordDetails.personalDetails.contactAddress', ${ukAddress}, 'https://www.google.com')}" ></div>
+                            </th:block>
+                            <th:block th:unless="${isUKResident}">
+                                <div th:replace="~{fragments/summaryRow :: summaryRow('landlordDetails.personalDetails.country', ${ukAddress}, 'https://www.google.com')}" ></div>
+                                <div th:replace="~{fragments/summaryRow :: summaryRow('landlordDetails.personalDetails.homeCountryAddress', ${internationalAddress}, 'https://www.google.com')}" ></div>
+                                <div th:replace="~{fragments/summaryRow :: summaryRow('landlordDetails.personalDetails.ukAddress', ${ukAddress}, 'https://www.google.com')}" ></div>
+                            </th:block>
+                        </dl>
+                        <h2 class="govuk-heading-m" th:text="#{landlordDetails.personalDetails.optionalChoices.heading}">landlordDetails.personalDetails.optionalChoices.heading</h2>
+                        <p class="govuk-hint" th:text="#{landlordDetails.personalDetails.optionalChoices.hint}">landlordDetails.personalDetails.optionalChoices.hint</p>
+                        <dl class="govuk-summary-list">
+                            <div th:replace="~{fragments/summaryRow :: summaryRow('landlordDetails.personalDetails.optionalChoices.legalChanges', 'commonText.yes', 'https://www.google.com')}" ></div>
+                            <div th:replace="~{fragments/summaryRow :: summaryRow('landlordDetails.personalDetails.optionalChoices.research', 'commonText.no', 'https://www.google.com')}" ></div>
+                        </dl>
+                    </th:block>
+                </div>
+
+                <div th:replace="~{fragments/tabs/tabsPanel :: tabsPanel('registered-properties', ~{:: #registered-properties-panel-content})}">
+                    <th:block id="registered-properties-panel-content">
+                        <h2 class="govuk-heading-m">TODO: PRSD-701</h2>
+                        <p class="govuk-body">This tab will show details of registered properties, and will be implemented as part of PRSD-701</p>
+                    </th:block>
+                </div>
+            </th:block>
+        </div>
+
+
+    </div>
+</main>
+</html>


### PR DESCRIPTION
This is explicitly missing several elements that will come in later tickets:
* User consent information 
* Country of residence
* Id Verification status
* Back link to dashboard

and several elements that will be done as part of this ticket in a future PR:
* Adding change buttons to each row for which it is relevant
* Adding tests for the controller
* Adding the top section of the page with the user's LRN and a delete account button.

![image](https://github.com/user-attachments/assets/07ef021f-cc60-4338-b421-faa5b7bcf4e6)
