### PR TITLE
PRSD-600: Don't diplay absent links

### DIFF
--- a/src/main/resources/templates/fragments/taskList/taskListItem.html
+++ b/src/main/resources/templates/fragments/taskList/taskListItem.html
@@ -1,7 +1,7 @@
 
 <li th:fragment="taskListItem(task, id)"  class="govuk-task-list__item" th:classappend="${task.url != null} ? 'govuk-task-list__item--with-link' : ''">
     <div class="govuk-task-list__name-and-hint">
-        <a class="govuk-link" th:classappend="${task.url != null} ? 'govuk-task-list__link' : ''"
+        <a class="govuk-link 'govuk-task-list__link" th:remove="${task.url == null} ? tag : none"
            th:href="${task.url}"
            th:text="#{${task.nameKey}}"
            th:aria-describedby="${id}">

--- a/src/main/resources/templates/fragments/taskList/taskListItem.html
+++ b/src/main/resources/templates/fragments/taskList/taskListItem.html
@@ -1,7 +1,7 @@
 
 <li th:fragment="taskListItem(task, id)"  class="govuk-task-list__item" th:classappend="${task.url != null} ? 'govuk-task-list__item--with-link' : ''">
     <div class="govuk-task-list__name-and-hint">
-        <a class="govuk-link 'govuk-task-list__link" th:remove="${task.url == null} ? tag : none"
+        <a class="govuk-link govuk-task-list__link" th:remove="${task.url == null} ? tag : none"
            th:href="${task.url}"
            th:text="#{${task.nameKey}}"
            th:aria-describedby="${id}">


### PR DESCRIPTION
The names of "Cannot start yet" tasks should not display as links.

![image](https://github.com/user-attachments/assets/029cf677-d34c-4914-b61a-3716652d8899)
