### PR TITLE
PRSD-663: Manually Bind Filter Request to View

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/SearchRegisterController.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/SearchRegisterController.kt
@@ -52,7 +52,7 @@ class SearchRegisterController(
             landlordService.searchForLandlords(
                 searchRequest.searchTerm!!,
                 principal.name,
-                searchRequest.restrictToLA,
+                searchRequest.restrictToLA ?: false,
                 requestedPageIndex = page - 1,
             )
 
@@ -97,8 +97,8 @@ class SearchRegisterController(
             propertyOwnershipService.searchForProperties(
                 searchRequest.searchTerm!!,
                 principal.name,
-                searchRequest.restrictToLA,
-                searchRequest.restrictToLicenses.ifEmpty { LicensingType.entries },
+                searchRequest.restrictToLA ?: false,
+                searchRequest.restrictToLicenses ?: LicensingType.entries,
                 requestedPageIndex = page - 1,
             )
 

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/helpers/URIQueryBuilder.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/helpers/URIQueryBuilder.kt
@@ -13,8 +13,6 @@ class URIQueryBuilder private constructor(
                     .fromUriString(httpServletRequest.requestURI)
                     .query(httpServletRequest.queryString),
             )
-
-        private fun getHiddenParam(name: String) = "_$name"
     }
 
     fun build() = uriComponentsBuilder.encode().build()
@@ -36,9 +34,7 @@ class URIQueryBuilder private constructor(
     }
 
     fun removeParam(name: String): URIQueryBuilder {
-        uriComponentsBuilder
-            .replaceQueryParam(name)
-            .replaceQueryParam(getHiddenParam(name))
+        uriComponentsBuilder.replaceQueryParam(name)
         return this
     }
 

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/requestModels/searchModels/LandlordSearchRequestModel.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/requestModels/searchModels/LandlordSearchRequestModel.kt
@@ -1,5 +1,5 @@
 package uk.gov.communities.prsdb.webapp.models.requestModels.searchModels
 
 class LandlordSearchRequestModel : SearchRequestModel() {
-    var restrictToLA: Boolean = false
+    var restrictToLA: Boolean? = null
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/requestModels/searchModels/PropertySearchRequestModel.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/requestModels/searchModels/PropertySearchRequestModel.kt
@@ -3,7 +3,7 @@ package uk.gov.communities.prsdb.webapp.models.requestModels.searchModels
 import uk.gov.communities.prsdb.webapp.constants.enums.LicensingType
 
 class PropertySearchRequestModel : SearchRequestModel() {
-    var restrictToLA: Boolean = false
+    var restrictToLA: Boolean? = null
 
-    var restrictToLicenses: List<LicensingType> = emptyList()
+    var restrictToLicenses: List<LicensingType>? = null
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/requestModels/searchModels/SearchRequestModel.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/requestModels/searchModels/SearchRequestModel.kt
@@ -11,5 +11,11 @@ abstract class SearchRequestModel {
         this::class
             .memberProperties
             .filterNot { it.name in listOf("searchTerm", "showFilter") }
-            .map { Pair(it.name, it.getter.call(this)) }
+            .map { property ->
+                when (val value = property.getter.call(this)) {
+                    null -> emptyList()
+                    is Collection<*> -> value.map { singleValue -> Pair(property.name, singleValue) }
+                    else -> listOf(Pair(property.name, value))
+                }
+            }.flatten()
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/filterPanelModels/FilterPanelViewModel.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/filterPanelModels/FilterPanelViewModel.kt
@@ -62,6 +62,8 @@ class FilterViewModel(
                     }
                 }.map { SelectedFilterOptionViewModel(searchRequestProperty, it, httpServletRequest) }
     }
+
+    fun isOptionSelected(option: CheckboxViewModel<Any>) = selectedOptions.any { it.value == option.value }
 }
 
 class SelectedFilterOptionViewModel(
@@ -71,10 +73,12 @@ class SelectedFilterOptionViewModel(
 ) {
     val labelMsgOrVal = selectedOption.labelMsgKey ?: selectedOption.valueStr
 
+    val value = selectedOption.value
+
     val removeLink =
         URIQueryBuilder
             .fromHTTPServletRequest(httpServletRequest)
-            .removeParamValue(searchRequestProperty, selectedOption.value.toString())
+            .removeParamValue(searchRequestProperty, value.toString())
             .removeParam("page")
             .build()
             .toUriString()

--- a/src/main/resources/templates/fragments/filterPanel.html
+++ b/src/main/resources/templates/fragments/filterPanel.html
@@ -72,9 +72,10 @@
                                     <div class="govuk-checkboxes__item" th:each="option: ${filter.options}"
                                          th:with="checkboxInputID=|${filter.searchRequestProperty}-${option.valueStr}|">
                                         <input class="govuk-checkboxes__input" type="checkbox"
-                                               th:field="*{__${filter.searchRequestProperty}__}"
+                                               th:name="${filter.searchRequestProperty}"
                                                th:value="${option.value}"
-                                               th:id="${checkboxInputID}">
+                                               th:id="${checkboxInputID}"
+                                               th:checked="${filter.isOptionSelected(option)}">
                                         <label class="govuk-label govuk-checkboxes__label"
                                                th:for="${checkboxInputID}"
                                                th:text="${option.labelMsgKey != null ? #messages.msg(option.labelMsgKey) : option.value}">

--- a/src/main/resources/templates/fragments/searchBar.html
+++ b/src/main/resources/templates/fragments/searchBar.html
@@ -11,7 +11,7 @@
         </div>
 
         <input type="hidden" th:each="filterProp:${searchRequest.getFilterPropertyNameValuePairs()}"
-               th:field="*{__${filterProp.first}__}" th:value="${filterProp.second}">
+               th:name="${filterProp.first}" th:value="${filterProp.second}">
 
         <button type="submit" class="govuk-button moj-search__button " data-module="govuk-button"
                 th:text="#{searchButtonText}">

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/helpers/URIQueryBuilderTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/helpers/URIQueryBuilderTests.kt
@@ -153,7 +153,7 @@ class URIQueryBuilderTests {
 
     @Test
     fun `removeParamValue returns the updated URI (multi-value param)`() {
-        mockHTTPServletRequest.queryString = "name1=value1a&name1=value1b&&name2=value2"
+        mockHTTPServletRequest.queryString = "name1=value1a&name1=value1b&name2=value2"
         val expectedUpdatedURI = "${mockHTTPServletRequest.requestURI}?name2=value2&name1=value1b"
 
         val updatedURI =

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/helpers/URIQueryBuilderTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/helpers/URIQueryBuilderTests.kt
@@ -92,7 +92,7 @@ class URIQueryBuilderTests {
 
     @Test
     fun `removeParam returns the updated URI`() {
-        mockHTTPServletRequest.queryString = "name1=value1&_name1=hiddenValue1&name2=value2"
+        mockHTTPServletRequest.queryString = "name1=value1&name2=value2"
 
         val expectedUpdatedURI = "${mockHTTPServletRequest.requestURI}?name2=value2"
 
@@ -123,7 +123,7 @@ class URIQueryBuilderTests {
 
     @Test
     fun `removeParams returns the updated URI`() {
-        mockHTTPServletRequest.queryString = "name1=value1&_name1=hiddenValue1&name2=value2"
+        mockHTTPServletRequest.queryString = "name1=value1&name2=value2"
         val expectedUpdatedURI = "${mockHTTPServletRequest.requestURI}"
 
         val updatedURI =
@@ -138,7 +138,7 @@ class URIQueryBuilderTests {
 
     @Test
     fun `removeParamValue returns the updated URI (single value param)`() {
-        mockHTTPServletRequest.queryString = "name1=value1&_name1=hiddenValue1&name2=value2"
+        mockHTTPServletRequest.queryString = "name1=value1&name2=value2"
         val expectedUpdatedURI = "${mockHTTPServletRequest.requestURI}?name2=value2"
 
         val updatedURI =
@@ -153,8 +153,8 @@ class URIQueryBuilderTests {
 
     @Test
     fun `removeParamValue returns the updated URI (multi-value param)`() {
-        mockHTTPServletRequest.queryString = "name1=value1a&name1=value1b&_name1=hiddenValue1&name2=value2"
-        val expectedUpdatedURI = "${mockHTTPServletRequest.requestURI}?_name1=hiddenValue1&name2=value2&name1=value1b"
+        mockHTTPServletRequest.queryString = "name1=value1a&name1=value1b&&name2=value2"
+        val expectedUpdatedURI = "${mockHTTPServletRequest.requestURI}?name2=value2&name1=value1b"
 
         val updatedURI =
             URIQueryBuilder

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/models/requestModels/SearchRequestModelTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/models/requestModels/SearchRequestModelTests.kt
@@ -10,15 +10,23 @@ import kotlin.test.assertEquals
 class SearchRequestModelTests {
     class TestNoFilterSearchRequestModel : SearchRequestModel()
 
-    class TestFilterSearchRequestModel : SearchRequestModel() {
-        var filter1: String = "value1"
-        var filter2: String = "value2"
+    class TestNullValueFilterSearchRequestModel : SearchRequestModel() {
+        var filter: String? = null
+    }
+
+    class TestSingleValueFilterSearchRequestModel : SearchRequestModel() {
+        var filter: String = "value"
+    }
+
+    class TestMultiValueFilterSearchRequestModel : SearchRequestModel() {
+        var filter: List<String> = listOf("value1", "value2")
     }
 
     companion object {
         @JvmStatic
         fun provideSearchRequestModels(): List<Arguments> {
-            val testFilterSearchRequestModel = TestFilterSearchRequestModel()
+            val testSingleValueFilterSearchRequestModel = TestSingleValueFilterSearchRequestModel()
+            val testMultiValueFilterSearchRequestModel = TestMultiValueFilterSearchRequestModel()
 
             return listOf(
                 Arguments.of(
@@ -33,15 +41,34 @@ class SearchRequestModelTests {
                 ),
                 Arguments.of(
                     Named.of(
-                        "has filter properties",
-                        testFilterSearchRequestModel,
+                        "has a null-valued filter property",
+                        TestNullValueFilterSearchRequestModel(),
                     ),
                     Named.of(
-                        "a corresponding list of filter property name-value pairs",
+                        "an empty list",
+                        emptyList<Pair<String, Any>>(),
+                    ),
+                ),
+                Arguments.of(
+                    Named.of(
+                        "has a single-valued filter property",
+                        testSingleValueFilterSearchRequestModel,
+                    ),
+                    Named.of(
+                        "a corresponding list of one filter property name-value pair",
                         listOf(
-                            Pair("filter1", testFilterSearchRequestModel.filter1),
-                            Pair("filter2", testFilterSearchRequestModel.filter2),
+                            Pair("filter", testSingleValueFilterSearchRequestModel.filter),
                         ),
+                    ),
+                ),
+                Arguments.of(
+                    Named.of(
+                        "has a multi-valued filter property",
+                        testMultiValueFilterSearchRequestModel,
+                    ),
+                    Named.of(
+                        "a corresponding list of a filter property name-value pair per value",
+                        testMultiValueFilterSearchRequestModel.filter.map { Pair("filter", it) },
                     ),
                 ),
             )

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/FilterPanelViewModelTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/FilterPanelViewModelTests.kt
@@ -18,8 +18,8 @@ class FilterPanelViewModelTests {
     enum class TestFilterOptions { One, Two, Three }
 
     class TestSearchRequestModel : SearchRequestModel() {
-        var filter1: Boolean = false
-        var filter2: List<TestFilterOptions> = emptyList()
+        var filter1: Boolean? = null
+        var filter2: List<TestFilterOptions>? = null
     }
 
     class TestFilterPanelViewModel(
@@ -61,8 +61,11 @@ class FilterPanelViewModelTests {
 
     @Test
     fun `clearLink removes all filters`() {
+        searchRequestModel.filter1 = true
+        searchRequestModel.filter2 = listOf(TestFilterOptions.One, TestFilterOptions.Two)
+
         mockHttpServletRequest.queryString =
-            "showFilter=${searchRequestModel.showFilter}&filter1=true&&filter2=One&filter2=Two"
+            "showFilter=${searchRequestModel.showFilter}&filter1=true&filter2=One&filter2=Two"
         val expectedClearFiltersLink =
             "${mockHttpServletRequest.requestURI}?showFilter=${searchRequestModel.showFilter}"
 

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/FilterPanelViewModelTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/FilterPanelViewModelTests.kt
@@ -62,7 +62,7 @@ class FilterPanelViewModelTests {
     @Test
     fun `clearLink removes all filters`() {
         mockHttpServletRequest.queryString =
-            "showFilter=${searchRequestModel.showFilter}&_filter1=on&filter1=true&_filter2=on&filter2=One&filter2=Two"
+            "showFilter=${searchRequestModel.showFilter}&filter1=true&&filter2=One&filter2=Two"
         val expectedClearFiltersLink =
             "${mockHttpServletRequest.requestURI}?showFilter=${searchRequestModel.showFilter}"
 
@@ -144,8 +144,8 @@ class FilterPanelViewModelTests {
     fun `SelectedFilterOptionViewModel generates the selected option's remove link`() {
         val searchRequestProperty = "filter"
         val selectedOption: CheckboxViewModel<Any> = CheckboxViewModel(value = "value")
-        mockHttpServletRequest.queryString = "_filter=on&filter=value&filter=otherValue&page=2"
-        val expectedRemoveLink = "${mockHttpServletRequest.requestURI}?_filter=on&filter=otherValue"
+        mockHttpServletRequest.queryString = "filter=value&filter=otherValue&page=2"
+        val expectedRemoveLink = "${mockHttpServletRequest.requestURI}?filter=otherValue"
 
         val selectedFilterOptionViewModel =
             SelectedFilterOptionViewModel(searchRequestProperty, selectedOption, mockHttpServletRequest)


### PR DESCRIPTION
- Manually determines the state of each filter checkbox rather than letting Spring do it. This is done to avoid the hidden values [Spring+Thymeleaf](https://www.thymeleaf.org/doc/tutorials/3.1/thymeleafspring.html#checkbox-fields) adds to checkboxes.
- Makes `SearchRequestModel` filter properties nullable so filters only appear in URLs if they're active.



