### PR TITLE
PRSD-879: Landlord Registration - Save 1L User

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/database/repository/OneLoginUserRepository.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/database/repository/OneLoginUserRepository.kt
@@ -3,4 +3,4 @@ package uk.gov.communities.prsdb.webapp.database.repository
 import org.springframework.data.jpa.repository.JpaRepository
 import uk.gov.communities.prsdb.webapp.database.entity.OneLoginUser
 
-interface OneLoginUserRepository : JpaRepository<OneLoginUser?, String?>
+interface OneLoginUserRepository : JpaRepository<OneLoginUser, String>

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/LandlordService.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/LandlordService.kt
@@ -11,7 +11,6 @@ import uk.gov.communities.prsdb.webapp.constants.enums.RegistrationNumberType
 import uk.gov.communities.prsdb.webapp.database.entity.Landlord
 import uk.gov.communities.prsdb.webapp.database.repository.LandlordRepository
 import uk.gov.communities.prsdb.webapp.database.repository.LandlordWithListedPropertyCountRepository
-import uk.gov.communities.prsdb.webapp.database.repository.OneLoginUserRepository
 import uk.gov.communities.prsdb.webapp.models.dataModels.AddressDataModel
 import uk.gov.communities.prsdb.webapp.models.dataModels.RegistrationNumberDataModel
 import uk.gov.communities.prsdb.webapp.models.viewModels.LandlordSearchResultViewModel
@@ -20,7 +19,7 @@ import java.time.LocalDate
 @Service
 class LandlordService(
     private val landlordRepository: LandlordRepository,
-    private val oneLoginUserRepository: OneLoginUserRepository,
+    private val oneLoginUserService: OneLoginUserService,
     private val landlordWithListedPropertyCountRepository: LandlordWithListedPropertyCountRepository,
     private val addressService: AddressService,
     private val registrationNumberService: RegistrationNumberService,
@@ -31,8 +30,6 @@ class LandlordService(
         }
         return landlordRepository.findByRegistrationNumber_Number(regNum.number)
     }
-
-    fun retrieveLandlordIdByBaseUserId(baseUserId: String): Long? = landlordRepository.findByBaseUser_Id(baseUserId)?.id
 
     fun retrieveLandlordByBaseUserId(baseUserId: String): Landlord? = landlordRepository.findByBaseUser_Id(baseUserId)
 
