### PR TITLE
PRSD-651: Update Selected Filter View

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/requestModels/searchModels/SearchRequestModel.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/requestModels/searchModels/SearchRequestModel.kt
@@ -1,7 +1,15 @@
 package uk.gov.communities.prsdb.webapp.models.requestModels.searchModels
 
+import kotlin.reflect.full.memberProperties
+
 abstract class SearchRequestModel {
     var searchTerm: String? = null
 
     var showFilter: Boolean = true
+
+    fun getFilterPropertyNameValuePairs() =
+        this::class
+            .memberProperties
+            .filterNot { it.name in listOf("searchTerm", "showFilter") }
+            .map { Pair(it.name, it.getter.call(this)) }
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/filterPanelModels/FilterPanelViewModel.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/filterPanelModels/FilterPanelViewModel.kt
@@ -15,11 +15,11 @@ abstract class FilterPanelViewModel(
     val clearLink =
         URIQueryBuilder
             .fromHTTPServletRequest(httpServletRequest)
-            .removeParams(filters.map { it.searchRequestProperty })
+            .removeParams(searchRequestModel.getFilterPropertyNameValuePairs().map { it.first })
             .build()
             .toUriString()
 
-    val showFilterLink =
+    val toggleLink =
         URIQueryBuilder
             .fromHTTPServletRequest(httpServletRequest)
             .updateParam("showFilter", !searchRequestModel.showFilter)

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/filterPanelModels/FilterPanelViewModel.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/filterPanelModels/FilterPanelViewModel.kt
@@ -4,6 +4,7 @@ import jakarta.servlet.http.HttpServletRequest
 import uk.gov.communities.prsdb.webapp.helpers.URIQueryBuilder
 import uk.gov.communities.prsdb.webapp.models.requestModels.searchModels.SearchRequestModel
 import uk.gov.communities.prsdb.webapp.models.viewModels.CheckboxViewModel
+import kotlin.properties.Delegates
 import kotlin.reflect.full.memberProperties
 
 abstract class FilterPanelViewModel(
@@ -25,8 +26,11 @@ abstract class FilterPanelViewModel(
             .build()
             .toUriString()
 
+    var noFiltersSelected by Delegates.notNull<Boolean>()
+
     init {
         filters.forEach { it.initializeSelectedOptions(searchRequestModel, httpServletRequest) }
+        noFiltersSelected = filters.all { it.selectedOptions.isEmpty() }
     }
 }
 

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -36,6 +36,7 @@ filter.heading=Filter panel
 filter.selected.heading=Selected filters
 filter.selected.clearLink=Clear filters
 filter.selected.remove=Remove this filter
+filter.selected.noneSelectedText=No filters selected
 filter.applyButton=Apply filters
 filter.showButton=Show filters panel
 filter.closeButton=Close filters panel

--- a/src/main/resources/templates/fragments/filterPanel.html
+++ b/src/main/resources/templates/fragments/filterPanel.html
@@ -21,7 +21,7 @@
                             </h2>
                         </div>
                         <div class="moj-filter__heading-action govuk-!-margin-bottom-4"
-                             th:if="${!filterPanelViewModel.noFiltersSelected}">
+                             th:unless="${filterPanelViewModel.noFiltersSelected}">
                             <p>
                                 <a class="govuk-link govuk-link--no-visited-state"
                                    th:text="#{filter.selected.clearLink}"
@@ -33,8 +33,9 @@
                     </div>
 
                     <th:block th:each="filter:${filterPanelViewModel.filters}">
-                        <h3 class="govuk-heading-s govuk-!-margin-bottom-0" th:if="${!filter.selectedOptions.isEmpty()}"
-                            th:text="#{${filter.headingMsgKey}}"></h3>
+                        <h3 class="govuk-heading-s govuk-!-margin-bottom-0"
+                            th:unless="${filter.selectedOptions.isEmpty()}" th:text="#{${filter.headingMsgKey}}">
+                        </h3>
                         <ul class="moj-filter-tags" th:each="selectedOption:${filter.selectedOptions}">
                             <li>
                                 <a class="moj-filter__tag"

--- a/src/main/resources/templates/fragments/filterPanel.html
+++ b/src/main/resources/templates/fragments/filterPanel.html
@@ -95,7 +95,7 @@
 
         <div class="moj-action-bar">
             <a th:replace="~{fragments/buttons/secondaryButtonLink :: secondaryButtonLink(
-                    ${filterPanelViewModel.showFilterLink},
+                    ${filterPanelViewModel.toggleLink},
                     #{${searchRequest.showFilter ? 'filter.closeButton' : 'filter.showButton'}})}">
                 filter.showButton/filter.closeButton
             </a>

--- a/src/main/resources/templates/fragments/filterPanel.html
+++ b/src/main/resources/templates/fragments/filterPanel.html
@@ -32,7 +32,7 @@
                     </div>
 
                     <th:block th:each="filter:${filterPanelViewModel.filters}">
-                        <h3 class="govuk-heading-s govuk-!-margin-bottom-0"
+                        <h3 class="govuk-heading-s govuk-!-margin-bottom-0" th:if="${!filter.selectedOptions.isEmpty()}"
                             th:text="#{${filter.headingMsgKey}}"></h3>
                         <ul class="moj-filter-tags" th:each="selectedOption:${filter.selectedOptions}">
                             <li>

--- a/src/main/resources/templates/fragments/filterPanel.html
+++ b/src/main/resources/templates/fragments/filterPanel.html
@@ -20,7 +20,8 @@
                                 filter.selected.heading
                             </h2>
                         </div>
-                        <div class="moj-filter__heading-action govuk-!-margin-bottom-4">
+                        <div class="moj-filter__heading-action govuk-!-margin-bottom-4"
+                             th:if="${!filterPanelViewModel.noFiltersSelected}">
                             <p>
                                 <a class="govuk-link govuk-link--no-visited-state"
                                    th:text="#{filter.selected.clearLink}"
@@ -46,6 +47,10 @@
                             </li>
                         </ul>
                     </th:block>
+
+                    <p class="govuk-body" th:if="${filterPanelViewModel.noFiltersSelected}"
+                       th:text="#{filter.selected.noneSelectedText}">filter.selected.noneSelectedText</p>
+
                 </div>
 
                 <div class="moj-filter__options">

--- a/src/main/resources/templates/fragments/searchBar.html
+++ b/src/main/resources/templates/fragments/searchBar.html
@@ -1,5 +1,6 @@
 <div class="moj-search govuk-!-margin-bottom-6" th:fragment="searchBar(label, hint, searchRequest)">
     <form method="get" th:action="@{''}" th:object="${searchRequest}">
+
         <div class="govuk-form-group">
             <label class="govuk-label moj-search__label govuk-!-font-weight-bold" th:for="'searchTerm'"
                    th:text="${label}">
@@ -8,6 +9,10 @@
             <input class="govuk-input moj-search__input " type="search" th:field="*{searchTerm}"
                    aria-describedby="search-hint">
         </div>
+
+        <input type="hidden" th:each="filterProp:${searchRequest.getFilterPropertyNameValuePairs()}"
+               th:field="*{__${filterProp.first}__}" th:value="${filterProp.second}">
+
         <button type="submit" class="govuk-button moj-search__button " data-module="govuk-button"
                 th:text="#{searchButtonText}">
         </button>

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/SearchRegisterTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/SearchRegisterTests.kt
@@ -163,6 +163,23 @@ class SearchRegisterTests : IntegrationTest() {
             assertTrue(filter.getNoFiltersSelectedText().isVisible)
             assertTrue(resultTable.countRows() > 1)
         }
+
+        @Test
+        fun `selected filters persist across searches`(page: Page) {
+            // Search
+            val searchLandlordRegisterPage = navigator.goToLandlordSearchPage()
+            searchLandlordRegisterPage.searchBar.search("Alex")
+
+            // Apply LA filter
+            val filter = searchLandlordRegisterPage.getFilterPanel()
+            val laFilter = filter.getFilterCheckboxes("Show landlords operating in my authority")
+            laFilter.checkCheckbox("true")
+            filter.clickApplyFiltersButton()
+
+            // Search again
+            searchLandlordRegisterPage.searchBar.search("PRSD")
+            assertTrue(filter.getRemoveFilterTag("Landlords in my authority").isVisible)
+        }
     }
 
     @Nested
@@ -320,6 +337,23 @@ class SearchRegisterTests : IntegrationTest() {
             assertTrue(filter.getClearFiltersLink(isVisible = false).isHidden)
             assertTrue(filter.getNoFiltersSelectedText().isVisible)
             assertTrue(resultTable.countRows() > 1)
+        }
+
+        @Test
+        fun `selected filters persist across searches`(page: Page) {
+            // Search
+            val searchPropertyRegisterPage = navigator.goToPropertySearchPage()
+            searchPropertyRegisterPage.searchBar.search("Way")
+
+            // Apply LA filter
+            val filter = searchPropertyRegisterPage.getFilterPanel()
+            val laFilter = filter.getFilterCheckboxes("Show properties in my authority")
+            laFilter.checkCheckbox("true")
+            filter.clickApplyFiltersButton()
+
+            // Search again
+            searchPropertyRegisterPage.searchBar.search("PRSD")
+            assertTrue(filter.getRemoveFilterTag("Properties in my authority").isVisible)
         }
     }
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/SearchRegisterTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/SearchRegisterTests.kt
@@ -133,10 +133,10 @@ class SearchRegisterTests : IntegrationTest() {
             val filter = searchLandlordRegisterPage.getFilterPanel()
 
             // Toggle filter
-            filter.clickCloseFilterPanel()
+            searchLandlordRegisterPage.clickComponent(filter.getCloseFilterPanelButton())
             assertTrue(filter.getPanel(isVisible = false).isHidden)
 
-            filter.clickShowFilterPanel()
+            searchLandlordRegisterPage.clickComponent(filter.getShowFilterPanel())
             assertTrue(filter.getPanel().isVisible)
 
             // Apply LA filter
@@ -148,14 +148,14 @@ class SearchRegisterTests : IntegrationTest() {
             assertEquals(1, resultTable.countRows())
 
             // Remove LA filter
-            filter.clickRemoveFilterTag("Landlords in my authority")
+            searchLandlordRegisterPage.clickComponent(filter.getRemoveFilterTag("Landlords in my authority"))
             assertTrue(resultTable.countRows() > 1)
 
             // Clear all filters
             laFilter.checkCheckbox("true")
             filter.clickApplyFiltersButton()
 
-            filter.clickClearFiltersLink()
+            searchLandlordRegisterPage.clickComponent(filter.getClearFiltersLink())
             assertTrue(resultTable.countRows() > 1)
         }
     }
@@ -286,10 +286,10 @@ class SearchRegisterTests : IntegrationTest() {
             val filter = searchPropertyRegisterPage.getFilterPanel()
 
             // Toggle filter
-            filter.clickCloseFilterPanel()
+            searchPropertyRegisterPage.clickComponent(filter.getCloseFilterPanelButton())
             assertTrue(filter.getPanel(isVisible = false).isHidden)
 
-            filter.clickShowFilterPanel()
+            searchPropertyRegisterPage.clickComponent(filter.getShowFilterPanel())
             assertTrue(filter.getPanel().isVisible)
 
             // Apply LA filter
@@ -301,14 +301,14 @@ class SearchRegisterTests : IntegrationTest() {
             assertEquals(1, resultTable.countRows())
 
             // Remove LA filter
-            filter.clickRemoveFilterTag("Properties in my authority")
+            searchPropertyRegisterPage.clickComponent(filter.getRemoveFilterTag("Properties in my authority"))
             assertTrue(resultTable.countRows() > 1)
 
             // Clear all filters
             laFilter.checkCheckbox("true")
             filter.clickApplyFiltersButton()
 
-            filter.clickClearFiltersLink()
+            searchPropertyRegisterPage.clickComponent(filter.getClearFiltersLink())
             assertTrue(resultTable.countRows() > 1)
         }
     }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/SearchRegisterTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/SearchRegisterTests.kt
@@ -144,11 +144,14 @@ class SearchRegisterTests : IntegrationTest() {
             laFilter.checkCheckbox("true")
             filter.clickApplyFiltersButton()
 
+            val laFilterSelectedHeadingText = filter.getSelectedHeadings(expectedCount = 1).first().innerText()
+            assertContains(laFilterSelectedHeadingText, "Show landlords operating in my authority")
             val resultTable = searchLandlordRegisterPage.getResultTable()
             assertEquals(1, resultTable.countRows())
 
             // Remove LA filter
             searchLandlordRegisterPage.clickComponent(filter.getRemoveFilterTag("Landlords in my authority"))
+            assertTrue(filter.getSelectedHeadings(expectedCount = 0).isEmpty())
             assertTrue(resultTable.countRows() > 1)
 
             // Clear all filters
@@ -156,6 +159,8 @@ class SearchRegisterTests : IntegrationTest() {
             filter.clickApplyFiltersButton()
 
             searchLandlordRegisterPage.clickComponent(filter.getClearFiltersLink())
+            assertTrue(filter.getClearFiltersLink(isVisible = false).isHidden)
+            assertTrue(filter.getNoFiltersSelectedText().isVisible)
             assertTrue(resultTable.countRows() > 1)
         }
     }
@@ -297,11 +302,14 @@ class SearchRegisterTests : IntegrationTest() {
             laFilter.checkCheckbox("true")
             filter.clickApplyFiltersButton()
 
+            val laFilterSelectedHeadingText = filter.getSelectedHeadings(expectedCount = 1).first().innerText()
+            assertContains(laFilterSelectedHeadingText, "Show properties in my authority")
             val resultTable = searchPropertyRegisterPage.getResultTable()
             assertEquals(1, resultTable.countRows())
 
             // Remove LA filter
             searchPropertyRegisterPage.clickComponent(filter.getRemoveFilterTag("Properties in my authority"))
+            assertTrue(filter.getSelectedHeadings(expectedCount = 0).isEmpty())
             assertTrue(resultTable.countRows() > 1)
 
             // Clear all filters
@@ -309,6 +317,8 @@ class SearchRegisterTests : IntegrationTest() {
             filter.clickApplyFiltersButton()
 
             searchPropertyRegisterPage.clickComponent(filter.getClearFiltersLink())
+            assertTrue(filter.getClearFiltersLink(isVisible = false).isHidden)
+            assertTrue(filter.getNoFiltersSelectedText().isVisible)
             assertTrue(resultTable.countRows() > 1)
         }
     }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/components/BaseComponent.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/components/BaseComponent.kt
@@ -25,9 +25,10 @@ abstract class BaseComponent(
             locatorStr: String,
             locatorOptions: LocatorOptions? = null,
             index: Int = 0,
+            isVisible: Boolean = true,
         ): Locator {
             val component = page.locator(locatorStr, locatorOptions).nth(index)
-            assertLocatorIsValid(component)
+            assertLocatorIsValid(component, expectedLocatorCount = if (isVisible) 1 else 0)
             return component
         }
 
@@ -36,9 +37,10 @@ abstract class BaseComponent(
             locatorStr: String,
             locatorOptions: Locator.LocatorOptions? = null,
             index: Int = 0,
+            isVisible: Boolean = true,
         ): Locator {
             val component = parentLocator.locator(locatorStr, locatorOptions).nth(index)
-            assertLocatorIsValid(component)
+            assertLocatorIsValid(component, expectedLocatorCount = if (isVisible) 1 else 0)
             return component
         }
 
@@ -73,7 +75,8 @@ abstract class BaseComponent(
             page: Page,
             text: String,
             index: Int = 0,
-        ) = getComponent(page, ".govuk-link", LocatorOptions().setHasText(text), index)
+            isVisible: Boolean = true,
+        ) = getComponent(page, ".govuk-link", LocatorOptions().setHasText(text), index, isVisible)
     }
 
     init {
@@ -90,5 +93,6 @@ abstract class BaseComponent(
         locatorStr: String,
         locatorOptions: Locator.LocatorOptions? = null,
         index: Int = 0,
-    ): Locator = Companion.getChildComponent(locator, locatorStr, locatorOptions, index)
+        isVisible: Boolean = true,
+    ): Locator = Companion.getChildComponent(locator, locatorStr, locatorOptions, index, isVisible)
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/components/FilterPanel.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/components/FilterPanel.kt
@@ -2,7 +2,6 @@ package uk.gov.communities.prsdb.webapp.integration.pageObjects.components
 
 import com.microsoft.playwright.Locator
 import com.microsoft.playwright.Page
