### PR TITLE
Fix/prsd 600 unreachable in progress tasks

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/tasks/TaskList.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/tasks/TaskList.kt
@@ -36,14 +36,14 @@ abstract class TaskList<T : StepId>(
         journeyData: JourneyData,
         task: Task<T>,
     ): TaskStatus =
-        if (areAllStepsWithinTaskComplete(journeyData, task)) {
-            TaskStatus.COMPLETED
-        } else if (isStepWithIdComplete(journeyData, task.startingStepId)) {
-            TaskStatus.IN_PROGRESS
-        } else if (isStepWithIdReachable(journeyData, task.startingStepId)) {
-            TaskStatus.NOT_YET_STARTED
-        } else {
+        if (!isStepWithIdReachable(journeyData, task.startingStepId)) {
             TaskStatus.CANNOT_START_YET
+        } else if (!isStepWithIdComplete(journeyData, task.startingStepId)) {
+            TaskStatus.NOT_YET_STARTED
+        } else if (!areAllStepsWithinTaskComplete(journeyData, task)) {
+            TaskStatus.IN_PROGRESS
+        } else {
+            TaskStatus.COMPLETED
         }
 
     private fun isStepWithIdComplete(


### PR DESCRIPTION
Under the current schema it is possible for all the steps in a task to be complete, but for it to still be in status "Cannot start yet", if a previous task has gone from being complete to not being complete. This is possible if you alter an earlier answer to change the route through that task (for example if you change the answer to "Do you have tennants?" from "No" to "Yes", but haven't yet given the tennancy details).

Both this and the previous "In progress" bug were caused by the behaviour of multi-path tasks, so I've added a section of tests for those. I've tried cherry-picking these tests onto earlier commits to prove they fail when the bugs are present.
