### PR TITLE
PRSD-648: Interact with Session via Services

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/RegisterLAUserController.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/RegisterLAUserController.kt
@@ -81,7 +81,7 @@ class RegisterLAUserController(
         principal: Principal,
     ): String {
         val localAuthorityUserID =
-            localAuthorityDataService.getUserRegisteredThisSession()
+            localAuthorityDataService.getLastUserRegisteredThisSession()
                 ?: throw ResponseStatusException(
                     HttpStatus.BAD_REQUEST,
                     "$LA_USER_ID was not found in the session",

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/RegisterLAUserController.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/RegisterLAUserController.kt
@@ -1,6 +1,5 @@
 package uk.gov.communities.prsdb.webapp.controllers
 
-import jakarta.servlet.http.HttpSession
 import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Controller
 import org.springframework.ui.Model
@@ -21,10 +20,9 @@ import java.security.Principal
 @Controller
 @RequestMapping("/${REGISTER_LA_USER_JOURNEY_URL}")
 class RegisterLAUserController(
-    var laUserRegistrationJourney: LaUserRegistrationJourney,
-    var invitationService: LocalAuthorityInvitationService,
-    var localAuthorityDataService: LocalAuthorityDataService,
-    var session: HttpSession,
+    val laUserRegistrationJourney: LaUserRegistrationJourney,
+    val invitationService: LocalAuthorityInvitationService,
+    val localAuthorityDataService: LocalAuthorityDataService,
 ) {
     @GetMapping
     fun acceptInvitation(
@@ -83,7 +81,7 @@ class RegisterLAUserController(
         principal: Principal,
     ): String {
         val localAuthorityUserID =
-            session.getAttribute(LA_USER_ID)?.toString()?.toLong()
+            localAuthorityDataService.getUserRegisteredThisSession()
                 ?: throw ResponseStatusException(
                     HttpStatus.BAD_REQUEST,
                     "$LA_USER_ID was not found in the session",

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/RegisterPropertyController.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/RegisterPropertyController.kt
@@ -82,7 +82,7 @@ class RegisterPropertyController(
         principal: Principal,
     ): String {
         val propertyRegistrationNumber =
-            propertyRegistrationService.getPropertyRegisteredThisSession()
+            propertyRegistrationService.getLastPropertyRegisteredThisSession()
                 ?: throw ResponseStatusException(
                     HttpStatus.BAD_REQUEST,
                     "$PROPERTY_REGISTRATION_NUMBER was not found in the session",

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/RegisterPropertyController.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/RegisterPropertyController.kt
@@ -1,6 +1,5 @@
 package uk.gov.communities.prsdb.webapp.controllers
 
-import jakarta.servlet.http.HttpSession
 import org.springframework.http.HttpStatus
 import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.stereotype.Controller
@@ -17,6 +16,7 @@ import uk.gov.communities.prsdb.webapp.forms.journeys.PageData
 import uk.gov.communities.prsdb.webapp.forms.journeys.PropertyRegistrationJourney
 import uk.gov.communities.prsdb.webapp.models.dataModels.RegistrationNumberDataModel
 import uk.gov.communities.prsdb.webapp.services.PropertyOwnershipService
+import uk.gov.communities.prsdb.webapp.services.PropertyRegistrationService
 import java.security.Principal
 
 @PreAuthorize("hasRole('LANDLORD')")
@@ -25,7 +25,7 @@ import java.security.Principal
 class RegisterPropertyController(
     private val propertyRegistrationJourney: PropertyRegistrationJourney,
     private val propertyOwnershipService: PropertyOwnershipService,
-    private val session: HttpSession,
+    private val propertyRegistrationService: PropertyRegistrationService,
 ) {
     @GetMapping
     fun index(model: Model): String {
@@ -82,7 +82,7 @@ class RegisterPropertyController(
         principal: Principal,
     ): String {
         val propertyRegistrationNumber =
-            session.getAttribute(PROPERTY_REGISTRATION_NUMBER)?.toString()?.toLong()
+            propertyRegistrationService.getPropertyRegisteredThisSession()
                 ?: throw ResponseStatusException(
                     HttpStatus.BAD_REQUEST,
                     "$PROPERTY_REGISTRATION_NUMBER was not found in the session",

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/LaUserRegistrationJourney.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/LaUserRegistrationJourney.kt
@@ -1,10 +1,8 @@
 package uk.gov.communities.prsdb.webapp.forms.journeys
 
-import jakarta.servlet.http.HttpSession
 import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.stereotype.Component
 import org.springframework.validation.Validator
-import uk.gov.communities.prsdb.webapp.constants.LA_USER_ID
 import uk.gov.communities.prsdb.webapp.constants.enums.JourneyType
 import uk.gov.communities.prsdb.webapp.controllers.RegisterLAUserController.Companion.CONFIRMATION_PAGE_PATH_SEGMENT
 import uk.gov.communities.prsdb.webapp.forms.pages.LaUserRegistrationCheckAnswersPage
@@ -26,7 +24,6 @@ class LaUserRegistrationJourney(
     journeyDataService: JourneyDataService,
     private val invitationService: LocalAuthorityInvitationService,
     private val localAuthorityDataService: LocalAuthorityDataService,
-    private val session: HttpSession,
 ) : Journey<RegisterLaUserStepId>(
         journeyType = JourneyType.LA_USER_REGISTRATION,
         validator = validator,
@@ -143,13 +140,13 @@ class LaUserRegistrationJourney(
                 email = LaUserRegistrationJourneyDataHelper.getEmail(journeyData)!!,
             )
 
+        localAuthorityDataService.setUserRegisteredThisSession(localAuthorityUserID)
+
         val invitation = invitationService.getInvitationFromToken(token)
         invitationService.deleteInvitation(invitation)
         invitationService.clearTokenFromSession()
 
         journeyDataService.clearJourneyDataFromSession()
-
-        session.setAttribute(LA_USER_ID, localAuthorityUserID)
 
         return CONFIRMATION_PAGE_PATH_SEGMENT
     }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/LaUserRegistrationJourney.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/LaUserRegistrationJourney.kt
@@ -140,7 +140,7 @@ class LaUserRegistrationJourney(
                 email = LaUserRegistrationJourneyDataHelper.getEmail(journeyData)!!,
             )
 
-        localAuthorityDataService.setUserRegisteredThisSession(localAuthorityUserID)
+        localAuthorityDataService.setLastUserRegisteredThisSession(localAuthorityUserID)
 
         val invitation = invitationService.getInvitationFromToken(token)
         invitationService.deleteInvitation(invitation)

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/PropertyRegistrationJourney.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/PropertyRegistrationJourney.kt
@@ -666,7 +666,7 @@ class PropertyRegistrationJourney(
                     baseUserId = baseUserId,
                 )
 
-            propertyRegistrationService.setPropertyRegisteredThisSession(propertyRegistrationNumber.number)
+            propertyRegistrationService.setLastPropertyRegisteredThisSession(propertyRegistrationNumber.number)
 
             confirmationEmailSender.sendEmail(
                 landlordService.retrieveLandlordByBaseUserId(baseUserId)!!.email,

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/PropertyRegistrationJourney.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/PropertyRegistrationJourney.kt
@@ -1,12 +1,10 @@
 package uk.gov.communities.prsdb.webapp.forms.journeys
 
 import jakarta.persistence.EntityExistsException
-import jakarta.servlet.http.HttpSession
 import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.stereotype.Component
 import org.springframework.validation.Validator
 import uk.gov.communities.prsdb.webapp.constants.LANDLORD_DASHBOARD_URL
-import uk.gov.communities.prsdb.webapp.constants.PROPERTY_REGISTRATION_NUMBER
 import uk.gov.communities.prsdb.webapp.constants.REGISTER_PROPERTY_JOURNEY_URL
 import uk.gov.communities.prsdb.webapp.constants.enums.JourneyType
 import uk.gov.communities.prsdb.webapp.constants.enums.LandlordType
@@ -54,13 +52,12 @@ import uk.gov.communities.prsdb.webapp.services.PropertyRegistrationService
 class PropertyRegistrationJourney(
     validator: Validator,
     journeyDataService: JourneyDataService,
-    val addressLookupService: AddressLookupService,
-    val addressDataService: AddressDataService,
-    val propertyRegistrationService: PropertyRegistrationService,
-    val localAuthorityService: LocalAuthorityService,
-    val landlordService: LandlordService,
-    val session: HttpSession,
-    val confirmationEmailSender: EmailNotificationService<PropertyRegistrationConfirmationEmail>,
+    private val addressLookupService: AddressLookupService,
+    private val addressDataService: AddressDataService,
+    private val propertyRegistrationService: PropertyRegistrationService,
+    private val localAuthorityService: LocalAuthorityService,
+    private val landlordService: LandlordService,
+    private val confirmationEmailSender: EmailNotificationService<PropertyRegistrationConfirmationEmail>,
 ) : JourneyWithTaskList<RegisterPropertyStepId>(
         journeyType = JourneyType.PROPERTY_REGISTRATION,
         validator = validator,
@@ -119,7 +116,6 @@ class PropertyRegistrationJourney(
                     addressDataService,
                     landlordService,
                     confirmationEmailSender,
-                    session,
                 ),
             ),
         )
@@ -562,7 +558,12 @@ class PropertyRegistrationJourney(
         localAuthorityService: LocalAuthorityService,
     ) = Step(
         id = RegisterPropertyStepId.CheckAnswers,
-        page = PropertyRegistrationCheckAnswersPage(addressDataService, localAuthorityService, displaySectionHeader = true),
+        page =
+            PropertyRegistrationCheckAnswersPage(
+                addressDataService,
+                localAuthorityService,
+                displaySectionHeader = true,
+            ),
         nextAction = { _, _ -> Pair(RegisterPropertyStepId.Declaration, null) },
     )
 
@@ -572,7 +573,6 @@ class PropertyRegistrationJourney(
         addressDataService: AddressDataService,
         landlordService: LandlordService,
         confirmationEmailSender: EmailNotificationService<PropertyRegistrationConfirmationEmail>,
-        session: HttpSession,
     ) = Step(
         id = RegisterPropertyStepId.Declaration,
         page =
@@ -603,7 +603,6 @@ class PropertyRegistrationJourney(
                 addressDataService,
                 landlordService,
                 confirmationEmailSender,
-                session,
             )
         },
     )
@@ -650,7 +649,6 @@ class PropertyRegistrationJourney(
         addressDataService: AddressDataService,
         landlordService: LandlordService,
         confirmationEmailSender: EmailNotificationService<PropertyRegistrationConfirmationEmail>,
-        session: HttpSession,
     ): String {
         try {
             val address = PropertyRegistrationJourneyDataHelper.getAddress(journeyData, addressDataService)!!
@@ -668,6 +666,8 @@ class PropertyRegistrationJourney(
                     baseUserId = baseUserId,
                 )
 
+            propertyRegistrationService.setPropertyRegisteredThisSession(propertyRegistrationNumber.number)
+
             confirmationEmailSender.sendEmail(
                 landlordService.retrieveLandlordByBaseUserId(baseUserId)!!.email,
                 PropertyRegistrationConfirmationEmail(
@@ -678,8 +678,6 @@ class PropertyRegistrationJourney(
             )
 
             journeyDataService.deleteJourneyData()
-
-            session.setAttribute(PROPERTY_REGISTRATION_NUMBER, propertyRegistrationNumber.number)
 
             return CONFIRMATION_PAGE_PATH_SEGMENT
         } catch (exception: EntityExistsException) {

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/LocalAuthorityDataService.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/LocalAuthorityDataService.kt
@@ -1,5 +1,6 @@
 package uk.gov.communities.prsdb.webapp.services
 
+import jakarta.servlet.http.HttpSession
 import jakarta.transaction.Transactional
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.PageRequest
@@ -9,6 +10,7 @@ import org.springframework.http.HttpStatus
 import org.springframework.security.access.AccessDeniedException
 import org.springframework.stereotype.Service
 import org.springframework.web.server.ResponseStatusException
+import uk.gov.communities.prsdb.webapp.constants.LA_USER_ID
 import uk.gov.communities.prsdb.webapp.constants.MAX_ENTRIES_IN_LA_USERS_TABLE_PAGE
 import uk.gov.communities.prsdb.webapp.database.entity.LocalAuthority
 import uk.gov.communities.prsdb.webapp.database.entity.LocalAuthorityUser
@@ -19,9 +21,10 @@ import uk.gov.communities.prsdb.webapp.models.dataModels.LocalAuthorityUserDataM
 
 @Service
 class LocalAuthorityDataService(
-    val localAuthorityUserRepository: LocalAuthorityUserRepository,
-    val localAuthorityUserOrInvitationRepository: LocalAuthorityUserOrInvitationRepository,
-    val oneLoginUserService: OneLoginUserService,
+    private val localAuthorityUserRepository: LocalAuthorityUserRepository,
+    private val localAuthorityUserOrInvitationRepository: LocalAuthorityUserOrInvitationRepository,
+    private val oneLoginUserService: OneLoginUserService,
+    private val session: HttpSession,
 ) {
     fun getUserAndLocalAuthorityIfAuthorizedUser(
         localAuthorityId: Int,
@@ -129,4 +132,8 @@ class LocalAuthorityDataService(
     }
 
     fun getIsLocalAuthorityUser(baseUserId: String): Boolean = localAuthorityUserRepository.findByBaseUser_Id(baseUserId) != null
+
+    fun setUserRegisteredThisSession(localAuthorityUserId: Long) = session.setAttribute(LA_USER_ID, localAuthorityUserId)
+
+    fun getUserRegisteredThisSession() = session.getAttribute(LA_USER_ID)?.toString()?.toLong()
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/LocalAuthorityDataService.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/LocalAuthorityDataService.kt
@@ -133,7 +133,7 @@ class LocalAuthorityDataService(
 
     fun getIsLocalAuthorityUser(baseUserId: String): Boolean = localAuthorityUserRepository.findByBaseUser_Id(baseUserId) != null
 
-    fun setUserRegisteredThisSession(localAuthorityUserId: Long) = session.setAttribute(LA_USER_ID, localAuthorityUserId)
+    fun setLastUserRegisteredThisSession(localAuthorityUserId: Long) = session.setAttribute(LA_USER_ID, localAuthorityUserId)
 
-    fun getUserRegisteredThisSession() = session.getAttribute(LA_USER_ID)?.toString()?.toLong()
+    fun getLastUserRegisteredThisSession() = session.getAttribute(LA_USER_ID)?.toString()?.toLong()
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/PropertyRegistrationService.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/PropertyRegistrationService.kt
@@ -92,7 +92,7 @@ class PropertyRegistrationService(
         return propertyOwnership.registrationNumber
     }
 
-    fun setPropertyRegisteredThisSession(prn: Long) = session.setAttribute(PROPERTY_REGISTRATION_NUMBER, prn)
+    fun setLastPropertyRegisteredThisSession(prn: Long) = session.setAttribute(PROPERTY_REGISTRATION_NUMBER, prn)
 
-    fun getPropertyRegisteredThisSession() = session.getAttribute(PROPERTY_REGISTRATION_NUMBER)?.toString()?.toLong()
+    fun getLastPropertyRegisteredThisSession() = session.getAttribute(PROPERTY_REGISTRATION_NUMBER)?.toString()?.toLong()
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/PropertyRegistrationService.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/PropertyRegistrationService.kt
@@ -2,8 +2,10 @@ package uk.gov.communities.prsdb.webapp.services
 
 import jakarta.persistence.EntityExistsException
 import jakarta.persistence.EntityNotFoundException
+import jakarta.servlet.http.HttpSession
 import jakarta.transaction.Transactional
 import org.springframework.stereotype.Service
+import uk.gov.communities.prsdb.webapp.constants.PROPERTY_REGISTRATION_NUMBER
 import uk.gov.communities.prsdb.webapp.constants.enums.LandlordType
 import uk.gov.communities.prsdb.webapp.constants.enums.LicensingType
 import uk.gov.communities.prsdb.webapp.constants.enums.OwnershipType
@@ -23,6 +25,7 @@ class PropertyRegistrationService(
     private val propertyService: PropertyService,
     private val licenseService: LicenseService,
     private val propertyOwnershipService: PropertyOwnershipService,
+    private val session: HttpSession,
 ) {
     fun getIsAddressRegistered(
         uprn: Long,
@@ -88,4 +91,8 @@ class PropertyRegistrationService(
 
         return propertyOwnership.registrationNumber
     }
+
+    fun setPropertyRegisteredThisSession(prn: Long) = session.setAttribute(PROPERTY_REGISTRATION_NUMBER, prn)
+
+    fun getPropertyRegisteredThisSession() = session.getAttribute(PROPERTY_REGISTRATION_NUMBER)?.toString()?.toLong()
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/controllers/RegisterLAUserControllerTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/controllers/RegisterLAUserControllerTests.kt
@@ -77,7 +77,7 @@ class RegisterLAUserControllerTests(
         val laUserId = 0L
         val localAuthorityUser = MockLocalAuthorityData.createLocalAuthorityUser()
 
-        whenever(localAuthorityDataService.getUserRegisteredThisSession()).thenReturn(laUserId)
+        whenever(localAuthorityDataService.getLastUserRegisteredThisSession()).thenReturn(laUserId)
         whenever(localAuthorityDataService.getLocalAuthorityUserOrNull(laUserId)).thenReturn(localAuthorityUser)
 
         mvc
@@ -94,7 +94,7 @@ class RegisterLAUserControllerTests(
         val laUserId = 0L
         val localAuthorityUser = MockLocalAuthorityData.createLocalAuthorityUser()
 
-        whenever(localAuthorityDataService.getUserRegisteredThisSession()).thenReturn(null)
+        whenever(localAuthorityDataService.getLastUserRegisteredThisSession()).thenReturn(null)
         whenever(localAuthorityDataService.getLocalAuthorityUserOrNull(laUserId)).thenReturn(localAuthorityUser)
 
         mvc
@@ -107,7 +107,7 @@ class RegisterLAUserControllerTests(
     fun `getConfirmation returns 400 if the LA user ID in session is not valid`() {
         val laUserId = 0L
 
-        whenever(localAuthorityDataService.getUserRegisteredThisSession()).thenReturn(laUserId)
+        whenever(localAuthorityDataService.getLastUserRegisteredThisSession()).thenReturn(laUserId)
         whenever(localAuthorityDataService.getLocalAuthorityUserOrNull(laUserId)).thenReturn(null)
 
         mvc

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/controllers/RegisterLAUserControllerTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/controllers/RegisterLAUserControllerTests.kt
@@ -77,6 +77,7 @@ class RegisterLAUserControllerTests(
         val laUserId = 0L
         val localAuthorityUser = MockLocalAuthorityData.createLocalAuthorityUser()
 
+        whenever(localAuthorityDataService.getUserRegisteredThisSession()).thenReturn(laUserId)
         whenever(localAuthorityDataService.getLocalAuthorityUserOrNull(laUserId)).thenReturn(localAuthorityUser)
 
         mvc
@@ -93,6 +94,7 @@ class RegisterLAUserControllerTests(
         val laUserId = 0L
         val localAuthorityUser = MockLocalAuthorityData.createLocalAuthorityUser()
 
+        whenever(localAuthorityDataService.getUserRegisteredThisSession()).thenReturn(null)
         whenever(localAuthorityDataService.getLocalAuthorityUserOrNull(laUserId)).thenReturn(localAuthorityUser)
 
         mvc
@@ -105,6 +107,7 @@ class RegisterLAUserControllerTests(
     fun `getConfirmation returns 400 if the LA user ID in session is not valid`() {
         val laUserId = 0L
 
+        whenever(localAuthorityDataService.getUserRegisteredThisSession()).thenReturn(laUserId)
         whenever(localAuthorityDataService.getLocalAuthorityUserOrNull(laUserId)).thenReturn(null)
 
         mvc

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/controllers/RegisterPropertyControllerTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/controllers/RegisterPropertyControllerTests.kt
@@ -76,7 +76,9 @@ class RegisterPropertyControllerTests(
                 registrationNumber = RegistrationNumber(RegistrationNumberType.PROPERTY, propertyRegistrationNumber),
             )
 
-        whenever(propertyRegistrationService.getPropertyRegisteredThisSession()).thenReturn(propertyRegistrationNumber)
+        whenever(propertyRegistrationService.getLastPropertyRegisteredThisSession()).thenReturn(
+            propertyRegistrationNumber,
+        )
         whenever(propertyOwnershipService.retrievePropertyOwnership(propertyRegistrationNumber)).thenReturn(
             propertyOwnership,
         )
@@ -98,7 +100,7 @@ class RegisterPropertyControllerTests(
                 registrationNumber = RegistrationNumber(RegistrationNumberType.PROPERTY, propertyRegistrationNumber),
             )
 
-        whenever(propertyRegistrationService.getPropertyRegisteredThisSession()).thenReturn(null)
+        whenever(propertyRegistrationService.getLastPropertyRegisteredThisSession()).thenReturn(null)
         whenever(propertyOwnershipService.retrievePropertyOwnership(propertyRegistrationNumber)).thenReturn(
             propertyOwnership,
         )
@@ -113,7 +115,9 @@ class RegisterPropertyControllerTests(
     fun `getConfirmation returns 400 if the property ownership ID in session is not valid`() {
         val propertyRegistrationNumber = 0L
 
-        whenever(propertyRegistrationService.getPropertyRegisteredThisSession()).thenReturn(propertyRegistrationNumber)
+        whenever(propertyRegistrationService.getLastPropertyRegisteredThisSession()).thenReturn(
+            propertyRegistrationNumber,
+        )
         whenever(propertyOwnershipService.retrievePropertyOwnership(propertyRegistrationNumber)).thenReturn(null)
 
         mvc

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/controllers/RegisterPropertyControllerTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/controllers/RegisterPropertyControllerTests.kt
@@ -20,6 +20,7 @@ import uk.gov.communities.prsdb.webapp.forms.journeys.PropertyRegistrationJourne
 import uk.gov.communities.prsdb.webapp.forms.steps.RegisterPropertyStepId
 import uk.gov.communities.prsdb.webapp.mockObjects.MockLandlordData.Companion.createPropertyOwnership
 import uk.gov.communities.prsdb.webapp.services.PropertyOwnershipService
+import uk.gov.communities.prsdb.webapp.services.PropertyRegistrationService
 
 @WebMvcTest(RegisterPropertyController::class)
 class RegisterPropertyControllerTests(
@@ -30,6 +31,9 @@ class RegisterPropertyControllerTests(
 
     @MockBean
     lateinit var propertyOwnershipService: PropertyOwnershipService
+
+    @MockBean
+    lateinit var propertyRegistrationService: PropertyRegistrationService
 
     @BeforeEach
     fun setupMocks() {
@@ -72,6 +76,7 @@ class RegisterPropertyControllerTests(
                 registrationNumber = RegistrationNumber(RegistrationNumberType.PROPERTY, propertyRegistrationNumber),
             )
 
+        whenever(propertyRegistrationService.getPropertyRegisteredThisSession()).thenReturn(propertyRegistrationNumber)
         whenever(propertyOwnershipService.retrievePropertyOwnership(propertyRegistrationNumber)).thenReturn(
             propertyOwnership,
         )
@@ -93,6 +98,7 @@ class RegisterPropertyControllerTests(
                 registrationNumber = RegistrationNumber(RegistrationNumberType.PROPERTY, propertyRegistrationNumber),
             )
 
+        whenever(propertyRegistrationService.getPropertyRegisteredThisSession()).thenReturn(null)
         whenever(propertyOwnershipService.retrievePropertyOwnership(propertyRegistrationNumber)).thenReturn(
             propertyOwnership,
         )
@@ -107,6 +113,7 @@ class RegisterPropertyControllerTests(
     fun `getConfirmation returns 400 if the property ownership ID in session is not valid`() {
         val propertyRegistrationNumber = 0L
 
+        whenever(propertyRegistrationService.getPropertyRegisteredThisSession()).thenReturn(propertyRegistrationNumber)
         whenever(propertyOwnershipService.retrievePropertyOwnership(propertyRegistrationNumber)).thenReturn(null)
 
         mvc

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/forms/PropertyRegistrationJourneyTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/forms/PropertyRegistrationJourneyTests.kt
@@ -39,11 +39,12 @@ class PropertyRegistrationJourneyTests {
                     mock(),
                     mock(),
                     mock(),
-                    mock(),
                 )
 
             whenever(mockJourneyDataService.getJourneyDataFromSession()).thenReturn(mutableMapOf())
-            whenever(mockJourneyDataService.getContextId(principalName, JourneyType.PROPERTY_REGISTRATION)).thenReturn(null)
+            whenever(mockJourneyDataService.getContextId(principalName, JourneyType.PROPERTY_REGISTRATION)).thenReturn(
+                null,
+            )
 
             // Act
             testJourney.initialiseJourneyDataIfNotInitialised(principalName)
@@ -67,11 +68,12 @@ class PropertyRegistrationJourneyTests {
                     mock(),
                     mock(),
                     mock(),
-                    mock(),
                 )
 
             whenever(mockJourneyDataService.getJourneyDataFromSession()).thenReturn(mutableMapOf())
-            whenever(mockJourneyDataService.getContextId(principalName, JourneyType.PROPERTY_REGISTRATION)).thenReturn(contextId)
+            whenever(mockJourneyDataService.getContextId(principalName, JourneyType.PROPERTY_REGISTRATION)).thenReturn(
+                contextId,
+            )
 
             // Act
             testJourney.initialiseJourneyDataIfNotInitialised(principalName)
@@ -89,7 +91,6 @@ class PropertyRegistrationJourneyTests {
                 PropertyRegistrationJourney(
                     mock(),
                     mockJourneyDataService,
-                    mock(),
                     mock(),
                     mock(),
                     mock(),

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/LocalAuthorityDataServiceTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/LocalAuthorityDataServiceTests.kt
@@ -1,5 +1,6 @@
 package uk.gov.communities.prsdb.webapp.services
 
+import jakarta.servlet.http.HttpSession
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
@@ -46,6 +47,9 @@ class LocalAuthorityDataServiceTests {
 
     @Mock
     private lateinit var oneLoginUserService: OneLoginUserService
+
+    @Mock
+    private lateinit var mockHttpSession: HttpSession
 
     @InjectMocks
     private lateinit var localAuthorityDataService: LocalAuthorityDataService

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/PropertyRegistrationServiceTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/PropertyRegistrationServiceTests.kt
@@ -2,6 +2,7 @@ package uk.gov.communities.prsdb.webapp.services
 
 import jakarta.persistence.EntityExistsException
 import jakarta.persistence.EntityNotFoundException
+import jakarta.servlet.http.HttpSession
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Test
@@ -54,6 +55,9 @@ class PropertyRegistrationServiceTests {
 
     @Mock
     private lateinit var mockPropertyOwnershipService: PropertyOwnershipService
+
+    @Mock
+    private lateinit var mockHttpSession: HttpSession
 
     @InjectMocks
     private lateinit var propertyRegistrationService: PropertyRegistrationService


### PR DESCRIPTION
- Makes LA and property registration journeys interact with session via `LocalAuthorityDataService` and `PropertyRegistrationService` respectively
- Updates the affected tests