### PR TITLE
PRSD-651: Landlord Search LA Filter Service

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/SearchRegisterController.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/SearchRegisterController.kt
@@ -9,6 +9,7 @@ import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.util.UriComponentsBuilder
 import uk.gov.communities.prsdb.webapp.models.wrapperModels.SearchWrapperModel
 import uk.gov.communities.prsdb.webapp.services.LandlordService
+import java.security.Principal
 
 @Controller
 @RequestMapping("/search")
@@ -21,13 +22,15 @@ class SearchRegisterController(
         model: Model,
         @RequestParam(required = false) query: String?,
         @RequestParam(value = "page", required = false) page: Int = 1,
+        principal: Principal,
     ): String {
         if (!query.isNullOrBlank()) {
             if (page < 1) {
                 return "redirect:/search/landlord?query=$query"
             }
 
-            val pagedLandlordList = landlordService.searchForLandlords(query, currentPageNumber = page - 1)
+            val pagedLandlordList =
+                landlordService.searchForLandlords(query, principal.name, currentPageNumber = page - 1)
 
             if (pagedLandlordList.totalPages in 1..<page) {
                 return "redirect:/search/landlord?query=$query"

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/database/repository/LandlordRepository.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/database/repository/LandlordRepository.kt
@@ -24,7 +24,8 @@ interface LandlordRepository : JpaRepository<Landlord?, Long?> {
     )
     fun searchMatching(
         @Param("searchQuery") searchQuery: String,
-        @Param("laUserBaseId") laUserBaseId: String? = null,
+        @Param("laUserBaseId") laUserBaseId: String,
+        @Param("useLAFilter") useLAFilter: Boolean = false,
         pageable: Pageable,
     ): Page<Landlord>
 
@@ -37,7 +38,8 @@ interface LandlordRepository : JpaRepository<Landlord?, Long?> {
     )
     fun searchMatchingLRN(
         @Param("searchLRN") searchLRN: Long,
-        @Param("laUserBaseId") laUserBaseId: String? = null,
+        @Param("laUserBaseId") laUserBaseId: String,
+        @Param("useLAFilter") useLAFilter: Boolean = false,
         pageable: Pageable,
     ): Page<Landlord>
 
@@ -55,7 +57,7 @@ interface LandlordRepository : JpaRepository<Landlord?, Long?> {
                           WHERE l.id = po.primary_landlord_id 
                           AND po.is_active 
                           AND ol.id = :laUserBaseId)
-                  OR :laUserBaseId IS NULL) 
+                  OR NOT :useLAFilter) 
             """
     }
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/database/repository/LandlordRepository.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/database/repository/LandlordRepository.kt
@@ -18,11 +18,44 @@ interface LandlordRepository : JpaRepository<Landlord?, Long?> {
         "SELECT l.* " +
             "FROM landlord l  " +
             "WHERE (l.phone_number || ' ' || l.email || ' ' || l.name) %> :searchQuery " +
+            LA_FILTER +
             "ORDER BY (l.phone_number || ' ' || l.email || ' ' || l.name) <->> :searchQuery",
         nativeQuery = true,
     )
     fun searchMatching(
-        @Param("searchQuery")searchQuery: String,
+        @Param("searchQuery") searchQuery: String,
+        @Param("laUserBaseId") laUserBaseId: String? = null,
         pageable: Pageable,
     ): Page<Landlord>
+
+    @Query(
+        "SELECT l.* " +
+            "FROM landlord l JOIN registration_number r on l.registration_number_id = r.id " +
+            "WHERE r.number = :searchLRN " +
+            LA_FILTER,
+        nativeQuery = true,
+    )
+    fun searchMatchingLRN(
+        @Param("searchLRN") searchLRN: Long,
+        @Param("laUserBaseId") laUserBaseId: String? = null,
+        pageable: Pageable,
+    ): Page<Landlord>
+
+    companion object {
+        // Determines if the landlord has an active property ownership in the LA user's LA
+        private const val LA_FILTER =
+            """
+             AND (EXISTS (SELECT po.id 
+                          FROM property_ownership po 
+                          JOIN property p ON po.property_id = p.id 
+                          JOIN address a ON p.address_id = a.id
+                          JOIN local_authority la ON a.local_authority_id = la.id
+                          JOIN local_authority_user lau ON la.id = lau.local_authority_id
+                          JOIN one_login_user ol ON lau.subject_identifier = ol.id
+                          WHERE l.id = po.primary_landlord_id 
+                          AND po.is_active 
+                          AND ol.id = :laUserBaseId)
+                  OR :laUserBaseId IS NULL) 
+            """
+    }
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/dataModels/RegistrationNumberDataModel.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/dataModels/RegistrationNumberDataModel.kt
@@ -12,14 +12,19 @@ data class RegistrationNumberDataModel(
     val number: Long,
 ) {
     companion object {
-        fun parseOrNull(regNumString: String): RegistrationNumberDataModel? =
+        fun parseTypeOrNull(
+            regNumString: String,
+            type: RegistrationNumberType,
+        ): RegistrationNumberDataModel? =
             try {
-                parse(regNumString)
+                parse(regNumString).let { regNum -> if (regNum.isType(type)) regNum else null }
             } catch (_: Exception) {
                 null
             }
 
-        fun parse(regNumString: String): RegistrationNumberDataModel {
+        fun fromRegistrationNumber(regNum: RegistrationNumber) = RegistrationNumberDataModel(regNum.type, regNum.number)
+
+        private fun parse(regNumString: String): RegistrationNumberDataModel {
             val baseRegNumString = getBaseRegNumString(regNumString)
 
             validateBaseRegNumString(baseRegNumString)
@@ -33,8 +38,6 @@ data class RegistrationNumberDataModel(
 
             return RegistrationNumberDataModel(regNumType, regNumNumber)
         }
-
-        fun fromRegistrationNumber(regNum: RegistrationNumber) = RegistrationNumberDataModel(regNum.type, regNum.number)
 
         private fun getBaseRegNumString(regNumString: String): String = regNumString.filter { it.isLetterOrDigit() }.uppercase()
 
@@ -64,5 +67,5 @@ data class RegistrationNumberDataModel(
             regNumString.substring(REG_NUM_SEG_LENGTH)
     }
 
-    fun isType(type: RegistrationNumberType) = this.type == type
+    private fun isType(type: RegistrationNumberType) = this.type == type
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/LandlordService.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/LandlordService.kt
@@ -63,7 +63,8 @@ class LandlordService(
 
     fun searchForLandlords(
         searchTerm: String,
-        laUserId: String? = null,
+        laUserId: String,
+        useLAFilter: Boolean = false,
         currentPageNumber: Int = 0,
         pageSize: Int = MAX_ENTRIES_IN_LANDLORDS_SEARCH_PAGE,
     ): Page<LandlordSearchResultDataModel> {
@@ -72,9 +73,9 @@ class LandlordService(
 
         return (
             if (lrn == null) {
-                landlordRepository.searchMatching(searchTerm, laUserId, pageRequest)
+                landlordRepository.searchMatching(searchTerm, laUserId, useLAFilter, pageRequest)
             } else {
-                landlordRepository.searchMatchingLRN(lrn.number, laUserId, pageRequest)
+                landlordRepository.searchMatchingLRN(lrn.number, laUserId, useLAFilter, pageRequest)
             }
         ).map { LandlordSearchResultDataModel.fromLandlord(it) }
     }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/LandlordService.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/LandlordService.kt
@@ -2,7 +2,6 @@ package uk.gov.communities.prsdb.webapp.services
 
 import jakarta.transaction.Transactional
 import org.springframework.data.domain.Page
-import org.springframework.data.domain.PageImpl
 import org.springframework.data.domain.PageRequest
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
@@ -64,21 +63,19 @@ class LandlordService(
 
     fun searchForLandlords(
         searchTerm: String,
+        laUserId: String? = null,
         currentPageNumber: Int = 0,
         pageSize: Int = MAX_ENTRIES_IN_LANDLORDS_SEARCH_PAGE,
     ): Page<LandlordSearchResultDataModel> {
-        RegistrationNumberDataModel.parseOrNull(searchTerm)?.let { registrationNumber ->
-            if (registrationNumber.isType(RegistrationNumberType.LANDLORD)) {
-                retrieveLandlordByRegNum(registrationNumber)?.let { landlord ->
-                    return PageImpl(listOf(LandlordSearchResultDataModel.fromLandlord(landlord)))
-                }
-            }
-        }
-
+        val lrn = RegistrationNumberDataModel.parseTypeOrNull(searchTerm, RegistrationNumberType.LANDLORD)
         val pageRequest = PageRequest.of(currentPageNumber, pageSize)
 
-        return landlordRepository
-            .searchMatching(searchTerm, pageRequest)
-            .map { LandlordSearchResultDataModel.fromLandlord(it) }
+        return (
+            if (lrn == null) {
+                landlordRepository.searchMatching(searchTerm, laUserId, pageRequest)
+            } else {
+                landlordRepository.searchMatchingLRN(lrn.number, laUserId, pageRequest)
+            }
+        ).map { LandlordSearchResultDataModel.fromLandlord(it) }
     }
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/controllers/SearchRegisterControllerTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/controllers/SearchRegisterControllerTests.kt
@@ -51,7 +51,7 @@ class SearchRegisterControllerTests(
     @Test
     @WithMockUser(roles = ["LA_USER"])
     fun `searchRegisterController returns 200 for a valid page request`() {
-        whenever(landlordService.searchForLandlords("PRSDB", 1))
+        whenever(landlordService.searchForLandlords("PRSDB", currentPageNumber = 1))
             .thenReturn(
                 PageImpl(
                     listOf(
@@ -88,7 +88,7 @@ class SearchRegisterControllerTests(
     @Test
     @WithMockUser(roles = ["LA_USER"])
     fun `SearchRegisterController redirects if the requested page number is more than the total pages`() {
-        whenever(landlordService.searchForLandlords("PRSDB", 2))
+        whenever(landlordService.searchForLandlords("PRSDB", currentPageNumber = 2))
             .thenReturn(
                 PageImpl(
                     emptyList<LandlordSearchResultDataModel>(),

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/controllers/SearchRegisterControllerTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/controllers/SearchRegisterControllerTests.kt
@@ -51,7 +51,7 @@ class SearchRegisterControllerTests(
     @Test
     @WithMockUser(roles = ["LA_USER"])
     fun `searchRegisterController returns 200 for a valid page request`() {
-        whenever(landlordService.searchForLandlords("PRSDB", currentPageNumber = 1))
+        whenever(landlordService.searchForLandlords("PRSDB", "user", currentPageNumber = 1))
             .thenReturn(
                 PageImpl(
                     listOf(
@@ -88,7 +88,7 @@ class SearchRegisterControllerTests(
     @Test
     @WithMockUser(roles = ["LA_USER"])
     fun `SearchRegisterController redirects if the requested page number is more than the total pages`() {
-        whenever(landlordService.searchForLandlords("PRSDB", currentPageNumber = 2))
+        whenever(landlordService.searchForLandlords("PRSDB", "user", currentPageNumber = 2))
             .thenReturn(
                 PageImpl(
                     emptyList<LandlordSearchResultDataModel>(),

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/models/dataModels/RegistrationNumberDataModelTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/models/dataModels/RegistrationNumberDataModelTests.kt
@@ -1,8 +1,8 @@
 package uk.gov.communities.prsdb.webapp.models.dataModels
 
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Named
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
@@ -17,78 +17,86 @@ class RegistrationNumberDataModelTests {
         @JvmStatic
         fun provideParseableStringsAndRegNums() =
             listOf(
-                // Expected format
-                Arguments.of("L-CCCC-CCCC", RegistrationNumberDataModel(RegistrationNumberType.LANDLORD, MIN_REG_NUM)),
-                Arguments.of("P-9999-9999", RegistrationNumberDataModel(RegistrationNumberType.PROPERTY, MAX_REG_NUM)),
-                Arguments.of("A-CCCC-CCCC", RegistrationNumberDataModel(RegistrationNumberType.AGENT, MIN_REG_NUM)),
-                // Unexpected segmentation
-                Arguments.of("L99999999", RegistrationNumberDataModel(RegistrationNumberType.LANDLORD, MAX_REG_NUM)),
-                Arguments.of("L-999-999-99", RegistrationNumberDataModel(RegistrationNumberType.LANDLORD, MAX_REG_NUM)),
-                // Unexpected segmenting symbol
-                Arguments.of("L 9999 9999", RegistrationNumberDataModel(RegistrationNumberType.LANDLORD, MAX_REG_NUM)),
-                // Unexpected case
-                Arguments.of("l-cccc-cccc", RegistrationNumberDataModel(RegistrationNumberType.LANDLORD, MIN_REG_NUM)),
+                Arguments.of(
+                    Named.of("expected format - LRN", "L-CCCC-CCCC"),
+                    RegistrationNumberDataModel(RegistrationNumberType.LANDLORD, MIN_REG_NUM),
+                ),
+                Arguments.of(
+                    Named.of("expected format - PRN", "P-9999-9999"),
+                    RegistrationNumberDataModel(RegistrationNumberType.PROPERTY, MAX_REG_NUM),
+                ),
+                Arguments.of(
+                    Named.of("expected format - ARN", "A-CCCC-CCCC"),
+                    RegistrationNumberDataModel(RegistrationNumberType.AGENT, MIN_REG_NUM),
+                ),
+                Arguments.of(
+                    Named.of("unexpected segmentation - none", "L99999999"),
+                    RegistrationNumberDataModel(RegistrationNumberType.LANDLORD, MAX_REG_NUM),
+                ),
+                Arguments.of(
+                    Named.of("unexpected segmentation - too much", "L-999-999-99"),
+                    RegistrationNumberDataModel(RegistrationNumberType.LANDLORD, MAX_REG_NUM),
+                ),
+                Arguments.of(
+                    Named.of("unexpected segmenting symbol", "L 9999 9999"),
+                    RegistrationNumberDataModel(RegistrationNumberType.LANDLORD, MAX_REG_NUM),
+                ),
+                Arguments.of(
+                    Named.of("unexpected case", "l-cccc-cccc"),
+                    RegistrationNumberDataModel(RegistrationNumberType.LANDLORD, MIN_REG_NUM),
+                ),
             )
 
         @JvmStatic
         fun provideNonParseableRegNumStrings() =
             listOf(
-                // Invalid registration number type
-                "9-9999-9999",
-                // Invalid registration number characters
-                "L-1111-1111",
-                "L-LLLL-LLLL",
-                // Invalid registration number length
-                "L-9999-9999-9",
-                "L-9999",
+                Named.of("invalid registration number type", "9-9999-9999"),
+                Named.of("invalid registration number characters - number not in charset", "L-1111-1111"),
+                Named.of("invalid registration number characters - letter not in charset", "L-LLLL-LLLL"),
+                Named.of("invalid registration number length - too long", "L-9999-9999-9"),
+                Named.of("invalid registration number length - too short", "L-9999"),
             )
 
         @JvmStatic
         fun provideRegNumsAndStrings() =
             listOf(
-                Arguments.of(RegistrationNumberDataModel(RegistrationNumberType.LANDLORD, MIN_REG_NUM), "L-CCCC-CCCC"),
-                Arguments.of(RegistrationNumberDataModel(RegistrationNumberType.PROPERTY, MAX_REG_NUM), "P-9999-9999"),
-                Arguments.of(RegistrationNumberDataModel(RegistrationNumberType.AGENT, MAX_REG_NUM), "A-9999-9999"),
+                Arguments.of(
+                    Named.of("LRN", RegistrationNumberDataModel(RegistrationNumberType.LANDLORD, MIN_REG_NUM)),
+                    "L-CCCC-CCCC",
+                ),
+                Arguments.of(
+                    Named.of("PRN", RegistrationNumberDataModel(RegistrationNumberType.PROPERTY, MAX_REG_NUM)),
+                    "P-9999-9999",
+                ),
+                Arguments.of(
+                    Named.of("ARN", RegistrationNumberDataModel(RegistrationNumberType.AGENT, MAX_REG_NUM)),
+                    "A-9999-9999",
+                ),
             )
     }
 
-    @ParameterizedTest
+    @ParameterizedTest(name = "{0}")
     @MethodSource("provideParseableStringsAndRegNums")
-    fun `parse returns a corresponding registration number data model`(
+    fun `parseTypeOrNull returns a corresponding registration number data model when given an`(
         parseableString: String,
         expectedRegNum: RegistrationNumberDataModel,
     ) {
-        assertEquals(RegistrationNumberDataModel.parse(parseableString), expectedRegNum)
+        assertEquals(RegistrationNumberDataModel.parseTypeOrNull(parseableString, expectedRegNum.type), expectedRegNum)
     }
 
-    @ParameterizedTest
+    @ParameterizedTest(name = "{0}")
     @MethodSource("provideNonParseableRegNumStrings")
-    fun `parse throws an illegal argument exception when given an invalid registration number`(nonParseableString: String) {
-        assertThrows<IllegalArgumentException> { RegistrationNumberDataModel.parse(nonParseableString) }
+    fun `parseTypeOrNull returns null when given an`(nonParseableString: String) {
+        val anyType = RegistrationNumberType.LANDLORD
+
+        assertNull(RegistrationNumberDataModel.parseTypeOrNull(nonParseableString, anyType))
     }
 
-    @ParameterizedTest
-    @MethodSource("provideRegNumsAndStrings")
-    fun `toString returns a correctly formatted registration number string`(
-        regNum: RegistrationNumberDataModel,
-        expectedString: String,
-    ) {
-        assertEquals(regNum.toString(), expectedString)
-    }
+    @Test
+    fun `parseTypeOrNull returns null when the given registration number is not of the given type`() {
+        val landlordRegNumString = "L-CCCC-CCCC"
 
-    @ParameterizedTest
-    @MethodSource("provideParseableStringsAndRegNums")
-    fun `parseOrNull returns a corresponding registration number data model`(
-        parseableString: String,
-        expectedRegNum: RegistrationNumberDataModel,
-    ) {
-        assertEquals(RegistrationNumberDataModel.parseOrNull(parseableString), expectedRegNum)
-    }
-
-    @ParameterizedTest
-    @MethodSource("provideNonParseableRegNumStrings")
-    fun `parseOrNull returns null when given an invalid registration number`(nonParseableString: String) {
-        assertNull(RegistrationNumberDataModel.parseOrNull(nonParseableString))
+        assertNull(RegistrationNumberDataModel.parseTypeOrNull(landlordRegNumString, RegistrationNumberType.PROPERTY))
     }
 
     @Test
@@ -99,5 +107,14 @@ class RegistrationNumberDataModelTests {
         val registrationNumberDataModel = RegistrationNumberDataModel.fromRegistrationNumber(registrationNumber)
 
         assertEquals(expectedRegNumDataModel, registrationNumberDataModel)
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("provideRegNumsAndStrings")
+    fun `toString returns a correctly formatted registration number string when given a`(
+        regNum: RegistrationNumberDataModel,
+        expectedString: String,
+    ) {
+        assertEquals(regNum.toString(), expectedString)
     }
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/LandlordViewModelTest.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/LandlordViewModelTest.kt
@@ -14,6 +14,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.MethodSource
 import org.junit.jupiter.params.provider.ValueSource
+import uk.gov.communities.prsdb.webapp.constants.enums.RegistrationNumberType
 import uk.gov.communities.prsdb.webapp.database.entity.Address
 import uk.gov.communities.prsdb.webapp.database.entity.RegistrationNumber
 import uk.gov.communities.prsdb.webapp.mockObjects.MockLandlordData
@@ -120,7 +121,8 @@ class LandlordViewModelTest {
     @Test
     fun `Landlord personal details shows the correct lrn`() {
         // Arrange
-        val registrationNumber = RegistrationNumberDataModel.parse("LGYTKPJRR")
+        val registrationNumber =
+            RegistrationNumberDataModel.parseTypeOrNull("LGYTKPJRR", RegistrationNumberType.LANDLORD)!!
         val testLandlord =
             MockLandlordData.createLandlord(
                 registrationNumber = RegistrationNumber(registrationNumber.type, registrationNumber.number),
@@ -130,7 +132,10 @@ class LandlordViewModelTest {
         val viewModel = LandlordViewModel(testLandlord)
 
         // Assert
-        val lrn = viewModel.personalDetails.single { it.fieldHeading == "landlordDetails.personalDetails.lrn" }.getConvertedFieldValue()
+        val lrn =
+            viewModel.personalDetails
+                .single { it.fieldHeading == "landlordDetails.personalDetails.lrn" }
+                .getConvertedFieldValue()
         assertEquals(lrn, registrationNumber.toString())
     }
 

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/LandlordServiceTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/LandlordServiceTests.kt
@@ -12,8 +12,11 @@ import org.mockito.Mockito.verify
 import org.mockito.internal.matchers.apachecommons.ReflectionEquals
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.kotlin.any
+import org.mockito.kotlin.never
 import org.mockito.kotlin.whenever
 import org.mockito.quality.Strictness
+import org.springframework.data.domain.Page
 import org.springframework.data.domain.PageImpl
 import org.springframework.data.domain.PageRequest
 import uk.gov.communities.prsdb.webapp.constants.enums.RegistrationNumberType
@@ -192,6 +195,56 @@ class LandlordServiceTests {
             )
 
         assertEquals(expectedFormattedSearchResults, searchResults.content)
+    }
+
+    @Test
+    fun `searchForLandlords returns no results when given a non-landlord registration number`() {
+        val searchQuery = "P-CCCC-CCCC"
+        val laUserBaseId = "laUserBaseId"
+        val currentPageNumber = 0
+        val pageSize = 25
+        val expectedPageRequest = PageRequest.of(currentPageNumber, pageSize)
+        val expectedSearchResults = emptyList<LandlordSearchResultDataModel>()
+
+        whenever(
+            mockLandlordRepository.searchMatching(searchQuery, laUserBaseId, pageable = expectedPageRequest),
+        ).thenReturn(Page.empty())
+
+        val searchResults =
+            landlordService.searchForLandlords(
+                searchQuery,
+                laUserBaseId,
+                currentPageNumber = currentPageNumber,
+                pageSize = pageSize,
+            )
+
+        verify(mockLandlordRepository, never()).searchMatchingLRN(any(), any(), any(), any())
+        assertEquals(expectedSearchResults, searchResults.content)
+    }
+
+    @Test
+    fun `searchForLandlords returns no results when given a query that has no LRN or fuzzy search matches`() {
+        val searchQuery = "non-matching query"
+        val laUserBaseId = "laUserBaseId"
+        val currentPageNumber = 0
+        val pageSize = 25
+        val expectedPageRequest = PageRequest.of(currentPageNumber, pageSize)
+        val expectedSearchResults = emptyList<LandlordSearchResultDataModel>()
+
+        whenever(
+            mockLandlordRepository.searchMatching(searchQuery, laUserBaseId, pageable = expectedPageRequest),
+        ).thenReturn(Page.empty())
+
+        val searchResults =
+            landlordService.searchForLandlords(
+                searchQuery,
+                laUserBaseId,
+                currentPageNumber = currentPageNumber,
+                pageSize = pageSize,
+            )
+
+        verify(mockLandlordRepository, never()).searchMatchingLRN(any(), any(), any(), any())
+        assertEquals(expectedSearchResults, searchResults.content)
     }
 
     @Test

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/LandlordServiceTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/LandlordServiceTests.kt
@@ -152,10 +152,16 @@ class LandlordServiceTests {
             expectedSearchResults.map { LandlordSearchResultDataModel.fromLandlord(it) }
 
         whenever(
-            mockLandlordRepository.searchMatching(searchQuery, laUserBaseId, expectedPageRequest),
+            mockLandlordRepository.searchMatching(searchQuery, laUserBaseId, pageable = expectedPageRequest),
         ).thenReturn(PageImpl(expectedSearchResults))
 
-        val searchResults = landlordService.searchForLandlords(searchQuery, laUserBaseId, currentPageNumber, pageSize)
+        val searchResults =
+            landlordService.searchForLandlords(
+                searchQuery,
+                laUserBaseId,
+                currentPageNumber = currentPageNumber,
+                pageSize = pageSize,
+            )
 
         assertEquals(expectedFormattedSearchResults, searchResults.content)
     }
@@ -174,10 +180,16 @@ class LandlordServiceTests {
             expectedSearchResults.map { LandlordSearchResultDataModel.fromLandlord(it) }
 
         whenever(
-            mockLandlordRepository.searchMatchingLRN(searchLRN, laUserBaseId, expectedPageRequest),
+            mockLandlordRepository.searchMatchingLRN(searchLRN, laUserBaseId, pageable = expectedPageRequest),
         ).thenReturn(PageImpl(expectedSearchResults))
 
-        val searchResults = landlordService.searchForLandlords(searchQuery, laUserBaseId, currentPageNumber, pageSize)
+        val searchResults =
+            landlordService.searchForLandlords(
+                searchQuery,
+                laUserBaseId,
+                currentPageNumber = currentPageNumber,
+                pageSize = pageSize,
+            )
 
         assertEquals(expectedFormattedSearchResults, searchResults.content)
     }
@@ -185,7 +197,7 @@ class LandlordServiceTests {
     @Test
     fun `searchForLandlords returns the requested page of LandlordSearchResultDataModels`() {
         val searchQuery = "query"
-        val laUserId = null
+        val laUserBaseId = "laUserBaseId"
         val pageSize = 25
 
         val landlordsFromRepository = mutableListOf<Landlord>()
@@ -205,13 +217,25 @@ class LandlordServiceTests {
         val expectedFormattedSearchResults2 =
             expectedSearchResults2.map { LandlordSearchResultDataModel.fromLandlord(it) }
 
-        whenever(mockLandlordRepository.searchMatching(searchQuery, laUserId, expectedPageRequest1))
+        whenever(mockLandlordRepository.searchMatching(searchQuery, laUserBaseId, pageable = expectedPageRequest1))
             .thenReturn(PageImpl(expectedSearchResults1))
-        whenever(mockLandlordRepository.searchMatching(searchQuery, laUserId, expectedPageRequest2))
+        whenever(mockLandlordRepository.searchMatching(searchQuery, laUserBaseId, pageable = expectedPageRequest2))
             .thenReturn(PageImpl(expectedSearchResults2))
 
-        val searchResults1 = landlordService.searchForLandlords(searchQuery, laUserId, pageNumber1, pageSize)
-        val searchResults2 = landlordService.searchForLandlords(searchQuery, laUserId, pageNumber2, pageSize)
+        val searchResults1 =
+            landlordService.searchForLandlords(
+                searchQuery,
+                laUserBaseId,
+                currentPageNumber = pageNumber1,
+                pageSize = pageSize,
+            )
+        val searchResults2 =
+            landlordService.searchForLandlords(
+                searchQuery,
+                laUserBaseId,
+                currentPageNumber = pageNumber2,
+                pageSize = pageSize,
+            )
 
         assertEquals(expectedFormattedSearchResults1, searchResults1.content)
         assertEquals(expectedFormattedSearchResults2, searchResults2.content)

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/LandlordServiceTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/LandlordServiceTests.kt
@@ -2,13 +2,9 @@ package uk.gov.communities.prsdb.webapp.services
 
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
-import org.junit.jupiter.api.Named
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.extension.ExtendWith
-import org.junit.jupiter.params.ParameterizedTest
-import org.junit.jupiter.params.provider.Arguments
-import org.junit.jupiter.params.provider.MethodSource
 import org.mockito.ArgumentCaptor.captor
 import org.mockito.InjectMocks
 import org.mockito.Mock
@@ -16,8 +12,6 @@ import org.mockito.Mockito.verify
 import org.mockito.internal.matchers.apachecommons.ReflectionEquals
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.junit.jupiter.MockitoSettings
-import org.mockito.kotlin.any
-import org.mockito.kotlin.eq
 import org.mockito.kotlin.whenever
 import org.mockito.quality.Strictness
 import org.springframework.data.domain.PageImpl
@@ -52,48 +46,6 @@ class LandlordServiceTests {
 
     @InjectMocks
     private lateinit var landlordService: LandlordService
-
-    companion object {
-        private val landlord = createLandlord()
-
-        @JvmStatic
-        fun provideRegNumsAndExpectedSearchResults() =
-            listOf(
-                Arguments.of(
-                    Named.of(
-                        "the registration number is valid",
-                        RegistrationNumberDataModel.fromRegistrationNumber(landlord.registrationNumber).toString(),
-                    ),
-                    listOf(LandlordSearchResultDataModel.fromLandlord(landlord)),
-                ),
-                Arguments.of(
-                    Named.of(
-                        "the registration number does not exist",
-                        RegistrationNumberDataModel
-                            .fromRegistrationNumber(
-                                RegistrationNumber(RegistrationNumberType.LANDLORD, 1L),
-                            ).toString(),
-                    ),
-                    emptyList<LandlordSearchResultDataModel>(),
-                ),
-                Arguments.of(
-                    Named.of(
-                        "the registration number is of the wrong type",
-                        RegistrationNumberDataModel
-                            .fromRegistrationNumber(RegistrationNumber(RegistrationNumberType.PROPERTY, 0L))
-                            .toString(),
-                    ),
-                    emptyList<LandlordSearchResultDataModel>(),
-                ),
-                Arguments.of(
-                    Named.of(
-                        "the registration number is not a registration number",
-                        "not a registration number",
-                    ),
-                    emptyList<LandlordSearchResultDataModel>(),
-                ),
-            )
-    }
 
     @Test
     fun `retrieveLandlordByRegNum returns a landlord given its registration number`() {
@@ -188,69 +140,80 @@ class LandlordServiceTests {
         assertTrue(ReflectionEquals(expectedLandlord, "id").matches(landlordCaptor.value))
     }
 
-    @ParameterizedTest(name = "when {0}")
-    @MethodSource("provideRegNumsAndExpectedSearchResults")
-    fun `searchForLandlords returns a corresponding list of LandlordSearchResultDataModels (LRN query)`(
-        registrationNumber: String,
-        expectedSearchResults: List<LandlordSearchResultDataModel>,
-    ) {
-        whenever(mockLandlordRepository.findByRegistrationNumber_Number(landlord.registrationNumber.number))
-            .thenReturn(landlord)
-
-        whenever(mockLandlordRepository.searchMatching(eq(registrationNumber), any()))
-            .thenReturn(PageImpl(emptyList<Landlord>()))
-
-        val searchResults = landlordService.searchForLandlords(registrationNumber)
-
-        assertEquals(expectedSearchResults, searchResults.content)
-    }
-
     @Test
     fun `searchForLandlords returns a corresponding list of LandlordSearchResultDataModels`() {
         val searchQuery = "query"
-        val maxEntriesOnPage = 25
-        val pageRequest = PageRequest.of(0, maxEntriesOnPage)
-        val matchingLandlords = listOf(createLandlord(), createLandlord(), createLandlord())
-        val expectedSearchResults = matchingLandlords.map { LandlordSearchResultDataModel.fromLandlord(it) }
+        val laUserBaseId = "laUserBaseId"
+        val currentPageNumber = 0
+        val pageSize = 25
+        val expectedPageRequest = PageRequest.of(currentPageNumber, pageSize)
+        val expectedSearchResults = listOf(createLandlord(), createLandlord())
+        val expectedFormattedSearchResults =
+            expectedSearchResults.map { LandlordSearchResultDataModel.fromLandlord(it) }
 
-        whenever(mockLandlordRepository.searchMatching(searchQuery, pageRequest)).thenReturn(PageImpl(matchingLandlords))
+        whenever(
+            mockLandlordRepository.searchMatching(searchQuery, laUserBaseId, expectedPageRequest),
+        ).thenReturn(PageImpl(expectedSearchResults))
 
-        val searchResults = landlordService.searchForLandlords(searchQuery, 0, maxEntriesOnPage)
+        val searchResults = landlordService.searchForLandlords(searchQuery, laUserBaseId, currentPageNumber, pageSize)
 
-        assertEquals(expectedSearchResults, searchResults.content)
+        assertEquals(expectedFormattedSearchResults, searchResults.content)
     }
 
     @Test
-    fun `searchForLandlords returns the request page of LandlordSearchResultDataModels`() {
+    fun `searchForLandlords returns a corresponding list of LandlordSearchResultDataModels (LRN query)`() {
+        val searchQuery = "L-CCCC-CCCC"
+        val searchLRN =
+            RegistrationNumberDataModel.parseTypeOrNull(searchQuery, RegistrationNumberType.LANDLORD)!!.number
+        val laUserBaseId = "laUserBaseId"
+        val currentPageNumber = 0
+        val pageSize = 25
+        val expectedPageRequest = PageRequest.of(currentPageNumber, pageSize)
+        val expectedSearchResults = listOf(createLandlord(), createLandlord())
+        val expectedFormattedSearchResults =
+            expectedSearchResults.map { LandlordSearchResultDataModel.fromLandlord(it) }
+
+        whenever(
+            mockLandlordRepository.searchMatchingLRN(searchLRN, laUserBaseId, expectedPageRequest),
+        ).thenReturn(PageImpl(expectedSearchResults))
+
+        val searchResults = landlordService.searchForLandlords(searchQuery, laUserBaseId, currentPageNumber, pageSize)
+
+        assertEquals(expectedFormattedSearchResults, searchResults.content)
+    }
+
+    @Test
+    fun `searchForLandlords returns the requested page of LandlordSearchResultDataModels`() {
         val searchQuery = "query"
-        val maxEntriesOnPage = 25
+        val laUserId = null
+        val pageSize = 25
 
         val landlordsFromRepository = mutableListOf<Landlord>()
         for (i in 1..40) {
             landlordsFromRepository.add(createLandlord())
         }
 
-        val pageRequest1 = PageRequest.of(0, maxEntriesOnPage)
-        val pageRequest2 = PageRequest.of(1, maxEntriesOnPage)
+        val pageNumber1 = 0
+        val expectedPageRequest1 = PageRequest.of(pageNumber1, pageSize)
+        val expectedSearchResults1 = landlordsFromRepository.subList(0, pageSize)
+        val expectedFormattedSearchResults1 =
+            expectedSearchResults1.map { LandlordSearchResultDataModel.fromLandlord(it) }
 
-        whenever(mockLandlordRepository.searchMatching(searchQuery, pageRequest1))
-            .thenReturn(PageImpl(landlordsFromRepository.subList(0, maxEntriesOnPage)))
-        whenever(mockLandlordRepository.searchMatching(searchQuery, pageRequest2))
-            .thenReturn(PageImpl(landlordsFromRepository.subList(maxEntriesOnPage, 40)))
+        val pageNumber2 = 1
+        val expectedPageRequest2 = PageRequest.of(pageNumber2, pageSize)
+        val expectedSearchResults2 = landlordsFromRepository.subList(pageSize, 40)
+        val expectedFormattedSearchResults2 =
+            expectedSearchResults2.map { LandlordSearchResultDataModel.fromLandlord(it) }
 
-        val expectedSearchResultsPage1 =
-            landlordsFromRepository
-                .subList(0, maxEntriesOnPage)
-                .map { LandlordSearchResultDataModel.fromLandlord(it) }
-        val expectedSearchResultsPage2 =
-            landlordsFromRepository
-                .subList(maxEntriesOnPage, 40)
-                .map { LandlordSearchResultDataModel.fromLandlord(it) }
+        whenever(mockLandlordRepository.searchMatching(searchQuery, laUserId, expectedPageRequest1))
+            .thenReturn(PageImpl(expectedSearchResults1))
+        whenever(mockLandlordRepository.searchMatching(searchQuery, laUserId, expectedPageRequest2))
+            .thenReturn(PageImpl(expectedSearchResults2))
 
-        val searchResults1 = landlordService.searchForLandlords(searchQuery, 0, maxEntriesOnPage)
-        val searchResults2 = landlordService.searchForLandlords(searchQuery, 1, maxEntriesOnPage)
+        val searchResults1 = landlordService.searchForLandlords(searchQuery, laUserId, pageNumber1, pageSize)
+        val searchResults2 = landlordService.searchForLandlords(searchQuery, laUserId, pageNumber2, pageSize)
 
-        assertEquals(expectedSearchResultsPage1, searchResults1.content)
-        assertEquals(expectedSearchResultsPage2, searchResults2.content)
+        assertEquals(expectedFormattedSearchResults1, searchResults1.content)
+        assertEquals(expectedFormattedSearchResults2, searchResults2.content)
     }
 }


### PR DESCRIPTION
- Creates `LandlordRepository` methods for searching by a LRN or query with an optional LA filter
- Updates `LandlordService.searchForLandlords()` to use these repository methods
- Updates the affected tests