-import com.microsoft.playwright.Page.LocatorOptions
 
 class FilterPanel(
     private val page: Page,
@@ -14,7 +13,11 @@ class FilterPanel(
 
     fun getShowFilterPanel() = getButton(page, "Show filters panel")
 
-    fun getClearFiltersLink() = getLink(page, "Clear filters")
+    fun getClearFiltersLink(isVisible: Boolean = true) = getLink(page, "Clear filters", isVisible = isVisible)
+
+    fun getSelectedHeadings(expectedCount: Int) = getChildrenComponents(".moj-filter__selected >> h3", expectedCount)
+
+    fun getNoFiltersSelectedText() = getChildComponent(".moj-filter__selected", Locator.LocatorOptions().setHasText("No filters selected"))
 
     fun clickApplyFiltersButton() = Form(page, parentLocator = locator).submit()
 

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/components/FilterPanel.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/components/FilterPanel.kt
@@ -2,12 +2,13 @@ package uk.gov.communities.prsdb.webapp.integration.pageObjects.components
 
 import com.microsoft.playwright.Locator
 import com.microsoft.playwright.Page
+import com.microsoft.playwright.Page.LocatorOptions
 
 class FilterPanel(
     private val page: Page,
     locator: Locator = page.locator(".moj-filter-layout"),
 ) : BaseComponent(locator) {
-    fun getPanel(isVisible: Boolean = true) = if (isVisible) getChildComponent(".moj-filter") else locator.locator(".moj-filter")
+    fun getPanel(isVisible: Boolean = true) = getChildComponent(".moj-filter", isVisible = isVisible)
 
     fun getCloseFilterPanelButton() = getButton(page, "Close filters panel")
 

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/components/FilterPanel.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/components/FilterPanel.kt
@@ -9,27 +9,15 @@ class FilterPanel(
 ) : BaseComponent(locator) {
     fun getPanel(isVisible: Boolean = true) = if (isVisible) getChildComponent(".moj-filter") else locator.locator(".moj-filter")
 
-    fun clickCloseFilterPanel() {
-        getButton(page, "Close filters panel").click()
-        page.waitForLoadState()
-    }
+    fun getCloseFilterPanelButton() = getButton(page, "Close filters panel")
 
-    fun clickShowFilterPanel() {
-        getButton(page, "Show filters panel").click()
-        page.waitForLoadState()
-    }
+    fun getShowFilterPanel() = getButton(page, "Show filters panel")
 
-    fun clickClearFiltersLink() {
-        getLink(page, "Clear filters").click()
-        page.waitForLoadState()
-    }
+    fun getClearFiltersLink() = getLink(page, "Clear filters")
 
     fun clickApplyFiltersButton() = Form(page, parentLocator = locator).submit()
 
     fun getFilterCheckboxes(label: String? = null) = Form(page, parentLocator = locator).getCheckboxes(label)
 
-    fun clickRemoveFilterTag(filterOption: String) {
-        getChildComponent(".moj-filter__tag", Locator.LocatorOptions().setHasText(filterOption)).click()
-        page.waitForLoadState()
-    }
+    fun getRemoveFilterTag(filterOption: String) = getChildComponent(".moj-filter__tag", Locator.LocatorOptions().setHasText(filterOption))
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/basePages/BasePage.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/basePages/BasePage.kt
@@ -33,7 +33,7 @@ abstract class BasePage(
         ) = createValidPage(page, expectedPageClass)
     }
 
-    fun clickButton(locator: Locator) {
+    fun clickComponent(locator: Locator) {
         locator.click()
         page.waitForLoadState()
     }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/basePages/SearchRegisterBasePage.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/basePages/SearchRegisterBasePage.kt
@@ -25,5 +25,5 @@ abstract class SearchRegisterBasePage(
 
     fun getErrorMessageText() = getErrorMessage().innerText()
 
-    fun getErrorMessage(isVisible: Boolean = true) = if (isVisible) getComponent(page, "#no-results") else page.locator("#no-results")
+    fun getErrorMessage(isVisible: Boolean = true) = getComponent(page, "#no-results", isVisible = isVisible)
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/landlordRegistrationJourneyPages/ConfirmationPageLandlordRegistration.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/landlordRegistrationJourneyPages/ConfirmationPageLandlordRegistration.kt
@@ -13,5 +13,5 @@ class ConfirmationPageLandlordRegistration(
     private val confirmationBanner = BaseComponent.getConfirmationPageBanner(page)
     val registrationNumberText: String = getChildComponent(confirmationBanner, "strong").innerText()
 
-    fun clickGoToDashboard() = clickButton(BaseComponent.getButton(page, "Go to Dashboard"))
+    fun clickGoToDashboard() = clickComponent(BaseComponent.getButton(page, "Go to Dashboard"))
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/propertyRegistrationJourneyPages/ConfirmationPagePropertyRegistration.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/propertyRegistrationJourneyPages/ConfirmationPagePropertyRegistration.kt
@@ -13,5 +13,5 @@ class ConfirmationPagePropertyRegistration(
     private val detailTable = Table(page)
     val registrationNumberText: String = detailTable.getCell(0, 1).innerText()
 
-    fun clickGoToDashboard() = clickButton(BaseComponent.getButton(page, "Go to Dashboard"))
+    fun clickGoToDashboard() = clickComponent(BaseComponent.getButton(page, "Go to Dashboard"))
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/models/requestModels/SearchRequestModelTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/models/requestModels/SearchRequestModelTests.kt
@@ -1,0 +1,59 @@
+package uk.gov.communities.prsdb.webapp.models.requestModels
+
+import org.junit.jupiter.api.Named
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
+import uk.gov.communities.prsdb.webapp.models.requestModels.searchModels.SearchRequestModel
+import kotlin.test.assertEquals
+
+class SearchRequestModelTests {
+    class TestNoFilterSearchRequestModel : SearchRequestModel()
+
+    class TestFilterSearchRequestModel : SearchRequestModel() {
+        var filter1: String = "value1"
+        var filter2: String = "value2"
+    }
+
+    companion object {
+        @JvmStatic
+        fun provideSearchRequestModels(): List<Arguments> {
+            val testFilterSearchRequestModel = TestFilterSearchRequestModel()
+
+            return listOf(
+                Arguments.of(
+                    Named.of(
+                        "has no filter properties",
+                        TestNoFilterSearchRequestModel(),
+                    ),
+                    Named.of(
+                        "an empty list",
+                        emptyList<Pair<String, Any>>(),
+                    ),
+                ),
+                Arguments.of(
+                    Named.of(
+                        "has filter properties",
+                        testFilterSearchRequestModel,
+                    ),
+                    Named.of(
+                        "a corresponding list of filter property name-value pairs",
+                        listOf(
+                            Pair("filter1", testFilterSearchRequestModel.filter1),
+                            Pair("filter2", testFilterSearchRequestModel.filter2),
+                        ),
+                    ),
+                ),
+            )
+        }
+    }
+
+    @ParameterizedTest(name = "{1} when the SearchRequestModel {0}")
+    @MethodSource("provideSearchRequestModels")
+    fun `getFilterPropertyNameValuePairs returns`(
+        searchRequestModel: SearchRequestModel,
+        expectedNameValuePairs: List<Pair<String, Any>>,
+    ) {
+        assertEquals(searchRequestModel.getFilterPropertyNameValuePairs(), expectedNameValuePairs)
+    }
+}

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/FilterPanelViewModelTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/FilterPanelViewModelTests.kt
@@ -1,0 +1,155 @@
+package uk.gov.communities.prsdb.webapp.models.viewModels
+
+import jakarta.servlet.http.HttpServletRequest
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
+import org.springframework.mock.web.MockHttpServletRequest
+import uk.gov.communities.prsdb.webapp.models.requestModels.searchModels.SearchRequestModel
+import uk.gov.communities.prsdb.webapp.models.viewModels.filterPanelModels.FilterPanelViewModel
+import uk.gov.communities.prsdb.webapp.models.viewModels.filterPanelModels.FilterViewModel
+import uk.gov.communities.prsdb.webapp.models.viewModels.filterPanelModels.SelectedFilterOptionViewModel
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class FilterPanelViewModelTests {
+    enum class TestFilterOptions { One, Two, Three }
+
+    class TestSearchRequestModel : SearchRequestModel() {
+        var filter1: Boolean = false
+        var filter2: List<TestFilterOptions> = emptyList()
+    }
+
+    class TestFilterPanelViewModel(
+        searchRequestModel: TestSearchRequestModel,
+        httpServletRequest: HttpServletRequest,
+    ) : FilterPanelViewModel(
+            filters =
+                listOf(
+                    FilterViewModel(
+                        headingMsgKey = "filter.one.heading",
+                        searchRequestProperty = "filter1",
+                        options =
+                            listOf(
+                                CheckboxViewModel(value = true, labelMsgKey = "filter.one.label"),
+                            ),
+                    ),
+                    FilterViewModel(
+                        headingMsgKey = "filter.two.heading",
+                        searchRequestProperty = "filter2",
+                        options = TestFilterOptions.entries.map { CheckboxViewModel(value = it) },
+                    ),
+                ),
+            searchRequestModel = searchRequestModel,
+            httpServletRequest = httpServletRequest,
+        )
+
+    private fun FilterPanelViewModel.getSelectedOptionLabelsForFilter(filterSearchRequestProperty: String) =
+        filters.single { it.searchRequestProperty == filterSearchRequestProperty }.selectedOptions.map { it.labelMsgOrVal }
+
+    private lateinit var mockHttpServletRequest: MockHttpServletRequest
+    private lateinit var searchRequestModel: TestSearchRequestModel
+
+    @BeforeEach
+    fun setUp() {
+        mockHttpServletRequest = MockHttpServletRequest()
+        mockHttpServletRequest.requestURI = "example.com/page"
+        searchRequestModel = TestSearchRequestModel()
+    }
+
+    @Test
+    fun `clearLink removes all filters`() {
+        mockHttpServletRequest.queryString =
+            "showFilter=${searchRequestModel.showFilter}&_filter1=on&filter1=true&_filter2=on&filter2=One&filter2=Two"
+        val expectedClearFiltersLink =
+            "${mockHttpServletRequest.requestURI}?showFilter=${searchRequestModel.showFilter}"
+
+        val filterPanelViewModel = TestFilterPanelViewModel(searchRequestModel, mockHttpServletRequest)
+
+        assertEquals(expectedClearFiltersLink, filterPanelViewModel.clearLink)
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = [true, false])
+    fun `toggleLink inverts showFilter when`(showFilter: Boolean) {
+        searchRequestModel.showFilter = showFilter
+        val expectedToggleLink = "${mockHttpServletRequest.requestURI}?showFilter=${!showFilter}"
+
+        val filterPanelViewModel = TestFilterPanelViewModel(searchRequestModel, mockHttpServletRequest)
+
+        assertEquals(expectedToggleLink, filterPanelViewModel.toggleLink)
+    }
+
+    @Test
+    fun `FilterPanelViewModel generates no SelectedFilterOptionViewModels when no filters have selected options`() {
+        val filterPanelViewModel = TestFilterPanelViewModel(searchRequestModel, mockHttpServletRequest)
+
+        assertTrue(filterPanelViewModel.filters.all { it.selectedOptions.isEmpty() })
+        assertTrue(filterPanelViewModel.noFiltersSelected)
+    }
+
+    @Test
+    fun `FilterPanelViewModel generates the corresponding SelectedFilterOptionViewModel when a filter with one option is selected`() {
+        searchRequestModel.filter1 = true
+        val expectedSelectedOptionLabelsForFilter1 = listOf("filter.one.label")
+
+        val filterPanelViewModel = TestFilterPanelViewModel(searchRequestModel, mockHttpServletRequest)
+
+        assertEquals(
+            expectedSelectedOptionLabelsForFilter1,
+            filterPanelViewModel.getSelectedOptionLabelsForFilter("filter1"),
+        )
+        assertEquals(emptyList(), filterPanelViewModel.getSelectedOptionLabelsForFilter("filter2"))
+        assertFalse(filterPanelViewModel.noFiltersSelected)
+    }
+
+    @Test
+    fun `FilterPanelViewModel generates the corresponding SelectedFilterOptionViewModels when a filter has multiple options selected`() {
+        searchRequestModel.filter2 = listOf(TestFilterOptions.One, TestFilterOptions.Two)
+        val expectedSelectedOptionLabelsForFilter2 = listOf("One", "Two")
+
+        val filterPanelViewModel = TestFilterPanelViewModel(searchRequestModel, mockHttpServletRequest)
+
+        assertEquals(emptyList(), filterPanelViewModel.getSelectedOptionLabelsForFilter("filter1"))
+        assertEquals(
+            expectedSelectedOptionLabelsForFilter2,
+            filterPanelViewModel.getSelectedOptionLabelsForFilter("filter2"),
+        )
+        assertFalse(filterPanelViewModel.noFiltersSelected)
+    }
+
+    @Test
+    fun `FilterPanelViewModel generates the corresponding SelectedFilterOptionViewModels when multiple filters have options selected`() {
+        searchRequestModel.filter1 = true
+        searchRequestModel.filter2 = listOf(TestFilterOptions.One, TestFilterOptions.Two)
+        val expectedSelectedOptionLabelsForFilter1 = listOf("filter.one.label")
+        val expectedSelectedOptionLabelsForFilter2 = listOf("One", "Two")
+
+        val filterPanelViewModel = TestFilterPanelViewModel(searchRequestModel, mockHttpServletRequest)
+
+        assertEquals(
+            expectedSelectedOptionLabelsForFilter1,
+            filterPanelViewModel.getSelectedOptionLabelsForFilter("filter1"),
+        )
+        assertEquals(
+            expectedSelectedOptionLabelsForFilter2,
+            filterPanelViewModel.getSelectedOptionLabelsForFilter("filter2"),
+        )
+        assertFalse(filterPanelViewModel.noFiltersSelected)
+    }
+
+    @Test
+    fun `SelectedFilterOptionViewModel generates the selected option's remove link`() {
+        val searchRequestProperty = "filter"
+        val selectedOption: CheckboxViewModel<Any> = CheckboxViewModel(value = "value")
+        mockHttpServletRequest.queryString = "_filter=on&filter=value&filter=otherValue&page=2"
+        val expectedRemoveLink = "${mockHttpServletRequest.requestURI}?_filter=on&filter=otherValue"
+
+        val selectedFilterOptionViewModel =
+            SelectedFilterOptionViewModel(searchRequestProperty, selectedOption, mockHttpServletRequest)
+
+        assertEquals(expectedRemoveLink, selectedFilterOptionViewModel.removeLink)
+    }
+}


### PR DESCRIPTION
Features:
- Hides filter category heading if none of its options are selected
- Hides clear filters link and shows message when no filters are selected
- Persists selected filters across searches

Tests:
- Updates search page integration tests
- Creates `SearchRequestModelTests`
- Creates `FilterPanelViewModelTests`

Screenshot:
![image](https://github.com/user-attachments/assets/c3605d55-0725-4585-b065-b2a5152c539c)
