### PR TITLE
PRSD-884 Part 1: replace getMyThing functions with MyThing component classes

### DIFF
--- a/src/main/resources/templates/cancelLAUserInvitation.html
+++ b/src/main/resources/templates/cancelLAUserInvitation.html
@@ -7,7 +7,7 @@
         <header id="header">
             <h1 class="govuk-heading-l" th:text="#{cancelLAUserInvitation.heading}">cancelLAUserInvitation.heading</h1>
         </header>
-        <section>
+        <section data-testid="user-details-section">
             <p class="govuk-body">
                 <strong th:text="#{cancelLAUserInvitation.emailLabel}+':'">cancelLAUserInvitation.emailLabel:</strong>
                 <span th:text="${email}" th:remove="tag">email</span>

--- a/src/main/resources/templates/deleteLAUser.html
+++ b/src/main/resources/templates/deleteLAUser.html
@@ -7,7 +7,7 @@
             <header id="header">
                 <h1 class="govuk-heading-l" th:text="#{deleteLAUser.heading}">deleteLAUser.heading</h1>
             </header>
-            <section>
+            <section data-testid="user-details-section">
                 <p class="govuk-body">
                     <strong th:text="${user.userName}">user.name</strong>
                 </p>

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/CancelLaUserInvitationTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/CancelLaUserInvitationTests.kt
@@ -4,6 +4,7 @@ import com.microsoft.playwright.Page
 import com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat
 import org.junit.jupiter.api.Test
 import org.springframework.test.context.jdbc.Sql
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.BaseComponent.Companion.assertThat
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.CancelLaUserInvitationPage
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.CancelLaUserInvitationSuccessPage
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.ManageLaUsersPage

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/CancelLaUserInvitationTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/CancelLaUserInvitationTests.kt
@@ -29,7 +29,7 @@ class CancelLaUserInvitationTests : IntegrationTest() {
 
         // The success page confirms the user is deleted
         assertThat(successPage.confirmationBanner).containsText("You've cancelled invited.user@example.com's invitation from ISLE OF MAN")
-        successPage.returnButton.click()
+        successPage.returnButton.clickAndWait()
         manageUsersPage = assertPageIs(page, ManageLaUsersPage::class)
 
         // The invited user is no longer in the table

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/EditLAUserTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/EditLAUserTests.kt
@@ -54,7 +54,7 @@ class EditLAUserTests : IntegrationTest() {
         val editUserPage = assertPageIs(page, EditLaUserPage::class)
 
         // Delete the user
-        editUserPage.removeAccountButton.click()
+        editUserPage.removeAccountButton.clickAndWait()
         val confirmDeletePage = assertPageIs(page, ConfirmDeleteLaUserPage::class)
         assertThat(confirmDeletePage.userDetailsSection).containsText("Arthur Dent")
         // TODO PRSD-405: fix when LA users have email addresses
@@ -64,7 +64,7 @@ class EditLAUserTests : IntegrationTest() {
 
         // The success page confirms the user is deleted
         assertThat(successPage.confirmationBanner).containsText("You've removed Arthur Dent's account from ISLE OF MAN")
-        successPage.returnButton.click()
+        successPage.returnButton.clickAndWait()
         manageUsersPage = assertPageIs(page, ManageLaUsersPage::class)
 
         // The user is no longer in the table

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/EditLAUserTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/EditLAUserTests.kt
@@ -4,6 +4,7 @@ import com.microsoft.playwright.Page
 import com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat
 import org.junit.jupiter.api.Test
 import org.springframework.test.context.jdbc.Sql
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.BaseComponent.Companion.assertThat
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.ConfirmDeleteLaUserPage
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.DeleteLaUserSuccessPage
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.EditLaUserPage

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/InviteLaUsersTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/InviteLaUsersTests.kt
@@ -4,6 +4,7 @@ import com.microsoft.playwright.Page
 import com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat
 import org.junit.jupiter.api.Test
 import org.springframework.test.context.jdbc.Sql
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.BaseComponent.Companion.assertThat
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.InviteNewLaUserSuccessPage
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages.BasePage.Companion.assertPageIs
 

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/LandlordRegistrationJourneyTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/LandlordRegistrationJourneyTests.kt
@@ -108,7 +108,7 @@ class LandlordRegistrationJourneyTests : IntegrationTest() {
         )
 
         val confirmationPage = assertPageIs(page, ConfirmationPageLandlordRegistration::class)
-        assertEquals(createdLandlordRegNum.toString(), confirmationPage.registrationNumberText)
+        assertEquals(createdLandlordRegNum.toString(), confirmationPage.confirmationBanner.registrationNumberText)
         confirmationPage.goToDashboardButton.clickAndWait()
 
         // TODO PRSD-670: Replace with dashboard page
@@ -166,7 +166,7 @@ class LandlordRegistrationJourneyTests : IntegrationTest() {
         )
 
         val confirmationPage = assertPageIs(page, ConfirmationPageLandlordRegistration::class)
-        assertEquals(createdLandlordRegNum.toString(), confirmationPage.registrationNumberText)
+        assertEquals(createdLandlordRegNum.toString(), confirmationPage.confirmationBanner.registrationNumberText)
         confirmationPage.goToDashboardButton.clickAndWait()
 
         // TODO PRSD-670: Replace with dashboard page
@@ -231,7 +231,7 @@ class LandlordRegistrationJourneyTests : IntegrationTest() {
         )
 
         val confirmationPage = assertPageIs(page, ConfirmationPageLandlordRegistration::class)
-        assertEquals(createdLandlordRegNum.toString(), confirmationPage.registrationNumberText)
+        assertEquals(createdLandlordRegNum.toString(), confirmationPage.confirmationBanner.registrationNumberText)
         confirmationPage.goToDashboardButton.clickAndWait()
 
         // TODO PRSD-670: Replace with dashboard page
@@ -302,7 +302,7 @@ class LandlordRegistrationJourneyTests : IntegrationTest() {
         )
 
         val confirmationPage = assertPageIs(page, ConfirmationPageLandlordRegistration::class)
-        assertEquals(createdLandlordRegNum.toString(), confirmationPage.registrationNumberText)
+        assertEquals(createdLandlordRegNum.toString(), confirmationPage.confirmationBanner.registrationNumberText)
         confirmationPage.goToDashboardButton.clickAndWait()
 
         // TODO PRSD-670: Replace with dashboard page

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/LandlordRegistrationJourneyTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/LandlordRegistrationJourneyTests.kt
@@ -544,7 +544,7 @@ class LandlordRegistrationJourneyTests : IntegrationTest() {
         @Test
         fun `Clicking Search Again navigates to the previous step`(page: Page) {
             val selectAddressPage = navigator.goToLandlordRegistrationSelectAddressPage()
-            selectAddressPage.searchAgain.click()
+            selectAddressPage.searchAgain.clickAndWait()
             assertPageIs(page, LookupAddressFormPageLandlordRegistration::class)
         }
     }
@@ -603,7 +603,7 @@ class LandlordRegistrationJourneyTests : IntegrationTest() {
         @Test
         fun `Clicking Search Again navigates to the previous step`(page: Page) {
             val selectContactAddressPage = navigator.goToLandlordRegistrationSelectContactAddressPage()
-            selectContactAddressPage.searchAgain.click()
+            selectContactAddressPage.searchAgain.clickAndWait()
             assertPageIs(page, LookupContactAddressFormPageLandlordRegistration::class)
         }
     }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/LandlordRegistrationJourneyTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/LandlordRegistrationJourneyTests.kt
@@ -109,7 +109,7 @@ class LandlordRegistrationJourneyTests : IntegrationTest() {
 
         val confirmationPage = assertPageIs(page, ConfirmationPageLandlordRegistration::class)
         assertEquals(createdLandlordRegNum.toString(), confirmationPage.registrationNumberText)
-        confirmationPage.clickGoToDashboard()
+        confirmationPage.goToDashboardButton.clickAndWait()
 
         // TODO PRSD-670: Replace with dashboard page
         assertEquals("/", URI(page.url()).path)
@@ -167,7 +167,7 @@ class LandlordRegistrationJourneyTests : IntegrationTest() {
 
         val confirmationPage = assertPageIs(page, ConfirmationPageLandlordRegistration::class)
         assertEquals(createdLandlordRegNum.toString(), confirmationPage.registrationNumberText)
-        confirmationPage.clickGoToDashboard()
+        confirmationPage.goToDashboardButton.clickAndWait()
 
         // TODO PRSD-670: Replace with dashboard page
         assertEquals("/", URI(page.url()).path)
@@ -232,7 +232,7 @@ class LandlordRegistrationJourneyTests : IntegrationTest() {
 
         val confirmationPage = assertPageIs(page, ConfirmationPageLandlordRegistration::class)
         assertEquals(createdLandlordRegNum.toString(), confirmationPage.registrationNumberText)
-        confirmationPage.clickGoToDashboard()
+        confirmationPage.goToDashboardButton.clickAndWait()
 
         // TODO PRSD-670: Replace with dashboard page
         assertEquals("/", URI(page.url()).path)
@@ -303,7 +303,7 @@ class LandlordRegistrationJourneyTests : IntegrationTest() {
 
         val confirmationPage = assertPageIs(page, ConfirmationPageLandlordRegistration::class)
         assertEquals(createdLandlordRegNum.toString(), confirmationPage.registrationNumberText)
-        confirmationPage.clickGoToDashboard()
+        confirmationPage.goToDashboardButton.clickAndWait()
 
         // TODO PRSD-670: Replace with dashboard page
         assertEquals("/", URI(page.url()).path)

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/ManageLAUsersTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/ManageLAUsersTests.kt
@@ -3,6 +3,7 @@ package uk.gov.communities.prsdb.webapp.integration
 import com.microsoft.playwright.Page
 import com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat
 import org.springframework.test.context.jdbc.Sql
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.BaseComponent.Companion.assertThat
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.InviteNewLaUserPage
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.ManageLaUsersPage
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.ManageLaUsersPage.Companion.ACCESS_LEVEL_COL_INDEX
@@ -41,7 +42,7 @@ class ManageLAUsersTests : IntegrationTest() {
     @Test
     fun `invite button goes to invite new user page`(page: Page) {
         val managePage = navigator.goToManageLaUsers(localAuthorityId)
-        managePage.inviteAnotherUserButton.click()
+        managePage.inviteAnotherUserButton.clickAndWait()
         assertPageIs(page, InviteNewLaUserPage::class)
     }
 

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/PropertyDetailsTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/PropertyDetailsTests.kt
@@ -73,7 +73,7 @@ class PropertyDetailsTests : IntegrationTest() {
         @Test
         fun `the delete button redirects to the delete record page`(page: Page) {
             val detailsPage = navigator.goToPropertyDetailsLandlordView(1)
-            detailsPage.deleteButton.click()
+            detailsPage.deleteButton.clickAndWait()
 
             Assertions.assertEquals("/property-details/delete-record", URI(page.url()).path)
         }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/PropertyDetailsTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/PropertyDetailsTests.kt
@@ -44,7 +44,7 @@ class PropertyDetailsTests : IntegrationTest() {
         @Test
         fun `in the key details section the landlord name link goes the landlord view of landlord details`(page: Page) {
             val detailsPage = navigator.goToPropertyDetailsLandlordView(1)
-            detailsPage.clickLandlordNameLinkFromKeyDetails("Alexander Smith")
+            detailsPage.getLandlordNameLinkFromKeyDetails("Alexander Smith").clickAndWait()
 
             assertPageIs(page, LandlordDetailsPage::class)
             Assertions.assertEquals("/landlord-details", URI(page.url()).path)
@@ -55,7 +55,7 @@ class PropertyDetailsTests : IntegrationTest() {
             val detailsPage = navigator.goToPropertyDetailsLandlordView(1)
             detailsPage.goToLandlordDetails()
 
-            detailsPage.clickLandlordLinkFromLandlordDetails("Alexander Smith")
+            detailsPage.getLandlordLinkFromLandlordDetails("Alexander Smith").clickAndWait()
 
             assertPageIs(page, LandlordDetailsPage::class)
             Assertions.assertEquals("/landlord-details", URI(page.url()).path)
@@ -64,7 +64,7 @@ class PropertyDetailsTests : IntegrationTest() {
         @Test
         fun `the back link returns to the dashboard`(page: Page) {
             val detailsPage = navigator.goToPropertyDetailsLandlordView(1)
-            detailsPage.clickBackLink()
+            detailsPage.backLink.clickAndWait()
 
             // TODO: PRSD-647 add link to the dashboard
             Assertions.assertEquals("/property-details/1", URI(page.url()).path)
@@ -109,7 +109,7 @@ class PropertyDetailsTests : IntegrationTest() {
         @Test
         fun `in the key details section the landlord name link goes the local authority view of landlord details`(page: Page) {
             val detailsPage = navigator.goToPropertyDetailsLocalAuthorityView(1)
-            detailsPage.clickLandlordNameLinkFromKeyDetails("Alexander Smith")
+            detailsPage.getLandlordNameLinkFromKeyDetails("Alexander Smith").clickAndWait()
 
             assertPageIs(page, LocalAuthorityViewLandlordDetailsPage::class)
             Assertions.assertEquals("/landlord-details/1", URI(page.url()).path)
@@ -120,7 +120,7 @@ class PropertyDetailsTests : IntegrationTest() {
             val detailsPage = navigator.goToPropertyDetailsLocalAuthorityView(1)
             detailsPage.goToLandlordDetails()
 
-            detailsPage.clickLandlordLinkFromLandlordDetails("Alexander Smith")
+            detailsPage.getLandlordLinkFromLandlordDetails("Alexander Smith").clickAndWait()
 
             assertPageIs(page, LocalAuthorityViewLandlordDetailsPage::class)
             Assertions.assertEquals("/landlord-details/1", URI(page.url()).path)
@@ -129,7 +129,7 @@ class PropertyDetailsTests : IntegrationTest() {
         @Test
         fun `the back link returns to the dashboard`(page: Page) {
             val detailsPage = navigator.goToPropertyDetailsLocalAuthorityView(1)
-            detailsPage.clickBackLink()
+            detailsPage.backLink.clickAndWait()
 
             // TODO: PRSD-647 add link to the dashboard
             Assertions.assertEquals("/local-authority/property-details/1", URI(page.url()).path)

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/PropertyRegistrationJourneyTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/PropertyRegistrationJourneyTests.kt
@@ -92,7 +92,7 @@ class PropertyRegistrationJourneyTests : IntegrationTest() {
         // Start page (not a journey step, but it is how the user accesses the journey)
         val registerPropertyStartPage = navigator.goToPropertyRegistrationStartPage()
         assertThat(registerPropertyStartPage.heading).containsText("Enter your property details")
-        registerPropertyStartPage.startButton.click()
+        registerPropertyStartPage.startButton.clickAndWait()
         val taskListPage = assertPageIs(page, TaskListPagePropertyRegistration::class)
 
         // Task list page (part of the journey to support redirects)
@@ -205,7 +205,7 @@ class PropertyRegistrationJourneyTests : IntegrationTest() {
         assertEquals(expectedPropertyRegNum.toString(), confirmationPage.registrationNumberText)
 
         // go to dashboard
-        confirmationPage.clickGoToDashboard()
+        confirmationPage.goToDashboardButton.clickAndWait()
 
         // TODO PRSD-670: Replace with dashboard page
         assertEquals("/", URI(page.url()).path)

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/PropertyRegistrationJourneyTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/PropertyRegistrationJourneyTests.kt
@@ -263,7 +263,7 @@ class PropertyRegistrationJourneyTests : IntegrationTest() {
         @Test
         fun `Clicking Search Again navigates to the previous step`(page: Page) {
             val selectAddressPage = navigator.goToPropertyRegistrationSelectAddressPage()
-            selectAddressPage.searchAgain.click()
+            selectAddressPage.searchAgain.clickAndWait()
             assertPageIs(page, LookupAddressFormPagePropertyRegistration::class)
         }
 

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/SearchRegisterTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/SearchRegisterTests.kt
@@ -134,10 +134,10 @@ class SearchRegisterTests : IntegrationTest() {
             val filter = searchLandlordRegisterPage.getFilterPanel()
 
             // Toggle filter
-            searchLandlordRegisterPage.clickComponent(filter.getCloseFilterPanelButton())
+            filter.getCloseFilterPanelButton().clickAndWait()
             assertTrue(filter.getPanel().isHidden)
 
-            searchLandlordRegisterPage.clickComponent(filter.getShowFilterPanel())
+            filter.getShowFilterPanel().clickAndWait()
             assertTrue(filter.getPanel().isVisible)
 
             // Apply LA filter
@@ -318,10 +318,10 @@ class SearchRegisterTests : IntegrationTest() {
 
             // Toggle filter
             val filter = searchPropertyRegisterPage.getFilterPanel()
-            searchPropertyRegisterPage.clickComponent(filter.getCloseFilterPanelButton())
+            filter.getCloseFilterPanelButton().clickAndWait()
             assertTrue(filter.getPanel().isHidden)
 
-            searchPropertyRegisterPage.clickComponent(filter.getShowFilterPanel())
+            filter.getShowFilterPanel().clickAndWait()
             assertTrue(filter.getPanel().isVisible)
 
             // Apply LA filter

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/SearchRegisterTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/SearchRegisterTests.kt
@@ -60,7 +60,7 @@ class SearchRegisterTests : IntegrationTest() {
             assertThat(resultTable.getHeaderCell(LISTED_PROPERTY_COL_INDEX)).containsText("Listed properties")
             assertThat(resultTable.getCell(0, LISTED_PROPERTY_COL_INDEX)).containsText("30")
 
-            assertTrue(searchLandlordRegisterPage.getErrorMessage(isVisible = false).isHidden)
+            assertTrue(searchLandlordRegisterPage.getErrorMessage().isHidden)
         }
 
         @Test
@@ -135,7 +135,7 @@ class SearchRegisterTests : IntegrationTest() {
 
             // Toggle filter
             searchLandlordRegisterPage.clickComponent(filter.getCloseFilterPanelButton())
-            assertTrue(filter.getPanel(isVisible = false).isHidden)
+            assertTrue(filter.getPanel().isHidden)
 
             searchLandlordRegisterPage.clickComponent(filter.getShowFilterPanel())
             assertTrue(filter.getPanel().isVisible)
@@ -145,14 +145,14 @@ class SearchRegisterTests : IntegrationTest() {
             laFilter.checkCheckbox("true")
             filter.clickApplyFiltersButton()
 
-            val laFilterSelectedHeadingText = filter.getSelectedHeadings(expectedCount = 1).first().innerText()
+            val laFilterSelectedHeadingText = filter.getSelectedHeadings().first().innerText()
             assertContains(laFilterSelectedHeadingText, "Show landlords operating in my authority")
             val resultTable = searchLandlordRegisterPage.getResultTable()
             assertEquals(1, resultTable.countRows())
 
             // Remove LA filter
             searchLandlordRegisterPage.clickComponent(filter.getRemoveFilterTag("Landlords in my authority"))
-            assertTrue(filter.getSelectedHeadings(expectedCount = 0).isEmpty())
+            assertTrue(filter.getSelectedHeadings().isEmpty())
             assertTrue(resultTable.countRows() > 1)
 
             // Clear all filters
@@ -160,7 +160,7 @@ class SearchRegisterTests : IntegrationTest() {
             filter.clickApplyFiltersButton()
 
             searchLandlordRegisterPage.clickComponent(filter.getClearFiltersLink())
-            assertTrue(filter.getClearFiltersLink(isVisible = false).isHidden)
+            assertTrue(filter.getClearFiltersLink().isHidden)
             assertTrue(filter.getNoFiltersSelectedText().isVisible)
             assertTrue(resultTable.countRows() > 1)
         }
@@ -218,7 +218,7 @@ class SearchRegisterTests : IntegrationTest() {
             assertThat(resultTable.getHeaderCell(PROPERTY_LANDLORD_COL_INDEX)).containsText("Registered landlord")
             assertThat(resultTable.getCell(0, PROPERTY_LANDLORD_COL_INDEX)).containsText("Alexander Smith")
 
-            assertTrue(searchPropertyRegisterPage.getErrorMessage(isVisible = false).isHidden)
+            assertTrue(searchPropertyRegisterPage.getErrorMessage().isHidden)
         }
 
         @Test
@@ -319,7 +319,7 @@ class SearchRegisterTests : IntegrationTest() {
             // Toggle filter
             val filter = searchPropertyRegisterPage.getFilterPanel()
             searchPropertyRegisterPage.clickComponent(filter.getCloseFilterPanelButton())
-            assertTrue(filter.getPanel(isVisible = false).isHidden)
+            assertTrue(filter.getPanel().isHidden)
 
             searchPropertyRegisterPage.clickComponent(filter.getShowFilterPanel())
             assertTrue(filter.getPanel().isVisible)
@@ -329,7 +329,7 @@ class SearchRegisterTests : IntegrationTest() {
             laFilter.checkCheckbox("true")
             filter.clickApplyFiltersButton()
 
-            val laFilterSelectedHeadingText = filter.getSelectedHeadings(expectedCount = 1)[0].innerText()
+            val laFilterSelectedHeadingText = filter.getSelectedHeadings()[0].innerText()
             assertContains(laFilterSelectedHeadingText, "Show properties in my authority")
             assertEquals(expectedPropertyInLACount, resultTable.countRows())
 
@@ -338,7 +338,7 @@ class SearchRegisterTests : IntegrationTest() {
             licenseFilter.checkCheckbox(LicensingType.SELECTIVE_LICENCE.name)
             filter.clickApplyFiltersButton()
 
-            val licenseFilterSelectedHeadingText = filter.getSelectedHeadings(expectedCount = 2)[1].innerText()
+            val licenseFilterSelectedHeadingText = filter.getSelectedHeadings()[1].innerText()
             assertContains(licenseFilterSelectedHeadingText, "Property licence")
             assertEquals(expectedPropertyInLAWithSelectiveLicenseCount, resultTable.countRows())
 
@@ -349,12 +349,12 @@ class SearchRegisterTests : IntegrationTest() {
 
             // Remove LA filter
             searchPropertyRegisterPage.clickComponent(filter.getRemoveFilterTag("Properties in my authority"))
-            assertEquals(1, filter.getSelectedHeadings(expectedCount = 1).size)
+            assertEquals(1, filter.getSelectedHeadings().size)
             assertEquals(expectedPropertyWithSelectiveOrNoLicenseCount, resultTable.countRows())
 
             // Clear all filters
             searchPropertyRegisterPage.clickComponent(filter.getClearFiltersLink())
-            assertTrue(filter.getClearFiltersLink(isVisible = false).isHidden)
+            assertTrue(filter.getClearFiltersLink().isHidden)
             assertTrue(filter.getNoFiltersSelectedText().isVisible)
             assertEquals(expectedMatchingPropertyCount, resultTable.countRows())
         }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/SearchRegisterTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/SearchRegisterTests.kt
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.springframework.test.context.jdbc.Sql
 import uk.gov.communities.prsdb.webapp.constants.enums.LicensingType
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.BaseComponent.Companion.assertThat
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.SearchLandlordRegisterPage
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.SearchLandlordRegisterPage.Companion.ADDRESS_COL_INDEX
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.SearchLandlordRegisterPage.Companion.CONTACT_INFO_COL_INDEX
@@ -159,8 +160,8 @@ class SearchRegisterTests : IntegrationTest() {
             laFilter.checkCheckbox("true")
             filter.clickApplyFiltersButton()
 
-            searchLandlordRegisterPage.clickComponent(filter.getClearFiltersLink())
-            assertTrue(filter.getClearFiltersLink().isHidden)
+            filter.clearFiltersLink.clickAndWait()
+            assertThat(filter.clearFiltersLink).isHidden()
             assertTrue(filter.getNoFiltersSelectedText().isVisible)
             assertTrue(resultTable.countRows() > 1)
         }
@@ -353,8 +354,8 @@ class SearchRegisterTests : IntegrationTest() {
             assertEquals(expectedPropertyWithSelectiveOrNoLicenseCount, resultTable.countRows())
 
             // Clear all filters
-            searchPropertyRegisterPage.clickComponent(filter.getClearFiltersLink())
-            assertTrue(filter.getClearFiltersLink().isHidden)
+            filter.clearFiltersLink.clickAndWait()
+            assertThat(filter.clearFiltersLink).isHidden()
             assertTrue(filter.getNoFiltersSelectedText().isVisible)
             assertEquals(expectedMatchingPropertyCount, resultTable.countRows())
         }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/components/BaseComponent.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/components/BaseComponent.kt
@@ -7,7 +7,7 @@ import com.microsoft.playwright.assertions.LocatorAssertions
 import com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat
 
 abstract class BaseComponent(
-    protected val locator: Locator,
+    protected open val locator: Locator,
 ) {
     companion object {
         fun assertThat(component: BaseComponent): LocatorAssertions = assertThat(component.locator)
@@ -54,12 +54,6 @@ abstract class BaseComponent(
         fun getSubHeading(page: Page) = getComponent(page, "main header p")
 
         fun getConfirmationPageBanner(page: Page) = getComponent(page, ".govuk-panel--confirmation")
-
-        fun getLink(
-            page: Page,
-            text: String,
-            index: Int = 0,
-        ) = getComponent(page, ".govuk-link", LocatorOptions().setHasText(text), index)
     }
 
     protected fun getChildrenComponents(

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/components/BaseComponent.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/components/BaseComponent.kt
@@ -44,11 +44,6 @@ abstract class BaseComponent(
             return component.all()
         }
 
-        fun getSection(
-            page: Page,
-            index: Int = 0,
-        ) = getComponent(page, "section", index = index)
-
         fun getHeading(page: Page) = getComponent(page, "main header h1")
 
         fun getSubHeading(page: Page) = getComponent(page, "main header p")

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/components/BaseComponent.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/components/BaseComponent.kt
@@ -44,10 +44,6 @@ abstract class BaseComponent(
             return component.all()
         }
 
-        fun getHeading(page: Page) = getComponent(page, "main header h1")
-
-        fun getSubHeading(page: Page) = getComponent(page, "main header p")
-
         fun getConfirmationPageBanner(page: Page) = getComponent(page, ".govuk-panel--confirmation")
     }
 

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/components/BaseComponent.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/components/BaseComponent.kt
@@ -43,8 +43,6 @@ abstract class BaseComponent(
             val component = parentLocator.locator(locatorStr, locatorOptions)
             return component.all()
         }
-
-        fun getConfirmationPageBanner(page: Page) = getComponent(page, ".govuk-panel--confirmation")
     }
 
     protected fun getChildrenComponents(

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/components/BaseComponent.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/components/BaseComponent.kt
@@ -3,11 +3,15 @@ package uk.gov.communities.prsdb.webapp.integration.pageObjects.components
 import com.microsoft.playwright.Locator
 import com.microsoft.playwright.Page
 import com.microsoft.playwright.Page.LocatorOptions
+import com.microsoft.playwright.assertions.LocatorAssertions
+import com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat
 
 abstract class BaseComponent(
     protected val locator: Locator,
 ) {
     companion object {
+        fun assertThat(component: BaseComponent): LocatorAssertions = assertThat(component.locator)
+
         // TODO PRSD-884 Delete
         fun getComponent(
             page: Page,
@@ -50,11 +54,6 @@ abstract class BaseComponent(
         fun getSubHeading(page: Page) = getComponent(page, "main header p")
 
         fun getConfirmationPageBanner(page: Page) = getComponent(page, ".govuk-panel--confirmation")
-
-        fun getButton(
-            page: Page,
-            text: String? = null,
-        ) = getComponent(page, ".govuk-button", if (text == null) null else LocatorOptions().setHasText(text))
 
         fun getLink(
             page: Page,

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/components/BaseComponent.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/components/BaseComponent.kt
@@ -3,55 +3,40 @@ package uk.gov.communities.prsdb.webapp.integration.pageObjects.components
 import com.microsoft.playwright.Locator
 import com.microsoft.playwright.Page
 import com.microsoft.playwright.Page.LocatorOptions
-import org.junit.jupiter.api.Assertions.assertEquals
 
 abstract class BaseComponent(
     protected val locator: Locator,
 ) {
     companion object {
-        private fun assertLocatorIsValid(
-            locator: Locator,
-            expectedLocatorCount: Int = 1,
-        ) {
-            assertEquals(
-                expectedLocatorCount,
-                locator.count(),
-                "Expected $expectedLocatorCount instance of $locator, found ${locator.count()}",
-            )
-        }
-
+        // TODO PRSD-884 Delete
         fun getComponent(
             page: Page,
             locatorStr: String,
             locatorOptions: LocatorOptions? = null,
             index: Int = 0,
-            isVisible: Boolean = true,
         ): Locator {
             val component = page.locator(locatorStr, locatorOptions).nth(index)
-            assertLocatorIsValid(component, expectedLocatorCount = if (isVisible) 1 else 0)
             return component
         }
 
+        // TODO PRSD-884 Delete
         fun getChildComponent(
             parentLocator: Locator,
             locatorStr: String,
             locatorOptions: Locator.LocatorOptions? = null,
             index: Int = 0,
-            isVisible: Boolean = true,
         ): Locator {
             val component = parentLocator.locator(locatorStr, locatorOptions).nth(index)
-            assertLocatorIsValid(component, expectedLocatorCount = if (isVisible) 1 else 0)
             return component
         }
 
+        // TODO PRSD-884 Delete
         fun getChildrenComponents(
             parentLocator: Locator,
             locatorStr: String,
-            expectedChildrenCount: Int,
             locatorOptions: Locator.LocatorOptions? = null,
         ): List<Locator> {
             val component = parentLocator.locator(locatorStr, locatorOptions)
-            assertLocatorIsValid(component, expectedChildrenCount)
             return component.all()
         }
 
@@ -75,24 +60,17 @@ abstract class BaseComponent(
             page: Page,
             text: String,
             index: Int = 0,
-            isVisible: Boolean = true,
-        ) = getComponent(page, ".govuk-link", LocatorOptions().setHasText(text), index, isVisible)
-    }
-
-    init {
-        assertLocatorIsValid(locator)
+        ) = getComponent(page, ".govuk-link", LocatorOptions().setHasText(text), index)
     }
 
     protected fun getChildrenComponents(
         locatorStr: String,
-        expectedChildren: Int,
         locatorOptions: Locator.LocatorOptions? = null,
-    ): List<Locator> = Companion.getChildrenComponents(locator, locatorStr, expectedChildren, locatorOptions)
+    ): List<Locator> = Companion.getChildrenComponents(locator, locatorStr, locatorOptions)
 
     protected fun getChildComponent(
         locatorStr: String,
         locatorOptions: Locator.LocatorOptions? = null,
         index: Int = 0,
-        isVisible: Boolean = true,
-    ): Locator = Companion.getChildComponent(locator, locatorStr, locatorOptions, index, isVisible)
+    ): Locator = Companion.getChildComponent(locator, locatorStr, locatorOptions, index)
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/components/Button.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/components/Button.kt
@@ -1,0 +1,21 @@
+package uk.gov.communities.prsdb.webapp.integration.pageObjects.components
+
+import com.microsoft.playwright.Locator
+import com.microsoft.playwright.Page
+import com.microsoft.playwright.Page.LocatorOptions
+
+class Button(
+    locator: Locator,
+) : BaseComponent(locator) {
+    companion object {
+        fun byText(
+            page: Page,
+            text: String? = null,
+        ): Button = Button(page.locator(".govuk-button", if (text == null) null else LocatorOptions().setHasText(text)))
+    }
+
+    fun clickAndWait() {
+        locator.click()
+        locator.page().waitForLoadState()
+    }
+}

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/components/Button.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/components/Button.kt
@@ -9,9 +9,26 @@ class Button(
 ) : BaseComponent(locator),
     ClickAndWaitable {
     companion object {
+        fun default(page: Page) = factory(page, null)
+
         fun byText(
             page: Page,
-            text: String? = null,
-        ): Button = Button(page.locator(".govuk-button", if (text == null) null else LocatorOptions().setHasText(text)))
+            text: String,
+        ): Button = factory(page, text)
+
+        private fun factory(
+            page: Page,
+            text: String?,
+        ): Button =
+            Button(
+                page.locator(
+                    ".govuk-button",
+                    if (text == null) {
+                        null
+                    } else {
+                        LocatorOptions().setHasText(text)
+                    },
+                ),
+            )
     }
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/components/ClickAndWaitable.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/components/ClickAndWaitable.kt
@@ -1,0 +1,12 @@
+package uk.gov.communities.prsdb.webapp.integration.pageObjects.components
+
+import com.microsoft.playwright.Locator
+
+interface ClickAndWaitable {
+    val locator: Locator
+
+    fun clickAndWait() {
+        locator.click()
+        locator.page().waitForLoadState()
+    }
+}

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/components/ConfirmationBanner.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/components/ConfirmationBanner.kt
@@ -1,0 +1,7 @@
+package uk.gov.communities.prsdb.webapp.integration.pageObjects.components
+
+import com.microsoft.playwright.Page
+
+open class ConfirmationBanner(
+    page: Page,
+) : BaseComponent(page.locator(".govuk-panel--confirmation"))

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/components/FilterPanel.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/components/FilterPanel.kt
@@ -13,7 +13,7 @@ class FilterPanel(
 
     fun getShowFilterPanel() = Button.byText(page, "Show filters panel")
 
-    fun getClearFiltersLink() = getLink(page, "Clear filters")
+    val clearFiltersLink = Link.byText(page, "Clear filters")
 
     fun getSelectedHeadings() = getChildrenComponents(".moj-filter__selected >> h3")
 

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/components/FilterPanel.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/components/FilterPanel.kt
@@ -9,9 +9,9 @@ class FilterPanel(
 ) : BaseComponent(locator) {
     fun getPanel() = getChildComponent(".moj-filter")
 
-    fun getCloseFilterPanelButton() = getButton(page, "Close filters panel")
+    fun getCloseFilterPanelButton() = Button.byText(page, "Close filters panel")
 
-    fun getShowFilterPanel() = getButton(page, "Show filters panel")
+    fun getShowFilterPanel() = Button.byText(page, "Show filters panel")
 
     fun getClearFiltersLink() = getLink(page, "Clear filters")
 

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/components/FilterPanel.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/components/FilterPanel.kt
@@ -7,15 +7,15 @@ class FilterPanel(
     private val page: Page,
     locator: Locator = page.locator(".moj-filter-layout"),
 ) : BaseComponent(locator) {
-    fun getPanel(isVisible: Boolean = true) = getChildComponent(".moj-filter", isVisible = isVisible)
+    fun getPanel() = getChildComponent(".moj-filter")
 
     fun getCloseFilterPanelButton() = getButton(page, "Close filters panel")
 
     fun getShowFilterPanel() = getButton(page, "Show filters panel")
 
-    fun getClearFiltersLink(isVisible: Boolean = true) = getLink(page, "Clear filters", isVisible = isVisible)
+    fun getClearFiltersLink() = getLink(page, "Clear filters")
 
-    fun getSelectedHeadings(expectedCount: Int) = getChildrenComponents(".moj-filter__selected >> h3", expectedCount)
+    fun getSelectedHeadings() = getChildrenComponents(".moj-filter__selected >> h3")
 
     fun getNoFiltersSelectedText() = getChildComponent(".moj-filter__selected", Locator.LocatorOptions().setHasText("No filters selected"))
 

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/components/Heading.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/components/Heading.kt
@@ -1,0 +1,7 @@
+package uk.gov.communities.prsdb.webapp.integration.pageObjects.components
+
+import com.microsoft.playwright.Page
+
+class Heading(
+    page: Page,
+) : BaseComponent(page.locator("main header h1"))

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/components/Link.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/components/Link.kt
@@ -13,6 +13,6 @@ class Link(
             page: Page,
             text: String,
             index: Int = 0,
-        ): Button = Button(page.locator(".govuk-link", LocatorOptions().setHasText(text)).nth(index))
+        ): Link = Link(page.locator(".govuk-link", LocatorOptions().setHasText(text)).nth(index))
     }
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/components/Link.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/components/Link.kt
@@ -4,14 +4,15 @@ import com.microsoft.playwright.Locator
 import com.microsoft.playwright.Page
 import com.microsoft.playwright.Page.LocatorOptions
 
-class Button(
+class Link(
     override val locator: Locator,
 ) : BaseComponent(locator),
     ClickAndWaitable {
     companion object {
         fun byText(
             page: Page,
-            text: String? = null,
-        ): Button = Button(page.locator(".govuk-button", if (text == null) null else LocatorOptions().setHasText(text)))
+            text: String,
+            index: Int = 0,
+        ): Button = Button(page.locator(".govuk-link", LocatorOptions().setHasText(text)).nth(index))
     }
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/components/Section.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/components/Section.kt
@@ -1,0 +1,15 @@
+package uk.gov.communities.prsdb.webapp.integration.pageObjects.components
+
+import com.microsoft.playwright.Locator
+import com.microsoft.playwright.Page
+
+class Section(
+    locator: Locator,
+) : BaseComponent(locator) {
+    companion object {
+        fun byTestId(
+            page: Page,
+            testId: String,
+        ): Section = Section(page.locator("section[data-testid=\"$testId\"]"))
+    }
+}

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/components/SubHeading.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/components/SubHeading.kt
@@ -1,0 +1,7 @@
+package uk.gov.communities.prsdb.webapp.integration.pageObjects.components
+
+import com.microsoft.playwright.Page
+
+class SubHeading(
+    page: Page,
+) : BaseComponent(page.locator("main header p"))

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/components/Tabs.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/components/Tabs.kt
@@ -5,12 +5,11 @@ import com.microsoft.playwright.Page
 
 class Tabs(
     page: Page,
-    numberOfTabs: Int,
     locator: Locator = page.locator(".govuk-tabs"),
 ) : BaseComponent(locator) {
-    val tabsList = getChildrenComponents(".govuk-tabs__list >> .govuk-tabs__list-item", numberOfTabs)
+    val tabsList = getChildrenComponents(".govuk-tabs__list >> .govuk-tabs__list-item")
 
-    val tabPanels = getChildrenComponents(".govuk-tabs__panel", numberOfTabs)
+    val tabPanels = getChildrenComponents(".govuk-tabs__panel")
 
     var hiddenPanels = tabPanels.filter { it.isHidden }
 

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/CancelLaUserInvitationPage.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/CancelLaUserInvitationPage.kt
@@ -1,13 +1,13 @@
 package uk.gov.communities.prsdb.webapp.integration.pageObjects.pages
 
 import com.microsoft.playwright.Page
-import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.BaseComponent.Companion.getSection
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.Form
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.Section
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages.BasePage
 
 class CancelLaUserInvitationPage(
     page: Page,
 ) : BasePage(page, "/cancel-invitation") {
-    val userDetailsSection = getSection(page)
+    val userDetailsSection = Section.byTestId(page, "user-details-section")
     val form = Form(page)
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/CancelLaUserInvitationSuccessPage.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/CancelLaUserInvitationSuccessPage.kt
@@ -1,13 +1,13 @@
 package uk.gov.communities.prsdb.webapp.integration.pageObjects.pages
 
 import com.microsoft.playwright.Page
-import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.BaseComponent.Companion.getButton
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.BaseComponent.Companion.getConfirmationPageBanner
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.Button
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages.BasePage
 
 class CancelLaUserInvitationSuccessPage(
     page: Page,
 ) : BasePage(page, "/cancel-invitation/success") {
     val confirmationBanner = getConfirmationPageBanner(page)
-    val returnButton = getButton(page)
+    val returnButton = Button.byText(page)
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/CancelLaUserInvitationSuccessPage.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/CancelLaUserInvitationSuccessPage.kt
@@ -1,13 +1,13 @@
 package uk.gov.communities.prsdb.webapp.integration.pageObjects.pages
 
 import com.microsoft.playwright.Page
-import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.BaseComponent.Companion.getConfirmationPageBanner
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.Button
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.ConfirmationBanner
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages.BasePage
 
 class CancelLaUserInvitationSuccessPage(
     page: Page,
 ) : BasePage(page, "/cancel-invitation/success") {
-    val confirmationBanner = getConfirmationPageBanner(page)
+    val confirmationBanner = ConfirmationBanner(page)
     val returnButton = Button.byText(page)
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/CancelLaUserInvitationSuccessPage.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/CancelLaUserInvitationSuccessPage.kt
@@ -9,5 +9,5 @@ class CancelLaUserInvitationSuccessPage(
     page: Page,
 ) : BasePage(page, "/cancel-invitation/success") {
     val confirmationBanner = ConfirmationBanner(page)
-    val returnButton = Button.byText(page)
+    val returnButton = Button.default(page)
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/ConfirmDeleteLaUserPage.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/ConfirmDeleteLaUserPage.kt
@@ -1,13 +1,13 @@
 package uk.gov.communities.prsdb.webapp.integration.pageObjects.pages
 
 import com.microsoft.playwright.Page
-import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.BaseComponent.Companion.getSection
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.Form
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.Section
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages.BasePage
 
 class ConfirmDeleteLaUserPage(
     page: Page,
 ) : BasePage(page, "/delete-user/") {
-    val userDetailsSection = getSection(page)
+    val userDetailsSection = Section.byTestId(page, "user-details-section")
     val form = Form(page)
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/DeleteLaUserSuccessPage.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/DeleteLaUserSuccessPage.kt
@@ -1,13 +1,13 @@
 package uk.gov.communities.prsdb.webapp.integration.pageObjects.pages
 
 import com.microsoft.playwright.Page
-import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.BaseComponent.Companion.getButton
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.BaseComponent.Companion.getConfirmationPageBanner
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.Button
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages.BasePage
 
 class DeleteLaUserSuccessPage(
     page: Page,
 ) : BasePage(page, "/delete-user/success") {
     val confirmationBanner = getConfirmationPageBanner(page)
-    val returnButton = getButton(page)
+    val returnButton = Button.byText(page)
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/DeleteLaUserSuccessPage.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/DeleteLaUserSuccessPage.kt
@@ -1,13 +1,13 @@
 package uk.gov.communities.prsdb.webapp.integration.pageObjects.pages
 
 import com.microsoft.playwright.Page
-import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.BaseComponent.Companion.getConfirmationPageBanner
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.Button
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.ConfirmationBanner
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages.BasePage
 
 class DeleteLaUserSuccessPage(
     page: Page,
 ) : BasePage(page, "/delete-user/success") {
-    val confirmationBanner = getConfirmationPageBanner(page)
+    val confirmationBanner = ConfirmationBanner(page)
     val returnButton = Button.byText(page)
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/DeleteLaUserSuccessPage.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/DeleteLaUserSuccessPage.kt
@@ -9,5 +9,5 @@ class DeleteLaUserSuccessPage(
     page: Page,
 ) : BasePage(page, "/delete-user/success") {
     val confirmationBanner = ConfirmationBanner(page)
-    val returnButton = Button.byText(page)
+    val returnButton = Button.default(page)
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/EditLaUserPage.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/EditLaUserPage.kt
@@ -1,17 +1,17 @@
 package uk.gov.communities.prsdb.webapp.integration.pageObjects.pages
 
 import com.microsoft.playwright.Page
-import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.BaseComponent.Companion.getHeading
-import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.BaseComponent.Companion.getSubHeading
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.Button
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.Form
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.Heading
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.SubHeading
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages.BasePage
 
 class EditLaUserPage(
     page: Page,
 ) : BasePage(page, "/edit-user/") {
-    val name = getHeading(page)
-    val email = getSubHeading(page)
+    val name = Heading(page)
+    val email = SubHeading(page)
     val form = Form(page)
     val isManagerRadios = form.getRadios()
     val removeAccountButton = Button.byText(page, "Remove this account")

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/EditLaUserPage.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/EditLaUserPage.kt
@@ -1,9 +1,9 @@
 package uk.gov.communities.prsdb.webapp.integration.pageObjects.pages
 
 import com.microsoft.playwright.Page
-import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.BaseComponent.Companion.getButton
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.BaseComponent.Companion.getHeading
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.BaseComponent.Companion.getSubHeading
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.Button
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.Form
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages.BasePage
 
@@ -14,5 +14,5 @@ class EditLaUserPage(
     val email = getSubHeading(page)
     val form = Form(page)
     val isManagerRadios = form.getRadios()
-    val removeAccountButton = getButton(page, "Remove this account")
+    val removeAccountButton = Button.byText(page, "Remove this account")
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/InviteNewLaUserSuccessPage.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/InviteNewLaUserSuccessPage.kt
@@ -1,11 +1,11 @@
 package uk.gov.communities.prsdb.webapp.integration.pageObjects.pages
 
 import com.microsoft.playwright.Page
-import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.BaseComponent.Companion.getConfirmationPageBanner
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.ConfirmationBanner
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages.BasePage
 
 class InviteNewLaUserSuccessPage(
     page: Page,
 ) : BasePage(page, "/invite-new-user/success") {
-    val confirmationBanner = getConfirmationPageBanner(page)
+    val confirmationBanner = ConfirmationBanner(page)
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/ManageLaUsersPage.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/ManageLaUsersPage.kt
@@ -1,9 +1,8 @@
 package uk.gov.communities.prsdb.webapp.integration.pageObjects.pages
 
-import com.microsoft.playwright.Locator
 import com.microsoft.playwright.Page
-import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.BaseComponent.Companion.getButton
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.BaseComponent.Companion.getChildComponent
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.Button
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.Pagination
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.Table
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages.BasePage
@@ -12,8 +11,8 @@ class ManageLaUsersPage(
     page: Page,
 ) : BasePage(page, "/manage-users") {
     val table = Table(page)
-    val inviteAnotherUserButton = getButton(page, "Invite another user")
-    val returnToDashboardButton: Locator = getButton(page, "Return to dashboard")
+    val inviteAnotherUserButton = Button.byText(page, "Invite another user")
+    val returnToDashboardButton = Button.byText(page, "Return to dashboard")
 
     companion object {
         const val USERNAME_COL_INDEX: Int = 0

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/PropertyDetailsPage.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/PropertyDetailsPage.kt
@@ -7,7 +7,7 @@ import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages.B
 class PropertyDetailsPage(
     page: Page,
 ) : BasePage(page, "/property-details") {
-    val tabs = Tabs(page, 2)
+    val tabs = Tabs(page)
 
     fun getActiveTabPanelId() = tabs.getActiveTabPanelId()
 

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/PropertyDetailsPageLandlordView.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/PropertyDetailsPageLandlordView.kt
@@ -1,11 +1,11 @@
 package uk.gov.communities.prsdb.webapp.integration.pageObjects.pages
 
 import com.microsoft.playwright.Page
-import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.BaseComponent.Companion.getButton
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.Button
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages.PropertyDetailsBasePage
 
 class PropertyDetailsPageLandlordView(
     page: Page,
 ) : PropertyDetailsBasePage(page, "/property-details") {
-    val deleteButton = getButton(page, "Delete property record")
+    val deleteButton = Button.byText(page, "Delete property record")
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/basePages/LandlordDetailsBasePage.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/basePages/LandlordDetailsBasePage.kt
@@ -8,7 +8,7 @@ abstract class LandlordDetailsBasePage(
     page: Page,
     urlSegment: String,
 ) : BasePage(page, urlSegment) {
-    val tabs = Tabs(page, 2)
+    val tabs = Tabs(page)
     val table = Table(page)
 
     fun getActiveTabPanelId() = tabs.getActiveTabPanelId()

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/basePages/PropertyDetailsBasePage.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/basePages/PropertyDetailsBasePage.kt
@@ -8,7 +8,7 @@ abstract class PropertyDetailsBasePage(
     page: Page,
     urlSegment: String,
 ) : BasePage(page, urlSegment) {
-    val tabs = Tabs(page, 2)
+    val tabs = Tabs(page)
 
     fun getActiveTabPanelId() = tabs.getActiveTabPanelId()
 

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/basePages/PropertyDetailsBasePage.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/basePages/PropertyDetailsBasePage.kt
@@ -1,7 +1,7 @@
 package uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages
 
 import com.microsoft.playwright.Page
-import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.BaseComponent.Companion.getLink
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.Link
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.Tabs
 
 abstract class PropertyDetailsBasePage(
@@ -20,15 +20,9 @@ abstract class PropertyDetailsBasePage(
         tabs.goToTab("Property details")
     }
 
-    fun clickLandlordNameLinkFromKeyDetails(landlordName: String) {
-        getLink(page, landlordName, 0).click()
-    }
+    fun getLandlordNameLinkFromKeyDetails(landlordName: String) = Link.byText(page, landlordName, 0)
 
-    fun clickLandlordLinkFromLandlordDetails(landlordName: String) {
-        getLink(page, landlordName, 1).click()
-    }
+    fun getLandlordLinkFromLandlordDetails(landlordName: String) = Link.byText(page, landlordName, 1)
 
-    fun clickBackLink() {
-        getLink(page, "Back").click()
-    }
+    val backLink = Link.byText(page, "Back")
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/basePages/SearchRegisterBasePage.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/basePages/SearchRegisterBasePage.kt
@@ -25,5 +25,5 @@ abstract class SearchRegisterBasePage(
 
     fun getErrorMessageText() = getErrorMessage().innerText()
 
-    fun getErrorMessage(isVisible: Boolean = true) = getComponent(page, "#no-results", isVisible = isVisible)
+    fun getErrorMessage() = getComponent(page, "#no-results")
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/basePages/SelectAddressFormPage.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/basePages/SelectAddressFormPage.kt
@@ -1,12 +1,12 @@
 package uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages
 
 import com.microsoft.playwright.Page
-import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.BaseComponent.Companion.getLink
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.Link
 
 abstract class SelectAddressFormPage(
     page: Page,
     urlSegment: String,
 ) : FormBasePage(page, urlSegment) {
-    val searchAgain = getLink(page, "Search Again")
+    val searchAgain = Link.byText(page, "Search Again")
     val radios = form.getRadios()
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/landlordRegistrationJourneyPages/ConfirmationPageLandlordRegistration.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/landlordRegistrationJourneyPages/ConfirmationPageLandlordRegistration.kt
@@ -3,15 +3,20 @@ package uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.landlordRe
 import com.microsoft.playwright.Page
 import uk.gov.communities.prsdb.webapp.constants.REGISTER_LANDLORD_JOURNEY_URL
 import uk.gov.communities.prsdb.webapp.controllers.RegisterLandlordController.Companion.CONFIRMATION_PAGE_PATH_SEGMENT
-import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.BaseComponent
-import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.BaseComponent.Companion.getChildComponent
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.Button
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.ConfirmationBanner
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages.BasePage
 
 class ConfirmationPageLandlordRegistration(
     page: Page,
 ) : BasePage(page, "$REGISTER_LANDLORD_JOURNEY_URL/$CONFIRMATION_PAGE_PATH_SEGMENT") {
-    private val confirmationBanner = BaseComponent.getConfirmationPageBanner(page)
-    val registrationNumberText: String = getChildComponent(confirmationBanner, "strong").innerText()
+    val confirmationBanner = LandlordRegistrationConfirmationBanner(page)
     val goToDashboardButton = Button.byText(page, "Go to Dashboard")
+
+    class LandlordRegistrationConfirmationBanner(
+        page: Page,
+    ) : ConfirmationBanner(page) {
+        val registrationNumberText: String
+            get() = locator.locator("strong").innerText()
+    }
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/landlordRegistrationJourneyPages/ConfirmationPageLandlordRegistration.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/landlordRegistrationJourneyPages/ConfirmationPageLandlordRegistration.kt
@@ -5,6 +5,7 @@ import uk.gov.communities.prsdb.webapp.constants.REGISTER_LANDLORD_JOURNEY_URL
 import uk.gov.communities.prsdb.webapp.controllers.RegisterLandlordController.Companion.CONFIRMATION_PAGE_PATH_SEGMENT
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.BaseComponent
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.BaseComponent.Companion.getChildComponent
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.Button
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages.BasePage
 
 class ConfirmationPageLandlordRegistration(
@@ -12,6 +13,5 @@ class ConfirmationPageLandlordRegistration(
 ) : BasePage(page, "$REGISTER_LANDLORD_JOURNEY_URL/$CONFIRMATION_PAGE_PATH_SEGMENT") {
     private val confirmationBanner = BaseComponent.getConfirmationPageBanner(page)
     val registrationNumberText: String = getChildComponent(confirmationBanner, "strong").innerText()
-
-    fun clickGoToDashboard() = clickComponent(BaseComponent.getButton(page, "Go to Dashboard"))
+    val goToDashboardButton = Button.byText(page, "Go to Dashboard")
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/propertyRegistrationJourneyPages/ConfirmationPagePropertyRegistration.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/propertyRegistrationJourneyPages/ConfirmationPagePropertyRegistration.kt
@@ -3,7 +3,7 @@ package uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyRe
 import com.microsoft.playwright.Page
 import uk.gov.communities.prsdb.webapp.constants.REGISTER_PROPERTY_JOURNEY_URL
 import uk.gov.communities.prsdb.webapp.controllers.RegisterPropertyController.Companion.CONFIRMATION_PAGE_PATH_SEGMENT
-import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.BaseComponent
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.Button
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.Table
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages.BasePage
 
@@ -12,6 +12,5 @@ class ConfirmationPagePropertyRegistration(
 ) : BasePage(page, "$REGISTER_PROPERTY_JOURNEY_URL/$CONFIRMATION_PAGE_PATH_SEGMENT") {
     private val detailTable = Table(page)
     val registrationNumberText: String = detailTable.getCell(0, 1).innerText()
-
-    fun clickGoToDashboard() = clickComponent(BaseComponent.getButton(page, "Go to Dashboard"))
+    val goToDashboardButton = Button.byText(page, "Go to Dashboard")
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/propertyRegistrationJourneyPages/RegisterPropertyStartPage.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/propertyRegistrationJourneyPages/RegisterPropertyStartPage.kt
@@ -3,12 +3,12 @@ package uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyRe
 import com.microsoft.playwright.Locator
 import com.microsoft.playwright.Page
 import uk.gov.communities.prsdb.webapp.constants.REGISTER_PROPERTY_JOURNEY_URL
-import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.BaseComponent.Companion.getButton
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.Button
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages.BasePage
 
 class RegisterPropertyStartPage(
     page: Page,
 ) : BasePage(page, "/$REGISTER_PROPERTY_JOURNEY_URL") {
     val heading: Locator? = page.locator(".govuk-heading-l")
-    val startButton = getButton(page, "Start now")
+    val startButton = Button.byText(page, "Start now")
 }


### PR DESCRIPTION
This is a fairly mechanical set of changes. Although there's quite a lot in total, each change is quite simple - you might like to review each commit in turn.

The overview is:
* We no longer assert number of matching nodes when creating locators (in component constructors and in the various `getChildComponent`-like methods)
* In turn, this means we no longer need the various `isHidden` and `expectedNumber` type parameters that were plumbed through various methods
* The various `getMyThing` type methods on `BaseComponent.Companion` are now represented by equivalent `MyThing` component classes
* And where `MyThing` is used, it's now a `val` property. Relatedly, there's a preference for `page.component.performAction()` rather than `page.performActionOnComponent()`
* In particular `clickAndWait` (which waits for the page to load) has been pulled out into an interface with a default implementation, for use by those components that can be clicked to navigate.
* Because components are mostly a convenience wrapper around Locators, I've provided an `assertThat(component)` method that just passes through to `assertThat(locator)`

This is just part 1 of the tidy-up. Still to come will be tackling some of the more complex existing components, where changes might be a bit more involved, and then finally getting rid of the various `getChildCompnent` style methods.