### PR TITLE
Feat/prsd 658 local authority landlord record view integration tests

### DIFF
--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -298,6 +298,7 @@ landlordDetails.registeredProperties.table.registrationNumberHeading=Registratio
 landlordDetails.registeredProperties.table.licensingTypeHeading=Licensing type
 landlordDetails.registeredProperties.notLicensed.label=Not licensed
 
+
 forms.errorSummary.heading=There is a problem
 forms.errorMessage.prefix=Error:
 

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -298,7 +298,6 @@ landlordDetails.registeredProperties.table.registrationNumberHeading=Registratio
 landlordDetails.registeredProperties.table.licensingTypeHeading=Licensing type
 landlordDetails.registeredProperties.notLicensed.label=Not licensed
 
-
 forms.errorSummary.heading=There is a problem
 forms.errorMessage.prefix=Error:
 

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/LandlordDetailTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/LandlordDetailTests.kt
@@ -5,7 +5,6 @@ import com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.springframework.test.context.jdbc.Sql
-import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.InsetText
 import kotlin.test.assertEquals
 
 @Sql("/data-local.sql")
@@ -13,14 +12,14 @@ class LandlordDetailTests : IntegrationTest() {
     @Nested
     inner class LandlordDetailsView {
         @Test
-        fun `loading the landlord details page shows personal details`(page: Page) {
+        fun `the landlord details page loads with the landlords personal details tab selected by default`(page: Page) {
             val detailsPage = navigator.goToLandlordDetails()
 
             assertEquals(detailsPage.getActiveTabPanelId(), "personal-details")
         }
 
         @Test
-        fun `loading the landlord details page and selecting properties shows the registered properties`(page: Page) {
+        fun `loading the landlord details page and selecting properties shows the registered properties table`(page: Page) {
             val detailsPage = navigator.goToLandlordDetails()
 
             detailsPage.goToRegisteredProperties()
@@ -36,14 +35,14 @@ class LandlordDetailTests : IntegrationTest() {
     @Nested
     inner class LandlordDetailsLocalAuthorityView {
         @Test
-        fun `loading the landlord details page shows landlords personal details`(page: Page) {
+        fun `the landlord details page loads with the landlords personal details tab selected by default`(page: Page) {
             val detailsPage = navigator.goToLandlordDetailsAsALocalAuthorityUser(1)
 
             assertEquals(detailsPage.getActiveTabPanelId(), "personal-details")
         }
 
         @Test
-        fun `loading the landlord details page and selecting properties shows landlord's registered properties`(page: Page) {
+        fun `loading the landlord details page and selecting properties shows landlord's registered properties table`(page: Page) {
             val detailsPage = navigator.goToLandlordDetailsAsALocalAuthorityUser(1)
 
             detailsPage.goToRegisteredProperties()
@@ -59,9 +58,8 @@ class LandlordDetailTests : IntegrationTest() {
         @Test
         fun `loading the landlord details page shows the last time the landlords record was updated`(page: Page) {
             val detailsPage = navigator.goToLandlordDetailsAsALocalAuthorityUser(1)
-            val insetText = InsetText(detailsPage.page)
 
-            assertThat(insetText.spanText).containsText("updated these details on")
+            assertThat(detailsPage.insetText.spanText).containsText("updated these details on")
         }
     }
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/LandlordDetailTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/LandlordDetailTests.kt
@@ -40,8 +40,6 @@ class LandlordDetailTests : IntegrationTest() {
             val detailsPage = navigator.goToLandlordDetailsAsALocalAuthorityUser(1)
 
             assertEquals(detailsPage.getActiveTabPanelId(), "personal-details")
-            val insetText = InsetText(page)
-            assertThat(insetText.spanText).containsText("updated these details on")
         }
 
         @Test

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/LandlordDetailTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/LandlordDetailTests.kt
@@ -1,25 +1,69 @@
 package uk.gov.communities.prsdb.webapp.integration
 
 import com.microsoft.playwright.Page
+import com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.springframework.test.context.jdbc.Sql
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.InsetText
 import kotlin.test.assertEquals
 
 @Sql("/data-local.sql")
 class LandlordDetailTests : IntegrationTest() {
-    @Test
-    fun `loading the landlord details page shows personal details`(page: Page) {
-        val detailsPage = navigator.goToLandlordDetails()
+    @Nested
+    inner class LandlordDetailsView {
+        @Test
+        fun `loading the landlord details page shows personal details`(page: Page) {
+            val detailsPage = navigator.goToLandlordDetails()
 
-        assertEquals(detailsPage.getActiveTabPanelId(), "personal-details")
+            assertEquals(detailsPage.getActiveTabPanelId(), "personal-details")
+        }
+
+        @Test
+        fun `loading the landlord details page and selecting properties shows the registered properties`(page: Page) {
+            val detailsPage = navigator.goToLandlordDetails()
+
+            detailsPage.goToRegisteredProperties()
+
+            assertEquals(detailsPage.getActiveTabPanelId(), "registered-properties")
+            assertThat(detailsPage.table.getHeaderCell(0)).containsText("Property address")
+            assertThat(detailsPage.table.getHeaderCell(1)).containsText("Local authority")
+            assertThat(detailsPage.table.getHeaderCell(2)).containsText("Property licence")
+            assertThat(detailsPage.table.getHeaderCell(3)).containsText("Tenanted")
+        }
     }
 
-    @Test
-    fun `loading the landlord details page and selecting properties shows the registered properties`(page: Page) {
-        val detailsPage = navigator.goToLandlordDetails()
+    @Nested
+    inner class LandlordDetailsLocalAuthorityView {
+        @Test
+        fun `loading the landlord details page shows landlords personal details`(page: Page) {
+            val detailsPage = navigator.goToLandlordDetailsAsALocalAuthorityUser(1)
 
-        detailsPage.goToRegisteredProperties()
+            assertEquals(detailsPage.getActiveTabPanelId(), "personal-details")
+            val insetText = InsetText(page)
+            assertThat(insetText.spanText).containsText("updated these details on")
+        }
 
-        assertEquals(detailsPage.getActiveTabPanelId(), "registered-properties")
+        @Test
+        fun `loading the landlord details page and selecting properties shows landlord's registered properties`(page: Page) {
+            val detailsPage = navigator.goToLandlordDetailsAsALocalAuthorityUser(1)
+
+            detailsPage.goToRegisteredProperties()
+
+            assertEquals(detailsPage.getActiveTabPanelId(), "registered-properties")
+            assertThat(detailsPage.table.getHeaderCell(0)).containsText("Property address")
+            assertThat(detailsPage.table.getHeaderCell(1)).containsText("Registration number")
+            assertThat(detailsPage.table.getHeaderCell(2)).containsText("Local authority")
+            assertThat(detailsPage.table.getHeaderCell(3)).containsText("Licensing type")
+            assertThat(detailsPage.table.getHeaderCell(4)).containsText("Tenanted")
+        }
+
+        @Test
+        fun `loading the landlord details page shows the last time the landlords record was updated`(page: Page) {
+            val detailsPage = navigator.goToLandlordDetailsAsALocalAuthorityUser(1)
+            val insetText = InsetText(detailsPage.page)
+
+            assertThat(insetText.spanText).containsText("updated these details on")
+        }
     }
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/Navigator.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/Navigator.kt
@@ -369,5 +369,10 @@ class Navigator(
         return createValidPage(page, LandlordDetailsPage::class)
     }
 
+    fun goToLandlordDetailsAsALocalAuthorityUser(id: Long): LandlordDetailsPage {
+        navigate("landlord-details/$id")
+        return createValidPage(page, LandlordDetailsPage::class)
+    }
+
     private fun navigate(path: String): Response? = page.navigate("http://localhost:$port/$path")
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/Navigator.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/Navigator.kt
@@ -14,6 +14,7 @@ import uk.gov.communities.prsdb.webapp.forms.steps.LandlordRegistrationStepId
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.ErrorPage
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.InviteNewLaUserPage
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.LandlordDetailsPage
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.LocalAuthorityViewLandlordDetailsPage
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.ManageLaUsersPage
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.SearchLandlordRegisterPage
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages.BasePage.Companion.createValidPage
@@ -369,9 +370,9 @@ class Navigator(
         return createValidPage(page, LandlordDetailsPage::class)
     }
 
-    fun goToLandlordDetailsAsALocalAuthorityUser(id: Long): LandlordDetailsPage {
+    fun goToLandlordDetailsAsALocalAuthorityUser(id: Long): LocalAuthorityViewLandlordDetailsPage {
         navigate("landlord-details/$id")
-        return createValidPage(page, LandlordDetailsPage::class)
+        return createValidPage(page, LocalAuthorityViewLandlordDetailsPage::class)
     }
 
     private fun navigate(path: String): Response? = page.navigate("http://localhost:$port/$path")

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/components/InsetText.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/components/InsetText.kt
@@ -1,0 +1,11 @@
+package uk.gov.communities.prsdb.webapp.integration.pageObjects.components
+
+import com.microsoft.playwright.Locator
+import com.microsoft.playwright.Page
+
+class InsetText(
+    private val page: Page,
+    locator: Locator = page.locator(".govuk-inset-text"),
+) : BaseComponent(locator) {
+    val spanText = getChildComponent("span")
+}

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/LandlordDetailsPage.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/LandlordDetailsPage.kt
@@ -1,6 +1,7 @@
 package uk.gov.communities.prsdb.webapp.integration.pageObjects.pages
 
 import com.microsoft.playwright.Page
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.Table
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.Tabs
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages.BasePage
 
@@ -8,6 +9,7 @@ class LandlordDetailsPage(
     page: Page,
 ) : BasePage(page, "/landlord-details") {
     val tabs = Tabs(page, 2)
+    val table = Table(page)
 
     fun getActiveTabPanelId() = tabs.getActiveTabPanelId()
 

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/LocalAuthorityViewLandlordDetailsPage.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/LocalAuthorityViewLandlordDetailsPage.kt
@@ -1,8 +1,11 @@
 package uk.gov.communities.prsdb.webapp.integration.pageObjects.pages
 
 import com.microsoft.playwright.Page
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.InsetText
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages.LandlordDetailsBasePage
 
-class LandlordDetailsPage(
+class LocalAuthorityViewLandlordDetailsPage(
     page: Page,
-) : LandlordDetailsBasePage(page, "/landlord-details")
+) : LandlordDetailsBasePage(page, "/landlord-details") {
+    val insetText = InsetText(page)
+}

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/basePages/LandlordDetailsBasePage.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/basePages/LandlordDetailsBasePage.kt
@@ -1,0 +1,19 @@
+package uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages
+
+import com.microsoft.playwright.Page
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.Table
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.Tabs
+
+abstract class LandlordDetailsBasePage(
+    page: Page,
+    urlSegment: String,
+) : BasePage(page, urlSegment) {
+    val tabs = Tabs(page, 2)
+    val table = Table(page)
+
+    fun getActiveTabPanelId() = tabs.getActiveTabPanelId()
+
+    fun goToRegisteredProperties() {
+        tabs.goToTab("Registered properties")
+    }
+}


### PR DESCRIPTION
There are the integration tests for the Local Authority View for the Landlord Record page (testing the landlord's personal details (PRSD-656) and the registered properties tabs)

I've added explicit testing of the headings of the Registered Property Table and the contents of the Inset Text.
I haven't added explicit tests for the Summary Rows as they are covered by tests in `LandlordViewModelTest`.
I have also added tests for the headings of the Registered Property Table on the Landlord Record view as seen by the landlord themselves