### PR TITLE
chore/PRSD-NONE: add custodian codes to addresses in local-data

### DIFF
--- a/src/main/resources/data-local.sql
+++ b/src/main/resources/data-local.sql
@@ -66,13 +66,13 @@ VALUES (1, '09/13/24', 2001001001, 1),
 
 SELECT setval(pg_get_serial_sequence('registration_number', 'id'), (SELECT MAX(id) FROM registration_number));
 
-INSERT INTO address (id, created_date, last_modified_date, uprn, single_line_address)
-VALUES (1, '09/13/24', '09/13/24', 1, '1 Fictional Road'),
-       (2, '09/13/24', '09/13/24', 2, '2 Fake Way'),
-       (3, '09/13/24', '09/13/24', 3, '3 Imaginary Street'),
-       (4, '09/13/24', '09/13/24', 4, '4 Pretend Crescent'),
-       (5, '09/13/24', '09/13/24', 5, '5 Mythical Place'),
-       (6, '12/10/2024', '12/10/2024', 1123456, '1, Example Road, EG');
+INSERT INTO address (id, created_date, last_modified_date, uprn, single_line_address, custodian_code)
+VALUES (1, '09/13/24', '09/13/24', 1, '1 Fictional Road', '1940'),
+       (2, '09/13/24', '09/13/24', 2, '2 Fake Way', '1945'),
+       (3, '09/13/24', '09/13/24', 3, '3 Imaginary Street', '1945'),
+       (4, '09/13/24', '09/13/24', 4, '4 Pretend Crescent', '1945'),
+       (5, '09/13/24', '09/13/24', 5, '5 Mythical Place', '3245'),
+       (6, '12/10/2024', '12/10/2024', 1123456, '1, Example Road, EG', '3245');
 
 SELECT setval(pg_get_serial_sequence('address', 'id'), (SELECT MAX(id) FROM address));
 

--- a/src/main/resources/templates/landlordDetailsView.html
+++ b/src/main/resources/templates/landlordDetailsView.html
@@ -28,7 +28,8 @@
                     <th:block id="registered-properties-panel-content">
                         <table th:replace="~{fragments/tables/table :: table(
                             ${ { 'landlordDetails.registeredProperties.table.addressHeading', 'landlordDetails.registeredProperties.table.localAuthorityHeading', 'landlordDetails.registeredProperties.table.licenceHeading', 'landlordDetails.registeredProperties.table.tenantedHeading' } },
-                            ~{::tbody}
+                            ~{::tbody},
+                            null
                         )}
                     ">
                             <tbody class="govuk-table__body">


### PR DESCRIPTION
Now that the Registered property tab in the Landlord Record ("/landlord-details") has been merged in addresses in local data will need to have custodian codes to be able to populate the `RegisteredPropertyDataModel`. This PR adds custodian codes to the addresses in `data-local.sql`