### PR TITLE
feat/PRSD-658 add link for property page to addresses

### DIFF
--- a/src/main/resources/templates/localAuthorityLandlordDetailsView.html
+++ b/src/main/resources/templates/localAuthorityLandlordDetailsView.html
@@ -45,7 +45,9 @@
                     ">
                             <tbody class="govuk-table__body">
                             <tr class="govuk_table__row" th:each="property: ${registeredPropertiesList}">
-                                <td class="govuk-table__cell" th:text="${property.address}"></td>
+                                <td class="govuk-table__cell">
+                                    <a class="govuk-link" th:text="${property.address}" href="/">${property.address}</a>
+                                </td>
                                 <td class="govuk-table__cell" th:text="${property.registrationNumber}"></td>
                                 <td class="govuk-table__cell" th:text="${property.localAuthorityName}"></td>
                                 <td class="govuk-table__cell" th:text="${property.propertyLicence}"></td>


### PR DESCRIPTION
The addresses on the registered properties page should all have links that will redirect to their individual pages (but for now will redirect to their home pages).

This PR adds those links for the local authority view of the landlord's details page.

This is following QA on PRSD-658 and this [comment](https://mhclgdigital.atlassian.net/browse/PRSD-658?focusedCommentId=641827).