### PR TITLE
PRSD-596: fix "Sign in..." link

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/PropertyRegistrationJourney.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/PropertyRegistrationJourney.kt
@@ -560,7 +560,7 @@ class PropertyRegistrationJourney(
                     )
 
                 // TODO PRSD-670: Replace with a link to the dashboard page
-                val prsdUrl = "www.example.com"
+                val prsdUrl = "https://example.com"
 
                 confirmationEmailSender.sendEmail(
                     landlordService.retrieveLandlordByBaseUserId(baseUserId)!!.email,

--- a/src/main/resources/emails/PropertyRegistrationConfirmation.md
+++ b/src/main/resources/emails/PropertyRegistrationConfirmation.md
@@ -1,6 +1,6 @@
 # You have registered a property on the Private Rented Property Database.
 
-[Sign into database](((prsd url))) to view or update these properties.
+[Sign into the database](((prsd url))) to view or update these properties.
 
 ## You registered:
 

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/PropertyRegistrationJourneyTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/PropertyRegistrationJourneyTests.kt
@@ -177,7 +177,7 @@ class PropertyRegistrationJourneyTests : IntegrationTest() {
         //  check confirmation email
         verify(confirmationEmailSender).sendEmail(
             "alex.surname@example.com",
-            PropertyRegistrationConfirmationEmail(expectedPropertyRegNum.toString(), "1, Example Road, EG1 2AB", "www.example.com"),
+            PropertyRegistrationConfirmationEmail(expectedPropertyRegNum.toString(), "1, Example Road, EG1 2AB", "https://example.com"),
         )
 
         // Confirmation - render page


### PR DESCRIPTION
Fixes a typo, also changes the link so that it hopefully renders correctly in emails

(The www. version was showing next to the text for Kiran, rather than as a hyperlink)