### PR TITLE
PRSD-NONE: Uses reflection to set mock landlord createdDate

### DIFF
--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/mockObjects/MockLandlordData.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/mockObjects/MockLandlordData.kt
@@ -1,7 +1,5 @@
 package uk.gov.communities.prsdb.webapp.mockObjects
 
-import org.mockito.Mockito.mock
-import org.mockito.kotlin.whenever
 import org.springframework.test.util.ReflectionTestUtils
 import uk.gov.communities.prsdb.webapp.constants.enums.LandlordType
 import uk.gov.communities.prsdb.webapp.constants.enums.OccupancyType
@@ -39,19 +37,21 @@ class MockLandlordData {
             registrationNumber: RegistrationNumber = RegistrationNumber(RegistrationNumberType.LANDLORD, 0L),
             internationalAddress: String? = null,
             dateOfBirth: LocalDate? = null,
-            createdAt: Instant = Instant.now(),
+            createdDate: Instant = Instant.now(),
         ): Landlord {
-            val landlord: Landlord = mock()
-            whenever(landlord.baseUser).thenReturn(baseUser)
-            whenever(landlord.name).thenReturn(name)
-            whenever(landlord.email).thenReturn(email)
-            whenever(landlord.phoneNumber).thenReturn(phoneNumber)
-            whenever(landlord.address).thenReturn(address)
-            whenever(landlord.registrationNumber).thenReturn(registrationNumber)
-            whenever(landlord.dateOfBirth).thenReturn(dateOfBirth)
-            whenever(landlord.lastModifiedDate).thenReturn(Instant.now())
-            whenever(landlord.internationalAddress).thenReturn(internationalAddress)
-            whenever(landlord.createdDate).thenReturn(createdAt)
+            val landlord =
+                Landlord(
+                    baseUser = baseUser,
+                    name = name,
+                    email = email,
+                    phoneNumber = phoneNumber,
+                    address = address,
+                    registrationNumber = registrationNumber,
+                    internationalAddress = internationalAddress,
+                    dateOfBirth = dateOfBirth,
+                )
+
+            ReflectionTestUtils.setField(landlord, "createdDate", createdDate)
 
             return landlord
         }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/LandlordViewModelTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/LandlordViewModelTests.kt
@@ -103,7 +103,7 @@ class LandlordViewModelTests {
         // Arrange
         val testLandlord =
             MockLandlordData.createLandlord(
-                createdAt = OffsetDateTime.ofInstant(instant.toJavaInstant(), ZoneId.of(timeZoneID)).toInstant(),
+                createdDate = OffsetDateTime.ofInstant(instant.toJavaInstant(), ZoneId.of(timeZoneID)).toInstant(),
             )
 
         // Act

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/LandlordServiceTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/LandlordServiceTests.kt
@@ -11,11 +11,9 @@ import org.mockito.Mock
 import org.mockito.Mockito.verify
 import org.mockito.internal.matchers.apachecommons.ReflectionEquals
 import org.mockito.junit.jupiter.MockitoExtension
-import org.mockito.junit.jupiter.MockitoSettings
 import org.mockito.kotlin.any
 import org.mockito.kotlin.never
 import org.mockito.kotlin.whenever
-import org.mockito.quality.Strictness
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.PageImpl
 import org.springframework.data.domain.PageRequest
@@ -35,7 +33,6 @@ import uk.gov.communities.prsdb.webapp.models.viewModels.LandlordSearchResultVie
 import kotlin.test.assertNull
 
 @ExtendWith(MockitoExtension::class)
-@MockitoSettings(strictness = Strictness.LENIENT)
 class LandlordServiceTests {
     @Mock
     private lateinit var mockLandlordRepository: LandlordRepository


### PR DESCRIPTION
- This avoids 'unnecessary stubbings' errors