### PR TITLE
PRSD-NONE: Store address data within the journey data

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/AddressDataService.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/AddressDataService.kt
@@ -3,28 +3,30 @@ package uk.gov.communities.prsdb.webapp.services
 import jakarta.servlet.http.HttpSession
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
-import org.springframework.context.annotation.Scope
-import org.springframework.context.annotation.ScopedProxyMode
 import org.springframework.stereotype.Service
-import org.springframework.web.context.WebApplicationContext
 import uk.gov.communities.prsdb.webapp.forms.journeys.objectToStringKeyedMap
 import uk.gov.communities.prsdb.webapp.models.dataModels.AddressDataModel
 
 @Service
-@Scope(value = WebApplicationContext.SCOPE_REQUEST, proxyMode = ScopedProxyMode.TARGET_CLASS)
 class AddressDataService(
     private val session: HttpSession,
+    private val journeyDataService: JourneyDataService,
 ) {
-    fun getAddressData(singleLineAddress: String): AddressDataModel? =
-        Json.decodeFromString<Map<String, AddressDataModel>>(
-            session.getAttribute("addressData").toString(),
-        )[singleLineAddress]
+    fun getAddressData(singleLineAddress: String): AddressDataModel? {
+        val journeyData = journeyDataService.getJourneyDataFromSession()
+        val addressData = journeyData["address-data"] as String?
+        if (addressData == null) {
+            return null
+        } else {
+            return Json.decodeFromString<Map<String, AddressDataModel>>(addressData)[singleLineAddress]
+        }
+    }
 
-    fun setAddressData(addressDataList: List<AddressDataModel>) =
-        session.setAttribute(
-            "addressData",
-            Json.encodeToString(addressDataList.associateBy { it.singleLineAddress }),
-        )
+    fun setAddressData(addressDataList: List<AddressDataModel>) {
+        val journeyData = journeyDataService.getJourneyDataFromSession()
+        journeyData["address-data"] = Json.encodeToString(addressDataList.associateBy { it.singleLineAddress })
+        journeyDataService.setJourneyData(journeyData)
+    }
 
     fun getCachedAddressRegisteredResult(uprn: Long): Boolean? {
         val cachedResults = objectToStringKeyedMap(session.getAttribute("addressRegisteredResults")) ?: mutableMapOf()


### PR DESCRIPTION
When we search for addresses using postcode and house name/number we get a list of addresses which we are currently separately caching in the session. This change instead stores it in journey data (still in the session) so that when we save the journey data to the database it will be persisted. 