### PR TITLE
Fix Hibernate startup warnings about LocalAuthorityUserOrInvitation#CompositeKey

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/database/entity/LocalAuthorityUserOrInvitation.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/database/entity/LocalAuthorityUserOrInvitation.kt
@@ -8,15 +8,20 @@ import jakarta.persistence.IdClass
 import jakarta.persistence.JoinColumn
 import jakarta.persistence.ManyToOne
 import jakarta.persistence.Table
+import java.io.Serializable
 
 @Entity
 @Table(name = "local_authority_user_or_invitation")
 @IdClass(LocalAuthorityUserOrInvitation.CompositeKey::class)
 class LocalAuthorityUserOrInvitation() {
+    // Types used for IdClass must:
+    // - implement equals and hashCode (hence being a data class)
+    // - have a no-args constructor (hence having default values)
+    // - be serializable
     data class CompositeKey(
         val id: Long = 0,
         val entityType: String = "",
-    )
+    ) : Serializable
 
     @Id
     var id: Long = 0

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/database/entity/LocalAuthorityUserOrInvitation.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/database/entity/LocalAuthorityUserOrInvitation.kt
@@ -13,10 +13,10 @@ import jakarta.persistence.Table
 @Table(name = "local_authority_user_or_invitation")
 @IdClass(LocalAuthorityUserOrInvitation.CompositeKey::class)
 class LocalAuthorityUserOrInvitation() {
-    class CompositeKey {
-        val id: Long = 0
-        val entityType: String = ""
-    }
+    data class CompositeKey(
+        val id: Long = 0,
+        val entityType: String = "",
+    )
 
     @Id
     var id: Long = 0


### PR DESCRIPTION
I noticed that when starting the Spring app it logs the following warnings:
> HHH000038: Composite-id class does not override equals(): uk.gov.communities.prsdb.webapp.database.entity.LocalAuthorityUserOrInvitation$CompositeKey
HHH000039: Composite-id class does not override hashCode(): uk.gov.communities.prsdb.webapp.database.entity.LocalAuthorityUserOrInvitation$CompositeKey

Turns out the JPA spec requires that ID classes implement equals and hashCode, so I've turned CompositeKey into a data class to generate those methods. The spec also requires that ID classes are Serializable - I'm not really sure why, and we weren't getting warnings about that, but I've also made it Serializable just in case!