### PR TITLE
PRSD-650: Landlord Search - No Results

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/SearchRegisterController.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/SearchRegisterController.kt
@@ -28,7 +28,13 @@ class SearchRegisterController(
         model.addAttribute("searchWrapperModel", SearchWrapperModel())
         // TODO PRSD-656: add LA view of landlord details page base URL to model
         model.addAttribute("baseLandlordDetailsURL", "/landlord-details")
+        // TODO PRSD-659: add LA property search base URL to model
+        model.addAttribute("propertySearchURL", "property")
 
         return if (query?.isBlank() == true) "redirect:landlord" else "searchLandlord"
     }
+
+    // TODO PRSD-659: implement property search endpoint
+    @GetMapping("/property")
+    fun searchForProperties() = "error/404"
 }

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -259,6 +259,9 @@ landlordSearch.table.heading=Results
 landlordSearch.table.heading.landlord=Landlord
 landlordSearch.table.heading.address=Contact address
 landlordSearch.table.heading.info=Contact information
+landlordSearch.error.heading=No landlord record found
+landlordSearch.error.hint.beforeLink=There were no results for that search. Try a different search or
+landlordSearch.error.hint.link=search for a property
 landlordSearch.details.heading=Help find a landlord record
 landlordSearch.details.body=If you can't find a landlord record, they may not be registered. Local authorities can request the landlord registers with the database.
 

--- a/src/main/resources/templates/fragments/tables/table.html
+++ b/src/main/resources/templates/fragments/tables/table.html
@@ -1,4 +1,6 @@
-<table th:fragment="table(theadFields, tbodyFragment)" class="govuk-table">
+<table th:fragment="table(theadFields, tbodyFragment, caption)" class="govuk-table">
+    <caption th:if="${caption != null}" class="govuk-table__caption govuk-table__caption--m"
+             th:text="${caption}"></caption>
     <thead class="govuk-table__head">
     <tr class="govuk-table__row">
         <th scope="col" class="govuk-table__header" th:each="heading: ${theadFields}"

--- a/src/main/resources/templates/manageLAUsers.html
+++ b/src/main/resources/templates/manageLAUsers.html
@@ -12,7 +12,8 @@
         <section>
             <table th:replace="~{fragments/tables/table :: table(
                             ${ { 'manageLAUsers.table.usernameHeading', 'manageLAUsers.table.accessLevelHeading', 'manageLAUsers.table.accountStatusHeading', '' } },
-                            ~{::tbody}
+                            ~{::tbody},
+                            null
                         )}
                     ">
                 <tbody class="govuk-table__body">

--- a/src/main/resources/templates/registerPropertyConfirmation.html
+++ b/src/main/resources/templates/registerPropertyConfirmation.html
@@ -7,7 +7,7 @@
              th:replace="~{fragments/confirmationPageBanner :: confirmationPageBanner(#{registerProperty.confirmation.banner.heading}, ~{::#confirmation-banner/content()})}">
         </div>
         <section>
-            <table th:replace="~{fragments/tables/table :: table(${ {'registerProperty.confirmation.table.address.heading','registerProperty.confirmation.table.prn.heading'} }, ~{::tbody})}">
+            <table th:replace="~{fragments/tables/table :: table(${ {'registerProperty.confirmation.table.address.heading','registerProperty.confirmation.table.prn.heading'} }, ~{::tbody}, null)}">
                 <tbody class="govuk-table__body">
                 <tr class="govuk_table__row">
                     <td class="govuk-table__cell govuk-!-width-one-half" th:text="${singleLineAddress}"></td>

--- a/src/main/resources/templates/searchLandlord.html
+++ b/src/main/resources/templates/searchLandlord.html
@@ -34,11 +34,13 @@
             </table>
             <div th:if="${searchResults.size() == 0}" class="govuk-!-text-align-centre" id="no-results">
                 <h1 class="govuk-heading-l" th:text="#{landlordSearch.error.heading}">
-                    landlordSearch.error.heading</h1>
+                    landlordSearch.error.heading
+                </h1>
                 <div class="govuk-hint">
                     <span th:remove="tag" th:text="#{landlordSearch.error.hint.beforeLink}">landlordSearch.error.hint.beforeLink</span>
                     <a class="govuk-link" th:href="@{${propertySearchURL}}"
-                       th:text="#{landlordSearch.error.hint.link}">landlordSearch.error.hint.link</a>
+                       th:text="#{landlordSearch.error.hint.link}">landlordSearch.error.hint.link
+                    </a>
                 </div>
             </div>
         </th:block>

--- a/src/main/resources/templates/searchLandlord.html
+++ b/src/main/resources/templates/searchLandlord.html
@@ -32,7 +32,8 @@
                 </tr>
                 </tbody>
             </table>
-            <div th:if="${searchResults.size() == 0}" class="govuk-!-text-align-centre" id="no-results">
+            <div th:if="${searchResults.size() == 0}"
+                 class="govuk-!-text-align-centre govuk-!-margin-bottom-6" id="no-results">
                 <h1 class="govuk-heading-l" th:text="#{landlordSearch.error.heading}">
                     landlordSearch.error.heading
                 </h1>

--- a/src/main/resources/templates/searchLandlord.html
+++ b/src/main/resources/templates/searchLandlord.html
@@ -32,7 +32,7 @@
                 </tr>
                 </tbody>
             </table>
