### PR TITLE
PRSD-600: Create transaction section fragment and use section list

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/RegisterPropertyController.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/RegisterPropertyController.kt
@@ -57,11 +57,9 @@ class RegisterPropertyController(
         model: Model,
         principal: Principal,
     ): String {
-        val viewModelLists = registerPropertyTransaction.getTaskListPageViewModels(principal.name)
+        val listOfSections = registerPropertyTransaction.getTaskListSections(principal.name)
 
-        // TODO PRSD-600: Pass this list directly to the template and update the template to represent a list of sections
-        model.addAttribute("registerTasks", viewModelLists[0])
-        model.addAttribute("checkAndSubmitTasks", viewModelLists[1])
+        model.addAttribute("registerPropertyTaskSections", listOfSections)
 
         return "registerPropertyTaskList"
     }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/tasks/MultiTaskTransaction.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/tasks/MultiTaskTransaction.kt
@@ -3,21 +3,24 @@ package uk.gov.communities.prsdb.webapp.forms.tasks
 import uk.gov.communities.prsdb.webapp.constants.enums.JourneyType
 import uk.gov.communities.prsdb.webapp.forms.journeys.JourneyData
 import uk.gov.communities.prsdb.webapp.forms.steps.StepId
-import uk.gov.communities.prsdb.webapp.models.viewModels.TaskListItemViewModel
+import uk.gov.communities.prsdb.webapp.models.viewModels.TaskSectionViewModel
 import uk.gov.communities.prsdb.webapp.services.JourneyDataService
 
 abstract class MultiTaskTransaction<T : StepId>(
     private val journeyDataService: JourneyDataService,
 ) {
-    protected abstract val taskLists: List<TaskList<T>>
+    protected abstract val taskLists: List<TransactionSection<T>>
     protected abstract val journeyType: JourneyType
     protected abstract val taskListUrlSegment: String
 
-    fun getTaskListPageViewModels(principalName: String): List<List<TaskListItemViewModel>> {
+    fun getTaskListSections(principalName: String): List<TaskSectionViewModel> {
         loadJourneyDataIntoSessionIfNotLoaded(principalName)
 
         return taskLists.map {
-            it.getTaskListViewModels()
+            TaskSectionViewModel(
+                it.headingKey,
+                it.sectionTasks.getTaskListViewModels(),
+            )
         }
     }
 
@@ -41,4 +44,9 @@ abstract class MultiTaskTransaction<T : StepId>(
         data[taskListUrlSegment] = mutableMapOf<String, Any>()
         journeyDataService.setJourneyData(data)
     }
+
+    data class TransactionSection<T : StepId>(
+        val headingKey: String,
+        val sectionTasks: TaskList<T>,
+    )
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/tasks/RegisterPropertyMultiTaskTransaction.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/tasks/RegisterPropertyMultiTaskTransaction.kt
@@ -11,7 +11,11 @@ class RegisterPropertyMultiTaskTransaction(
     registerPropertiesTaskList: RegisterPropertiesTaskList,
     checkAndSubmitPropertiesTaskList: CheckAndSubmitPropertiesTaskList,
 ) : MultiTaskTransaction<RegisterPropertyStepId>(journeyDataService) {
-    override val taskLists: List<TaskList<RegisterPropertyStepId>> = listOf(registerPropertiesTaskList, checkAndSubmitPropertiesTaskList)
+    override val taskLists =
+        listOf(
+            TransactionSection("registerProperty.taskList.register.heading", registerPropertiesTaskList),
+            TransactionSection("registerProperty.taskList.checkAndSubmit.heading", checkAndSubmitPropertiesTaskList),
+        )
     override val journeyType: JourneyType = JourneyType.PROPERTY_REGISTRATION
     override val taskListUrlSegment: String = RegisterPropertyStepId.TaskList.urlPathSegment
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/TaskSectionViewModel.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/TaskSectionViewModel.kt
@@ -1,0 +1,6 @@
+package uk.gov.communities.prsdb.webapp.models.viewModels
+
+data class TaskSectionViewModel(
+    val headingKey: String,
+    val tasks: List<TaskListItemViewModel>,
+)

--- a/src/main/resources/templates/fragments/taskList/sectionTaskList.html
+++ b/src/main/resources/templates/fragments/taskList/sectionTaskList.html
@@ -1,8 +1,8 @@
 <th:block th:fragment="sectionTaskList(section, sectionNumber, transactionName)">
-    <h2 class="govuk-heading-m" th:text="${sectionNumber} + '. ' + #{${section.headingKey}}">sectionNumber + sectionHeading</h2>
+    <h2 class="govuk-heading-m" th:text="|${sectionNumber}.  #{${section.headingKey}}|">sectionNumber + sectionHeading</h2>
     <ul class="govuk-task-list">
-        <th:block th:each="task, iteratorStatus: ${section.tasks}">
-            <li th:replace="~{fragments/taskList/taskListItem :: taskListItem(${task}, ${transactionName} + '-' + ${sectionNumber} + '-' + ${iteratorStatus.index})}"></li>
+        <th:block th:each="task, iteratorStatus: ${section.tasks}" th:with="taskListItemId=${transactionName} + '-' + ${sectionNumber} + '-' + ${iteratorStatus.count}">
+            <li th:replace="~{fragments/taskList/taskListItem :: taskListItem(${task}, ${taskListItemId})}"></li>
         </th:block>
     </ul>
 </th:block>

--- a/src/main/resources/templates/fragments/taskList/sectionTaskList.html
+++ b/src/main/resources/templates/fragments/taskList/sectionTaskList.html
@@ -1,0 +1,8 @@
+<th:block th:fragment="sectionTaskList(section, sectionNumber, transactionName)">
+    <h2 class="govuk-heading-m" th:text="${sectionNumber} + '. ' + #{${section.headingKey}}">sectionNumber + sectionHeading</h2>
+    <ul class="govuk-task-list">
+        <th:block th:each="task, iteratorStatus: ${section.tasks}">
+            <li th:replace="~{fragments/taskList/taskListItem :: taskListItem(${task}, ${transactionName} + '-' + ${sectionNumber} + '-' + ${iteratorStatus.index})}"></li>
+        </th:block>
+    </ul>
+</th:block>

--- a/src/main/resources/templates/registerPropertyTaskList.html
+++ b/src/main/resources/templates/registerPropertyTaskList.html
@@ -12,7 +12,7 @@
             <p class="govuk-body" th:text="#{registerProperty.taskList.subtitle}">registerProperty.taskList.subtitle</p>
         </header>
         <section th:each="section, iteratorStatus: ${registerPropertyTaskSections}">
-            <div th:replace="~{fragments/taskList/sectionTaskList :: sectionTaskList(${section}, ${iteratorStatus.index} + 1, 'register-property-task')}"></div>
+            <div th:replace="~{fragments/taskList/sectionTaskList :: sectionTaskList(${section}, ${iteratorStatus.count}, 'register-property-task')}"></div>
         </section>
     </th:block>
 </main>

--- a/src/main/resources/templates/registerPropertyTaskList.html
+++ b/src/main/resources/templates/registerPropertyTaskList.html
@@ -1,3 +1,4 @@
+<!--/*@thymesVar id="registerPropertyTaskSections" type="List<TaskSectionViewModel>"*/-->
 <!DOCTYPE html>
 <html>
 <body th:replace="~{fragments/layout :: layout(#{registerProperty.title}, ~{::body/content()}, false)}">
@@ -10,19 +11,8 @@
             </h1>
             <p class="govuk-body" th:text="#{registerProperty.taskList.subtitle}">registerProperty.taskList.subtitle</p>
         </header>
-        <section>
-            <h2 class="govuk-heading-m" th:text="#{registerProperty.taskList.register.heading}">registerProperty.taskList.register.heading</h2>
-            <ul class="govuk-task-list">
-                <th:block th:each="task, iteratorStatus: ${registerTasks}">
-                    <li th:replace="~{fragments/taskList/taskListItem :: taskListItem(${task}, 'register-tasks-' + ${iteratorStatus.index})}"></li>
-                </th:block>
-            </ul>
-            <h2 class="govuk-heading-m" th:text="#{registerProperty.taskList.checkAndSubmit.heading}">registerProperty.taskList.checkAndSubmit.heading</h2>
-            <ul class="govuk-task-list">
-                <th:block th:each="task, iteratorStatus: ${checkAndSubmitTasks}" >
-                    <li th:replace="~{fragments/taskList/taskListItem :: taskListItem(${task}, 'check-and-submit-tasks-' + ${iteratorStatus.index})}"></li>
-                </th:block>
-            </ul>
+        <section th:each="section, iteratorStatus: ${registerPropertyTaskSections}">
+            <div th:replace="~{fragments/taskList/sectionTaskList :: sectionTaskList(${section}, ${iteratorStatus.index} + 1, 'register-property-task')}"></div>
         </section>
     </th:block>
 </main>


### PR DESCRIPTION
Final PR for PRSD-600: Adds numbering to the titles and makes the template use a list of fragments to generate the sections. I rename some terminology based on other ongoing discussion and update the tests to match the new View Models.

![image](https://github.com/user-attachments/assets/fe755ee6-66ff-4992-8584-8b5392d76c11)
