### PR TITLE
Feat/prsd 719 655 integration tests

### DIFF
--- a/src/main/resources/data-local.sql
+++ b/src/main/resources/data-local.sql
@@ -195,6 +195,7 @@ SELECT setval(pg_get_serial_sequence('property', 'id'), (SELECT MAX(id) FROM pro
 
 INSERT INTO license (id, license_type, license_number)
 VALUES (1, 1, 'L12345678');
+SELECT setval(pg_get_serial_sequence('license', 'id'), (SELECT MAX(id) FROM license));
 
 INSERT INTO property_ownership (id, is_active, occupancy_type, landlord_type, ownership_type, current_num_households,
                                 current_num_tenants,

--- a/src/main/resources/data-local.sql
+++ b/src/main/resources/data-local.sql
@@ -193,15 +193,18 @@ VALUES (1, 1, true, 1, 6),
 
 SELECT setval(pg_get_serial_sequence('property', 'id'), (SELECT MAX(id) FROM property));
 
+INSERT INTO license (id, license_type, license_number)
+VALUES (1, 1, 'L12345678');
+
 INSERT INTO property_ownership (id, is_active, occupancy_type, landlord_type, ownership_type, current_num_households,
                                 current_num_tenants,
-                                registration_number_id, primary_landlord_id, property_id, created_date)
-VALUES (1, true, 0, 0, 1, 1, 2, 6, 1, 1, '01/15/25'),
-       (2, false, 0, 0, 1, 1, 2, 34, 2, 2, '01/15/25'),
-       (3, true, 0, 0, 1, 1, 2, 35, 4, 3, '01/15/25'),
-       (4, true, 0, 0, 1, 1, 2, 36, 1, 4, '01/15/25'),
-       (5, true, 0, 0, 1, 1, 2, 37, 1, 5, '01/15/25'),
-       (6, false, 0, 0, 1, 1, 2, 38, 1, 6, '01/15/25'),
-       (7, true, 0, 0, 1, 0, 0, 39, 1, 7, '02/02/25');
+                                registration_number_id, primary_landlord_id, property_id, created_date, license_id)
+VALUES (1, true, 0, 0, 1, 1, 2, 6, 1, 1, '01/15/25', null),
+       (2, false, 0, 0, 1, 1, 2, 34, 2, 2, '01/15/25', null),
+       (3, true, 0, 0, 1, 1, 2, 35, 4, 3, '01/15/25', null),
+       (4, true, 0, 0, 1, 1, 2, 36, 1, 4, '01/15/25',null),
+       (5, true, 0, 0, 1, 1, 2, 37, 1, 5, '01/15/25', null),
+       (6, false, 0, 0, 1, 1, 2, 38, 1, 6, '01/15/25', null),
+       (7, true, 0, 0, 1, 0, 0, 39, 1, 7, '02/02/25', 1);
 
 SELECT setval(pg_get_serial_sequence('property_ownership', 'id'), (SELECT MAX(id) FROM property_ownership));

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/PropertyDetailsTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/PropertyDetailsTests.kt
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.springframework.test.context.jdbc.Sql
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.LandlordDetailsPage
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.LocalAuthorityViewLandlordDetailsPage
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages.BasePage.Companion.assertPageIs
 import java.net.URI
 import kotlin.test.assertEquals
@@ -14,27 +15,24 @@ import kotlin.test.assertEquals
 class PropertyDetailsTests : IntegrationTest() {
     @Nested
     inner class PropertyDetailsLandlordView {
-        // TODO: check in PRSD-723
         @Test
         fun `the property details page loads with the property details tab selected by default`(page: Page) {
-            val detailsPage = navigator.goToPropertyDetails(1)
+            val detailsPage = navigator.goToPropertyDetailsLandlordView(1)
 
             assertEquals(detailsPage.getActiveTabPanelId(), "property-details")
         }
 
-        // TODO: check in PRSD-723
         @Test
         fun `loading the landlord details page and clicking landlord details tab shows the landlords details tab`(page: Page) {
-            val detailsPage = navigator.goToPropertyDetails(1)
+            val detailsPage = navigator.goToPropertyDetailsLandlordView(1)
             detailsPage.goToLandlordDetails()
 
             assertEquals(detailsPage.getActiveTabPanelId(), "landlord-details")
         }
 
-        // TODO: check in PRSD-723
         @Test
         fun `when the landlord details tab is active clicking the property details tab shows property details tab`(page: Page) {
-            val detailsPage = navigator.goToPropertyDetails(1)
+            val detailsPage = navigator.goToPropertyDetailsLandlordView(1)
             println(detailsPage.page.content())
             detailsPage.goToLandlordDetails()
 
@@ -45,11 +43,49 @@ class PropertyDetailsTests : IntegrationTest() {
 
         @Test
         fun `the landlord name link goes the landlord view of landlord details`(page: Page) {
-            val detailsPage = navigator.goToPropertyDetails(1)
+            val detailsPage = navigator.goToPropertyDetailsLandlordView(1)
             detailsPage.clickLandlordNameLink("Alexander Smith")
 
             assertPageIs(page, LandlordDetailsPage::class)
             Assertions.assertEquals("/landlord-details", URI(page.url()).path)
+        }
+    }
+
+    @Nested
+    inner class PropertyDetailsLocalAuthorityView {
+        @Test
+        fun `the property details page loads with the property details tab selected by default`(page: Page) {
+            val detailsPage = navigator.goToPropertyDetailsLocalAuthorityView(1)
+
+            assertEquals(detailsPage.getActiveTabPanelId(), "property-details")
+        }
+
+        @Test
+        fun `loading the landlord details page and clicking landlord details tab shows the landlords details tab`(page: Page) {
+            val detailsPage = navigator.goToPropertyDetailsLocalAuthorityView(1)
+            detailsPage.goToLandlordDetails()
+
+            assertEquals(detailsPage.getActiveTabPanelId(), "landlord-details")
+        }
+
+        @Test
+        fun `when the landlord details tab is active clicking the property details tab shows property details tab`(page: Page) {
+            val detailsPage = navigator.goToPropertyDetailsLocalAuthorityView(1)
+            println(detailsPage.page.content())
+            detailsPage.goToLandlordDetails()
+
+            detailsPage.goToPropertyDetails()
+
+            assertEquals(detailsPage.getActiveTabPanelId(), "property-details")
+        }
+
+        @Test
+        fun `the landlord name link goes the landlord view of landlord details`(page: Page) {
+            val detailsPage = navigator.goToPropertyDetailsLocalAuthorityView(1)
+            detailsPage.clickLandlordNameLink("Alexander Smith")
+
+            assertPageIs(page, LocalAuthorityViewLandlordDetailsPage::class)
+            Assertions.assertEquals("/landlord-details/1", URI(page.url()).path)
         }
     }
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/PropertyDetailsTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/PropertyDetailsTests.kt
@@ -49,6 +49,23 @@ class PropertyDetailsTests : IntegrationTest() {
             assertPageIs(page, LandlordDetailsPage::class)
             Assertions.assertEquals("/landlord-details", URI(page.url()).path)
         }
+
+        @Test
+        fun `the back link returns to the dashboard`(page: Page) {
+            val detailsPage = navigator.goToPropertyDetailsLandlordView(1)
+            detailsPage.clickBackLink()
+
+            // TODO: PRSD-647 add link to the dashboard
+            Assertions.assertEquals("/property-details/1", URI(page.url()).path)
+        }
+
+        @Test
+        fun `the delete button redirects to the delete record page`(page: Page) {
+            val detailsPage = navigator.goToPropertyDetailsLandlordView(1)
+            detailsPage.deleteButton.click()
+
+            Assertions.assertEquals("/property-details/delete-record", URI(page.url()).path)
+        }
     }
 
     @Nested
@@ -86,6 +103,15 @@ class PropertyDetailsTests : IntegrationTest() {
 
             assertPageIs(page, LocalAuthorityViewLandlordDetailsPage::class)
             Assertions.assertEquals("/landlord-details/1", URI(page.url()).path)
+        }
+
+        @Test
+        fun `the back link returns to the dashboard`(page: Page) {
+            val detailsPage = navigator.goToPropertyDetailsLocalAuthorityView(1)
+            detailsPage.clickBackLink()
+
+            // TODO: PRSD-647 add link to the dashboard
+            Assertions.assertEquals("/local-authority/property-details/1", URI(page.url()).path)
         }
     }
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/PropertyDetailsTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/PropertyDetailsTests.kt
@@ -1,0 +1,55 @@
+package uk.gov.communities.prsdb.webapp.integration
+
+import com.microsoft.playwright.Page
+import org.junit.jupiter.api.Assertions
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.test.context.jdbc.Sql
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.LandlordDetailsPage
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages.BasePage.Companion.assertPageIs
+import java.net.URI
+import kotlin.test.assertEquals
+
+@Sql("/data-local.sql")
+class PropertyDetailsTests : IntegrationTest() {
+    @Nested
+    inner class PropertyDetailsLandlordView {
+        // TODO: check in PRSD-723
+        @Test
+        fun `the property details page loads with the property details tab selected by default`(page: Page) {
+            val detailsPage = navigator.goToPropertyDetails(1)
+
+            assertEquals(detailsPage.getActiveTabPanelId(), "property-details")
+        }
+
+        // TODO: check in PRSD-723
+        @Test
+        fun `loading the landlord details page and clicking landlord details tab shows the landlords details tab`(page: Page) {
+            val detailsPage = navigator.goToPropertyDetails(1)
+            detailsPage.goToLandlordDetails()
+
+            assertEquals(detailsPage.getActiveTabPanelId(), "landlord-details")
+        }
+
+        // TODO: check in PRSD-723
+        @Test
+        fun `when the landlord details tab is active clicking the property details tab shows property details tab`(page: Page) {
+            val detailsPage = navigator.goToPropertyDetails(1)
+            println(detailsPage.page.content())
+            detailsPage.goToLandlordDetails()
+
+            detailsPage.goToPropertyDetails()
+
+            assertEquals(detailsPage.getActiveTabPanelId(), "property-details")
+        }
+
+        @Test
+        fun `the landlord name link goes the landlord view of landlord details`(page: Page) {
+            val detailsPage = navigator.goToPropertyDetails(1)
+            detailsPage.clickLandlordNameLink("Alexander Smith")
+
+            assertPageIs(page, LandlordDetailsPage::class)
+            Assertions.assertEquals("/landlord-details", URI(page.url()).path)
+        }
+    }
+}

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/PropertyDetailsTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/PropertyDetailsTests.kt
@@ -33,7 +33,6 @@ class PropertyDetailsTests : IntegrationTest() {
         @Test
         fun `when the landlord details tab is active clicking the property details tab shows property details tab`(page: Page) {
             val detailsPage = navigator.goToPropertyDetailsLandlordView(1)
-            println(detailsPage.page.content())
             detailsPage.goToLandlordDetails()
 
             detailsPage.goToPropertyDetails()
@@ -88,7 +87,6 @@ class PropertyDetailsTests : IntegrationTest() {
         @Test
         fun `when the landlord details tab is active clicking the property details tab shows property details tab`(page: Page) {
             val detailsPage = navigator.goToPropertyDetailsLocalAuthorityView(1)
-            println(detailsPage.page.content())
             detailsPage.goToLandlordDetails()
 
             detailsPage.goToPropertyDetails()
@@ -97,7 +95,7 @@ class PropertyDetailsTests : IntegrationTest() {
         }
 
         @Test
-        fun `the landlord name link goes the landlord view of landlord details`(page: Page) {
+        fun `the landlord name link goes the local authority view of landlord details`(page: Page) {
             val detailsPage = navigator.goToPropertyDetailsLocalAuthorityView(1)
             detailsPage.clickLandlordNameLink("Alexander Smith")
 

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/Navigator.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/Navigator.kt
@@ -17,7 +17,8 @@ import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.InviteNewLa
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.LandlordDetailsPage
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.LocalAuthorityViewLandlordDetailsPage
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.ManageLaUsersPage
-import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.PropertyDetailsPage
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.PropertyDetailsPageLandlordView
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.PropertyDetailsPageLocalAuthorityView
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.SearchLandlordRegisterPage
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages.BasePage.Companion.createValidPage
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.laUserRegistrationJourneyPages.CheckAnswersPageLaUserRegistration
@@ -392,9 +393,14 @@ class Navigator(
         return createValidPage(page, LocalAuthorityViewLandlordDetailsPage::class)
     }
 
-    fun goToPropertyDetails(id: Long): PropertyDetailsPage {
+    fun goToPropertyDetailsLandlordView(id: Long): PropertyDetailsPageLandlordView {
         navigate("property-details/$id")
-        return createValidPage(page, PropertyDetailsPage::class)
+        return createValidPage(page, PropertyDetailsPageLandlordView::class)
+    }
+
+    fun goToPropertyDetailsLocalAuthorityView(id: Long): PropertyDetailsPageLocalAuthorityView {
+        navigate("local-authority/property-details/$id")
+        return createValidPage(page, PropertyDetailsPageLocalAuthorityView::class)
     }
 
     fun navigate(path: String): Response? = page.navigate("http://localhost:$port/$path")

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/Navigator.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/Navigator.kt
@@ -17,6 +17,7 @@ import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.InviteNewLa
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.LandlordDetailsPage
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.LocalAuthorityViewLandlordDetailsPage
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.ManageLaUsersPage
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.PropertyDetailsPage
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.SearchLandlordRegisterPage
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages.BasePage.Companion.createValidPage
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.laUserRegistrationJourneyPages.CheckAnswersPageLaUserRegistration
@@ -391,5 +392,10 @@ class Navigator(
         return createValidPage(page, LocalAuthorityViewLandlordDetailsPage::class)
     }
 
-    private fun navigate(path: String): Response? = page.navigate("http://localhost:$port/$path")
+    fun goToPropertyDetails(id: Long): PropertyDetailsPage {
+        navigate("property-details/$id")
+        return createValidPage(page, PropertyDetailsPage::class)
+    }
+
+    fun navigate(path: String): Response? = page.navigate("http://localhost:$port/$path")
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/PropertyDetailsPage.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/PropertyDetailsPage.kt
@@ -1,0 +1,26 @@
+package uk.gov.communities.prsdb.webapp.integration.pageObjects.pages
+
+import com.microsoft.playwright.Page
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.BaseComponent.Companion.getLink
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.Tabs
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages.BasePage
+
+class PropertyDetailsPage(
+    page: Page,
+) : BasePage(page, "/property-details") {
+    val tabs = Tabs(page, 2)
+
+    fun getActiveTabPanelId() = tabs.getActiveTabPanelId()
+
+    fun goToLandlordDetails() {
+        tabs.goToTab("Landlord details")
+    }
+
+    fun goToPropertyDetails() {
+        tabs.goToTab("Property details")
+    }
+
+    fun clickLandlordNameLink(landlordName: String) {
+        getLink(page, landlordName).click()
+    }
+}

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/PropertyDetailsPageLandlordView.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/PropertyDetailsPageLandlordView.kt
@@ -1,8 +1,11 @@
 package uk.gov.communities.prsdb.webapp.integration.pageObjects.pages
 
 import com.microsoft.playwright.Page
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.BaseComponent.Companion.getButton
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages.PropertyDetailsBasePage
 
 class PropertyDetailsPageLandlordView(
     page: Page,
-) : PropertyDetailsBasePage(page, "/property-details")
+) : PropertyDetailsBasePage(page, "/property-details") {
+    val deleteButton = getButton(page, "Delete property record")
+}

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/PropertyDetailsPageLandlordView.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/PropertyDetailsPageLandlordView.kt
@@ -1,0 +1,8 @@
+package uk.gov.communities.prsdb.webapp.integration.pageObjects.pages
+
+import com.microsoft.playwright.Page
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages.PropertyDetailsBasePage
+
+class PropertyDetailsPageLandlordView(
+    page: Page,
+) : PropertyDetailsBasePage(page, "/property-details")

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/PropertyDetailsPageLocalAuthorityView.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/PropertyDetailsPageLocalAuthorityView.kt
@@ -1,0 +1,8 @@
+package uk.gov.communities.prsdb.webapp.integration.pageObjects.pages
+
+import com.microsoft.playwright.Page
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages.PropertyDetailsBasePage
+
+class PropertyDetailsPageLocalAuthorityView(
+    page: Page,
+) : PropertyDetailsBasePage(page, "/local-authority/property-details")

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/basePages/PropertyDetailsBasePage.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/basePages/PropertyDetailsBasePage.kt
@@ -1,13 +1,13 @@
-package uk.gov.communities.prsdb.webapp.integration.pageObjects.pages
+package uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages
 
 import com.microsoft.playwright.Page
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.BaseComponent.Companion.getLink
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.Tabs
-import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages.BasePage
 
-class PropertyDetailsPage(
+abstract class PropertyDetailsBasePage(
     page: Page,
-) : BasePage(page, "/property-details") {
+    urlSegment: String,
+) : BasePage(page, urlSegment) {
     val tabs = Tabs(page, 2)
 
     fun getActiveTabPanelId() = tabs.getActiveTabPanelId()

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/basePages/PropertyDetailsBasePage.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/basePages/PropertyDetailsBasePage.kt
@@ -23,4 +23,8 @@ abstract class PropertyDetailsBasePage(
     fun clickLandlordNameLink(landlordName: String) {
         getLink(page, landlordName).click()
     }
+
+    fun clickBackLink() {
+        getLink(page, "Back").click()
+    }
 }


### PR DESCRIPTION
- Adds integration tests for the property details page (landlord and local authority view, PRSD-719 and PRSD-655)
- Modifies data-local.sql to include an unoccupied, licensed property (for QA of PRSD-655 and PRSD-719)
- Some of this was taken from the PRSD-723 branch