@@ -49,7 +46,7 @@ class LandlordService(
         nonEnglandOrWalesAddress: String? = null,
         dateOfBirth: LocalDate? = null,
     ): Landlord {
-        val baseUser = oneLoginUserRepository.getReferenceById(baseUserId)
+        val baseUser = oneLoginUserService.findOrCreate1LUser(baseUserId)
         val address = addressService.findOrCreateAddress(addressDataModel)
         val registrationNumber = registrationNumberService.createRegistrationNumber(RegistrationNumberType.LANDLORD)
 

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/LocalAuthorityDataService.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/LocalAuthorityDataService.kt
@@ -1,5 +1,6 @@
 package uk.gov.communities.prsdb.webapp.services
 
+import jakarta.transaction.Transactional
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.PageRequest
 import org.springframework.data.domain.Sort
@@ -13,7 +14,6 @@ import uk.gov.communities.prsdb.webapp.database.entity.LocalAuthority
 import uk.gov.communities.prsdb.webapp.database.entity.LocalAuthorityUser
 import uk.gov.communities.prsdb.webapp.database.repository.LocalAuthorityUserOrInvitationRepository
 import uk.gov.communities.prsdb.webapp.database.repository.LocalAuthorityUserRepository
-import uk.gov.communities.prsdb.webapp.database.repository.OneLoginUserRepository
 import uk.gov.communities.prsdb.webapp.models.dataModels.LocalAuthorityUserAccessLevelDataModel
 import uk.gov.communities.prsdb.webapp.models.dataModels.LocalAuthorityUserDataModel
 
@@ -21,7 +21,7 @@ import uk.gov.communities.prsdb.webapp.models.dataModels.LocalAuthorityUserDataM
 class LocalAuthorityDataService(
     val localAuthorityUserRepository: LocalAuthorityUserRepository,
     val localAuthorityUserOrInvitationRepository: LocalAuthorityUserOrInvitationRepository,
-    val oneLoginUserRepository: OneLoginUserRepository,
+    val oneLoginUserService: OneLoginUserService,
 ) {
     fun getUserAndLocalAuthorityIfAuthorizedUser(
         localAuthorityId: Int,
@@ -105,17 +105,16 @@ class LocalAuthorityDataService(
         localAuthorityUserRepository.deleteById(localAuthorityUserId)
     }
 
+    @Transactional
     fun registerNewUser(
         baseUserId: String,
         localAuthority: LocalAuthority,
         name: String,
         email: String,
     ) {
-        val oneLoginUser = oneLoginUserRepository.getReferenceById(baseUserId)
-
         localAuthorityUserRepository.save(
             LocalAuthorityUser(
-                baseUser = oneLoginUser,
+                baseUser = oneLoginUserService.findOrCreate1LUser(baseUserId),
                 isManager = false,
                 localAuthority = localAuthority,
                 name = name,

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/OneLoginUserService.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/OneLoginUserService.kt
@@ -1,0 +1,16 @@
+package uk.gov.communities.prsdb.webapp.services
+
+import jakarta.transaction.Transactional
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Service
+import uk.gov.communities.prsdb.webapp.database.entity.OneLoginUser
+import uk.gov.communities.prsdb.webapp.database.repository.OneLoginUserRepository
+
+@Service
+class OneLoginUserService(
+    private val oneLoginUserRepository: OneLoginUserRepository,
+) {
+    @Transactional
+    fun findOrCreate1LUser(baseUserId: String): OneLoginUser =
+        oneLoginUserRepository.findByIdOrNull(baseUserId) ?: oneLoginUserRepository.save(OneLoginUser(baseUserId))
+}

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/LandlordServiceTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/LandlordServiceTests.kt
@@ -26,7 +26,6 @@ import uk.gov.communities.prsdb.webapp.database.entity.OneLoginUser
 import uk.gov.communities.prsdb.webapp.database.entity.RegistrationNumber
 import uk.gov.communities.prsdb.webapp.database.repository.LandlordRepository
 import uk.gov.communities.prsdb.webapp.database.repository.LandlordWithListedPropertyCountRepository
-import uk.gov.communities.prsdb.webapp.database.repository.OneLoginUserRepository
 import uk.gov.communities.prsdb.webapp.mockObjects.MockLandlordData.Companion.createLandlord
 import uk.gov.communities.prsdb.webapp.models.dataModels.AddressDataModel
 import uk.gov.communities.prsdb.webapp.models.dataModels.RegistrationNumberDataModel
@@ -39,7 +38,7 @@ class LandlordServiceTests {
     private lateinit var mockLandlordRepository: LandlordRepository
 
     @Mock
-    private lateinit var mockOneLoginUserRepository: OneLoginUserRepository
+    private lateinit var mockOneLoginUserService: OneLoginUserService
 
     @Mock
     private lateinit var mockLandlordWithListedPropertyCountRepository: LandlordWithListedPropertyCountRepository
@@ -128,7 +127,7 @@ class LandlordServiceTests {
                 null,
             )
 
-        whenever(mockOneLoginUserRepository.getReferenceById(baseUserId)).thenReturn(baseUser)
+        whenever(mockOneLoginUserService.findOrCreate1LUser(baseUserId)).thenReturn(baseUser)
         whenever(mockAddressService.findOrCreateAddress(addressDataModel)).thenReturn(address)
         whenever(mockRegistrationNumberService.createRegistrationNumber(RegistrationNumberType.LANDLORD)).thenReturn(
             registrationNumber,

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/OneLoginUserServiceTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/OneLoginUserServiceTests.kt
@@ -1,0 +1,53 @@
+package uk.gov.communities.prsdb.webapp.services
+
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.ArgumentCaptor.captor
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.internal.matchers.apachecommons.ReflectionEquals
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import uk.gov.communities.prsdb.webapp.database.entity.OneLoginUser
+import uk.gov.communities.prsdb.webapp.database.repository.OneLoginUserRepository
+import uk.gov.communities.prsdb.webapp.mockObjects.MockOneLoginUserData
+import java.util.Optional
+import kotlin.test.assertEquals
+
+@ExtendWith(MockitoExtension::class)
+class OneLoginUserServiceTests {
+    @Mock
+    private lateinit var oneLoginUserRepository: OneLoginUserRepository
+
+    @InjectMocks
+    private lateinit var oneLoginUserService: OneLoginUserService
+
+    @Test
+    fun `findOrCreate1LUser returns the corresponding 1L user when given their ID`() {
+        val oneLoginUser = MockOneLoginUserData.createOneLoginUser()
+        whenever(oneLoginUserRepository.findById(oneLoginUser.id)).thenReturn(Optional.of(oneLoginUser))
+
+        val foundOneLoginUser = oneLoginUserService.findOrCreate1LUser(oneLoginUser.id)
+
+        assertEquals(oneLoginUser, foundOneLoginUser)
+        verify(oneLoginUserRepository, never()).save(any())
+    }
+
+    @Test
+    fun `findOrCreate1LUser creates and returns a 1L user when given an unsaved ID`() {
+        val oneLoginUser = MockOneLoginUserData.createOneLoginUser()
+        whenever(oneLoginUserRepository.findById(oneLoginUser.id)).thenReturn(Optional.empty())
+        whenever(oneLoginUserRepository.save(any())).thenReturn(oneLoginUser)
+
+        val createdOneLoginUser = oneLoginUserService.findOrCreate1LUser(oneLoginUser.id)
+
+        val oneLoginUserCaptor = captor<OneLoginUser>()
+        verify(oneLoginUserRepository).save(oneLoginUserCaptor.capture())
+        assertTrue(ReflectionEquals(oneLoginUser).matches(oneLoginUserCaptor.value))
+        assertEquals(oneLoginUser, createdOneLoginUser)
+    }
+}


### PR DESCRIPTION
- Updates `LandlordService.createLandlord` (and its tests) to save the user's 1L details