### PR TITLE
chore/PRSD-NONE-rename-RegisteredPropertyDataModel-to-RegisteredPrope…

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/RegisteredPropertyViewModel.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/RegisteredPropertyViewModel.kt
@@ -1,11 +1,12 @@
-package uk.gov.communities.prsdb.webapp.models.dataModels
+package uk.gov.communities.prsdb.webapp.models.viewModels
 
 import uk.gov.communities.prsdb.webapp.constants.enums.LicensingType
 import uk.gov.communities.prsdb.webapp.database.entity.License
 import uk.gov.communities.prsdb.webapp.database.entity.PropertyOwnership
 import uk.gov.communities.prsdb.webapp.helpers.converters.MessageKeyConverter
+import uk.gov.communities.prsdb.webapp.models.dataModels.RegistrationNumberDataModel
 
-data class RegisteredPropertyDataModel(
+data class RegisteredPropertyViewModel(
     val address: String,
     val registrationNumber: String,
     val localAuthorityName: String,
@@ -13,8 +14,8 @@ data class RegisteredPropertyDataModel(
     val isTenantedMessageKey: String,
 ) {
     companion object {
-        fun fromPropertyOwnership(propertyOwnership: PropertyOwnership): RegisteredPropertyDataModel =
-            RegisteredPropertyDataModel(
+        fun fromPropertyOwnership(propertyOwnership: PropertyOwnership): RegisteredPropertyViewModel =
+            RegisteredPropertyViewModel(
                 address = propertyOwnership.property.address.singleLineAddress,
                 registrationNumber =
                     RegistrationNumberDataModel

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/PropertyOwnershipService.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/PropertyOwnershipService.kt
@@ -13,7 +13,7 @@ import uk.gov.communities.prsdb.webapp.database.entity.License
 import uk.gov.communities.prsdb.webapp.database.entity.Property
 import uk.gov.communities.prsdb.webapp.database.entity.PropertyOwnership
 import uk.gov.communities.prsdb.webapp.database.repository.PropertyOwnershipRepository
-import uk.gov.communities.prsdb.webapp.models.dataModels.RegisteredPropertyDataModel
+import uk.gov.communities.prsdb.webapp.models.viewModels.RegisteredPropertyViewModel
 
 @Service
 class PropertyOwnershipService(
@@ -50,14 +50,14 @@ class PropertyOwnershipService(
         )
     }
 
-    fun getRegisteredPropertiesForLandlord(baseUserId: String): List<RegisteredPropertyDataModel> =
+    fun getRegisteredPropertiesForLandlord(baseUserId: String): List<RegisteredPropertyViewModel> =
         retrieveAllRegisteredPropertiesForLandlord(baseUserId).map { propertyOwnership ->
-            RegisteredPropertyDataModel.fromPropertyOwnership(propertyOwnership)
+            RegisteredPropertyViewModel.fromPropertyOwnership(propertyOwnership)
         }
 
-    fun getRegisteredPropertiesForLandlord(landlordId: Long): List<RegisteredPropertyDataModel> =
+    fun getRegisteredPropertiesForLandlord(landlordId: Long): List<RegisteredPropertyViewModel> =
         retrieveAllRegisteredPropertiesForLandlord(landlordId).map { propertyOwnership ->
-            RegisteredPropertyDataModel.fromPropertyOwnership(propertyOwnership)
+            RegisteredPropertyViewModel.fromPropertyOwnership(propertyOwnership)
         }
 
     fun retrievePropertyOwnership(id: Long): PropertyOwnership? = propertyOwnershipRepository.findByIdOrNull(id)

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/RegisteredPropertyViewModelTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/RegisteredPropertyViewModelTests.kt
@@ -1,4 +1,4 @@
-package uk.gov.communities.prsdb.webapp.models.dataModels
+package uk.gov.communities.prsdb.webapp.models.viewModels
 
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
@@ -12,10 +12,11 @@ import uk.gov.communities.prsdb.webapp.database.entity.RegistrationNumber
 import uk.gov.communities.prsdb.webapp.mockObjects.MockLandlordData.Companion.createAddress
 import uk.gov.communities.prsdb.webapp.mockObjects.MockLandlordData.Companion.createProperty
 import uk.gov.communities.prsdb.webapp.mockObjects.MockLandlordData.Companion.createPropertyOwnership
+import uk.gov.communities.prsdb.webapp.models.dataModels.RegistrationNumberDataModel
 
-class RegisteredPropertyDataModelTests {
+class RegisteredPropertyViewModelTests {
     @Test
-    fun `Returns a RegisteredPropertyDataModel from a PropertyOwnership`() {
+    fun `Returns a RegisteredPropertyViewModel from a PropertyOwnership`() {
         val address = "11 Example Road, EG1 2AB"
         val registrationNumber = RegistrationNumber(RegistrationNumberType.PROPERTY, 1233456)
         val localAuthority = LocalAuthority(11, "DERBYSHIRE DALES DISTRICT COUNCIL", "1045")
@@ -39,8 +40,8 @@ class RegisteredPropertyDataModelTests {
                 currentNumTenants = 0,
             )
 
-        val expectedRegisteredPropertyDataModel =
-            RegisteredPropertyDataModel(
+        val expectedRegisteredPropertyViewModel =
+            RegisteredPropertyViewModel(
                 address,
                 expectedRegistrationNumber,
                 expectedLocalAuthority,
@@ -48,9 +49,9 @@ class RegisteredPropertyDataModelTests {
                 expectedIsTenantedMessageKey,
             )
 
-        val result = RegisteredPropertyDataModel.fromPropertyOwnership(propertyOwnership)
+        val result = RegisteredPropertyViewModel.fromPropertyOwnership(propertyOwnership)
 
-        assertEquals(expectedRegisteredPropertyDataModel, result)
+        assertEquals(expectedRegisteredPropertyViewModel, result)
     }
 
     @ParameterizedTest
@@ -65,7 +66,7 @@ class RegisteredPropertyDataModelTests {
     ) {
         val propertyOwnership = createPropertyOwnership(currentNumTenants = currentNumTenants)
 
-        val result = RegisteredPropertyDataModel.fromPropertyOwnership(propertyOwnership)
+        val result = RegisteredPropertyViewModel.fromPropertyOwnership(propertyOwnership)
 
         assertEquals(result.isTenantedMessageKey, expectedMessageKey)
     }
@@ -85,7 +86,7 @@ class RegisteredPropertyDataModelTests {
 
         val propertyOwnership = createPropertyOwnership(license = licence)
 
-        val result = RegisteredPropertyDataModel.fromPropertyOwnership(propertyOwnership)
+        val result = RegisteredPropertyViewModel.fromPropertyOwnership(propertyOwnership)
 
         assertEquals(result.propertyLicence, expectedDisplayName)
     }
@@ -94,7 +95,7 @@ class RegisteredPropertyDataModelTests {
     fun `Returns correct licensing display name for property with no licence`() {
         val propertyOwnership = createPropertyOwnership(license = null)
 
-        val result = RegisteredPropertyDataModel.fromPropertyOwnership(propertyOwnership)
+        val result = RegisteredPropertyViewModel.fromPropertyOwnership(propertyOwnership)
 
         assertEquals(result.propertyLicence, "Not Licenced")
     }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/PropertyOwnershipServiceTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/PropertyOwnershipServiceTests.kt
@@ -29,8 +29,8 @@ import uk.gov.communities.prsdb.webapp.mockObjects.MockLandlordData.Companion.cr
 import uk.gov.communities.prsdb.webapp.mockObjects.MockLandlordData.Companion.createLandlord
 import uk.gov.communities.prsdb.webapp.mockObjects.MockLandlordData.Companion.createProperty
 import uk.gov.communities.prsdb.webapp.mockObjects.MockLandlordData.Companion.createPropertyOwnership
-import uk.gov.communities.prsdb.webapp.models.dataModels.RegisteredPropertyDataModel
 import uk.gov.communities.prsdb.webapp.models.dataModels.RegistrationNumberDataModel
+import uk.gov.communities.prsdb.webapp.models.viewModels.RegisteredPropertyViewModel
 
 @ExtendWith(MockitoExtension::class)
 class PropertyOwnershipServiceTests {
@@ -174,16 +174,16 @@ class PropertyOwnershipServiceTests {
         private val landlordsProperties: List<PropertyOwnership> =
             listOf(propertyOwnership1, propertyOwnership2)
 
-        private val expectedResults: List<RegisteredPropertyDataModel> =
+        private val expectedResults: List<RegisteredPropertyViewModel> =
             listOf(
-                RegisteredPropertyDataModel(
+                RegisteredPropertyViewModel(
                     address1,
                     expectedRegistrationNumber,
                     expectedLocalAuthority,
                     expectedPropertyLicence,
                     expectedIsTenantedMessageKey,
                 ),
-                RegisteredPropertyDataModel(
+                RegisteredPropertyViewModel(
                     address2,
                     expectedRegistrationNumber,
                     expectedLocalAuthority,


### PR DESCRIPTION
…rtyViewModel
This PR renames `RegisteredPropertyDataModel` to `RegisteredPropertyViewModel` a decision from this [comment](https://github.com/communitiesuk/prsdb-webapp/pull/152#discussion_r1928380705) thread on a PR 152 local authority of view landlord's details.

In this PR both the related test file name is updated, both files have been moved into their respective `viewModel` folders and references to `RegisteredPropertyDataModel` have been updated to `RegisteredPropertyViewModel`
