### PR TITLE
PRSD-661: Property Search Pagination

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/constants/PaginationConstants.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/constants/PaginationConstants.kt
@@ -2,3 +2,4 @@ package uk.gov.communities.prsdb.webapp.constants
 
 const val MAX_ENTRIES_IN_LA_USERS_TABLE_PAGE = 10
 const val MAX_ENTRIES_IN_LANDLORDS_SEARCH_PAGE = 25
+const val MAX_ENTRIES_IN_PROPERTIES_SEARCH_PAGE = 25

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/SearchRegisterController.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/SearchRegisterController.kt
@@ -51,7 +51,7 @@ class SearchRegisterController(
                 searchRequest.searchTerm!!,
                 principal.name,
                 searchRequest.restrictToLA,
-                currentPageNumber = page - 1,
+                requestedPageIndex = page - 1,
             )
 
         if (isPageOutOfBounds(pagedLandlordList, page)) {
@@ -90,7 +90,7 @@ class SearchRegisterController(
         }
 
         val pagedSearchResults =
-            propertyOwnershipService.searchForProperties(searchRequest.searchTerm!!, currentPageNumber = page - 1)
+            propertyOwnershipService.searchForProperties(searchRequest.searchTerm!!, requestedPageIndex = page - 1)
 
         if (isPageOutOfBounds(pagedSearchResults, page)) {
             return getRedirectForPageOutOfBounds(httpServletRequest)

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/SearchRegisterController.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/SearchRegisterController.kt
@@ -54,7 +54,9 @@ class SearchRegisterController(
                 currentPageNumber = page - 1,
             )
 
-        getRedirectIfPageOutOfBounds(pagedLandlordList, page, httpServletRequest)?.let { redirect -> return redirect }
+        if (isPageOutOfBounds(pagedLandlordList, page)) {
+            return getRedirectForPageOutOfBounds(httpServletRequest)
+        }
 
         model.addAttribute("searchResults", pagedLandlordList.content)
         model.addAttribute(
@@ -90,7 +92,9 @@ class SearchRegisterController(
         val pagedSearchResults =
             propertyOwnershipService.searchForProperties(searchRequest.searchTerm!!, currentPageNumber = page - 1)
 
-        getRedirectIfPageOutOfBounds(pagedSearchResults, page, httpServletRequest)?.let { redirect -> return redirect }
+        if (isPageOutOfBounds(pagedSearchResults, page)) {
+            return getRedirectForPageOutOfBounds(httpServletRequest)
+        }
 
         model.addAttribute("searchResults", pagedSearchResults.content)
         model.addAttribute(
@@ -104,15 +108,13 @@ class SearchRegisterController(
         return "searchProperty"
     }
 
-    private fun getRedirectIfPageOutOfBounds(
+    private fun isPageOutOfBounds(
         pagedList: Page<out Any>,
         page: Int,
-        httpServletRequest: HttpServletRequest,
-    ) = if (pagedList.totalPages != 0 && pagedList.totalPages < page) {
+    ) = pagedList.totalPages != 0 && pagedList.totalPages < page
+
+    private fun getRedirectForPageOutOfBounds(httpServletRequest: HttpServletRequest) =
         "redirect:${
             URIQueryBuilder.fromHTTPServletRequest(httpServletRequest).removeParam("page").build().toUriString()
         }"
-    } else {
-        null
-    }
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/database/repository/PropertyOwnershipRepository.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/database/repository/PropertyOwnershipRepository.kt
@@ -1,5 +1,7 @@
 package uk.gov.communities.prsdb.webapp.database.repository
 
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.query.Param
@@ -40,7 +42,8 @@ interface PropertyOwnershipRepository : JpaRepository<PropertyOwnership, Long> {
     )
     fun searchMatchingPRN(
         @Param("searchPRN") searchPRN: Long,
-    ): List<PropertyOwnership>
+        pageable: Pageable,
+    ): Page<PropertyOwnership>
 
     @Query(
         "SELECT po.* " +
@@ -52,7 +55,8 @@ interface PropertyOwnershipRepository : JpaRepository<PropertyOwnership, Long> {
     )
     fun searchMatchingUPRN(
         @Param("searchUPRN") searchUPRN: Long,
-    ): List<PropertyOwnership>
+        pageable: Pageable,
+    ): Page<PropertyOwnership>
 
     @Query(
         "SELECT po.* " +
@@ -65,5 +69,6 @@ interface PropertyOwnershipRepository : JpaRepository<PropertyOwnership, Long> {
     )
     fun searchMatching(
         @Param("searchTerm") searchTerm: String,
-    ): List<PropertyOwnership>
+        pageable: Pageable,
+    ): Page<PropertyOwnership>
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/LandlordService.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/LandlordService.kt
@@ -70,11 +70,11 @@ class LandlordService(
         searchTerm: String,
         laBaseUserId: String,
         restrictToLA: Boolean = false,
-        currentPageNumber: Int = 0,
+        requestedPageIndex: Int = 0,
         pageSize: Int = MAX_ENTRIES_IN_LANDLORDS_SEARCH_PAGE,
     ): Page<LandlordSearchResultViewModel> {
         val lrn = RegistrationNumberDataModel.parseTypeOrNull(searchTerm, RegistrationNumberType.LANDLORD)
-        val pageRequest = PageRequest.of(currentPageNumber, pageSize)
+        val pageRequest = PageRequest.of(requestedPageIndex, pageSize)
 
         val landlordPage =
             if (lrn == null) {

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/PropertyOwnershipService.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/PropertyOwnershipService.kt
@@ -97,12 +97,12 @@ class PropertyOwnershipService(
 
     fun searchForProperties(
         searchTerm: String,
-        currentPageNumber: Int = 0,
+        requestedPageIndex: Int = 0,
         pageSize: Int = MAX_ENTRIES_IN_PROPERTIES_SEARCH_PAGE,
     ): Page<PropertySearchResultViewModel> {
         val prn = RegistrationNumberDataModel.parseTypeOrNull(searchTerm, RegistrationNumberType.PROPERTY)
         val uprn = AddressHelper.parseUprnOrNull(searchTerm)
-        val pageRequest = PageRequest.of(currentPageNumber, pageSize)
+        val pageRequest = PageRequest.of(requestedPageIndex, pageSize)
 
         val matchingProperties =
             if (prn != null) {

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/PropertyOwnershipService.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/PropertyOwnershipService.kt
@@ -1,9 +1,12 @@
 package uk.gov.communities.prsdb.webapp.services
 
 import jakarta.transaction.Transactional
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.PageRequest
 import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Service
 import org.springframework.web.server.ResponseStatusException
+import uk.gov.communities.prsdb.webapp.constants.MAX_ENTRIES_IN_PROPERTIES_SEARCH_PAGE
 import uk.gov.communities.prsdb.webapp.constants.enums.LandlordType
 import uk.gov.communities.prsdb.webapp.constants.enums.OccupancyType
 import uk.gov.communities.prsdb.webapp.constants.enums.OwnershipType
@@ -92,17 +95,22 @@ class PropertyOwnershipService(
     fun retrievePropertyOwnershipById(propertyOwnershipId: Long): PropertyOwnership? =
         propertyOwnershipRepository.findByIdAndIsActiveTrue(propertyOwnershipId)
 
-    fun searchForProperties(searchTerm: String): List<PropertySearchResultViewModel> {
+    fun searchForProperties(
+        searchTerm: String,
+        currentPageNumber: Int = 0,
+        pageSize: Int = MAX_ENTRIES_IN_PROPERTIES_SEARCH_PAGE,
+    ): Page<PropertySearchResultViewModel> {
         val prn = RegistrationNumberDataModel.parseTypeOrNull(searchTerm, RegistrationNumberType.PROPERTY)
         val uprn = AddressHelper.parseUprnOrNull(searchTerm)
+        val pageRequest = PageRequest.of(currentPageNumber, pageSize)
 
         val matchingProperties =
             if (prn != null) {
-                propertyOwnershipRepository.searchMatchingPRN(prn.number)
+                propertyOwnershipRepository.searchMatchingPRN(prn.number, pageRequest)
             } else if (uprn != null) {
-                propertyOwnershipRepository.searchMatchingUPRN(uprn)
+                propertyOwnershipRepository.searchMatchingUPRN(uprn, pageRequest)
             } else {
-                propertyOwnershipRepository.searchMatching(searchTerm)
+                propertyOwnershipRepository.searchMatching(searchTerm, pageRequest)
             }
 
         return matchingProperties.map { PropertySearchResultViewModel.fromPropertyOwnership(it) }

--- a/src/main/resources/templates/searchProperty.html
+++ b/src/main/resources/templates/searchProperty.html
@@ -17,6 +17,8 @@
 
         <th:block th:if="${searchResults != null}">
 
+            <nav th:replace="~{fragments/pagination/pagination :: pagination(${paginationViewModel})}"></nav>
+
             <table th:replace="~{fragments/tables/table :: table(
                             ${ {'propertySearch.table.heading.address','propertySearch.table.heading.prn','propertySearch.table.heading.la', 'propertySearch.table.heading.landlord'} },
                             ~{::tbody},
@@ -56,6 +58,8 @@
                     </a>
                 </div>
             </div>
+
+            <nav th:replace="~{fragments/pagination/pagination :: pagination(${paginationViewModel})}"></nav>
 
         </th:block>
 

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/controllers/SearchRegisterControllerTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/controllers/SearchRegisterControllerTests.kt
@@ -58,7 +58,7 @@ class SearchRegisterControllerTests(
     @Test
     @WithMockUser(roles = ["LA_USER"])
     fun `searchForLandlords returns 200 for a valid page request`() {
-        whenever(landlordService.searchForLandlords("PRSDB", "user", currentPageNumber = 1))
+        whenever(landlordService.searchForLandlords("PRSDB", "user", requestedPageIndex = 1))
             .thenReturn(
                 PageImpl(
                     listOf(
@@ -95,7 +95,7 @@ class SearchRegisterControllerTests(
     @Test
     @WithMockUser(roles = ["LA_USER"])
     fun `searchForLandlords redirects if the requested page number is more than the total pages`() {
-        whenever(landlordService.searchForLandlords("PRSDB", "user", currentPageNumber = 2))
+        whenever(landlordService.searchForLandlords("PRSDB", "user", requestedPageIndex = 2))
             .thenReturn(
                 PageImpl(
                     emptyList<LandlordSearchResultViewModel>(),
@@ -115,7 +115,7 @@ class SearchRegisterControllerTests(
     @Test
     @WithMockUser(roles = ["LA_USER"])
     fun `searchForProperties returns 200 for a valid page request`() {
-        whenever(propertyOwnershipService.searchForProperties("PRSDB", currentPageNumber = 1))
+        whenever(propertyOwnershipService.searchForProperties("PRSDB", requestedPageIndex = 1))
             .thenReturn(
                 PageImpl(
                     listOf(PropertySearchResultViewModel.fromPropertyOwnership(MockLandlordData.createPropertyOwnership())),
@@ -140,7 +140,7 @@ class SearchRegisterControllerTests(
     @Test
     @WithMockUser(roles = ["LA_USER"])
     fun `searchForProperties redirects if the requested page number is more than the total pages`() {
-        whenever(propertyOwnershipService.searchForProperties("PRSDB", currentPageNumber = 2))
+        whenever(propertyOwnershipService.searchForProperties("PRSDB", requestedPageIndex = 2))
             .thenReturn(
                 PageImpl(
                     emptyList<PropertySearchResultViewModel>(),

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/controllers/SearchRegisterControllerTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/controllers/SearchRegisterControllerTests.kt
@@ -10,7 +10,10 @@ import org.springframework.security.test.context.support.WithMockUser
 import org.springframework.test.web.servlet.get
 import org.springframework.web.context.WebApplicationContext
 import uk.gov.communities.prsdb.webapp.constants.MAX_ENTRIES_IN_LANDLORDS_SEARCH_PAGE
+import uk.gov.communities.prsdb.webapp.constants.MAX_ENTRIES_IN_PROPERTIES_SEARCH_PAGE
+import uk.gov.communities.prsdb.webapp.mockObjects.MockLandlordData
 import uk.gov.communities.prsdb.webapp.models.viewModels.LandlordSearchResultViewModel
+import uk.gov.communities.prsdb.webapp.models.viewModels.PropertySearchResultViewModel
 import uk.gov.communities.prsdb.webapp.services.LandlordService
 import uk.gov.communities.prsdb.webapp.services.PropertyOwnershipService
 import kotlin.test.Test
@@ -105,6 +108,48 @@ class SearchRegisterControllerTests(
             )
 
         mvc.get("/search/landlord?searchTerm=PRSDB&page=3").andExpect {
+            status { is3xxRedirection() }
+        }
+    }
+
+    @Test
+    @WithMockUser(roles = ["LA_USER"])
+    fun `searchForProperties returns 200 for a valid page request`() {
+        whenever(propertyOwnershipService.searchForProperties("PRSDB", currentPageNumber = 1))
+            .thenReturn(
+                PageImpl(
+                    listOf(PropertySearchResultViewModel.fromPropertyOwnership(MockLandlordData.createPropertyOwnership())),
+                    PageRequest.of(1, MAX_ENTRIES_IN_PROPERTIES_SEARCH_PAGE),
+                    2,
+                ),
+            )
+
+        mvc.get("/search/property?searchTerm=PRSDB&page=2").andExpect {
+            status { isOk() }
+        }
+    }
+
+    @Test
+    @WithMockUser(roles = ["LA_USER"])
+    fun `searchForProperties returns 404 if the requested page number is less than 1`() {
+        mvc.get("/search/property?searchTerm=PRSDB&page=0").andExpect {
+            status { isNotFound() }
+        }
+    }
+
+    @Test
+    @WithMockUser(roles = ["LA_USER"])
+    fun `searchForProperties redirects if the requested page number is more than the total pages`() {
+        whenever(propertyOwnershipService.searchForProperties("PRSDB", currentPageNumber = 2))
+            .thenReturn(
+                PageImpl(
+                    emptyList<PropertySearchResultViewModel>(),
+                    PageRequest.of(2, MAX_ENTRIES_IN_LANDLORDS_SEARCH_PAGE),
+                    1,
+                ),
+            )
+
+        mvc.get("/search/property?searchTerm=PRSDB&page=3").andExpect {
             status { is3xxRedirection() }
         }
     }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/SearchRegisterTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/SearchRegisterTests.kt
@@ -5,8 +5,6 @@ import com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertThrows
-import org.opentest4j.AssertionFailedError
 import org.springframework.test.context.jdbc.Sql
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.SearchLandlordRegisterPage
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.SearchLandlordRegisterPage.Companion.ADDRESS_COL_INDEX
@@ -30,8 +28,7 @@ class SearchRegisterTests : IntegrationTest() {
         fun `results table does not show before search has been requested`() {
             val searchLandlordRegisterPage = navigator.goToLandlordSearchPage()
 
-            val exception = assertThrows<AssertionFailedError> { searchLandlordRegisterPage.getResultTable() }
-            assertContains(exception.message!!, "Expected 1 instance of Locator@.govuk-table, found 0")
+            assertTrue(searchLandlordRegisterPage.getHiddenResultTable().isHidden)
         }
 
         @Test
@@ -39,8 +36,7 @@ class SearchRegisterTests : IntegrationTest() {
             val searchLandlordRegisterPage = navigator.goToLandlordSearchPage()
             searchLandlordRegisterPage.searchBar.search("")
 
-            val exception = assertThrows<AssertionFailedError> { searchLandlordRegisterPage.getResultTable() }
-            assertContains(exception.message!!, "Expected 1 instance of Locator@.govuk-table, found 0")
+            assertTrue(searchLandlordRegisterPage.getHiddenResultTable().isHidden)
         }
 
         @Test
@@ -57,17 +53,13 @@ class SearchRegisterTests : IntegrationTest() {
 
             assertThat(resultTable.getHeaderCell(CONTACT_INFO_COL_INDEX)).containsText("Contact information")
             assertThat(
-                resultTable.getCell(
-                    0,
-                    CONTACT_INFO_COL_INDEX,
-                ),
+                resultTable.getCell(0, CONTACT_INFO_COL_INDEX),
             ).containsText("7111111111\nalex.surname@example.com")
 
             assertThat(resultTable.getHeaderCell(LISTED_PROPERTY_COL_INDEX)).containsText("Listed properties")
             assertThat(resultTable.getCell(0, LISTED_PROPERTY_COL_INDEX)).containsText("30")
 
-            val exception = assertThrows<AssertionFailedError> { searchLandlordRegisterPage.getErrorMessage() }
-            assertContains(exception.message!!, "Expected 1 instance of Locator@#no-results >> nth=0, found 0")
+            assertTrue(searchLandlordRegisterPage.getErrorMessage(isVisible = false).isHidden)
         }
 
         @Test
@@ -86,6 +78,7 @@ class SearchRegisterTests : IntegrationTest() {
             val searchLandlordRegisterPage = navigator.goToLandlordSearchPage()
             searchLandlordRegisterPage.searchBar.search("L-CKSQ-3SX9")
             searchLandlordRegisterPage.getLandlordLink(rowIndex = 0).click()
+
             assertContains(page.url(), "/landlord-details/1")
         }
 
@@ -111,8 +104,7 @@ class SearchRegisterTests : IntegrationTest() {
             val searchLandlordRegisterPage = navigator.goToLandlordSearchPage()
             searchLandlordRegisterPage.searchBar.search("Alex")
 
-            val exception = assertThrows<AssertionFailedError> { searchLandlordRegisterPage.getPaginationComponent() }
-            assertContains(exception.message!!, "Expected 1 instance of Locator@.govuk-pagination >> nth=0, found 0")
+            assertTrue(searchLandlordRegisterPage.getHiddenPaginationComponent().isHidden)
         }
 
         @Test
@@ -142,11 +134,7 @@ class SearchRegisterTests : IntegrationTest() {
 
             // Toggle filter
             filter.clickCloseFilterPanel()
-            val exception = assertThrows<AssertionFailedError> { filter.getPanel() }
-            assertContains(
-                exception.message!!,
-                "Expected 1 instance of Locator@.moj-filter-layout >> .moj-filter >> nth=0, found 0",
-            )
+            assertTrue(filter.getPanel(isVisible = false).isHidden)
 
             filter.clickShowFilterPanel()
             assertTrue(filter.getPanel().isVisible)
@@ -178,8 +166,7 @@ class SearchRegisterTests : IntegrationTest() {
         fun `results table does not show before search has been requested`() {
             val searchPropertyRegisterPage = navigator.goToPropertySearchPage()
 
-            val exception = assertThrows<AssertionFailedError> { searchPropertyRegisterPage.getResultTable() }
-            assertContains(exception.message!!, "Expected 1 instance of Locator@.govuk-table, found 0")
+            assertTrue(searchPropertyRegisterPage.getHiddenResultTable().isHidden)
         }
 
         @Test
@@ -187,8 +174,7 @@ class SearchRegisterTests : IntegrationTest() {
             val searchPropertyRegisterPage = navigator.goToPropertySearchPage()
             searchPropertyRegisterPage.searchBar.search("")
 
-            val exception = assertThrows<AssertionFailedError> { searchPropertyRegisterPage.getResultTable() }
-            assertContains(exception.message!!, "Expected 1 instance of Locator@.govuk-table, found 0")
+            assertTrue(searchPropertyRegisterPage.getHiddenResultTable().isHidden)
         }
 
         @Test
@@ -209,8 +195,7 @@ class SearchRegisterTests : IntegrationTest() {
             assertThat(resultTable.getHeaderCell(PROPERTY_LANDLORD_COL_INDEX)).containsText("Registered landlord")
             assertThat(resultTable.getCell(0, PROPERTY_LANDLORD_COL_INDEX)).containsText("Alexander Smith")
 
-            val exception = assertThrows<AssertionFailedError> { searchPropertyRegisterPage.getErrorMessage() }
-            assertContains(exception.message!!, "Expected 1 instance of Locator@#no-results >> nth=0, found 0")
+            assertTrue(searchPropertyRegisterPage.getErrorMessage(isVisible = false).isHidden)
         }
 
         @Test
@@ -237,6 +222,7 @@ class SearchRegisterTests : IntegrationTest() {
             val searchPropertyRegisterPage = navigator.goToPropertySearchPage()
             searchPropertyRegisterPage.searchBar.search("P-C5YY-J34H")
             searchPropertyRegisterPage.getPropertyLink(rowIndex = 0).click()
+
             assertContains(page.url(), "/local-authority/property-details/1")
         }
 
@@ -245,6 +231,7 @@ class SearchRegisterTests : IntegrationTest() {
             val searchPropertyRegisterPage = navigator.goToPropertySearchPage()
             searchPropertyRegisterPage.searchBar.search("P-C5YY-J34H")
             searchPropertyRegisterPage.getLandlordLink(rowIndex = 0).click()
+
             assertContains(page.url(), "/landlord-details/1")
         }
 
@@ -270,16 +257,13 @@ class SearchRegisterTests : IntegrationTest() {
             val searchPropertyRegisterPage = navigator.goToPropertySearchPage()
             searchPropertyRegisterPage.searchBar.search("Way")
 
-            val exception = assertThrows<AssertionFailedError> { searchPropertyRegisterPage.getPaginationComponent() }
-            assertContains(exception.message!!, "Expected 1 instance of Locator@.govuk-pagination >> nth=0, found 0")
+            assertTrue(searchPropertyRegisterPage.getHiddenPaginationComponent().isHidden)
         }
 
         @Test
         fun `pagination links lead to the intended pages`(page: Page) {
             val searchPropertyRegisterPage = navigator.goToPropertySearchPage()
             searchPropertyRegisterPage.searchBar.search("PRSDB")
-
-            println(searchPropertyRegisterPage.getResultTable().countRows())
 
             searchPropertyRegisterPage.getPaginationComponent().getNextLink().click()
             assertContains(page.url(), "page=2")

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/SearchRegisterTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/SearchRegisterTests.kt
@@ -64,7 +64,7 @@ class SearchRegisterTests : IntegrationTest() {
             ).containsText("7111111111\nalex.surname@example.com")
 
             assertThat(resultTable.getHeaderCell(LISTED_PROPERTY_COL_INDEX)).containsText("Listed properties")
-            assertThat(resultTable.getCell(0, LISTED_PROPERTY_COL_INDEX)).containsText("29")
+            assertThat(resultTable.getCell(0, LISTED_PROPERTY_COL_INDEX)).containsText("30")
 
             val exception = assertThrows<AssertionFailedError> { searchLandlordRegisterPage.getErrorMessage() }
             assertContains(exception.message!!, "Expected 1 instance of Locator@#no-results >> nth=0, found 0")
@@ -263,6 +263,35 @@ class SearchRegisterTests : IntegrationTest() {
             searchPropertyRegisterPage.getLandlordSearchLink().click()
 
             assertPageIs(page, SearchLandlordRegisterPage::class)
+        }
+
+        @Test
+        fun `pagination component does not show if there is only one page of results`(page: Page) {
+            val searchPropertyRegisterPage = navigator.goToPropertySearchPage()
+            searchPropertyRegisterPage.searchBar.search("Way")
+
+            val exception = assertThrows<AssertionFailedError> { searchPropertyRegisterPage.getPaginationComponent() }
+            assertContains(exception.message!!, "Expected 1 instance of Locator@.govuk-pagination >> nth=0, found 0")
+        }
+
+        @Test
+        fun `pagination links lead to the intended pages`(page: Page) {
+            val searchPropertyRegisterPage = navigator.goToPropertySearchPage()
+            searchPropertyRegisterPage.searchBar.search("PRSDB")
+
+            println(searchPropertyRegisterPage.getResultTable().countRows())
+
+            searchPropertyRegisterPage.getPaginationComponent().getNextLink().click()
+            assertContains(page.url(), "page=2")
+            val nextPage = assertPageIs(page, SearchPropertyRegisterPage::class)
+
+            nextPage.getPaginationComponent().getPreviousLink().click()
+            assertContains(page.url(), "page=1")
+            val previousPage = assertPageIs(page, SearchPropertyRegisterPage::class)
+
+            previousPage.getPaginationComponent().getPageNumberLink(2).click()
+            assertContains(page.url(), "page=2")
+            assertPageIs(page, SearchPropertyRegisterPage::class)
         }
     }
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/components/FilterPanel.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/components/FilterPanel.kt
@@ -7,7 +7,7 @@ class FilterPanel(
     private val page: Page,
     locator: Locator = page.locator(".moj-filter-layout"),
 ) : BaseComponent(locator) {
-    fun getPanel() = getChildComponent(".moj-filter")
+    fun getPanel(isVisible: Boolean = true) = if (isVisible) getChildComponent(".moj-filter") else locator.locator(".moj-filter")
 
     fun clickCloseFilterPanel() {
         getButton(page, "Close filters panel").click()

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/components/Pagination.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/components/Pagination.kt
@@ -5,7 +5,7 @@ import com.microsoft.playwright.Page
 
 class Pagination(
     private val page: Page,
-    locator: Locator = page.locator(".govuk-pagination").first(),
+    locator: Locator = getLocator(page),
 ) : BaseComponent(locator) {
     fun getPreviousLink() = getLinkWithText("Previous")
 
@@ -18,4 +18,8 @@ class Pagination(
     fun getNextLink() = getLinkWithText("Next")
 
     private fun getLinkWithText(text: String) = getChildComponent(".govuk-pagination__link", Locator.LocatorOptions().setHasText(text))
+
+    companion object {
+        fun getLocator(page: Page) = page.locator(".govuk-pagination").first()
+    }
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/components/Table.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/components/Table.kt
@@ -5,18 +5,22 @@ import com.microsoft.playwright.Page
 
 class Table(
     page: Page,
-    locator: Locator = page.locator(".govuk-table"),
+    locator: Locator = getLocator(page),
 ) : BaseComponent(locator) {
-    fun getHeaderCell(colIndex: Int) = Companion.getChildComponent(getHeaderRow(), "th", index = colIndex)
+    fun getHeaderCell(colIndex: Int) = getChildComponent(getHeaderRow(), "th", index = colIndex)
 
     fun getCell(
         rowIndex: Int,
         colIndex: Int,
-    ) = Companion.getChildComponent(getRow(rowIndex), "td", index = colIndex)
+    ) = getChildComponent(getRow(rowIndex), "td", index = colIndex)
 
     fun countRows() = locator.locator("tbody").locator("tr").count()
 
     private fun getHeaderRow() = getChildComponent("thead tr")
 
     private fun getRow(index: Int) = getChildComponent("tbody tr", index = index)
+
+    companion object {
+        fun getLocator(page: Page): Locator = page.locator(".govuk-table")
+    }
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/basePages/SearchRegisterBasePage.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/basePages/SearchRegisterBasePage.kt
@@ -17,9 +17,13 @@ abstract class SearchRegisterBasePage(
 
     fun getResultTable() = Table(page)
 
+    fun getHiddenResultTable() = Table.getLocator(page)
+
     fun getPaginationComponent() = Pagination(page)
+
+    fun getHiddenPaginationComponent() = Pagination.getLocator(page)
 
     fun getErrorMessageText() = getErrorMessage().innerText()
 
-    fun getErrorMessage() = getComponent(page, "#no-results")
+    fun getErrorMessage(isVisible: Boolean = true) = if (isVisible) getComponent(page, "#no-results") else page.locator("#no-results")
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/LandlordServiceTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/LandlordServiceTests.kt
@@ -153,9 +153,9 @@ class LandlordServiceTests {
     fun `searchForLandlords returns a corresponding list of LandlordSearchResultViewModels`() {
         val searchTerm = "searchTerm"
         val laUserBaseId = "laUserBaseId"
-        val currentPageNumber = 0
+        val requestedPageNumber = 0
         val pageSize = 25
-        val pageRequest = PageRequest.of(currentPageNumber, pageSize)
+        val pageRequest = PageRequest.of(requestedPageNumber, pageSize)
 
         val matchingLandlords = mutableListOf<Landlord>()
         val matchingLandlordsWithListedPropertyCount = mutableListOf<LandlordWithListedPropertyCount>()
@@ -182,7 +182,7 @@ class LandlordServiceTests {
             landlordService.searchForLandlords(
                 searchTerm,
                 laUserBaseId,
-                currentPageNumber = currentPageNumber,
+                requestedPageIndex = requestedPageNumber,
                 pageSize = pageSize,
             )
 
@@ -195,9 +195,9 @@ class LandlordServiceTests {
         val searchLRN =
             RegistrationNumberDataModel.parseTypeOrNull(searchTerm, RegistrationNumberType.LANDLORD)!!.number
         val laUserBaseId = "laUserBaseId"
-        val currentPageNumber = 0
+        val requestedPageIndex = 0
         val pageSize = 25
-        val pageRequest = PageRequest.of(currentPageNumber, pageSize)
+        val pageRequest = PageRequest.of(requestedPageIndex, pageSize)
         val matchingLandlord = listOf(createLandlord())
         val matchingLandlordWithListedPropertyCount =
             listOf(LandlordWithListedPropertyCount(matchingLandlord[0].id, matchingLandlord[0], 0))
@@ -218,7 +218,7 @@ class LandlordServiceTests {
             landlordService.searchForLandlords(
                 searchTerm,
                 laUserBaseId,
-                currentPageNumber = currentPageNumber,
+                requestedPageIndex = requestedPageIndex,
                 pageSize = pageSize,
             )
 
@@ -229,9 +229,9 @@ class LandlordServiceTests {
     fun `searchForLandlords returns no results when given a non-landlord registration number`() {
         val searchTerm = "P-CCCC-CCCC"
         val laUserBaseId = "laUserBaseId"
-        val currentPageNumber = 0
+        val requestedPageIndex = 0
         val pageSize = 25
-        val expectedPageRequest = PageRequest.of(currentPageNumber, pageSize)
+        val expectedPageRequest = PageRequest.of(requestedPageIndex, pageSize)
         val expectedSearchResults = emptyList<LandlordSearchResultViewModel>()
 
         whenever(
@@ -242,7 +242,7 @@ class LandlordServiceTests {
             landlordService.searchForLandlords(
                 searchTerm,
                 laUserBaseId,
-                currentPageNumber = currentPageNumber,
+                requestedPageIndex = requestedPageIndex,
                 pageSize = pageSize,
             )
 
@@ -254,9 +254,9 @@ class LandlordServiceTests {
     fun `searchForLandlords returns no results when given a searchTerm that has no LRN or fuzzy search matches`() {
         val searchTerm = "non-matching searchTerm"
         val laUserBaseId = "laUserBaseId"
-        val currentPageNumber = 0
+        val requestedPageIndex = 0
         val pageSize = 25
-        val expectedPageRequest = PageRequest.of(currentPageNumber, pageSize)
+        val expectedPageRequest = PageRequest.of(requestedPageIndex, pageSize)
         val expectedSearchResults = emptyList<LandlordSearchResultViewModel>()
 
         whenever(
@@ -267,7 +267,7 @@ class LandlordServiceTests {
             landlordService.searchForLandlords(
                 searchTerm,
                 laUserBaseId,
-                currentPageNumber = currentPageNumber,
+                requestedPageIndex = requestedPageIndex,
                 pageSize = pageSize,
             )
 
@@ -295,8 +295,8 @@ class LandlordServiceTests {
             )
         }
 
-        val pageNumber1 = 0
-        val pageRequest1 = PageRequest.of(pageNumber1, pageSize)
+        val pageIndex1 = 0
+        val pageRequest1 = PageRequest.of(pageIndex1, pageSize)
         val matchingLandlordsPage1 = matchingLandlords.subList(0, pageSize)
         val matchingLandlordsWithListedPropertiesPage1 = matchingLandlordsWithListedPropertyCount.subList(0, pageSize)
         val expectedFormattedSearchResultsPage1 =
@@ -306,8 +306,8 @@ class LandlordServiceTests {
                 )
             }
 
-        val pageNumber2 = 1
-        val pageRequest2 = PageRequest.of(pageNumber2, pageSize)
+        val pageIndex2 = 1
+        val pageRequest2 = PageRequest.of(pageIndex2, pageSize)
         val matchingLandlordsPage2 = matchingLandlords.subList(pageSize, 40)
         val matchingLandlordsWithListedPropertiesPage2 = matchingLandlordsWithListedPropertyCount.subList(pageSize, 40)
         val expectedFormattedSearchResultsPage2 =
@@ -330,14 +330,14 @@ class LandlordServiceTests {
             landlordService.searchForLandlords(
                 searchTerm,
                 laUserBaseId,
-                currentPageNumber = pageNumber1,
+                requestedPageIndex = pageIndex1,
                 pageSize = pageSize,
             )
         val searchResults2 =
             landlordService.searchForLandlords(
                 searchTerm,
                 laUserBaseId,
-                currentPageNumber = pageNumber2,
+                requestedPageIndex = pageIndex2,
                 pageSize = pageSize,
             )
 

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/PropertyOwnershipServiceTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/PropertyOwnershipServiceTests.kt
@@ -29,10 +29,7 @@ import uk.gov.communities.prsdb.webapp.database.entity.Property
 import uk.gov.communities.prsdb.webapp.database.entity.PropertyOwnership
 import uk.gov.communities.prsdb.webapp.database.entity.RegistrationNumber
 import uk.gov.communities.prsdb.webapp.database.repository.PropertyOwnershipRepository
-import uk.gov.communities.prsdb.webapp.mockObjects.MockLandlordData.Companion.createAddress
-import uk.gov.communities.prsdb.webapp.mockObjects.MockLandlordData.Companion.createLandlord
-import uk.gov.communities.prsdb.webapp.mockObjects.MockLandlordData.Companion.createProperty
-import uk.gov.communities.prsdb.webapp.mockObjects.MockLandlordData.Companion.createPropertyOwnership
+import uk.gov.communities.prsdb.webapp.mockObjects.MockLandlordData
 import uk.gov.communities.prsdb.webapp.models.dataModels.RegistrationNumberDataModel
 import uk.gov.communities.prsdb.webapp.models.viewModels.PropertySearchResultViewModel
 import uk.gov.communities.prsdb.webapp.models.viewModels.RegisteredPropertyViewModel
@@ -143,27 +140,26 @@ class PropertyOwnershipServiceTests {
 
     @Nested
     inner class GetLandlordRegisteredPropertiesDetails {
-        private val landlord = createLandlord()
+        private val landlord = MockLandlordData.createLandlord()
 
         private val address1 = "11 Example Road, EG1 2AB"
         private val address2 = "12 Example Road, EG1 2AB"
         private val localAuthority = LocalAuthority(11, "DERBYSHIRE DALES DISTRICT COUNCIL", "1045")
         private val registrationNumber = RegistrationNumber(RegistrationNumberType.PROPERTY, 1233456)
 
-        private val property1 = createProperty(address = createAddress(address1, localAuthority))
-        private val property2 = createProperty(address = createAddress(address2, localAuthority))
+        private val property1 =
+            MockLandlordData.createProperty(address = MockLandlordData.createAddress(address1, localAuthority))
+        private val property2 =
+            MockLandlordData.createProperty(address = MockLandlordData.createAddress(address2, localAuthority))
 
         private val expectedLocalAuthority = localAuthority.name
         private val expectedRegistrationNumber =
-            RegistrationNumberDataModel
-                .fromRegistrationNumber(
-                    registrationNumber,
-                ).toString()
+            RegistrationNumberDataModel.fromRegistrationNumber(registrationNumber).toString()
         private val expectedPropertyLicence = "Not Licenced"
         private val expectedIsTenantedMessageKey = "commonText.no"
 
         private val propertyOwnership1 =
-            createPropertyOwnership(
+            MockLandlordData.createPropertyOwnership(
                 primaryLandlord = landlord,
                 property = property1,
                 registrationNumber = registrationNumber,
@@ -171,7 +167,7 @@ class PropertyOwnershipServiceTests {
                 currentNumTenants = 0,
             )
         private val propertyOwnership2 =
-            createPropertyOwnership(
+            MockLandlordData.createPropertyOwnership(
                 primaryLandlord = landlord,
                 property = property2,
                 registrationNumber = registrationNumber,
@@ -234,7 +230,7 @@ class PropertyOwnershipServiceTests {
     @Test
     fun `searchForProperties returns a single matching property when the search term is a PRN`() {
         val searchPRN = RegistrationNumberDataModel(RegistrationNumberType.PROPERTY, 123)
-        val prnMatchingPropertyOwnership = listOf(createPropertyOwnership())
+        val prnMatchingPropertyOwnership = listOf(MockLandlordData.createPropertyOwnership())
         val expectedSearchResults =
             prnMatchingPropertyOwnership.map { PropertySearchResultViewModel.fromPropertyOwnership(it) }
 
@@ -271,7 +267,17 @@ class PropertyOwnershipServiceTests {
         val searchUPRN = "123"
 
         val uprnMatchingPropertyOwnership =
-            listOf(createPropertyOwnership(property = createProperty(address = createAddress(uprn = searchUPRN.toLong()))))
+            listOf(
+                MockLandlordData.createPropertyOwnership(
+                    property =
+                        MockLandlordData.createProperty(
+                            address =
+                                MockLandlordData.createAddress(
+                                    uprn = searchUPRN.toLong(),
+                                ),
+                        ),
+                ),
+            )
         val expectedSearchResults =
             uprnMatchingPropertyOwnership.map { PropertySearchResultViewModel.fromPropertyOwnership(it) }
 
@@ -293,7 +299,8 @@ class PropertyOwnershipServiceTests {
     fun `searchForProperties returns a collection of fuzzy matches when the search term is not a PRN or UPRN`() {
         val searchTerm = "EG1 2AB"
 
-        val fuzzyMatchingPropertyOwnerships = listOf(createPropertyOwnership(), createPropertyOwnership())
+        val fuzzyMatchingPropertyOwnerships =
+            listOf(MockLandlordData.createPropertyOwnership(), MockLandlordData.createPropertyOwnership())
         val expectedSearchResults =
             fuzzyMatchingPropertyOwnerships.map { PropertySearchResultViewModel.fromPropertyOwnership(it) }
 

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/PropertyOwnershipServiceTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/PropertyOwnershipServiceTests.kt
@@ -320,14 +320,14 @@ class PropertyOwnershipServiceTests {
         val pageSize = 25
         val matchingProperties = (1..40).map { MockLandlordData.createPropertyOwnership() }
 
-        val pageNumber1 = 0
-        val pageRequest1 = PageRequest.of(pageNumber1, pageSize)
+        val pageIndex1 = 0
+        val pageRequest1 = PageRequest.of(pageIndex1, pageSize)
         val matchingPropertiesPage1 = matchingProperties.subList(0, pageSize)
         val expectedPage1SearchResults =
             matchingPropertiesPage1.map { PropertySearchResultViewModel.fromPropertyOwnership(it) }
 
-        val pageNumber2 = 1
-        val pageRequest2 = PageRequest.of(pageNumber2, pageSize)
+        val pageIndex2 = 1
+        val pageRequest2 = PageRequest.of(pageIndex2, pageSize)
         val matchingPropertiesPage2 = matchingProperties.subList(pageSize, matchingProperties.size)
         val expectedPage2SearchResults =
             matchingPropertiesPage2.map { PropertySearchResultViewModel.fromPropertyOwnership(it) }
@@ -337,8 +337,8 @@ class PropertyOwnershipServiceTests {
         whenever(mockPropertyOwnershipRepository.searchMatching(searchTerm, pageable = pageRequest2))
             .thenReturn(PageImpl(matchingPropertiesPage2))
 
-        val searchResults1 = propertyOwnershipService.searchForProperties(searchTerm, pageNumber1)
-        val searchResults2 = propertyOwnershipService.searchForProperties(searchTerm, pageNumber2)
+        val searchResults1 = propertyOwnershipService.searchForProperties(searchTerm, pageIndex1)
+        val searchResults2 = propertyOwnershipService.searchForProperties(searchTerm, pageIndex2)
 
         assertEquals(expectedPage1SearchResults, searchResults1.content)
         assertEquals(expectedPage2SearchResults, searchResults2.content)

--- a/src/test/resources/data-search.sql
+++ b/src/test/resources/data-search.sql
@@ -109,7 +109,8 @@ VALUES (1, '09/13/24', 2001001001, 1),
        (61, '12/10/24', 0006001029, 0),
        (62, '12/10/24', 0006001030, 0),
        (63, '12/10/24', 0006001031, 0),
-       (64, '12/10/24', 0006001032, 0);
+       (64, '12/10/24', 0006001032, 0),
+       (65, '12/10/24', 0006001033, 0);
 
 
 INSERT INTO address (id, created_date, last_modified_date, uprn, single_line_address, local_authority_id)
@@ -149,7 +150,8 @@ VALUES (1, '09/13/24', '09/13/24', 1, '1 Fictional Road', 1),
        (34, '05/02/25', '05/02/25', 1034, '22 PRSDB Square, EG1 2AV', 1),
        (35, '05/02/25', '05/02/25', 1035, '23 PRSDB Square, EG1 2AW', 1),
        (36, '05/02/25', '05/02/25', 1036, '24 PRSDB Square, EG1 2AX', 1),
-       (37, '05/02/25', '05/02/25', 1037, '25 PRSDB Square, EG1 2AY', 1);
+       (37, '05/02/25', '05/02/25', 1037, '25 PRSDB Square, EG1 2AY', 1),
+       (38, '05/02/25', '05/02/25', 1038, '26 PRSDB Square, EG1 2AZ', 1);
 
 INSERT INTO landlord (id, created_date, last_modified_date, registration_number_id, address_id, date_of_birth,
                       is_active, phone_number, subject_identifier, name, email)
@@ -229,7 +231,8 @@ VALUES (1, 1, true, 1, 6),
        (29, 1, true, 1, 34),
        (30, 1, true, 1, 35),
        (31, 1, true, 1, 36),
-       (32, 1, true, 1, 37);
+       (32, 1, true, 1, 37),
+       (33, 1, true, 1, 38);
 
 INSERT INTO property_ownership (id, is_active, occupancy_type, landlord_type, ownership_type, current_num_households,
                                 current_num_tenants,
@@ -265,4 +268,5 @@ VALUES (1, true, 0, 0, 1, 1, 2, 6, 1, 1, '01/15/25'),
        (29, true, 0, 0, 1, 0, 0, 61, 1, 29, '05/02/25'),
        (30, true, 0, 0, 1, 0, 0, 62, 1, 30, '05/02/25'),
        (31, true, 0, 0, 1, 0, 0, 63, 1, 31, '05/02/25'),
-       (32, true, 0, 0, 1, 0, 0, 64, 1, 32, '05/02/25');
+       (32, true, 0, 0, 1, 0, 0, 64, 1, 32, '05/02/25'),
+       (33, true, 0, 0, 1, 0, 0, 65, 1, 33, '05/02/25');


### PR DESCRIPTION
Features:
- Updates `PropertyOwnershipService.searchForProperties` to return a (requested) page
- Adds pagination to property search page

Tests:
- Updates affected `PropertyOwnershipService.searchForProperties` tests
- Tests pagination in 
  - PropertyOwnershipService.searchProperties
  - Property search endpoint
  - Property search page

Screenshot:
![image](https://github.com/user-attachments/assets/cb6eaded-c875-4e62-b93b-8496cf252339)