### PR TITLE
feat/PRSD-785 Align licensing terminology across screens

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/constants/enums/LicensingType.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/constants/enums/LicensingType.kt
@@ -1,10 +1,8 @@
 package uk.gov.communities.prsdb.webapp.constants.enums
 
-enum class LicensingType(
-    val displayName: String,
-) {
-    SELECTIVE_LICENCE("Selective licence"),
-    HMO_MANDATORY_LICENCE("HMO licence"),
-    HMO_ADDITIONAL_LICENCE("Additional licence"),
-    NO_LICENSING("Not Licenced"),
+enum class LicensingType {
+    SELECTIVE_LICENCE,
+    HMO_MANDATORY_LICENCE,
+    HMO_ADDITIONAL_LICENCE,
+    NO_LICENSING,
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/RegisteredPropertyViewModel.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/RegisteredPropertyViewModel.kt
@@ -1,7 +1,6 @@
 package uk.gov.communities.prsdb.webapp.models.viewModels
 
 import uk.gov.communities.prsdb.webapp.constants.enums.LicensingType
-import uk.gov.communities.prsdb.webapp.database.entity.License
 import uk.gov.communities.prsdb.webapp.database.entity.PropertyOwnership
 import uk.gov.communities.prsdb.webapp.helpers.converters.MessageKeyConverter
 import uk.gov.communities.prsdb.webapp.models.dataModels.RegistrationNumberDataModel
@@ -25,14 +24,8 @@ data class RegisteredPropertyViewModel(
                 localAuthorityName =
                     propertyOwnership.property.address.localAuthority!!
                         .name,
-                propertyLicence = getLicenceTypeDisplayName(propertyOwnership.license),
+                propertyLicence = MessageKeyConverter.convert(propertyOwnership.license?.licenseType ?: LicensingType.NO_LICENSING),
                 isTenantedMessageKey = MessageKeyConverter.convert(propertyOwnership.currentNumTenants > 0),
             )
-
-        // TODO PRSD-785 use MessageKeyConverter here and remove display names on LicensingType
-        private fun getLicenceTypeDisplayName(licence: License?): String {
-            val licenceType = licence?.licenseType ?: LicensingType.NO_LICENSING
-            return licenceType.displayName
-        }
     }
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/RegisteredPropertyViewModel.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/RegisteredPropertyViewModel.kt
@@ -9,7 +9,7 @@ data class RegisteredPropertyViewModel(
     val address: String,
     val registrationNumber: String,
     val localAuthorityName: String,
-    val propertyLicence: String,
+    val licenseTypeMessageKey: String,
     val isTenantedMessageKey: String,
 ) {
     companion object {
@@ -24,7 +24,7 @@ data class RegisteredPropertyViewModel(
                 localAuthorityName =
                     propertyOwnership.property.address.localAuthority!!
                         .name,
-                propertyLicence = MessageKeyConverter.convert(propertyOwnership.license?.licenseType ?: LicensingType.NO_LICENSING),
+                licenseTypeMessageKey = MessageKeyConverter.convert(propertyOwnership.license?.licenseType ?: LicensingType.NO_LICENSING),
                 isTenantedMessageKey = MessageKeyConverter.convert(propertyOwnership.currentNumTenants > 0),
             )
     }

--- a/src/main/resources/templates/landlordDetailsView.html
+++ b/src/main/resources/templates/landlordDetailsView.html
@@ -46,7 +46,7 @@
                                         <span th:remove="tag" th:text="${property.registrationNumber}"></span>
                                     </td>
                                     <td class="govuk-table__cell govuk-!-width-one-quarter" th:text="${property.localAuthorityName}"></td>
-                                    <td class="govuk-table__cell govuk-!-width-one-quarter" th:text="${property.propertyLicence}"></td>
+                                    <td class="govuk-table__cell govuk-!-width-one-quarter" th:text="#{${property.propertyLicence}}"></td>
                                     <td class="govuk-table__cell govuk-!-width-one-quarter" th:text="#{${property.isTenantedMessageKey}}"></td>
                                 </tr>
                             </tbody>

--- a/src/main/resources/templates/landlordDetailsView.html
+++ b/src/main/resources/templates/landlordDetailsView.html
@@ -46,7 +46,7 @@
                                         <span th:remove="tag" th:text="${property.registrationNumber}"></span>
                                     </td>
                                     <td class="govuk-table__cell govuk-!-width-one-quarter" th:text="${property.localAuthorityName}"></td>
-                                    <td class="govuk-table__cell govuk-!-width-one-quarter" th:text="#{${property.propertyLicence}}"></td>
+                                    <td class="govuk-table__cell govuk-!-width-one-quarter" th:text="#{${property.licenseTypeMessageKey}}"></td>
                                     <td class="govuk-table__cell govuk-!-width-one-quarter" th:text="#{${property.isTenantedMessageKey}}"></td>
                                 </tr>
                             </tbody>

--- a/src/main/resources/templates/localAuthorityLandlordDetailsView.html
+++ b/src/main/resources/templates/localAuthorityLandlordDetailsView.html
@@ -44,7 +44,7 @@
                                     </td>
                                     <td class="govuk-table__cell" th:text="${property.registrationNumber}"></td>
                                     <td class="govuk-table__cell" th:text="${property.localAuthorityName}"></td>
-                                    <td class="govuk-table__cell" th:text="${property.propertyLicence}"></td>
+                                    <td class="govuk-table__cell" th:text="#{${property.propertyLicence}}"></td>
                                     <td class="govuk-table__cell" th:text="#{${property.isTenantedMessageKey}}"></td>
                                 </tr>
                                 </tbody>

--- a/src/main/resources/templates/localAuthorityLandlordDetailsView.html
+++ b/src/main/resources/templates/localAuthorityLandlordDetailsView.html
@@ -44,7 +44,7 @@
                                     </td>
                                     <td class="govuk-table__cell" th:text="${property.registrationNumber}"></td>
                                     <td class="govuk-table__cell" th:text="${property.localAuthorityName}"></td>
-                                    <td class="govuk-table__cell" th:text="#{${property.propertyLicence}}"></td>
+                                    <td class="govuk-table__cell" th:text="#{${property.licenseTypeMessageKey}}"></td>
                                     <td class="govuk-table__cell" th:text="#{${property.isTenantedMessageKey}}"></td>
                                 </tr>
                                 </tbody>

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/RegisteredPropertyViewModelTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/RegisteredPropertyViewModelTests.kt
@@ -29,7 +29,7 @@ class RegisteredPropertyViewModelTests {
                 .fromRegistrationNumber(
                     registrationNumber,
                 ).toString()
-        val expectedPropertyLicence = "Not Licenced"
+        val expectedPropertyLicence = "None"
         val expectedIsTenantedMessageKey = "commonText.no"
 
         val propertyOwnership =
@@ -74,9 +74,9 @@ class RegisteredPropertyViewModelTests {
     @ParameterizedTest
     @CsvSource(
         "SELECTIVE_LICENCE,Selective licence",
-        "HMO_MANDATORY_LICENCE,HMO licence",
-        "HMO_ADDITIONAL_LICENCE,Additional licence",
-        "NO_LICENSING,Not Licenced",
+        "HMO_MANDATORY_LICENCE,HMO mandatory licence",
+        "HMO_ADDITIONAL_LICENCE,HMO additional licence",
+        "NO_LICENSING,None",
     )
     fun `Returns correct licensing display name for licence`(
         licensingType: LicensingType,
@@ -97,6 +97,6 @@ class RegisteredPropertyViewModelTests {
 
         val result = RegisteredPropertyViewModel.fromPropertyOwnership(propertyOwnership)
 
-        assertEquals(result.propertyLicence, "Not Licenced")
+        assertEquals(result.propertyLicence, "None")
     }
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/RegisteredPropertyViewModelTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/RegisteredPropertyViewModelTests.kt
@@ -88,7 +88,7 @@ class RegisteredPropertyViewModelTests {
 
         val result = RegisteredPropertyViewModel.fromPropertyOwnership(propertyOwnership)
 
-        assertEquals(result.propertyLicence, expectedDisplayName)
+        assertEquals(result.licenseTypeMessageKey, expectedDisplayName)
     }
 
     @Test
@@ -97,6 +97,6 @@ class RegisteredPropertyViewModelTests {
 
         val result = RegisteredPropertyViewModel.fromPropertyOwnership(propertyOwnership)
 
-        assertEquals(result.propertyLicence, "forms.checkPropertyAnswers.propertyDetails.noLicensing")
+        assertEquals(result.licenseTypeMessageKey, "forms.checkPropertyAnswers.propertyDetails.noLicensing")
     }
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/RegisteredPropertyViewModelTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/RegisteredPropertyViewModelTests.kt
@@ -29,7 +29,7 @@ class RegisteredPropertyViewModelTests {
                 .fromRegistrationNumber(
                     registrationNumber,
                 ).toString()
-        val expectedPropertyLicence = "None"
+        val expectedPropertyLicence = "forms.checkPropertyAnswers.propertyDetails.noLicensing"
         val expectedIsTenantedMessageKey = "commonText.no"
 
         val propertyOwnership =
@@ -73,10 +73,10 @@ class RegisteredPropertyViewModelTests {
 
     @ParameterizedTest
     @CsvSource(
-        "SELECTIVE_LICENCE,Selective licence",
-        "HMO_MANDATORY_LICENCE,HMO mandatory licence",
-        "HMO_ADDITIONAL_LICENCE,HMO additional licence",
-        "NO_LICENSING,None",
+        "SELECTIVE_LICENCE,forms.licensingType.radios.option.selectiveLicence.label",
+        "HMO_MANDATORY_LICENCE,forms.licensingType.radios.option.hmoMandatory.label",
+        "HMO_ADDITIONAL_LICENCE,forms.licensingType.radios.option.hmoAdditional.label",
+        "NO_LICENSING,forms.checkPropertyAnswers.propertyDetails.noLicensing",
     )
     fun `Returns correct licensing display name for licence`(
         licensingType: LicensingType,
@@ -97,6 +97,6 @@ class RegisteredPropertyViewModelTests {
 
         val result = RegisteredPropertyViewModel.fromPropertyOwnership(propertyOwnership)
 
-        assertEquals(result.propertyLicence, "None")
+        assertEquals(result.propertyLicence, "forms.checkPropertyAnswers.propertyDetails.noLicensing")
     }
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/PropertyOwnershipServiceTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/PropertyOwnershipServiceTests.kt
@@ -159,7 +159,7 @@ class PropertyOwnershipServiceTests {
         private val expectedLocalAuthority = localAuthority.name
         private val expectedRegistrationNumber =
             RegistrationNumberDataModel.fromRegistrationNumber(registrationNumber).toString()
-        private val expectedPropertyLicence = "None"
+        private val expectedPropertyLicence = "forms.checkPropertyAnswers.propertyDetails.noLicensing"
         private val expectedIsTenantedMessageKey = "commonText.no"
 
         private val propertyOwnership1 =

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/PropertyOwnershipServiceTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/PropertyOwnershipServiceTests.kt
@@ -159,7 +159,7 @@ class PropertyOwnershipServiceTests {
         private val expectedLocalAuthority = localAuthority.name
         private val expectedRegistrationNumber =
             RegistrationNumberDataModel.fromRegistrationNumber(registrationNumber).toString()
-        private val expectedPropertyLicence = "Not Licenced"
+        private val expectedPropertyLicence = "None"
         private val expectedIsTenantedMessageKey = "commonText.no"
 
         private val propertyOwnership1 =


### PR DESCRIPTION
On the Landlord Record page in the property details tab - changed some of the displayed names for `LicencingType`, by using the `MessageKeyConverter` in `RegisteredPropertyViewModel` so that the names are unified across all screens.

Changes:
HMO licence -> HMO mandatory licence
Additional licence -> HMO additional licence
Not Licenced -> None

![image](https://github.com/user-attachments/assets/accdb7bc-048b-472d-8b98-3c2abe1fe0ad)




