### PR TITLE
Feat/prsd 655 add last updated to property details

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/PropertyDetailsController.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/PropertyDetailsController.kt
@@ -1,5 +1,6 @@
 package uk.gov.communities.prsdb.webapp.controllers
 
+import kotlinx.datetime.toKotlinInstant
 import org.springframework.http.HttpStatus
 import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.stereotype.Controller
@@ -8,6 +9,7 @@ import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.server.ResponseStatusException
+import uk.gov.communities.prsdb.webapp.helpers.DateTimeHelper
 import uk.gov.communities.prsdb.webapp.models.viewModels.PropertyDetailsLandlordViewModel
 import uk.gov.communities.prsdb.webapp.models.viewModels.PropertyDetailsViewModel
 import uk.gov.communities.prsdb.webapp.services.LandlordService
@@ -62,6 +64,12 @@ class PropertyDetailsController(
             throw ResponseStatusException(HttpStatus.BAD_REQUEST, "Property ownership $propertyOwnershipId is inactive")
         }
 
+        val lastModifiedDate =
+            DateTimeHelper.getDateInUK(
+                propertyOwnership.lastModifiedDate?.toKotlinInstant() ?: propertyOwnership.createdDate.toKotlinInstant(),
+            )
+        val lastModifiedBy = propertyOwnership.primaryLandlord.name
+
         val propertyDetails =
             PropertyDetailsViewModel(
                 propertyOwnership = propertyOwnership,
@@ -71,6 +79,8 @@ class PropertyDetailsController(
             )
 
         model.addAttribute("propertyDetails", propertyDetails)
+        model.addAttribute("lastModifiedDate", lastModifiedDate)
+        model.addAttribute("lastModifiedBy", lastModifiedBy)
 
         // TODO PRSD-647: Replace with link to dashboard
         model.addAttribute("backUrl", "/")

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -293,11 +293,12 @@ landlordSearch.error.hint.link=search for a property
 landlordSearch.details.heading=Help find a landlord record
 landlordSearch.details.body=If you can't find a landlord record, they may not be registered. Local authorities can request the landlord registers with the database.
 
+lastUpdated.afterName=updated these details on
+lastUpdated.afterDate=.
+
 landlordDetails.title=Landlord record
 landlordDetails.heading=Landlord record
 landlordDetails.removeRecord=Delete record
-landlordDetails.lastUpdated.afterName=updated these details on
-landlordDetails.lastUpdated.afterDate=.
 landlordDetails.personalDetails.heading=Personal details
 landlordDetails.personalDetails.lrn=Landlord registration number
 landlordDetails.personalDetails.registrationDate=Database registration date

--- a/src/main/resources/templates/fragments/lastModified.html
+++ b/src/main/resources/templates/fragments/lastModified.html
@@ -1,0 +1,11 @@
+<th:block th:fragment="lastModified(lastModifiedBy, lastModifiedDate)"
+     th:if="${lastModifiedDate != null}" >
+    <div th:replace="~{fragments/warningInsetText :: warningInsetText(~{:: #last-updated-text})}">
+        <th:block id="last-updated-text">
+            <strong th:text="${lastModifiedBy}">name</strong>
+            <span th:text="' ' + #{lastUpdated.afterName} + ' '">landlordDetails.lastUpdated.afterName</span>
+            <strong th:text="${lastModifiedDate}">lastModifiedDate</strong>
+            <span th:text="#{lastUpdated.afterDate}">landlordDetails.lastUpdated.afterDate</span>
+        </th:block>
+    </div>
+</th:block>

--- a/src/main/resources/templates/localAuthorityLandlordDetailsView.html
+++ b/src/main/resources/templates/localAuthorityLandlordDetailsView.html
@@ -7,13 +7,7 @@
 
             <h1 class="govuk-heading-l" th:text="${name}">name</h1>
 
-            <div th:replace="~{fragments/warningInsetText :: warningInsetText(~{:: #last-updated-text})}">
-                <th:block id="last-updated-text">
-                    <strong th:text="${name}">name</strong>
-                    <span th:text="' ' + #{landlordDetails.lastUpdated.afterName} + ' '">landlordDetails.lastUpdated.afterName</span>
-                    <strong th:text="${lastModifiedDate}">lastModifiedDate</strong>
-                    <span th:text="#{landlordDetails.lastUpdated.afterDate}">landlordDetails.lastUpdated.afterDate</span>
-                </th:block>
+            <div th:replace="~{fragments/lastModified :: lastModified(${name}, ${lastModifiedDate})}">
             </div>
 
             <div th:replace="~{fragments/tabs/tabs :: tabs(~{:: #tabs-content})}" >

--- a/src/main/resources/templates/propertyDetailsView.html
+++ b/src/main/resources/templates/propertyDetailsView.html
@@ -11,6 +11,8 @@
         </div>
         <div th:replace="~{fragments/keyDetailsList :: keyDetailsList(${propertyDetails.keyDetails})}">
         </div>
+        <div th:replace="~{fragments/lastModified :: lastModified(${lastModifiedBy}, ${lastModifiedDate})}">
+        </div>
 
         <div th:replace="~{fragments/tabs/tabs :: tabs(~{:: #tabs-content})}" >
           <th:block id="tabs-content">

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/PropertyDetailsTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/PropertyDetailsTests.kt
@@ -1,6 +1,7 @@
 package uk.gov.communities.prsdb.webapp.integration
 
 import com.microsoft.playwright.Page
+import com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -121,6 +122,13 @@ class PropertyDetailsTests : IntegrationTest() {
 
             // TODO: PRSD-647 add link to the dashboard
             Assertions.assertEquals("/local-authority/property-details/1", URI(page.url()).path)
+        }
+
+        @Test
+        fun `loading the landlord details page shows the last time the landlords record was updated`(page: Page) {
+            val detailsPage = navigator.goToPropertyDetailsLocalAuthorityView(1)
+
+            assertThat(detailsPage.insetText.spanText).containsText("updated these details on")
         }
     }
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/PropertyDetailsPageLocalAuthorityView.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/PropertyDetailsPageLocalAuthorityView.kt
@@ -1,8 +1,11 @@
 package uk.gov.communities.prsdb.webapp.integration.pageObjects.pages
 
 import com.microsoft.playwright.Page
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.InsetText
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages.PropertyDetailsBasePage
 
 class PropertyDetailsPageLocalAuthorityView(
     page: Page,
-) : PropertyDetailsBasePage(page, "/local-authority/property-details")
+) : PropertyDetailsBasePage(page, "/local-authority/property-details") {
+    val insetText = InsetText(page)
+}


### PR DESCRIPTION
- Make a `lastModifed `fragment from what was in `localAuthorityLandlordDetailsView`
- Use the `lastModified `fragment to add a "Last updated by..." section to the local authority view of the property details page (but not the landlord view)

![image](https://github.com/user-attachments/assets/04802f15-75c2-407b-9aa4-e35a112c9e6d)