-            <div th:if="${searchResults.size() == 0}" class="govuk-!-text-align-centre">
+            <div th:if="${searchResults.size() == 0}" class="govuk-!-text-align-centre" id="no-results">
                 <h1 class="govuk-heading-l" th:text="#{landlordSearch.error.heading}">
                     landlordSearch.error.heading</h1>
                 <div class="govuk-hint">

--- a/src/main/resources/templates/searchLandlord.html
+++ b/src/main/resources/templates/searchLandlord.html
@@ -32,6 +32,15 @@
                 </tr>
                 </tbody>
             </table>
+            <div th:if="${searchResults.size() == 0}" class="govuk-!-text-align-centre">
+                <h1 class="govuk-heading-l" th:text="#{landlordSearch.error.heading}">
+                    landlordSearch.error.heading</h1>
+                <div class="govuk-hint">
+                    <span th:remove="tag" th:text="#{landlordSearch.error.hint.beforeLink}">landlordSearch.error.hint.beforeLink</span>
+                    <a class="govuk-link" th:href="@{${propertySearchURL}}"
+                       th:text="#{landlordSearch.error.hint.link}">landlordSearch.error.hint.link</a>
+                </div>
+            </div>
         </th:block>
         <details id="details-content"
                  th:replace="~{fragments/details :: details(#{landlordSearch.details.heading},~{::#details-content/content()})}">

--- a/src/main/resources/templates/searchLandlord.html
+++ b/src/main/resources/templates/searchLandlord.html
@@ -10,10 +10,10 @@
             #{landlordSearch.searchBar.label}, #{landlordSearch.searchBar.hint}, ${searchWrapperModel})}">
         </th:block>
         <th:block th:if="${searchResults != null}">
-            <h2 class="govuk-heading-m" th:text="#{landlordSearch.table.heading}">landlordSearch.table.heading</h2>
             <table th:replace="~{fragments/tables/table :: table(
                 ${ {'landlordSearch.table.heading.landlord','landlordSearch.table.heading.address','landlordSearch.table.heading.info'} },
-                ~{::tbody}
+                ~{::tbody},
+                #{landlordSearch.table.heading}
             )}">
                 <tbody class="govuk-table__body">
                 <tr class="govuk_table__row" th:each="landlord: ${searchResults}">

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/SearchRegisterTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/SearchRegisterTests.kt
@@ -37,6 +37,9 @@ class SearchRegisterTests : IntegrationTest() {
 
         assertThat(resultTable.getHeaderCell(CONTACT_INFO_COL_INDEX)).containsText("Contact information")
         assertThat(resultTable.getCell(0, CONTACT_INFO_COL_INDEX)).containsText("7111111111\nalex.surname@example.com")
+
+        val exception = assertThrows<AssertionFailedError> { searchLandlordRegisterPage.getErrorMessage() }
+        assertContains(exception.message!!, "Expected 1 instance of Locator@#no-results >> nth=0, found 0")
     }
 
     @Test
@@ -59,5 +62,24 @@ class SearchRegisterTests : IntegrationTest() {
         // TODO PRSD-656: Replace with landlord details page assertion
         assertPageIs(page, ErrorPage::class)
         assertContains(page.url(), "/landlord-details/1")
+    }
+
+    @Test
+    fun `error shows if search has no results`() {
+        val searchLandlordRegisterPage = navigator.goToSearchLandlordRegister()
+        searchLandlordRegisterPage.searchBar.search("non-matching query")
+
+        assertContains(searchLandlordRegisterPage.getErrorMessageText(), "No landlord record found")
+    }
+
+    @Test
+    fun `property search link shows if search has no results`(page: Page) {
+        val searchLandlordRegisterPage = navigator.goToSearchLandlordRegister()
+        searchLandlordRegisterPage.searchBar.search("non-matching query")
+        searchLandlordRegisterPage.getPropertySearchLink().click()
+
+        // TODO PRSD-659: Replace with landlord details page assertion
+        assertPageIs(page, ErrorPage::class)
+        assertContains(page.url(), "/search/property")
     }
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/SearchLandlordRegisterPage.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/SearchLandlordRegisterPage.kt
@@ -2,6 +2,7 @@ package uk.gov.communities.prsdb.webapp.integration.pageObjects.pages
 
 import com.microsoft.playwright.Page
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.BaseComponent.Companion.getChildComponent
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.BaseComponent.Companion.getComponent
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.SearchBar
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.Table
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages.BasePage
@@ -14,6 +15,12 @@ class SearchLandlordRegisterPage(
     fun getResultTable() = Table(page)
 
     fun getLandlordLink(rowIndex: Int) = getChildComponent(getResultTable().getCell(rowIndex, LANDLORD_COL_INDEX), "a")
+
+    fun getErrorMessageText() = getErrorMessage().innerText()
+
+    fun getPropertySearchLink() = getChildComponent(getErrorMessage(), "a")
+
+    fun getErrorMessage() = getComponent(page, "#no-results")
 
     companion object {
         const val LANDLORD_COL_INDEX: Int = 0


### PR DESCRIPTION
Overarching changes:
- Adds optional caption to `table.html`

Features:
- Updates search landlord page to show error when no results are found
- Creates placeholder property search endpoint

Tests:
- Updates integration tests for landlord search page

Screenshot:
![image](https://github.com/user-attachments/assets/dac90d0c-848f-4a50-a3c3-e7bf2bf9e3a0)