### PR TITLE
PRSD-648: Creates LA User in POST Request

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/constants/SessionAttributes.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/constants/SessionAttributes.kt
@@ -2,4 +2,6 @@ package uk.gov.communities.prsdb.webapp.constants
 
 const val LA_USER_INVITATION_TOKEN: String = "la-user-invitation-token"
 
+const val LA_USER_ID = "la-user-id"
+
 const val PROPERTY_REGISTRATION_NUMBER = "propertyRegistrationNumber"

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/RegisterLAUserController.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/RegisterLAUserController.kt
@@ -52,7 +52,10 @@ class RegisterLAUserController(
         model: Model,
     ): String {
         val token = invitationService.getTokenFromSession()
-        if (token == null || !invitationService.tokenIsValid(token)) return REDIRECT_FOR_INVALID_TOKEN
+        if (token == null || !invitationService.tokenIsValid(token)) {
+            invitationService.clearTokenFromSession()
+            return REDIRECT_FOR_INVALID_TOKEN
+        }
 
         return laUserRegistrationJourney.populateModelAndGetViewName(
             laUserRegistrationJourney.getStepId(stepName),

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/RegisterLAUserController.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/RegisterLAUserController.kt
@@ -9,7 +9,6 @@ import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.server.ResponseStatusException
-import uk.gov.communities.prsdb.webapp.constants.LA_USER_ID
 import uk.gov.communities.prsdb.webapp.constants.REGISTER_LA_USER_JOURNEY_URL
 import uk.gov.communities.prsdb.webapp.forms.journeys.LaUserRegistrationJourney
 import uk.gov.communities.prsdb.webapp.forms.journeys.PageData
@@ -37,7 +36,7 @@ class RegisterLAUserController(
             return "redirect:${REGISTER_LA_USER_JOURNEY_URL}/${laUserRegistrationJourney.initialStepId.urlPathSegment}"
         }
 
-        return REDIRECT_FOR_INVALID_TOKEN
+        return "redirect:$INVALID_LINK_PAGE_PATH_SEGMENT"
     }
 
     @GetMapping("/{stepName}")
@@ -49,7 +48,7 @@ class RegisterLAUserController(
         val token = invitationService.getTokenFromSession()
         if (token == null || !invitationService.tokenIsValid(token)) {
             invitationService.clearTokenFromSession()
-            return REDIRECT_FOR_INVALID_TOKEN
+            return "redirect:$INVALID_LINK_PAGE_PATH_SEGMENT"
         }
 
         return laUserRegistrationJourney.populateModelAndGetViewName(
@@ -81,10 +80,10 @@ class RegisterLAUserController(
         principal: Principal,
     ): String {
         val localAuthorityUserID =
-            localAuthorityDataService.getLastUserRegisteredThisSession()
+            localAuthorityDataService.getLastUserIdRegisteredThisSession()
                 ?: throw ResponseStatusException(
                     HttpStatus.BAD_REQUEST,
-                    "$LA_USER_ID was not found in the session",
+                    "No registered LA user was found in the session",
                 )
 
         val localAuthorityUser =
@@ -105,7 +104,5 @@ class RegisterLAUserController(
     companion object {
         const val CONFIRMATION_PAGE_PATH_SEGMENT = "confirmation"
         const val INVALID_LINK_PAGE_PATH_SEGMENT = "invalid-link"
-
-        private const val REDIRECT_FOR_INVALID_TOKEN = "redirect:$INVALID_LINK_PAGE_PATH_SEGMENT"
     }
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/RegisterLAUserController.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/RegisterLAUserController.kt
@@ -92,14 +92,14 @@ class RegisterLAUserController(
                     "$LA_USER_ID was not found in the session",
                 )
 
-        val localAuthority =
-            localAuthorityDataService.getLocalAuthorityOrNullFromUserID(localAuthorityUserID)
+        val localAuthorityUser =
+            localAuthorityDataService.getLocalAuthorityUserOrNull(localAuthorityUserID)
                 ?: throw ResponseStatusException(
                     HttpStatus.BAD_REQUEST,
                     "No LA user with ID $localAuthorityUserID was found in the database",
                 )
 
-        model.addAttribute("localAuthority", localAuthority.name)
+        model.addAttribute("localAuthority", localAuthorityUser.localAuthority.name)
 
         return "registerLAUserSuccess"
     }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/RegisterLAUserController.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/RegisterLAUserController.kt
@@ -1,6 +1,5 @@
 package uk.gov.communities.prsdb.webapp.controllers
 
-import jakarta.servlet.http.HttpSession
 import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Controller
 import org.springframework.ui.Model
@@ -21,10 +20,9 @@ import java.security.Principal
 @Controller
 @RequestMapping("/${REGISTER_LA_USER_JOURNEY_URL}")
 class RegisterLAUserController(
-    var laUserRegistrationJourney: LaUserRegistrationJourney,
-    var invitationService: LocalAuthorityInvitationService,
-    var localAuthorityDataService: LocalAuthorityDataService,
-    var session: HttpSession,
+    val laUserRegistrationJourney: LaUserRegistrationJourney,
+    val invitationService: LocalAuthorityInvitationService,
+    val localAuthorityDataService: LocalAuthorityDataService,
 ) {
     @GetMapping
     fun acceptInvitation(
@@ -83,7 +81,7 @@ class RegisterLAUserController(
         principal: Principal,
     ): String {
         val localAuthorityUserID =
-            session.getAttribute(LA_USER_ID)?.toString()?.toLong()
+            localAuthorityDataService.getLastUserRegisteredThisSession()
                 ?: throw ResponseStatusException(
                     HttpStatus.BAD_REQUEST,
                     "$LA_USER_ID was not found in the session",

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/RegisterPropertyController.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/RegisterPropertyController.kt
@@ -1,6 +1,5 @@
 package uk.gov.communities.prsdb.webapp.controllers
 
-import jakarta.servlet.http.HttpSession
 import org.springframework.http.HttpStatus
 import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.stereotype.Controller
@@ -17,6 +16,7 @@ import uk.gov.communities.prsdb.webapp.forms.journeys.PageData
 import uk.gov.communities.prsdb.webapp.forms.journeys.PropertyRegistrationJourney
 import uk.gov.communities.prsdb.webapp.models.dataModels.RegistrationNumberDataModel
 import uk.gov.communities.prsdb.webapp.services.PropertyOwnershipService
+import uk.gov.communities.prsdb.webapp.services.PropertyRegistrationService
 import java.security.Principal
 
 @PreAuthorize("hasRole('LANDLORD')")
@@ -25,7 +25,7 @@ import java.security.Principal
 class RegisterPropertyController(
     private val propertyRegistrationJourney: PropertyRegistrationJourney,
     private val propertyOwnershipService: PropertyOwnershipService,
-    private val session: HttpSession,
+    private val propertyRegistrationService: PropertyRegistrationService,
 ) {
     @GetMapping
     fun index(model: Model): String {
@@ -82,7 +82,7 @@ class RegisterPropertyController(
         principal: Principal,
     ): String {
         val propertyRegistrationNumber =
-            session.getAttribute(PROPERTY_REGISTRATION_NUMBER)?.toString()?.toLong()
+            propertyRegistrationService.getLastPropertyRegisteredThisSession()
                 ?: throw ResponseStatusException(
                     HttpStatus.BAD_REQUEST,
                     "$PROPERTY_REGISTRATION_NUMBER was not found in the session",

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/RegisterPropertyController.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/RegisterPropertyController.kt
@@ -10,7 +10,6 @@ import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.server.ResponseStatusException
-import uk.gov.communities.prsdb.webapp.constants.PROPERTY_REGISTRATION_NUMBER
 import uk.gov.communities.prsdb.webapp.constants.REGISTER_PROPERTY_JOURNEY_URL
 import uk.gov.communities.prsdb.webapp.forms.journeys.PageData
 import uk.gov.communities.prsdb.webapp.forms.journeys.PropertyRegistrationJourney
@@ -82,10 +81,10 @@ class RegisterPropertyController(
         principal: Principal,
     ): String {
         val propertyRegistrationNumber =
-            propertyRegistrationService.getLastPropertyRegisteredThisSession()
+            propertyRegistrationService.getLastPrnRegisteredThisSession()
                 ?: throw ResponseStatusException(
                     HttpStatus.BAD_REQUEST,
-                    "$PROPERTY_REGISTRATION_NUMBER was not found in the session",
+                    "No registered property was found in the session",
                 )
         val propertyOwnership =
             propertyOwnershipService.retrievePropertyOwnership(propertyRegistrationNumber)

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/LaUserRegistrationJourney.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/LaUserRegistrationJourney.kt
@@ -25,8 +25,8 @@ class LaUserRegistrationJourney(
     validator: Validator,
     journeyDataService: JourneyDataService,
     private val invitationService: LocalAuthorityInvitationService,
-    localAuthorityDataService: LocalAuthorityDataService,
-    session: HttpSession,
+    private val localAuthorityDataService: LocalAuthorityDataService,
+    private val session: HttpSession,
 ) : Journey<RegisterLaUserStepId>(
         journeyType = JourneyType.LA_USER_REGISTRATION,
         validator = validator,
@@ -41,7 +41,7 @@ class LaUserRegistrationJourney(
                 landingPageStep(),
                 registerUserStep(),
                 emailStep(),
-                checkAnswersStep(journeyDataService, invitationService, localAuthorityDataService, session),
+                checkAnswersStep(),
             ),
         )
 
@@ -111,44 +111,28 @@ class LaUserRegistrationJourney(
             saveAfterSubmit = false,
         )
 
-    private fun checkAnswersStep(
-        journeyDataService: JourneyDataService,
-        invitationService: LocalAuthorityInvitationService,
-        localAuthorityDataService: LocalAuthorityDataService,
-        session: HttpSession,
-    ) = Step(
-        id = RegisterLaUserStepId.CheckAnswers,
-        page =
-            LaUserRegistrationCheckAnswersPage(
-                formModel = CheckAnswersFormModel::class,
-                templateName = "forms/checkAnswersForm",
-                content =
-                    mapOf(
-                        "title" to "registerLAUser.title",
-                        "summaryName" to "registerLaUser.checkAnswers.summaryName",
-                        "submitButtonText" to "forms.buttons.confirm",
-                    ),
-                invitationService,
-            ),
-        handleSubmitAndRedirect = { journeyData, _ ->
-            checkAnswersHandleSubmitAndRedirect(
-                journeyData,
-                journeyDataService,
-                invitationService,
-                localAuthorityDataService,
-                session,
-            )
-        },
-        saveAfterSubmit = false,
-    )
+    private fun checkAnswersStep() =
+        Step(
+            id = RegisterLaUserStepId.CheckAnswers,
+            page =
+                LaUserRegistrationCheckAnswersPage(
+                    formModel = CheckAnswersFormModel::class,
+                    templateName = "forms/checkAnswersForm",
+                    content =
+                        mapOf(
+                            "title" to "registerLAUser.title",
+                            "summaryName" to "registerLaUser.checkAnswers.summaryName",
+                            "submitButtonText" to "forms.buttons.confirm",
+                        ),
+                    invitationService,
+                ),
+            handleSubmitAndRedirect = { journeyData, _ ->
+                checkAnswersHandleSubmitAndRedirect(journeyData)
+            },
+            saveAfterSubmit = false,
+        )
 
-    private fun checkAnswersHandleSubmitAndRedirect(
-        journeyData: JourneyData,
-        journeyDataService: JourneyDataService,
-        invitationService: LocalAuthorityInvitationService,
-        localAuthorityDataService: LocalAuthorityDataService,
-        session: HttpSession,
-    ): String {
+    private fun checkAnswersHandleSubmitAndRedirect(journeyData: JourneyData): String {
         val token = invitationService.getTokenFromSession()!!
 
         val localAuthorityUserID =

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/LaUserRegistrationJourney.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/LaUserRegistrationJourney.kt
@@ -24,7 +24,7 @@ import uk.gov.communities.prsdb.webapp.services.LocalAuthorityInvitationService
 class LaUserRegistrationJourney(
     validator: Validator,
     journeyDataService: JourneyDataService,
-    invitationService: LocalAuthorityInvitationService,
+    private val invitationService: LocalAuthorityInvitationService,
     localAuthorityDataService: LocalAuthorityDataService,
     session: HttpSession,
 ) : Journey<RegisterLaUserStepId>(
@@ -44,6 +44,15 @@ class LaUserRegistrationJourney(
                 checkAnswersStep(journeyDataService, invitationService, localAuthorityDataService, session),
             ),
         )
+
+    fun initialiseJourneyData(token: String) {
+        val journeyData = journeyDataService.getJourneyDataFromSession()
+        val formData: PageData = mutableMapOf("emailAddress" to invitationService.getEmailAddressForToken(token))
+        val emailStep = steps.single { step -> step.id == RegisterLaUserStepId.Email }
+
+        emailStep.updateJourneyData(journeyData, formData, null)
+        journeyDataService.setJourneyData(journeyData)
+    }
 
     private fun landingPageStep() =
         Step(

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/LaUserRegistrationJourney.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/LaUserRegistrationJourney.kt
@@ -1,10 +1,8 @@
 package uk.gov.communities.prsdb.webapp.forms.journeys
 
-import jakarta.servlet.http.HttpSession
 import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.stereotype.Component
 import org.springframework.validation.Validator
-import uk.gov.communities.prsdb.webapp.constants.LA_USER_ID
 import uk.gov.communities.prsdb.webapp.constants.enums.JourneyType
 import uk.gov.communities.prsdb.webapp.controllers.RegisterLAUserController.Companion.CONFIRMATION_PAGE_PATH_SEGMENT
 import uk.gov.communities.prsdb.webapp.forms.pages.LaUserRegistrationCheckAnswersPage
@@ -26,7 +24,6 @@ class LaUserRegistrationJourney(
     journeyDataService: JourneyDataService,
     private val invitationService: LocalAuthorityInvitationService,
     private val localAuthorityDataService: LocalAuthorityDataService,
-    private val session: HttpSession,
 ) : Journey<RegisterLaUserStepId>(
         journeyType = JourneyType.LA_USER_REGISTRATION,
         validator = validator,
@@ -143,13 +140,13 @@ class LaUserRegistrationJourney(
                 email = LaUserRegistrationJourneyDataHelper.getEmail(journeyData)!!,
             )
 
+        localAuthorityDataService.setLastUserRegisteredThisSession(localAuthorityUserID)
+
         val invitation = invitationService.getInvitationFromToken(token)
         invitationService.deleteInvitation(invitation)
         invitationService.clearTokenFromSession()
 
         journeyDataService.clearJourneyDataFromSession()
-
-        session.setAttribute(LA_USER_ID, localAuthorityUserID)
 
         return CONFIRMATION_PAGE_PATH_SEGMENT
     }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/LaUserRegistrationJourney.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/LaUserRegistrationJourney.kt
@@ -140,7 +140,7 @@ class LaUserRegistrationJourney(
                 email = LaUserRegistrationJourneyDataHelper.getEmail(journeyData)!!,
             )
 
-        localAuthorityDataService.setLastUserRegisteredThisSession(localAuthorityUserID)
+        localAuthorityDataService.setLastUserIdRegisteredThisSession(localAuthorityUserID)
 
         val invitation = invitationService.getInvitationFromToken(token)
         invitationService.deleteInvitation(invitation)

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/PropertyRegistrationJourney.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/PropertyRegistrationJourney.kt
@@ -628,7 +628,7 @@ class PropertyRegistrationJourney(
                     baseUserId = baseUserId,
                 )
 
-            propertyRegistrationService.setLastPropertyRegisteredThisSession(propertyRegistrationNumber.number)
+            propertyRegistrationService.setLastPrnRegisteredThisSession(propertyRegistrationNumber.number)
 
             confirmationEmailSender.sendEmail(
                 landlordService.retrieveLandlordByBaseUserId(baseUserId)!!.email,

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/LocalAuthorityDataService.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/LocalAuthorityDataService.kt
@@ -106,21 +106,24 @@ class LocalAuthorityDataService(
     }
 
     @Transactional
-    fun registerNewUser(
+    fun registerUserAndReturnID(
         baseUserId: String,
         localAuthority: LocalAuthority,
         name: String,
         email: String,
-    ) {
-        localAuthorityUserRepository.save(
-            LocalAuthorityUser(
-                baseUser = oneLoginUserService.findOrCreate1LUser(baseUserId),
-                isManager = false,
-                localAuthority = localAuthority,
-                name = name,
-                email = email,
-            ),
-        )
+    ) : Long {
+        val localAuthorityUser =
+            localAuthorityUserRepository.save(
+                LocalAuthorityUser(
+                    baseUser = oneLoginUserService.findOrCreate1LUser(baseUserId),
+                    isManager = false,
+                    localAuthority = localAuthority,
+                    name = name,
+                    email = email,
+                ),
+            )
+
+        return localAuthorityUser.id
     }
 
     fun getIsLocalAuthorityUser(baseUserId: String): Boolean = localAuthorityUserRepository.findByBaseUser_Id(baseUserId) != null

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/LocalAuthorityDataService.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/LocalAuthorityDataService.kt
@@ -133,7 +133,7 @@ class LocalAuthorityDataService(
 
     fun getIsLocalAuthorityUser(baseUserId: String): Boolean = localAuthorityUserRepository.findByBaseUser_Id(baseUserId) != null
 
-    fun setLastUserRegisteredThisSession(localAuthorityUserId: Long) = session.setAttribute(LA_USER_ID, localAuthorityUserId)
+    fun setLastUserIdRegisteredThisSession(localAuthorityUserId: Long) = session.setAttribute(LA_USER_ID, localAuthorityUserId)
 
-    fun getLastUserRegisteredThisSession() = session.getAttribute(LA_USER_ID)?.toString()?.toLong()
+    fun getLastUserIdRegisteredThisSession() = session.getAttribute(LA_USER_ID)?.toString()?.toLong()
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/LocalAuthorityDataService.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/LocalAuthorityDataService.kt
@@ -89,8 +89,7 @@ class LocalAuthorityDataService(
         }
     }
 
-    fun getLocalAuthorityOrNullFromUserID(localAuthorityUserId: Long): LocalAuthority? =
-        localAuthorityUserRepository.findByIdOrNull(localAuthorityUserId)?.localAuthority
+    fun getLocalAuthorityUserOrNull(localAuthorityUserId: Long) = localAuthorityUserRepository.findByIdOrNull(localAuthorityUserId)
 
     fun updateUserAccessLevel(
         localAuthorityUserAccessLevel: LocalAuthorityUserAccessLevelDataModel,

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/LocalAuthorityDataService.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/LocalAuthorityDataService.kt
@@ -114,7 +114,7 @@ class LocalAuthorityDataService(
         localAuthority: LocalAuthority,
         name: String,
         email: String,
-    ) : Long {
+    ): Long {
         val localAuthorityUser =
             localAuthorityUserRepository.save(
                 LocalAuthorityUser(

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/LocalAuthorityDataService.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/LocalAuthorityDataService.kt
@@ -1,5 +1,6 @@
 package uk.gov.communities.prsdb.webapp.services
 
+import jakarta.servlet.http.HttpSession
 import jakarta.transaction.Transactional
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.PageRequest
@@ -9,6 +10,7 @@ import org.springframework.http.HttpStatus
 import org.springframework.security.access.AccessDeniedException
 import org.springframework.stereotype.Service
 import org.springframework.web.server.ResponseStatusException
+import uk.gov.communities.prsdb.webapp.constants.LA_USER_ID
 import uk.gov.communities.prsdb.webapp.constants.MAX_ENTRIES_IN_LA_USERS_TABLE_PAGE
 import uk.gov.communities.prsdb.webapp.database.entity.LocalAuthority
 import uk.gov.communities.prsdb.webapp.database.entity.LocalAuthorityUser
@@ -19,9 +21,10 @@ import uk.gov.communities.prsdb.webapp.models.dataModels.LocalAuthorityUserDataM
 
 @Service
 class LocalAuthorityDataService(
-    val localAuthorityUserRepository: LocalAuthorityUserRepository,
-    val localAuthorityUserOrInvitationRepository: LocalAuthorityUserOrInvitationRepository,
-    val oneLoginUserService: OneLoginUserService,
+    private val localAuthorityUserRepository: LocalAuthorityUserRepository,
+    private val localAuthorityUserOrInvitationRepository: LocalAuthorityUserOrInvitationRepository,
+    private val oneLoginUserService: OneLoginUserService,
+    private val session: HttpSession,
 ) {
     fun getUserAndLocalAuthorityIfAuthorizedUser(
         localAuthorityId: Int,
@@ -129,4 +132,8 @@ class LocalAuthorityDataService(
     }
 
     fun getIsLocalAuthorityUser(baseUserId: String): Boolean = localAuthorityUserRepository.findByBaseUser_Id(baseUserId) != null
+
+    fun setLastUserRegisteredThisSession(localAuthorityUserId: Long) = session.setAttribute(LA_USER_ID, localAuthorityUserId)
+
+    fun getLastUserRegisteredThisSession() = session.getAttribute(LA_USER_ID)?.toString()?.toLong()
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/LocalAuthorityDataService.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/LocalAuthorityDataService.kt
@@ -89,6 +89,9 @@ class LocalAuthorityDataService(
         }
     }
 
+    fun getLocalAuthorityOrNullFromUserID(localAuthorityUserId: Long): LocalAuthority? =
+        localAuthorityUserRepository.findByIdOrNull(localAuthorityUserId)?.localAuthority
+
     fun updateUserAccessLevel(
         localAuthorityUserAccessLevel: LocalAuthorityUserAccessLevelDataModel,
         localAuthorityUserId: Long,

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/PropertyRegistrationService.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/PropertyRegistrationService.kt
@@ -2,8 +2,10 @@ package uk.gov.communities.prsdb.webapp.services
 
 import jakarta.persistence.EntityExistsException
 import jakarta.persistence.EntityNotFoundException
+import jakarta.servlet.http.HttpSession
 import jakarta.transaction.Transactional
 import org.springframework.stereotype.Service
+import uk.gov.communities.prsdb.webapp.constants.PROPERTY_REGISTRATION_NUMBER
 import uk.gov.communities.prsdb.webapp.constants.enums.LicensingType
 import uk.gov.communities.prsdb.webapp.constants.enums.OwnershipType
 import uk.gov.communities.prsdb.webapp.constants.enums.PropertyType
@@ -22,6 +24,7 @@ class PropertyRegistrationService(
     private val propertyService: PropertyService,
     private val licenseService: LicenseService,
     private val propertyOwnershipService: PropertyOwnershipService,
+    private val session: HttpSession,
 ) {
     fun getIsAddressRegistered(
         uprn: Long,
@@ -85,4 +88,8 @@ class PropertyRegistrationService(
 
         return propertyOwnership.registrationNumber
     }
+
+    fun setLastPropertyRegisteredThisSession(prn: Long) = session.setAttribute(PROPERTY_REGISTRATION_NUMBER, prn)
+
+    fun getLastPropertyRegisteredThisSession() = session.getAttribute(PROPERTY_REGISTRATION_NUMBER)?.toString()?.toLong()
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/PropertyRegistrationService.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/PropertyRegistrationService.kt
@@ -89,7 +89,7 @@ class PropertyRegistrationService(
         return propertyOwnership.registrationNumber
     }
 
-    fun setLastPropertyRegisteredThisSession(prn: Long) = session.setAttribute(PROPERTY_REGISTRATION_NUMBER, prn)
+    fun setLastPrnRegisteredThisSession(prn: Long) = session.setAttribute(PROPERTY_REGISTRATION_NUMBER, prn)
 
-    fun getLastPropertyRegisteredThisSession() = session.getAttribute(PROPERTY_REGISTRATION_NUMBER)?.toString()?.toLong()
+    fun getLastPrnRegisteredThisSession() = session.getAttribute(PROPERTY_REGISTRATION_NUMBER)?.toString()?.toLong()
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/controllers/RegisterLAUserControllerTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/controllers/RegisterLAUserControllerTests.kt
@@ -77,7 +77,7 @@ class RegisterLAUserControllerTests(
         val laUserId = 0L
         val localAuthorityUser = MockLocalAuthorityData.createLocalAuthorityUser()
 
-        whenever(localAuthorityDataService.getLastUserRegisteredThisSession()).thenReturn(laUserId)
+        whenever(localAuthorityDataService.getLastUserIdRegisteredThisSession()).thenReturn(laUserId)
         whenever(localAuthorityDataService.getLocalAuthorityUserOrNull(laUserId)).thenReturn(localAuthorityUser)
 
         mvc
@@ -94,7 +94,7 @@ class RegisterLAUserControllerTests(
         val laUserId = 0L
         val localAuthorityUser = MockLocalAuthorityData.createLocalAuthorityUser()
 
-        whenever(localAuthorityDataService.getLastUserRegisteredThisSession()).thenReturn(null)
+        whenever(localAuthorityDataService.getLastUserIdRegisteredThisSession()).thenReturn(null)
         whenever(localAuthorityDataService.getLocalAuthorityUserOrNull(laUserId)).thenReturn(localAuthorityUser)
 
         mvc
@@ -107,7 +107,7 @@ class RegisterLAUserControllerTests(
     fun `getConfirmation returns 400 if the LA user ID in session is not valid`() {
         val laUserId = 0L
 
-        whenever(localAuthorityDataService.getLastUserRegisteredThisSession()).thenReturn(laUserId)
+        whenever(localAuthorityDataService.getLastUserIdRegisteredThisSession()).thenReturn(laUserId)
         whenever(localAuthorityDataService.getLocalAuthorityUserOrNull(laUserId)).thenReturn(null)
 
         mvc

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/controllers/RegisterLAUserControllerTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/controllers/RegisterLAUserControllerTests.kt
@@ -104,9 +104,9 @@ class RegisterLAUserControllerTests(
     @WithMockUser
     fun `getConfirmation returns 200 if an LA user has been registered`() {
         val laUserId = 0L
-        val localAuthority = MockLocalAuthorityData.createLocalAuthority()
+        val localAuthorityUser = MockLocalAuthorityData.createLocalAuthorityUser()
 
-        whenever(localAuthorityDataService.getLocalAuthorityOrNullFromUserID(laUserId)).thenReturn(localAuthority)
+        whenever(localAuthorityDataService.getLocalAuthorityUserOrNull(laUserId)).thenReturn(localAuthorityUser)
 
         mvc
             .perform(
@@ -120,9 +120,9 @@ class RegisterLAUserControllerTests(
     @WithMockUser
     fun `getConfirmation returns 400 if there's no LA user ID in session`() {
         val laUserId = 0L
-        val localAuthority = MockLocalAuthorityData.createLocalAuthority()
+        val localAuthorityUser = MockLocalAuthorityData.createLocalAuthorityUser()
 
-        whenever(localAuthorityDataService.getLocalAuthorityOrNullFromUserID(laUserId)).thenReturn(localAuthority)
+        whenever(localAuthorityDataService.getLocalAuthorityUserOrNull(laUserId)).thenReturn(localAuthorityUser)
 
         mvc
             .get("/$REGISTER_LA_USER_JOURNEY_URL/$CONFIRMATION_PAGE_PATH_SEGMENT")
@@ -134,7 +134,7 @@ class RegisterLAUserControllerTests(
     fun `getConfirmation returns 400 if the LA user ID in session is not valid`() {
         val laUserId = 0L
 
-        whenever(localAuthorityDataService.getLocalAuthorityOrNullFromUserID(laUserId)).thenReturn(null)
+        whenever(localAuthorityDataService.getLocalAuthorityUserOrNull(laUserId)).thenReturn(null)
 
         mvc
             .perform(

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/controllers/RegisterLAUserControllerTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/controllers/RegisterLAUserControllerTests.kt
@@ -77,6 +77,7 @@ class RegisterLAUserControllerTests(
         val laUserId = 0L
         val localAuthorityUser = MockLocalAuthorityData.createLocalAuthorityUser()
 
+        whenever(localAuthorityDataService.getLastUserRegisteredThisSession()).thenReturn(laUserId)
         whenever(localAuthorityDataService.getLocalAuthorityUserOrNull(laUserId)).thenReturn(localAuthorityUser)
 
         mvc
@@ -93,6 +94,7 @@ class RegisterLAUserControllerTests(
         val laUserId = 0L
         val localAuthorityUser = MockLocalAuthorityData.createLocalAuthorityUser()
 
+        whenever(localAuthorityDataService.getLastUserRegisteredThisSession()).thenReturn(null)
         whenever(localAuthorityDataService.getLocalAuthorityUserOrNull(laUserId)).thenReturn(localAuthorityUser)
 
         mvc
@@ -105,6 +107,7 @@ class RegisterLAUserControllerTests(
     fun `getConfirmation returns 400 if the LA user ID in session is not valid`() {
         val laUserId = 0L
 
+        whenever(localAuthorityDataService.getLastUserRegisteredThisSession()).thenReturn(laUserId)
         whenever(localAuthorityDataService.getLocalAuthorityUserOrNull(laUserId)).thenReturn(null)
 
         mvc

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/controllers/RegisterPropertyControllerTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/controllers/RegisterPropertyControllerTests.kt
@@ -76,7 +76,7 @@ class RegisterPropertyControllerTests(
                 registrationNumber = RegistrationNumber(RegistrationNumberType.PROPERTY, propertyRegistrationNumber),
             )
 
-        whenever(propertyRegistrationService.getLastPropertyRegisteredThisSession()).thenReturn(
+        whenever(propertyRegistrationService.getLastPrnRegisteredThisSession()).thenReturn(
             propertyRegistrationNumber,
         )
         whenever(propertyOwnershipService.retrievePropertyOwnership(propertyRegistrationNumber)).thenReturn(
@@ -100,7 +100,7 @@ class RegisterPropertyControllerTests(
                 registrationNumber = RegistrationNumber(RegistrationNumberType.PROPERTY, propertyRegistrationNumber),
             )
 
-        whenever(propertyRegistrationService.getLastPropertyRegisteredThisSession()).thenReturn(null)
+        whenever(propertyRegistrationService.getLastPrnRegisteredThisSession()).thenReturn(null)
         whenever(propertyOwnershipService.retrievePropertyOwnership(propertyRegistrationNumber)).thenReturn(
             propertyOwnership,
         )
@@ -115,7 +115,7 @@ class RegisterPropertyControllerTests(
     fun `getConfirmation returns 400 if the property ownership ID in session is not valid`() {
         val propertyRegistrationNumber = 0L
 
-        whenever(propertyRegistrationService.getLastPropertyRegisteredThisSession()).thenReturn(
+        whenever(propertyRegistrationService.getLastPrnRegisteredThisSession()).thenReturn(
             propertyRegistrationNumber,
         )
         whenever(propertyOwnershipService.retrievePropertyOwnership(propertyRegistrationNumber)).thenReturn(null)

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/controllers/RegisterPropertyControllerTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/controllers/RegisterPropertyControllerTests.kt
@@ -20,6 +20,7 @@ import uk.gov.communities.prsdb.webapp.forms.journeys.PropertyRegistrationJourne
 import uk.gov.communities.prsdb.webapp.forms.steps.RegisterPropertyStepId
 import uk.gov.communities.prsdb.webapp.mockObjects.MockLandlordData.Companion.createPropertyOwnership
 import uk.gov.communities.prsdb.webapp.services.PropertyOwnershipService
+import uk.gov.communities.prsdb.webapp.services.PropertyRegistrationService
 
 @WebMvcTest(RegisterPropertyController::class)
 class RegisterPropertyControllerTests(
@@ -30,6 +31,9 @@ class RegisterPropertyControllerTests(
 
     @MockBean
     lateinit var propertyOwnershipService: PropertyOwnershipService
+
+    @MockBean
+    lateinit var propertyRegistrationService: PropertyRegistrationService
 
     @BeforeEach
     fun setupMocks() {
@@ -72,6 +76,9 @@ class RegisterPropertyControllerTests(
                 registrationNumber = RegistrationNumber(RegistrationNumberType.PROPERTY, propertyRegistrationNumber),
             )
 
+        whenever(propertyRegistrationService.getLastPropertyRegisteredThisSession()).thenReturn(
+            propertyRegistrationNumber,
+        )
         whenever(propertyOwnershipService.retrievePropertyOwnership(propertyRegistrationNumber)).thenReturn(
             propertyOwnership,
         )
@@ -93,6 +100,7 @@ class RegisterPropertyControllerTests(
                 registrationNumber = RegistrationNumber(RegistrationNumberType.PROPERTY, propertyRegistrationNumber),
             )
 
+        whenever(propertyRegistrationService.getLastPropertyRegisteredThisSession()).thenReturn(null)
         whenever(propertyOwnershipService.retrievePropertyOwnership(propertyRegistrationNumber)).thenReturn(
             propertyOwnership,
         )
@@ -107,6 +115,9 @@ class RegisterPropertyControllerTests(
     fun `getConfirmation returns 400 if the property ownership ID in session is not valid`() {
         val propertyRegistrationNumber = 0L
 
+        whenever(propertyRegistrationService.getLastPropertyRegisteredThisSession()).thenReturn(
+            propertyRegistrationNumber,
+        )
         whenever(propertyOwnershipService.retrievePropertyOwnership(propertyRegistrationNumber)).thenReturn(null)
 
         mvc

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/forms/PropertyRegistrationJourneyTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/forms/PropertyRegistrationJourneyTests.kt
@@ -39,11 +39,12 @@ class PropertyRegistrationJourneyTests {
                     mock(),
                     mock(),
                     mock(),
-                    mock(),
                 )
 
             whenever(mockJourneyDataService.getJourneyDataFromSession()).thenReturn(mutableMapOf())
-            whenever(mockJourneyDataService.getContextId(principalName, JourneyType.PROPERTY_REGISTRATION)).thenReturn(null)
+            whenever(mockJourneyDataService.getContextId(principalName, JourneyType.PROPERTY_REGISTRATION)).thenReturn(
+                null,
+            )
 
             // Act
             testJourney.initialiseJourneyDataIfNotInitialised(principalName)
@@ -67,11 +68,12 @@ class PropertyRegistrationJourneyTests {
                     mock(),
                     mock(),
                     mock(),
-                    mock(),
                 )
 
             whenever(mockJourneyDataService.getJourneyDataFromSession()).thenReturn(mutableMapOf())
-            whenever(mockJourneyDataService.getContextId(principalName, JourneyType.PROPERTY_REGISTRATION)).thenReturn(contextId)
+            whenever(mockJourneyDataService.getContextId(principalName, JourneyType.PROPERTY_REGISTRATION)).thenReturn(
+                contextId,
+            )
 
             // Act
             testJourney.initialiseJourneyDataIfNotInitialised(principalName)
@@ -89,7 +91,6 @@ class PropertyRegistrationJourneyTests {
                 PropertyRegistrationJourney(
                     mock(),
                     mockJourneyDataService,
-                    mock(),
                     mock(),
                     mock(),
                     mock(),

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/LaUserRegistrationJourneyTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/LaUserRegistrationJourneyTests.kt
@@ -5,65 +5,87 @@ import com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.boot.test.mock.mockito.SpyBean
 import org.springframework.test.context.jdbc.Sql
-import uk.gov.communities.prsdb.webapp.database.entity.LocalAuthority
+import uk.gov.communities.prsdb.webapp.database.entity.LocalAuthorityInvitation
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.BaseComponent.Companion.assertThat
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages.BasePage.Companion.assertPageIs
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.laUserRegistrationJourneyPages.CheckAnswersPageLaUserRegistration
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.laUserRegistrationJourneyPages.ConfirmationPageLaUserRegistration
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.laUserRegistrationJourneyPages.EmailFormPageLaUserRegistration
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.laUserRegistrationJourneyPages.NameFormPageLaUserRegistration
-import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.laUserRegistrationJourneyPages.SuccessPageLaUserRegistration
 import uk.gov.communities.prsdb.webapp.services.LocalAuthorityInvitationService
+import uk.gov.communities.prsdb.webapp.services.LocalAuthorityService
+import java.util.UUID
 
 @Sql("/data-mockuser-not-lauser.sql")
 class LaUserRegistrationJourneyTests : IntegrationTest() {
+    @SpyBean
+    lateinit var localAuthorityService: LocalAuthorityService
+
     @MockBean
     lateinit var invitationService: LocalAuthorityInvitationService
 
+    lateinit var invitation: LocalAuthorityInvitation
+
     @BeforeEach
     fun setup() {
-        val testToken = "test token"
-        whenever(invitationService.getTokenFromSession()).thenReturn(testToken)
-        whenever(invitationService.tokenIsValid(testToken)).thenReturn(true)
-        val testLocalAuthority = LocalAuthority(1, "Test Authority", "custodian code")
-        whenever(invitationService.getAuthorityForToken(testToken)).thenReturn(testLocalAuthority)
+        invitation =
+            LocalAuthorityInvitation(
+                id = 0L,
+                token = UUID.randomUUID(),
+                email = "anyEmail@test.com",
+                invitingAuthority = localAuthorityService.retrieveLocalAuthorityById(1),
+            )
+
+        whenever(invitationService.getTokenFromSession()).thenReturn(invitation.token.toString())
+        whenever(invitationService.getInvitationFromToken(invitation.token.toString())).thenReturn(invitation)
+        whenever(invitationService.tokenIsValid(invitation.token.toString())).thenCallRealMethod()
+        whenever(invitationService.getAuthorityForToken(invitation.token.toString())).thenCallRealMethod()
     }
 
-    @Nested
-    inner class LaUserRegistrationLandingPage {
-        @Test
-        fun `Page renders when we navigate to it`() {
-            val landingPage = navigator.goToLaUserRegistrationLandingPage()
-            assertThat(landingPage.headingCaption).containsText("Before you register")
-            assertThat(landingPage.heading).containsText("Registering as a local authority user")
-        }
+    @Test
+    fun `User can navigate the whole journey if pages are correctly filled in`(page: Page) {
+        // Landing page - render
+        val landingPage = navigator.goToLaUserRegistrationLandingPage()
+        assertThat(landingPage.headingCaption).containsText("Before you register")
+        assertThat(landingPage.heading).containsText("Registering as a local authority user")
+        // Submit and go to next page
+        landingPage.clickBeginButton()
+        val namePage = assertPageIs(page, NameFormPageLaUserRegistration::class)
 
-        @Test
-        fun `Clicking submit redirects to the name step`(page: Page) {
-            val landingPage = navigator.goToLaUserRegistrationLandingPage()
-            landingPage.clickBeginButton()
-            assertPageIs(page, NameFormPageLaUserRegistration::class)
-        }
+        // Name page - render
+        assertThat(namePage.form.getFieldsetHeading()).containsText("What is your full name?")
+        // Fill in, submit and go to next page
+        namePage.nameInput.fill("Test User")
+        namePage.form.submit()
+        val emailPage = assertPageIs(page, EmailFormPageLaUserRegistration::class)
+
+        // Email page - render
+        assertThat(emailPage.form.getFieldsetHeading()).containsText("What is your work email address?")
+        // Fill in, submit and go to next page
+        emailPage.emailInput.fill("test@example.com")
+        emailPage.form.submit()
+        val checkAnswersPage = assertPageIs(page, CheckAnswersPageLaUserRegistration::class)
+
+        // Check answers page - render
+        assertThat(checkAnswersPage.heading).containsText("Check your answers")
+        // Submit and go to next page
+        checkAnswersPage.form.submit()
+        val confirmationPage = assertPageIs(page, ConfirmationPageLaUserRegistration::class)
+
+        verify(invitationService).deleteInvitation(invitation)
+
+        // Confirmation page - render
+        assertThat(confirmationPage.bannerHeading).containsText("You've registered as a ${invitation.invitingAuthority.name} user")
+        assertThat(confirmationPage.bodyHeading).containsText("What happens next")
     }
 
     @Nested
     inner class LaUserRegistrationStepName {
-        @Test
-        fun `Page renders when we navigate to this step through the registration journey`() {
-            val namePage = navigator.goToLaUserRegistrationNameFormPage()
-            assertThat(namePage.form.getFieldsetHeading()).containsText("What is your full name?")
-        }
-
-        @Test
-        fun `Submitting a valid name redirects to the next step`(page: Page) {
-            val namePage = navigator.goToLaUserRegistrationNameFormPage()
-            namePage.nameInput.fill("Test User")
-            namePage.form.submit()
-            assertPageIs(page, EmailFormPageLaUserRegistration::class)
-        }
-
         @Test
         fun `Submitting an empty name returns an error`() {
             val namePage = navigator.goToLaUserRegistrationNameFormPage()
@@ -75,20 +97,6 @@ class LaUserRegistrationJourneyTests : IntegrationTest() {
 
     @Nested
     inner class LaUserRegistrationStepEmail {
-        @Test
-        fun `Page renders when we navigate to this step through the registration journey`() {
-            val emailPage = navigator.goToLaUserRegistrationEmailFormPage()
-            assertThat(emailPage.form.getFieldsetHeading()).containsText("What is your work email address?")
-        }
-
-        @Test
-        fun `Submitting a valid email redirects to the next step`(page: Page) {
-            val emailPage = navigator.goToLaUserRegistrationEmailFormPage()
-            emailPage.emailInput.fill("test@example.com")
-            emailPage.form.submit()
-            assertPageIs(page, CheckAnswersPageLaUserRegistration::class)
-        }
-
         @Test
         fun `Submitting an empty e-mail address returns an error`() {
             val emailPage = navigator.goToLaUserRegistrationEmailFormPage()
@@ -115,12 +123,6 @@ class LaUserRegistrationJourneyTests : IntegrationTest() {
     @Nested
     inner class LaUserRegistrationCheckAnswers {
         @Test
-        fun `Page renders when we navigate to this step through the registration journey`() {
-            val checkAnswersPage = navigator.goToLaUserRegistrationCheckAnswersPage()
-            assertThat(checkAnswersPage.heading).containsText("Check your answers")
-        }
-
-        @Test
         fun `Change Name link navigates to the name step`(page: Page) {
             val checkAnswersPage = navigator.goToLaUserRegistrationCheckAnswersPage()
             checkAnswersPage.form.summaryList.nameRow
@@ -135,28 +137,14 @@ class LaUserRegistrationJourneyTests : IntegrationTest() {
                 .clickActionLinkAndWait()
             assertPageIs(page, EmailFormPageLaUserRegistration::class)
         }
-
-        @Test
-        fun `Submitting redirects to the success page`(page: Page) {
-            val checkAnswersPage = navigator.goToLaUserRegistrationCheckAnswersPage()
-            checkAnswersPage.form.submit()
-            assertPageIs(page, SuccessPageLaUserRegistration::class)
-        }
     }
 
     @Nested
     inner class LaUserRegistrationSuccess {
         @Test
-        fun `Page renders when we navigate to this step through the registration journey`() {
-            val successPage = navigator.goToLaUserRegistrationSuccessPage()
-            assertThat(successPage.bannerHeading).containsText("You've registered as a Test Authority user")
-            assertThat(successPage.bodyHeading).containsText("What happens next")
-        }
-
-        @Test
-        fun `Navigating directly to here with an incomplete form returns a 500 error page`() {
-            val successPage = navigator.skipToLaUserRegistrationSuccessPage()
-            assertThat(successPage.errorHeading).containsText("Sorry, there is a problem with the service")
+        fun `Navigating directly to here with an incomplete form returns a 400 error page`() {
+            val errorPage = navigator.skipToLaUserRegistrationConfirmationPage()
+            assertThat(errorPage.heading).containsText("Sorry, there is a problem with the service")
         }
     }
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/Navigator.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/Navigator.kt
@@ -235,28 +235,28 @@ class Navigator(
         return createValidPage(page, ErrorPage::class)
     }
 
-    fun goToLaUserRegistrationLandingPage(): LandingPageLaUserRegistration {
-        navigate("register-local-authority-user/landing-page")
+    fun goToLaUserRegistrationLandingPage(token: String): LandingPageLaUserRegistration {
+        navigate("$REGISTER_LA_USER_JOURNEY_URL?token=$token")
         return createValidPage(page, LandingPageLaUserRegistration::class)
     }
 
-    fun goToLaUserRegistrationNameFormPage(): NameFormPageLaUserRegistration {
-        val landingPage = goToLaUserRegistrationLandingPage()
+    fun goToLaUserRegistrationNameFormPage(token: String): NameFormPageLaUserRegistration {
+        val landingPage = goToLaUserRegistrationLandingPage(token)
         landingPage.clickBeginButton()
         val namePage = createValidPage(page, NameFormPageLaUserRegistration::class)
         return namePage
     }
 
-    fun goToLaUserRegistrationEmailFormPage(): EmailFormPageLaUserRegistration {
-        val namePage = goToLaUserRegistrationNameFormPage()
+    fun goToLaUserRegistrationEmailFormPage(token: String): EmailFormPageLaUserRegistration {
+        val namePage = goToLaUserRegistrationNameFormPage(token)
         namePage.nameInput.fill("Test user")
         namePage.form.submit()
         val emailPage = createValidPage(page, EmailFormPageLaUserRegistration::class)
         return emailPage
     }
 
-    fun goToLaUserRegistrationCheckAnswersPage(): CheckAnswersPageLaUserRegistration {
-        val emailPage = goToLaUserRegistrationEmailFormPage()
+    fun goToLaUserRegistrationCheckAnswersPage(token: String): CheckAnswersPageLaUserRegistration {
+        val emailPage = goToLaUserRegistrationEmailFormPage(token)
         emailPage.emailInput.fill("test.user@example.com")
         emailPage.form.submit()
         val checkAnswersPage = createValidPage(page, CheckAnswersPageLaUserRegistration::class)

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/Navigator.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/Navigator.kt
@@ -6,6 +6,7 @@ import org.mockito.kotlin.any
 import org.mockito.kotlin.whenever
 import uk.gov.communities.prsdb.webapp.constants.MANUAL_ADDRESS_CHOSEN
 import uk.gov.communities.prsdb.webapp.constants.REGISTER_LANDLORD_JOURNEY_URL
+import uk.gov.communities.prsdb.webapp.constants.REGISTER_LA_USER_JOURNEY_URL
 import uk.gov.communities.prsdb.webapp.constants.REGISTER_PROPERTY_JOURNEY_URL
 import uk.gov.communities.prsdb.webapp.constants.enums.LicensingType
 import uk.gov.communities.prsdb.webapp.constants.enums.OwnershipType
@@ -25,7 +26,6 @@ import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.laUserRegis
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.laUserRegistrationJourneyPages.EmailFormPageLaUserRegistration
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.laUserRegistrationJourneyPages.LandingPageLaUserRegistration
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.laUserRegistrationJourneyPages.NameFormPageLaUserRegistration
-import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.laUserRegistrationJourneyPages.SuccessPageLaUserRegistration
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.landlordRegistrationJourneyPages.CheckAnswersPageLandlordRegistration
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.landlordRegistrationJourneyPages.ConfirmIdentityFormPageLandlordRegistration
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.landlordRegistrationJourneyPages.CountryOfResidenceFormPageLandlordRegistration
@@ -61,6 +61,7 @@ import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyReg
 import uk.gov.communities.prsdb.webapp.models.formModels.VerifiedIdentityModel
 import uk.gov.communities.prsdb.webapp.services.OneLoginIdentityService
 import java.time.LocalDate
+import uk.gov.communities.prsdb.webapp.controllers.RegisterLAUserController.Companion.CONFIRMATION_PAGE_PATH_SEGMENT as LA_CONFIRMATION
 import uk.gov.communities.prsdb.webapp.controllers.RegisterLandlordController.Companion.CONFIRMATION_PAGE_PATH_SEGMENT as LANDLORD_CONFIRMATION
 import uk.gov.communities.prsdb.webapp.controllers.RegisterPropertyController.Companion.CONFIRMATION_PAGE_PATH_SEGMENT as PROPERTY_CONFIRMATION
 
@@ -262,16 +263,9 @@ class Navigator(
         return checkAnswersPage
     }
 
-    fun goToLaUserRegistrationSuccessPage(): SuccessPageLaUserRegistration {
-        val checkAnswersPage = goToLaUserRegistrationCheckAnswersPage()
-        checkAnswersPage.form.submit()
-        val successPage = createValidPage(page, SuccessPageLaUserRegistration::class)
-        return successPage
-    }
-
-    fun skipToLaUserRegistrationSuccessPage(): SuccessPageLaUserRegistration {
-        navigate("register-local-authority-user/success")
-        return createValidPage(page, SuccessPageLaUserRegistration::class)
+    fun skipToLaUserRegistrationConfirmationPage(): ErrorPage {
+        navigate("$REGISTER_LA_USER_JOURNEY_URL/$LA_CONFIRMATION")
+        return createValidPage(page, ErrorPage::class)
     }
 
     fun goToPropertyRegistrationStartPage(): RegisterPropertyStartPage {

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/laUserRegistrationJourneyPages/ConfirmationPageLaUserRegistration.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/laUserRegistrationJourneyPages/ConfirmationPageLaUserRegistration.kt
@@ -2,12 +2,12 @@ package uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.laUserRegi
 
 import com.microsoft.playwright.Page
 import uk.gov.communities.prsdb.webapp.constants.REGISTER_LA_USER_JOURNEY_URL
+import uk.gov.communities.prsdb.webapp.controllers.RegisterLAUserController.Companion.CONFIRMATION_PAGE_PATH_SEGMENT
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages.BasePage
 
-class SuccessPageLaUserRegistration(
+class ConfirmationPageLaUserRegistration(
     page: Page,
-) : BasePage(page, "/$REGISTER_LA_USER_JOURNEY_URL/success") {
+) : BasePage(page, "/$REGISTER_LA_USER_JOURNEY_URL/$CONFIRMATION_PAGE_PATH_SEGMENT") {
     val bannerHeading = page.locator(".govuk-panel__title")
     val bodyHeading = page.locator(".govuk-heading-m")
-    val errorHeading = page.locator(".govuk-heading-l")
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/LocalAuthorityDataServiceTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/LocalAuthorityDataServiceTests.kt
@@ -13,6 +13,7 @@ import org.mockito.InjectMocks
 import org.mockito.Mock
 import org.mockito.internal.matchers.apachecommons.ReflectionEquals
 import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.springframework.data.domain.PageImpl
@@ -312,25 +313,30 @@ class LocalAuthorityDataServiceTests {
     }
 
     @Test
-    fun `registerNewUser adds a new user to local_authority_user`() {
+    fun `registerUserAndReturnID adds a new user to local_authority_user and returns the generated ID`() {
         // Arrange
         val baseUser = createOneLoginUser()
         val localAuthority = createLocalAuthority()
         val newLocalAuthorityUser = createLocalAuthorityUser(baseUser, localAuthority, isManager = false)
+
         whenever(oneLoginUserService.findOrCreate1LUser(baseUser.id)).thenReturn(baseUser)
+        whenever(localAuthorityUserRepository.save(any())).thenReturn(newLocalAuthorityUser)
 
         // Act
-        localAuthorityDataService.registerNewUser(
-            baseUser.id,
-            localAuthority,
-            newLocalAuthorityUser.name,
-            newLocalAuthorityUser.email,
-        )
+        val localAuthorityUserID =
+            localAuthorityDataService.registerUserAndReturnID(
+                baseUser.id,
+                localAuthority,
+                newLocalAuthorityUser.name,
+                newLocalAuthorityUser.email,
+            )
 
         // Assert
         val localAuthorityUserCaptor = captor<LocalAuthorityUser>()
         verify(localAuthorityUserRepository).save(localAuthorityUserCaptor.capture())
         assertTrue(ReflectionEquals(newLocalAuthorityUser, "id").matches(localAuthorityUserCaptor.value))
+
+        assertEquals(newLocalAuthorityUser.id, localAuthorityUserID)
     }
 
     @Test

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/LocalAuthorityDataServiceTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/LocalAuthorityDataServiceTests.kt
@@ -1,5 +1,6 @@
 package uk.gov.communities.prsdb.webapp.services
 
+import jakarta.servlet.http.HttpSession
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
@@ -46,6 +47,9 @@ class LocalAuthorityDataServiceTests {
 
     @Mock
     private lateinit var oneLoginUserService: OneLoginUserService
+
+    @Mock
+    private lateinit var mockHttpSession: HttpSession
 
     @InjectMocks
     private lateinit var localAuthorityDataService: LocalAuthorityDataService

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/PropertyRegistrationServiceTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/PropertyRegistrationServiceTests.kt
@@ -2,6 +2,7 @@ package uk.gov.communities.prsdb.webapp.services
 
 import jakarta.persistence.EntityExistsException
 import jakarta.persistence.EntityNotFoundException
+import jakarta.servlet.http.HttpSession
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Test
@@ -53,6 +54,9 @@ class PropertyRegistrationServiceTests {
 
     @Mock
     private lateinit var mockPropertyOwnershipService: PropertyOwnershipService
+
+    @Mock
+    private lateinit var mockHttpSession: HttpSession
 
     @InjectMocks
     private lateinit var propertyRegistrationService: PropertyRegistrationService


### PR DESCRIPTION
- Creates LA user in the `handleSubmitAndRedirect()` of the check answers step instead of the confirmation endpoint
- Adds ID of created LA user to session
- Uses cached ID to retrieve LA for confirmation page
- Updates affected tests