### PR TITLE
Chore/prsd 901 refactor step details iteration

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/Journey.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/Journey.kt
@@ -7,6 +7,7 @@ import org.springframework.web.server.ResponseStatusException
 import org.springframework.web.util.UriComponentsBuilder
 import uk.gov.communities.prsdb.webapp.constants.enums.JourneyType
 import uk.gov.communities.prsdb.webapp.constants.enums.TaskStatus
+import uk.gov.communities.prsdb.webapp.exceptions.PrsdbWebException
 import uk.gov.communities.prsdb.webapp.forms.steps.Step
 import uk.gov.communities.prsdb.webapp.forms.steps.StepDetails
 import uk.gov.communities.prsdb.webapp.forms.steps.StepId
@@ -219,4 +220,51 @@ abstract class Journey<T : StepId>(
         initialStepId: T,
         steps: Set<Step<T>>,
     ): List<JourneySection<T>> = listOf(JourneySection.withOneTask(JourneyTask(initialStepId, steps)))
+}
+
+class JourneyWithJourneyData<T : StepId>(
+    val journeyData: JourneyData,
+    val steps: Set<Step<T>>,
+    val initialStepId: T,
+    val validator: Validator,
+) : Iterable<StepDetails<T>> {
+    override fun iterator(): Iterator<StepDetails<T>> = JourneyIterator(journeyData, steps, initialStepId, validator)
+}
+
+class JourneyIterator<T : StepId>(
+    val journeyData: JourneyData,
+    val steps: Set<Step<T>>,
+    val initialStepId: T,
+    val validator: Validator,
+) : Iterator<StepDetails<T>> {
+    lateinit var currentStepDetails: StepDetails<T>
+
+    override fun hasNext(): Boolean {
+        if (!this::currentStepDetails.isInitialized) return steps.count { step -> step.id == initialStepId } == 1
+        val pageData = JourneyDataHelper.getPageData(journeyData, currentStepDetails.step.name, currentStepDetails.subPageNumber)
+        if (pageData == null || !currentStepDetails.step.isSatisfied(validator, pageData)) {
+            return false
+        }
+
+        return currentStepDetails.step.nextAction(journeyData, currentStepDetails.subPageNumber).first != null
+    }
+
+    override fun next(): StepDetails<T> {
+        if (!this::currentStepDetails.isInitialized) {
+            currentStepDetails = StepDetails(steps.single { step -> step.id == initialStepId }, null, mutableMapOf())
+        } else {
+            val pageData = JourneyDataHelper.getPageData(journeyData, currentStepDetails.step.name, currentStepDetails.subPageNumber)
+            if (pageData == null || !currentStepDetails.step.isSatisfied(validator, pageData)) {
+                throw PrsdbWebException("Does not have next")
+            }
+            val stepData = JourneyDataHelper.getPageData(journeyData, currentStepDetails.step.name, null)
+            currentStepDetails.filteredJourneyData[currentStepDetails.step.name] = stepData
+
+            val (nextStepId, nextSubPageNumber) = currentStepDetails.step.nextAction(journeyData, currentStepDetails.subPageNumber)
+            if (nextStepId == null) throw PrsdbWebException("Does not have next")
+            val nextStep = steps.single { step -> step.id == nextStepId }
+            currentStepDetails = StepDetails(nextStep, nextSubPageNumber, currentStepDetails.filteredJourneyData)
+        }
+        return currentStepDetails
+    }
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/Journey.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/Journey.kt
@@ -21,7 +21,7 @@ abstract class Journey<T : StepId>(
     private val journeyType: JourneyType,
     protected val validator: Validator,
     protected val journeyDataService: JourneyDataService,
-) {
+) : Iterable<StepDetails<T>> {
     abstract val initialStepId: T
     val steps: Set<Step<T>>
         get() = sections.flatMap { section -> section.tasks }.flatMap { task -> task.steps }.toSet()
@@ -53,10 +53,10 @@ abstract class Journey<T : StepId>(
                 HttpStatus.NOT_FOUND,
                 "Step ${stepId.urlPathSegment} not valid for journey ${journeyType.urlPathSegment}",
             )
-        if (!isStepReachable(journeyData, requestedStep, subPageNumber)) {
+        if (!isStepReachable(requestedStep, subPageNumber)) {
             return "redirect:${getUnreachableStepRedirect(journeyData)}"
         }
-        val prevStepDetails = getPrevStep(journeyData, requestedStep, subPageNumber)
+        val prevStepDetails = getPrevStep(requestedStep, subPageNumber)
         val prevStepUrl = getPrevStepUrl(prevStepDetails?.step, prevStepDetails?.subPageNumber)
         val pageData =
             submittedPageData ?: JourneyDataHelper.getPageData(journeyData, requestedStep.name, subPageNumber)
@@ -127,72 +127,22 @@ abstract class Journey<T : StepId>(
     }
 
     fun isStepReachable(
-        journeyData: JourneyData,
         targetStep: Step<T>,
         targetSubPageNumber: Int? = null,
     ): Boolean {
         // Initial page is always reachable
         if (targetStep.id == initialStepId) return true
         // All other steps are reachable if and only if we can find their previous step by traversal
-        return getPrevStep(journeyData, targetStep, targetSubPageNumber) != null
+        return getPrevStep(targetStep, targetSubPageNumber) != null
     }
 
-    protected open fun getPrevStep(
-        journeyData: JourneyData,
+    private fun getPrevStep(
         targetStep: Step<T>,
         targetSubPageNumber: Int?,
-    ): StepDetails<T>? {
-        if (targetStep.id == initialStepId && targetSubPageNumber == null) return null
-        val initialStep = steps.singleOrNull { step -> step.id == initialStepId } ?: return null
-        var currentStep = initialStep
-        lateinit var prevStep: Step<T>
-        var prevSubPageNumber: Int? = null
-        var currentSubPageNumber: Int? = null
-        val filteredJourneyData: JourneyData = mutableMapOf()
-        while (!(currentStep.id == targetStep.id && currentSubPageNumber == targetSubPageNumber)) {
-            val pageData = JourneyDataHelper.getPageData(journeyData, currentStep.name, currentSubPageNumber)
-            if (pageData == null || !currentStep.isSatisfied(validator, pageData)) return null
-
-            // This stores journeyData for only the journey path the user is on
-            // and excludes user data for pages in the journey that belong to a different path
-            val stepData = JourneyDataHelper.getPageData(journeyData, currentStep.name, null)
-            filteredJourneyData[currentStep.name] = stepData
-
-            val (nextStepId, nextSubPageNumber) = currentStep.nextAction(journeyData, currentSubPageNumber)
-            val nextStep = steps.singleOrNull { step -> step.id == nextStepId } ?: return null
-            prevStep = currentStep
-            prevSubPageNumber = currentSubPageNumber
-            currentStep = nextStep
-            currentSubPageNumber = nextSubPageNumber
-        }
-        return StepDetails(prevStep, prevSubPageNumber, filteredJourneyData)
-    }
-
-    protected fun getLastReachableStep(journeyData: JourneyData): StepDetails<T>? {
-        val initialStep = steps.single { step -> step.id == initialStepId }
-        var currentStepDetails: StepDetails<T>? = StepDetails(initialStep, null, mutableMapOf())
-        while (currentStepDetails != null) {
-            val pageData = JourneyDataHelper.getPageData(journeyData, currentStepDetails.step.name, currentStepDetails.subPageNumber)
-            if (pageData == null || !currentStepDetails.step.isSatisfied(validator, pageData)) {
-                return currentStepDetails
-            }
-
-            // This stores journeyData for only the journey path the user is on
-            // and excludes user data for pages in the journey that belong to a different path
-            val stepData = JourneyDataHelper.getPageData(journeyData, currentStepDetails.step.name, null)
-            currentStepDetails.filteredJourneyData[currentStepDetails.step.name] = stepData
-
-            val (nextStepId, nextSubPageNumber) = currentStepDetails.step.nextAction(journeyData, currentStepDetails.subPageNumber)
-            currentStepDetails =
-                nextStepId?.let {
-                    val nextStep = steps.single { step -> step.id == nextStepId }
-                    StepDetails(nextStep, nextSubPageNumber, currentStepDetails!!.filteredJourneyData)
-                }
-        }
-
-        // TODO PRSD-901: This should not return null if the journey is completely valid
-        return null
-    }
+    ): StepDetails<T>? =
+        zipWithNext()
+            .singleOrNull { (_, next) -> next.step == targetStep && next.subPageNumber == targetSubPageNumber }
+            ?.first
 
     private fun getPrevStepUrl(
         prevStep: Step<T>?,
@@ -212,7 +162,7 @@ abstract class Journey<T : StepId>(
         task: JourneyTask<T>,
         journeyData: JourneyData,
     ): TaskStatus {
-        val canTaskBeStarted = isStepReachable(journeyData, task.steps.single { it.id == task.startingStepId })
+        val canTaskBeStarted = isStepReachable(task.steps.single { it.id == task.startingStepId })
         return task.getTaskStatus(journeyData, validator, canTaskBeStarted)
     }
 
@@ -220,20 +170,14 @@ abstract class Journey<T : StepId>(
         initialStepId: T,
         steps: Set<Step<T>>,
     ): List<JourneySection<T>> = listOf(JourneySection.withOneTask(JourneyTask(initialStepId, steps)))
+
+    override fun iterator(): Iterator<StepDetails<T>> =
+        StepDetailsIterator(journeyDataService.getJourneyDataFromSession(), steps, initialStepId, validator)
 }
 
-class JourneyWithJourneyData<T : StepId>(
+class StepDetailsIterator<T : StepId>(
     val journeyData: JourneyData,
-    val steps: Set<Step<T>>,
-    val initialStepId: T,
-    val validator: Validator,
-) : Iterable<StepDetails<T>> {
-    override fun iterator(): Iterator<StepDetails<T>> = JourneyIterator(journeyData, steps, initialStepId, validator)
-}
-
-class JourneyIterator<T : StepId>(
-    val journeyData: JourneyData,
-    val steps: Set<Step<T>>,
+    val steps: Iterable<Step<T>>,
     val initialStepId: T,
     val validator: Validator,
 ) : Iterator<StepDetails<T>> {

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/Journey.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/Journey.kt
@@ -7,7 +7,6 @@ import org.springframework.web.server.ResponseStatusException
 import org.springframework.web.util.UriComponentsBuilder
 import uk.gov.communities.prsdb.webapp.constants.enums.JourneyType
 import uk.gov.communities.prsdb.webapp.constants.enums.TaskStatus
-import uk.gov.communities.prsdb.webapp.exceptions.PrsdbWebException
 import uk.gov.communities.prsdb.webapp.forms.steps.Step
 import uk.gov.communities.prsdb.webapp.forms.steps.StepDetails
 import uk.gov.communities.prsdb.webapp.forms.steps.StepId
@@ -172,43 +171,5 @@ abstract class Journey<T : StepId>(
     ): List<JourneySection<T>> = listOf(JourneySection.withOneTask(JourneyTask(initialStepId, steps)))
 
     override fun iterator(): Iterator<StepDetails<T>> =
-        StepDetailsIterator(journeyDataService.getJourneyDataFromSession(), steps, initialStepId, validator)
-}
-
-class StepDetailsIterator<T : StepId>(
-    val journeyData: JourneyData,
-    val steps: Iterable<Step<T>>,
-    val initialStepId: T,
-    val validator: Validator,
-) : Iterator<StepDetails<T>> {
-    lateinit var currentStepDetails: StepDetails<T>
-
-    override fun hasNext(): Boolean {
-        if (!this::currentStepDetails.isInitialized) return steps.count { step -> step.id == initialStepId } == 1
-        val pageData = JourneyDataHelper.getPageData(journeyData, currentStepDetails.step.name, currentStepDetails.subPageNumber)
-        if (pageData == null || !currentStepDetails.step.isSatisfied(validator, pageData)) {
-            return false
-        }
-
-        return currentStepDetails.step.nextAction(journeyData, currentStepDetails.subPageNumber).first != null
-    }
-
-    override fun next(): StepDetails<T> {
-        if (!this::currentStepDetails.isInitialized) {
-            currentStepDetails = StepDetails(steps.single { step -> step.id == initialStepId }, null, mutableMapOf())
-        } else {
-            val pageData = JourneyDataHelper.getPageData(journeyData, currentStepDetails.step.name, currentStepDetails.subPageNumber)
-            if (pageData == null || !currentStepDetails.step.isSatisfied(validator, pageData)) {
-                throw PrsdbWebException("Does not have next")
-            }
-            val stepData = JourneyDataHelper.getPageData(journeyData, currentStepDetails.step.name, null)
-            currentStepDetails.filteredJourneyData[currentStepDetails.step.name] = stepData
-
-            val (nextStepId, nextSubPageNumber) = currentStepDetails.step.nextAction(journeyData, currentStepDetails.subPageNumber)
-            if (nextStepId == null) throw PrsdbWebException("Does not have next")
-            val nextStep = steps.single { step -> step.id == nextStepId }
-            currentStepDetails = StepDetails(nextStep, nextSubPageNumber, currentStepDetails.filteredJourneyData)
-        }
-        return currentStepDetails
-    }
+        ReachableStepDetailsIterator(journeyDataService.getJourneyDataFromSession(), steps, initialStepId, validator)
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/ReachableStepDetailsIterator.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/ReachableStepDetailsIterator.kt
@@ -36,24 +36,13 @@ class ReachableStepDetailsIterator<T : StepId>(
     }
 
     private fun initialStepDetails() =
-        steps.singleOrNull { step -> step.id == initialStepId }.let {
-            if (it == null) {
-                throw NoSuchElementException("Journey does not have initial step")
-            } else {
-                val nextFilteredJourneyData = subsequentFilteredJourneyData(currentFilteredJourneyData, it.name)
-                StepDetails(it, null, nextFilteredJourneyData.toMutableMap())
-            }
-        }
-
-    private fun getInitialStepDetailsProcedural(): StepDetails<T> {
-        val initialStepOrNull = steps.singleOrNull { step -> step.id == initialStepId }
-        if (initialStepOrNull == null) {
-            throw NoSuchElementException("Journey does not have initial step")
-        }
-
-        val nextFilteredJourneyData = subsequentFilteredJourneyData(currentFilteredJourneyData, initialStepOrNull.name)
-        return StepDetails(initialStepOrNull, null, nextFilteredJourneyData.toMutableMap())
-    }
+        steps.singleOrNull { step -> step.id == initialStepId }?.let {
+            StepDetails(
+                it,
+                null,
+                subsequentFilteredJourneyData(currentFilteredJourneyData, it.name).toMutableMap(),
+            )
+        } ?: throw NoSuchElementException("Journey does not have initial step")
 
     private fun subsequentStepDetails(currentStep: StepDetails<T>): StepDetails<T> {
         if (!isStepSatisfied(currentStep)) {

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/ReachableStepDetailsIterator.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/ReachableStepDetailsIterator.kt
@@ -13,6 +13,7 @@ class ReachableStepDetailsIterator<T : StepId>(
     private val validator: Validator,
 ) : Iterator<StepDetails<T>> {
     private lateinit var currentStepDetails: StepDetails<T>
+    private var currentFilteredJourneyData: Map<String, Any?> = mapOf()
     private val immutableJourneyData = journeyData.toMap()
 
     override fun hasNext(): Boolean {
@@ -38,7 +39,7 @@ class ReachableStepDetailsIterator<T : StepId>(
             if (it == null) {
                 throw NoSuchElementException("Journey does not have initial step")
             } else {
-                StepDetails(it, null, mutableMapOf())
+                StepDetails(it, null, currentFilteredJourneyData.toMutableMap())
             }
         }
 
@@ -60,7 +61,7 @@ class ReachableStepDetailsIterator<T : StepId>(
     }
 
     private fun subsequentStepDetailsOrNull(currentStep: StepDetails<T>): StepDetails<T>? {
-        val filteredJourneyData = subsequentFilteredJourneyData(currentStep.filteredJourneyData)
+        currentFilteredJourneyData = subsequentFilteredJourneyData(currentFilteredJourneyData)
 
         val (nextStepId, nextSubPageNumber) =
             currentStep.step.nextAction(
@@ -72,7 +73,7 @@ class ReachableStepDetailsIterator<T : StepId>(
         if (nextStep == null) {
             return null
         }
-        return StepDetails(nextStep, nextSubPageNumber, filteredJourneyData.toMutableMap())
+        return StepDetails(nextStep, nextSubPageNumber, currentFilteredJourneyData.toMutableMap())
     }
 
     private fun subsequentFilteredJourneyData(filteredJourneyData: Map<String, Any?>): Map<String, Any?> {

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/ReachableStepDetailsIterator.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/ReachableStepDetailsIterator.kt
@@ -1,0 +1,46 @@
+package uk.gov.communities.prsdb.webapp.forms.journeys
+
+import org.springframework.validation.Validator
+import uk.gov.communities.prsdb.webapp.exceptions.PrsdbWebException
+import uk.gov.communities.prsdb.webapp.forms.steps.Step
+import uk.gov.communities.prsdb.webapp.forms.steps.StepDetails
+import uk.gov.communities.prsdb.webapp.forms.steps.StepId
+import uk.gov.communities.prsdb.webapp.helpers.JourneyDataHelper
+
+class ReachableStepDetailsIterator<T : StepId>(
+    val journeyData: JourneyData,
+    val steps: Iterable<Step<T>>,
+    val initialStepId: T,
+    val validator: Validator,
+) : Iterator<StepDetails<T>> {
+    lateinit var currentStepDetails: StepDetails<T>
+
+    override fun hasNext(): Boolean {
+        if (!this::currentStepDetails.isInitialized) return steps.count { step -> step.id == initialStepId } == 1
+        val pageData = JourneyDataHelper.getPageData(journeyData, currentStepDetails.step.name, currentStepDetails.subPageNumber)
+        if (pageData == null || !currentStepDetails.step.isSatisfied(validator, pageData)) {
+            return false
+        }
+
+        return currentStepDetails.step.nextAction(journeyData, currentStepDetails.subPageNumber).first != null
+    }
+
+    override fun next(): StepDetails<T> {
+        if (!this::currentStepDetails.isInitialized) {
+            currentStepDetails = StepDetails(steps.single { step -> step.id == initialStepId }, null, mutableMapOf())
+        } else {
+            val pageData = JourneyDataHelper.getPageData(journeyData, currentStepDetails.step.name, currentStepDetails.subPageNumber)
+            if (pageData == null || !currentStepDetails.step.isSatisfied(validator, pageData)) {
+                throw PrsdbWebException("Does not have next")
+            }
+            val stepData = JourneyDataHelper.getPageData(journeyData, currentStepDetails.step.name, null)
+            currentStepDetails.filteredJourneyData[currentStepDetails.step.name] = stepData
+
+            val (nextStepId, nextSubPageNumber) = currentStepDetails.step.nextAction(journeyData, currentStepDetails.subPageNumber)
+            if (nextStepId == null) throw PrsdbWebException("Does not have next")
+            val nextStep = steps.single { step -> step.id == nextStepId }
+            currentStepDetails = StepDetails(nextStep, nextSubPageNumber, currentStepDetails.filteredJourneyData)
+        }
+        return currentStepDetails
+    }
+}

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/UpdateLandlordDetailsJourney.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/UpdateLandlordDetailsJourney.kt
@@ -98,18 +98,16 @@ class UpdateLandlordDetailsJourney(
         if (journeyData[ORIGINAL_LANDLORD_DATA_KEY] == null) {
             UpdateDetailsStepId.UpdateDetails.urlPathSegment
         } else {
-            getLastReachableStep(journeyData)!!.step.id.urlPathSegment
+            last().step.id.urlPathSegment
         }
 
-    override fun getPrevStep(
-        journeyData: JourneyData,
-        targetStep: Step<UpdateDetailsStepId>,
-        targetSubPageNumber: Int?,
-    ): StepDetails<UpdateDetailsStepId>? {
-        val originalLandlordData = JourneyDataHelper.getPageData(journeyData, ORIGINAL_LANDLORD_DATA_KEY) ?: return null
+    override fun iterator(): Iterator<StepDetails<UpdateDetailsStepId>> {
+        val journeyData = journeyDataService.getJourneyDataFromSession()
+        val originalLandlordData =
+            JourneyDataHelper.getPageData(journeyData, ORIGINAL_LANDLORD_DATA_KEY)
+                ?: return StepDetailsIterator(journeyData, steps, initialStepId, validator)
         val updatedLandlordData = getUpdatedLandlordData(journeyData, originalLandlordData)
-
-        return super.getPrevStep(updatedLandlordData, targetStep, targetSubPageNumber)
+        return StepDetailsIterator(updatedLandlordData, steps, initialStepId, validator)
     }
 
     private fun getUpdatedLandlordData(

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/UpdateLandlordDetailsJourney.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/UpdateLandlordDetailsJourney.kt
@@ -105,9 +105,9 @@ class UpdateLandlordDetailsJourney(
         val journeyData = journeyDataService.getJourneyDataFromSession()
         val originalLandlordData =
             JourneyDataHelper.getPageData(journeyData, ORIGINAL_LANDLORD_DATA_KEY)
-                ?: return StepDetailsIterator(journeyData, steps, initialStepId, validator)
+                ?: return ReachableStepDetailsIterator(journeyData, steps, initialStepId, validator)
         val updatedLandlordData = getUpdatedLandlordData(journeyData, originalLandlordData)
-        return StepDetailsIterator(updatedLandlordData, steps, initialStepId, validator)
+        return ReachableStepDetailsIterator(updatedLandlordData, steps, initialStepId, validator)
     }
 
     private fun getUpdatedLandlordData(

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/JourneyDataService.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/JourneyDataService.kt
@@ -22,17 +22,9 @@ class JourneyDataService(
     private val oneLoginUserRepository: OneLoginUserRepository,
     private val objectMapper: ObjectMapper,
 ) {
-    var journeyDataCache: Map<String, Any?>? = null
-
-    fun getJourneyDataFromSession(): JourneyData {
-        if (journeyDataCache == null) {
-            journeyDataCache = objectToStringKeyedMap(session.getAttribute("journeyData"))?.toMap() ?: mapOf()
-        }
-        return journeyDataCache!!.toMutableMap()
-    }
+    fun getJourneyDataFromSession(): JourneyData = objectToStringKeyedMap(session.getAttribute("journeyData")) ?: mutableMapOf()
 
     fun setJourneyData(journeyData: JourneyData) {
-        journeyDataCache = journeyData.toMap()
         session.setAttribute("journeyData", journeyData)
     }
 
@@ -95,7 +87,6 @@ class JourneyDataService(
     }
 
     fun clearJourneyDataFromSession() {
-        journeyDataCache = null
         session.setAttribute("journeyData", null)
     }
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/JourneyDataService.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/JourneyDataService.kt
@@ -22,9 +22,17 @@ class JourneyDataService(
     private val oneLoginUserRepository: OneLoginUserRepository,
     private val objectMapper: ObjectMapper,
 ) {
-    fun getJourneyDataFromSession(): JourneyData = objectToStringKeyedMap(session.getAttribute("journeyData")) ?: mutableMapOf()
+    var journeyDataCache: Map<String, Any?>? = null
+
+    fun getJourneyDataFromSession(): JourneyData {
+        if (journeyDataCache == null) {
+            journeyDataCache = objectToStringKeyedMap(session.getAttribute("journeyData"))?.toMap() ?: mapOf()
+        }
+        return journeyDataCache!!.toMutableMap()
+    }
 
     fun setJourneyData(journeyData: JourneyData) {
+        journeyDataCache = journeyData.toMap()
         session.setAttribute("journeyData", journeyData)
     }
 
@@ -87,6 +95,7 @@ class JourneyDataService(
     }
 
     fun clearJourneyDataFromSession() {
+        journeyDataCache = null
         session.setAttribute("journeyData", null)
     }
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/ReachableStepDetailsIteratorTest.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/ReachableStepDetailsIteratorTest.kt
@@ -1,0 +1,395 @@
+package uk.gov.communities.prsdb.webapp.forms.journeys
+
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.mockito.Mockito.mock
+import uk.gov.communities.prsdb.webapp.forms.steps.Step
+import uk.gov.communities.prsdb.webapp.forms.steps.StepId
+import kotlin.test.assertEquals
+
+class ReachableStepDetailsIteratorTest {
+    @Nested
+    inner class HasNextTests {
+        @Test
+        fun `hasNext returns false if the journey is completed and the current step is the last step`() {
+            // Arrange
+            val testIterator =
+                TestIteratorBuilder()
+                    .initialised()
+                    .addStepToEnd(TestStepModel("1"))
+                    .build()
+
+            // Act && assert
+            assertFalse(testIterator.hasNext())
+        }
+
+        @Test
+        fun `hasNext returns false if the current step hasn't been completed`() {
+            // Arrange
+            val testIterator =
+                TestIteratorBuilder()
+                    .initialised()
+                    .addStepToEndWithoutJourneyData(TestStepModel("1", isSatisfied = true))
+                    .addStepToEndWithoutJourneyData(TestStepModel("2", isSatisfied = true))
+                    .build()
+
+            // Act && assert
+            assertFalse(testIterator.hasNext())
+        }
+
+        @Test
+        fun `hasNext returns false if the current step has been completed with invalid data`() {
+            // Arrange
+            val testIterator =
+                TestIteratorBuilder()
+                    .initialised()
+                    .addStepToEnd(TestStepModel("1", isSatisfied = false))
+                    .addStepToEnd(TestStepModel("2", isSatisfied = false))
+                    .build()
+
+            // Act && assert
+            assertFalse(testIterator.hasNext())
+        }
+
+        @Test
+        fun `hasNext returns true if the current step has been completed with valid data and isn't the last step in the journey`() {
+            // Arrange
+            val testIterator =
+                TestIteratorBuilder()
+                    .initialised()
+                    .addStepToEnd(TestStepModel("1", isSatisfied = true))
+                    .addStepToEnd(TestStepModel("2", isSatisfied = false))
+                    .build()
+
+            // Act && assert
+            assertTrue(testIterator.hasNext())
+        }
+
+        @Test
+        fun `hasNext returns false if it hasn't been initialised and there is no initial step`() {
+            // Arrange
+            val testIterator =
+                TestIteratorBuilder()
+                    .withMissingFirstStep()
+                    .addStepToEnd(TestStepModel("1", isSatisfied = true))
+                    .addStepToEnd(TestStepModel("2", isSatisfied = false))
+                    .withMissingFirstStep()
+                    .build()
+
+            // Act && assert
+            assertFalse(testIterator.hasNext())
+        }
+
+        @Test
+        fun `hasNext returns false if it hasn't been initialised and there are multiple initial steps`() {
+            // Arrange
+            val testIterator =
+                TestIteratorBuilder()
+                    .addStepToEnd(TestStepModel("1", isSatisfied = true))
+                    .addStepToEnd(TestStepModel("2", isSatisfied = false))
+                    .addStepToEnd(TestStepModel("1", isSatisfied = true))
+                    .build()
+
+            // Act && assert
+            assertFalse(testIterator.hasNext())
+        }
+
+        @Test
+        fun `hasNext returns true if it hasn't been initialised and there is a valid initial step`() {
+            // Arrange
+            val testIterator =
+                TestIteratorBuilder()
+                    .addStepToEnd(TestStepModel("1", isSatisfied = true))
+                    .addStepToEnd(TestStepModel("2", isSatisfied = false))
+                    .build()
+
+            // Act && assert
+            assertTrue(testIterator.hasNext())
+        }
+    }
+
+    @Nested
+    inner class NextTests {
+        @Test
+        fun `next returns the initial step if it hasn't been initialised`() {
+            // Arrange
+            val firstUrlSegment = "test step id"
+            val testIterator =
+                TestIteratorBuilder()
+                    .addStepToEnd(TestStepModel(firstUrlSegment, isSatisfied = true))
+                    .addStepToEnd(TestStepModel("2", isSatisfied = false))
+                    .build()
+
+            // Act && assert
+            assertEquals(TestStepId(firstUrlSegment), testIterator.next().step.id)
+        }
+
+        @Test
+        fun `next returns the the current step's next action if it has initialised`() {
+            // Arrange
+            val subsequentUrlSegment = "test step id"
+            val testIterator =
+                TestIteratorBuilder()
+                    .initialised()
+                    .addStepToEnd(TestStepModel("1", isSatisfied = true))
+                    .addStepToEnd(TestStepModel(subsequentUrlSegment, isSatisfied = false))
+                    .build()
+
+            // Act
+            val nextStepDetails = testIterator.next()
+
+            // Assert
+            assertEquals(TestStepId(subsequentUrlSegment), nextStepDetails.step.id)
+        }
+
+        @Test
+        fun `next adds the current step's data to the filtered journey data of the next step`() {
+            // Arrange
+            val currentStepModel = TestStepModel("1", isSatisfied = true)
+            val builder =
+                TestIteratorBuilder()
+                    .onStep(1)
+                    .addStepToEnd(currentStepModel)
+                    .addStepToEnd(TestStepModel("2", isSatisfied = true))
+            val pageDataForStep = builder.getDataForStep(currentStepModel.urlPathSegment)
+
+            val testIterator = builder.build()
+
+            // Act
+            val nextStepDetails = testIterator.next()
+
+            // Assert
+            assertEquals(pageDataForStep, nextStepDetails.filteredJourneyData[currentStepModel.urlPathSegment])
+        }
+
+        @Test
+        fun `next does not add the next step's data to the filtered journey data of the next step`() {
+            // Arrange
+            val stepModel = TestStepModel("1", isSatisfied = true)
+            val builder = TestIteratorBuilder().addStepToEnd(stepModel)
+
+            val testIterator = builder.build()
+
+            // Act
+            val nextStepDetails = testIterator.next()
+
+            // Assert
+            assertNull(nextStepDetails.filteredJourneyData[stepModel.urlPathSegment])
+        }
+
+        @Test
+        fun `next does not change any of the filtered journey data except the for the current steps data`() {
+            // Arrange
+            val builder =
+                TestIteratorBuilder()
+                    .onStep(4)
+                    .addStepToEnd(TestStepModel("1", isSatisfied = true))
+                    .addStepToEnd(TestStepModel("2", isSatisfied = true))
+                    .addStepToEnd(TestStepModel("3", isSatisfied = true))
+                    .addStepToEnd(TestStepModel("4", isSatisfied = true))
+                    .addStepToEnd(TestStepModel("5", isSatisfied = true))
+                    .addStepToEnd(TestStepModel("6", isSatisfied = true))
+
+            val testIterator = builder.build()
+
+            // Act
+            val currentStepDetails = testIterator.next()
+            val nextStepDetails = testIterator.next()
+
+            // Assert
+            val previousFilteredJourneyData = currentStepDetails.filteredJourneyData
+            for (key in previousFilteredJourneyData.keys) {
+                if (key != nextStepDetails.step.id.urlPathSegment) {
+                    assertEquals(previousFilteredJourneyData[key], nextStepDetails.filteredJourneyData[key])
+                }
+            }
+        }
+
+        @Test
+        fun `next throws an exception if the current step does not have valid data`() {
+            // Arrange
+            val testIterator =
+                TestIteratorBuilder()
+                    .initialised()
+                    .addStepToEnd(TestStepModel("1", isSatisfied = false))
+                    .addStepToEnd(TestStepModel("2", isSatisfied = false))
+                    .build()
+
+            // Act && assert
+            assertThrows<NoSuchElementException> { testIterator.next() }
+        }
+
+        @Test
+        fun `next throws an exception if the current step does not have a next action`() {
+            // Arrange
+            val testIterator =
+                TestIteratorBuilder()
+                    .initialised()
+                    .addStepToEnd(TestStepModel("1"))
+                    .build()
+
+            // Act && assert
+            assertThrows<NoSuchElementException> { testIterator.next() }
+        }
+    }
+
+    @Nested
+    inner class ImmutableJourneyDataTests {
+        @Test
+        fun `Changing the initialising journey data after the iterator is created does not change the iterator`() {
+            // Arrange
+            val previousModel = TestStepModel("1")
+            val builder =
+                TestIteratorBuilder()
+                    .onStep(2)
+                    .addStepToEnd(previousModel)
+                    .addStepToEnd(TestStepModel("2"))
+                    .addStepToEnd(TestStepModel("3"))
+
+            val testIterator = builder.build()
+
+            // Act
+            builder.clearJourneyData()
+            val testStepDetails = testIterator.next()
+
+            // Assert
+            assertTrue(testStepDetails.filteredJourneyData.containsKey(previousModel.urlPathSegment))
+        }
+
+        @Test
+        fun `Changing the current step's filtered journey data does not affect the next step's journey data`() {
+            // Arrange
+            val previousModel = TestStepModel("1")
+            val testIterator =
+                TestIteratorBuilder()
+                    .onStep(1)
+                    .addStepToEnd(previousModel)
+                    .addStepToEnd(TestStepModel("2"))
+                    .addStepToEnd(TestStepModel("3"))
+                    .build()
+            val currentStepDetails = testIterator.next()
+
+            // Act
+            currentStepDetails.filteredJourneyData.clear()
+            val nextStepDetails = testIterator.next()
+
+            // Assert
+            assertTrue(nextStepDetails.filteredJourneyData.containsKey(previousModel.urlPathSegment))
+        }
+
+        @Test
+        fun `If a nextStep function updates the journey data, that does not affect the next step's journey data`() {
+            // Arrange
+            val previousModel = TestStepModel("1")
+            val testIterator =
+                TestIteratorBuilder()
+                    .onStep(2)
+                    .addStepToEnd(previousModel)
+                    .addStepToEnd(TestStepModel("2", customNextActionAddition = { journeyData -> journeyData.clear() }))
+                    .addStepToEnd(TestStepModel("3"))
+                    .build()
+
+            // Act
+            val nextStepDetails = testIterator.next()
+
+            // Assert
+            assertTrue(nextStepDetails.filteredJourneyData.containsKey(previousModel.urlPathSegment))
+        }
+    }
+}
+
+data class TestStepId(
+    override val urlPathSegment: String,
+) : StepId
+
+data class TestStepModel(
+    val urlPathSegment: String,
+    val isSatisfied: Boolean = true,
+    val customNextActionAddition: ((JourneyData) -> Unit)? = null,
+)
+
+class TestIteratorBuilder {
+    private var initialised = false
+    private val steps: MutableList<TestStepModel> = mutableListOf()
+    private val journeyData: JourneyData = mutableMapOf()
+    private var missingFirstStep: Boolean = false
+    private var onStep: Int? = null
+
+    fun initialised(): TestIteratorBuilder {
+        initialised = true
+        return this
+    }
+
+    fun onStep(step: Int): TestIteratorBuilder {
+        onStep = step
+        return this
+    }
+
+    fun withMissingFirstStep(): TestIteratorBuilder {
+        missingFirstStep = true
+        return this
+    }
+
+    fun addStepToEnd(stepModel: TestStepModel): TestIteratorBuilder {
+        journeyData[stepModel.urlPathSegment] = mapOf("urlPathSegment" to stepModel.urlPathSegment, "isSatisfied" to stepModel.isSatisfied)
+        return addStepToEndWithoutJourneyData(stepModel)
+    }
+
+    fun addStepToEndWithoutJourneyData(stepModel: TestStepModel): TestIteratorBuilder {
+        steps.add(stepModel)
+        return this
+    }
+
+    fun build(): ReachableStepDetailsIterator<TestStepId> {
+        val linkedSteps =
+            steps.zipWithNext {
+                    stepModel,
+                    nextStepModel,
+                ->
+                testStep(stepModel.urlPathSegment, nextStepModel.urlPathSegment, stepModel.isSatisfied, stepModel.customNextActionAddition)
+            } + testStep(steps.last().urlPathSegment, isSatisfied = steps.last().isSatisfied)
+
+        val firstStepId =
+            if (missingFirstStep) {
+                // A concatenation of all strings in a list cannot be contained by the list
+                TestStepId(steps.joinToString { it.urlPathSegment })
+            } else {
+                TestStepId(steps.first().urlPathSegment)
+            }
+
+        val iterator = ReachableStepDetailsIterator(journeyData, linkedSteps, firstStepId, mock())
+
+        val currentOnStep = onStep
+        if (currentOnStep != null) {
+            repeat(currentOnStep) { iterator.next() }
+        } else if (initialised) {
+            iterator.next()
+        }
+
+        return iterator
+    }
+
+    private fun testStep(
+        urlPathSegment: String,
+        nextSegment: String? = null,
+        isSatisfied: Boolean = true,
+        customNextActionAddition: ((JourneyData) -> Unit)? = null,
+    ) = Step(
+        TestStepId(urlPathSegment),
+        mock(),
+        handleSubmitAndRedirect = null,
+        isSatisfied = { _, _ -> isSatisfied },
+        nextAction = { journeyData, _ ->
+            customNextActionAddition?.invoke(journeyData)
+            Pair(nextSegment?.let { TestStepId(it) }, null)
+        },
+    )
+
+    fun getDataForStep(urlPathSegment: String): Any? = journeyData[urlPathSegment]
+
+    fun clearJourneyData() = journeyData.clear()
+}

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/ReachableStepDetailsIteratorTest.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/ReachableStepDetailsIteratorTest.kt
@@ -1,7 +1,6 @@
 package uk.gov.communities.prsdb.webapp.forms.journeys
 
 import org.junit.jupiter.api.Assertions.assertFalse
-import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -149,14 +148,14 @@ class ReachableStepDetailsIteratorTest {
         }
 
         @Test
-        fun `next adds the current step's data to the filtered journey data of the next step`() {
+        fun `next adds the next step's data to the filtered journey data of the next step`() {
             // Arrange
-            val currentStepModel = TestStepModel("1", isSatisfied = true)
+            val currentStepModel = TestStepModel("2", isSatisfied = true)
             val builder =
                 TestIteratorBuilder()
                     .onStep(1)
+                    .addStepToEnd(TestStepModel("1", isSatisfied = true))
                     .addStepToEnd(currentStepModel)
-                    .addStepToEnd(TestStepModel("2", isSatisfied = true))
             val pageDataForStep = builder.getDataForStep(currentStepModel.urlPathSegment)
 
             val testIterator = builder.build()
@@ -166,21 +165,6 @@ class ReachableStepDetailsIteratorTest {
 
             // Assert
             assertEquals(pageDataForStep, nextStepDetails.filteredJourneyData[currentStepModel.urlPathSegment])
-        }
-
-        @Test
-        fun `next does not add the next step's data to the filtered journey data of the next step`() {
-            // Arrange
-            val stepModel = TestStepModel("1", isSatisfied = true)
-            val builder = TestIteratorBuilder().addStepToEnd(stepModel)
-
-            val testIterator = builder.build()
-
-            // Act
-            val nextStepDetails = testIterator.next()
-
-            // Assert
-            assertNull(nextStepDetails.filteredJourneyData[stepModel.urlPathSegment])
         }
 
         @Test

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/ReachableStepDetailsIteratorTest.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/ReachableStepDetailsIteratorTest.kt
@@ -6,10 +6,12 @@ import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
-import org.mockito.Mockito.mock
-import uk.gov.communities.prsdb.webapp.forms.steps.Step
 import uk.gov.communities.prsdb.webapp.forms.steps.StepId
 import kotlin.test.assertEquals
+
+data class TestStepId(
+    override val urlPathSegment: String,
+) : StepId
 
 class ReachableStepDetailsIteratorTest {
     @Nested
@@ -300,96 +302,4 @@ class ReachableStepDetailsIteratorTest {
             assertTrue(nextStepDetails.filteredJourneyData.containsKey(previousModel.urlPathSegment))
         }
     }
-}
-
-data class TestStepId(
-    override val urlPathSegment: String,
-) : StepId
-
-data class TestStepModel(
-    val urlPathSegment: String,
-    val isSatisfied: Boolean = true,
-    val customNextActionAddition: ((JourneyData) -> Unit)? = null,
-)
-
-class TestIteratorBuilder {
-    private var initialised = false
-    private val steps: MutableList<TestStepModel> = mutableListOf()
-    private val journeyData: JourneyData = mutableMapOf()
-    private var missingFirstStep: Boolean = false
-    private var onStep: Int? = null
-
-    fun initialised(): TestIteratorBuilder {
-        initialised = true
-        return this
-    }
-
-    fun onStep(step: Int): TestIteratorBuilder {
-        onStep = step
-        return this
-    }
-
-    fun withMissingFirstStep(): TestIteratorBuilder {
-        missingFirstStep = true
-        return this
-    }
-
-    fun addStepToEnd(stepModel: TestStepModel): TestIteratorBuilder {
-        journeyData[stepModel.urlPathSegment] = mapOf("urlPathSegment" to stepModel.urlPathSegment, "isSatisfied" to stepModel.isSatisfied)
-        return addStepToEndWithoutJourneyData(stepModel)
-    }
-
-    fun addStepToEndWithoutJourneyData(stepModel: TestStepModel): TestIteratorBuilder {
-        steps.add(stepModel)
-        return this
-    }
-
-    fun build(): ReachableStepDetailsIterator<TestStepId> {
-        val linkedSteps =
-            steps.zipWithNext {
-                    stepModel,
-                    nextStepModel,
-                ->
-                testStep(stepModel.urlPathSegment, nextStepModel.urlPathSegment, stepModel.isSatisfied, stepModel.customNextActionAddition)
-            } + testStep(steps.last().urlPathSegment, isSatisfied = steps.last().isSatisfied)
-
-        val firstStepId =
-            if (missingFirstStep) {
-                // A concatenation of all strings in a list cannot be contained by the list
-                TestStepId(steps.joinToString { it.urlPathSegment })
-            } else {
-                TestStepId(steps.first().urlPathSegment)
-            }
-
-        val iterator = ReachableStepDetailsIterator(journeyData, linkedSteps, firstStepId, mock())
-
-        val currentOnStep = onStep
-        if (currentOnStep != null) {
-            repeat(currentOnStep) { iterator.next() }
-        } else if (initialised) {
-            iterator.next()
-        }
-
-        return iterator
-    }
-
-    private fun testStep(
-        urlPathSegment: String,
-        nextSegment: String? = null,
-        isSatisfied: Boolean = true,
-        customNextActionAddition: ((JourneyData) -> Unit)? = null,
-    ) = Step(
-        TestStepId(urlPathSegment),
-        mock(),
-        handleSubmitAndRedirect = null,
-        isSatisfied = { _, _ -> isSatisfied },
-        nextAction = { journeyData, _ ->
-            customNextActionAddition?.invoke(journeyData)
-            Pair(nextSegment?.let { TestStepId(it) }, null)
-        },
-    )
-
-    fun getDataForStep(urlPathSegment: String): Any? = journeyData[urlPathSegment]
-
-    fun clearJourneyData() = journeyData.clear()
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/ReachableStepDetailsIteratorTest.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/ReachableStepDetailsIteratorTest.kt
@@ -21,7 +21,7 @@ class ReachableStepDetailsIteratorTest {
             val testIterator =
                 TestIteratorBuilder()
                     .initialised()
-                    .addStepToEnd(TestStepModel("1"))
+                    .withFirstStep(TestStepModel("1"))
                     .build()
 
             // Act && assert
@@ -33,9 +33,10 @@ class ReachableStepDetailsIteratorTest {
             // Arrange
             val testIterator =
                 TestIteratorBuilder()
-                    .initialised()
-                    .addStepToEndWithoutJourneyData(TestStepModel("1", isSatisfied = true))
-                    .addStepToEndWithoutJourneyData(TestStepModel("2", isSatisfied = true))
+                    .onStep(2)
+                    .withFirstStep(TestStepModel("1", isSatisfied = true))
+                    .withNextStepWithoutPageData(TestStepModel("2", isSatisfied = true))
+                    .withNextStepWithoutPageData(TestStepModel("3", isSatisfied = true))
                     .build()
 
             // Act && assert
@@ -48,8 +49,8 @@ class ReachableStepDetailsIteratorTest {
             val testIterator =
                 TestIteratorBuilder()
                     .initialised()
-                    .addStepToEnd(TestStepModel("1", isSatisfied = false))
-                    .addStepToEnd(TestStepModel("2", isSatisfied = false))
+                    .withFirstStep(TestStepModel("1", isSatisfied = false))
+                    .withNextStep(TestStepModel("2", isSatisfied = false))
                     .build()
 
             // Act && assert
@@ -62,8 +63,8 @@ class ReachableStepDetailsIteratorTest {
             val testIterator =
                 TestIteratorBuilder()
                     .initialised()
-                    .addStepToEnd(TestStepModel("1", isSatisfied = true))
-                    .addStepToEnd(TestStepModel("2", isSatisfied = false))
+                    .withFirstStep(TestStepModel("1", isSatisfied = true))
+                    .withNextStep(TestStepModel("2", isSatisfied = false))
                     .build()
 
             // Act && assert
@@ -75,10 +76,8 @@ class ReachableStepDetailsIteratorTest {
             // Arrange
             val testIterator =
                 TestIteratorBuilder()
-                    .withMissingFirstStep()
-                    .addStepToEnd(TestStepModel("1", isSatisfied = true))
-                    .addStepToEnd(TestStepModel("2", isSatisfied = false))
-                    .withMissingFirstStep()
+                    .withNextStep(TestStepModel("1", isSatisfied = true))
+                    .withNextStep(TestStepModel("2", isSatisfied = false))
                     .build()
 
             // Act && assert
@@ -88,11 +87,12 @@ class ReachableStepDetailsIteratorTest {
         @Test
         fun `hasNext returns false if it hasn't been initialised and there are multiple initial steps`() {
             // Arrange
+            val initialStepSegment = "initial step segment"
             val testIterator =
                 TestIteratorBuilder()
-                    .addStepToEnd(TestStepModel("1", isSatisfied = true))
-                    .addStepToEnd(TestStepModel("2", isSatisfied = false))
-                    .addStepToEnd(TestStepModel("1", isSatisfied = true))
+                    .withFirstStep(TestStepModel(initialStepSegment, isSatisfied = true))
+                    .withNextStep(TestStepModel("2", isSatisfied = false))
+                    .withNextStep(TestStepModel(initialStepSegment, isSatisfied = true))
                     .build()
 
             // Act && assert
@@ -104,8 +104,8 @@ class ReachableStepDetailsIteratorTest {
             // Arrange
             val testIterator =
                 TestIteratorBuilder()
-                    .addStepToEnd(TestStepModel("1", isSatisfied = true))
-                    .addStepToEnd(TestStepModel("2", isSatisfied = false))
+                    .withFirstStep(TestStepModel("1", isSatisfied = true))
+                    .withNextStep(TestStepModel("2", isSatisfied = false))
                     .build()
 
             // Act && assert
@@ -121,8 +121,8 @@ class ReachableStepDetailsIteratorTest {
             val firstUrlSegment = "test step id"
             val testIterator =
                 TestIteratorBuilder()
-                    .addStepToEnd(TestStepModel(firstUrlSegment, isSatisfied = true))
-                    .addStepToEnd(TestStepModel("2", isSatisfied = false))
+                    .withFirstStep(TestStepModel(firstUrlSegment, isSatisfied = true))
+                    .withNextStep(TestStepModel("2", isSatisfied = false))
                     .build()
 
             // Act && assert
@@ -136,8 +136,8 @@ class ReachableStepDetailsIteratorTest {
             val testIterator =
                 TestIteratorBuilder()
                     .initialised()
-                    .addStepToEnd(TestStepModel("1", isSatisfied = true))
-                    .addStepToEnd(TestStepModel(subsequentUrlSegment, isSatisfied = false))
+                    .withFirstStep(TestStepModel("1", isSatisfied = true))
+                    .withNextStep(TestStepModel(subsequentUrlSegment, isSatisfied = false))
                     .build()
 
             // Act
@@ -154,8 +154,8 @@ class ReachableStepDetailsIteratorTest {
             val builder =
                 TestIteratorBuilder()
                     .onStep(1)
-                    .addStepToEnd(TestStepModel("1", isSatisfied = true))
-                    .addStepToEnd(currentStepModel)
+                    .withFirstStep(TestStepModel("1", isSatisfied = true))
+                    .withNextStep(currentStepModel)
             val pageDataForStep = builder.getDataForStep(currentStepModel.urlPathSegment)
 
             val testIterator = builder.build()
@@ -173,12 +173,12 @@ class ReachableStepDetailsIteratorTest {
             val builder =
                 TestIteratorBuilder()
                     .onStep(4)
-                    .addStepToEnd(TestStepModel("1", isSatisfied = true))
-                    .addStepToEnd(TestStepModel("2", isSatisfied = true))
-                    .addStepToEnd(TestStepModel("3", isSatisfied = true))
-                    .addStepToEnd(TestStepModel("4", isSatisfied = true))
-                    .addStepToEnd(TestStepModel("5", isSatisfied = true))
-                    .addStepToEnd(TestStepModel("6", isSatisfied = true))
+                    .withFirstStep(TestStepModel("1", isSatisfied = true))
+                    .withNextStep(TestStepModel("2", isSatisfied = true))
+                    .withNextStep(TestStepModel("3", isSatisfied = true))
+                    .withNextStep(TestStepModel("4", isSatisfied = true))
+                    .withNextStep(TestStepModel("5", isSatisfied = true))
+                    .withNextStep(TestStepModel("6", isSatisfied = true))
 
             val testIterator = builder.build()
 
@@ -201,8 +201,8 @@ class ReachableStepDetailsIteratorTest {
             val testIterator =
                 TestIteratorBuilder()
                     .initialised()
-                    .addStepToEnd(TestStepModel("1", isSatisfied = false))
-                    .addStepToEnd(TestStepModel("2", isSatisfied = false))
+                    .withFirstStep(TestStepModel("1", isSatisfied = false))
+                    .withNextStep(TestStepModel("2", isSatisfied = false))
                     .build()
 
             // Act && assert
@@ -215,7 +215,7 @@ class ReachableStepDetailsIteratorTest {
             val testIterator =
                 TestIteratorBuilder()
                     .initialised()
-                    .addStepToEnd(TestStepModel("1"))
+                    .withFirstStep(TestStepModel("1"))
                     .build()
 
             // Act && assert
@@ -232,9 +232,9 @@ class ReachableStepDetailsIteratorTest {
             val builder =
                 TestIteratorBuilder()
                     .onStep(2)
-                    .addStepToEnd(previousModel)
-                    .addStepToEnd(TestStepModel("2"))
-                    .addStepToEnd(TestStepModel("3"))
+                    .withFirstStep(previousModel)
+                    .withNextStep(TestStepModel("2"))
+                    .withNextStep(TestStepModel("3"))
 
             val testIterator = builder.build()
 
@@ -253,9 +253,9 @@ class ReachableStepDetailsIteratorTest {
             val testIterator =
                 TestIteratorBuilder()
                     .onStep(1)
-                    .addStepToEnd(previousModel)
-                    .addStepToEnd(TestStepModel("2"))
-                    .addStepToEnd(TestStepModel("3"))
+                    .withFirstStep(previousModel)
+                    .withNextStep(TestStepModel("2"))
+                    .withNextStep(TestStepModel("3"))
                     .build()
             val currentStepDetails = testIterator.next()
 
@@ -274,9 +274,9 @@ class ReachableStepDetailsIteratorTest {
             val testIterator =
                 TestIteratorBuilder()
                     .onStep(2)
-                    .addStepToEnd(previousModel)
-                    .addStepToEnd(TestStepModel("2", customNextActionAddition = { journeyData -> journeyData.clear() }))
-                    .addStepToEnd(TestStepModel("3"))
+                    .withFirstStep(previousModel)
+                    .withNextStep(TestStepModel("2", customNextActionAddition = { journeyData -> journeyData.clear() }))
+                    .withNextStep(TestStepModel("3"))
                     .build()
 
             // Act

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/TestIteratorBuilder.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/TestIteratorBuilder.kt
@@ -1,0 +1,92 @@
+package uk.gov.communities.prsdb.webapp.forms.journeys
+
+import org.mockito.Mockito.mock
+import uk.gov.communities.prsdb.webapp.forms.steps.Step
+
+data class TestStepModel(
+    val urlPathSegment: String,
+    val isSatisfied: Boolean = true,
+    val customNextActionAddition: ((JourneyData) -> Unit)? = null,
+)
+
+class TestIteratorBuilder {
+    private var initialised = false
+    private val steps: MutableList<TestStepModel> = mutableListOf()
+    private val journeyData: JourneyData = mutableMapOf()
+    private var missingFirstStep: Boolean = false
+    private var onStep: Int? = null
+
+    fun initialised(): TestIteratorBuilder {
+        initialised = true
+        return this
+    }
+
+    fun onStep(step: Int): TestIteratorBuilder {
+        onStep = step
+        return this
+    }
+
+    fun withMissingFirstStep(): TestIteratorBuilder {
+        missingFirstStep = true
+        return this
+    }
+
+    fun addStepToEnd(stepModel: TestStepModel): TestIteratorBuilder {
+        journeyData[stepModel.urlPathSegment] = mapOf("urlPathSegment" to stepModel.urlPathSegment, "isSatisfied" to stepModel.isSatisfied)
+        return addStepToEndWithoutJourneyData(stepModel)
+    }
+
+    fun addStepToEndWithoutJourneyData(stepModel: TestStepModel): TestIteratorBuilder {
+        steps.add(stepModel)
+        return this
+    }
+
+    fun build(): ReachableStepDetailsIterator<TestStepId> {
+        val linkedSteps =
+            steps.zipWithNext {
+                    stepModel,
+                    nextStepModel,
+                ->
+                testStep(stepModel.urlPathSegment, nextStepModel.urlPathSegment, stepModel.isSatisfied, stepModel.customNextActionAddition)
+            } + testStep(steps.last().urlPathSegment, isSatisfied = steps.last().isSatisfied)
+
+        val firstStepId =
+            if (missingFirstStep) {
+                // A concatenation of all strings in a list cannot be contained by the list
+                TestStepId(steps.joinToString { it.urlPathSegment })
+            } else {
+                TestStepId(steps.first().urlPathSegment)
+            }
+
+        val iterator = ReachableStepDetailsIterator(journeyData, linkedSteps, firstStepId, mock())
+
+        val currentOnStep = onStep
+        if (currentOnStep != null) {
+            repeat(currentOnStep) { iterator.next() }
+        } else if (initialised) {
+            iterator.next()
+        }
+
+        return iterator
+    }
+
+    private fun testStep(
+        urlPathSegment: String,
+        nextSegment: String? = null,
+        isSatisfied: Boolean = true,
+        customNextActionAddition: ((JourneyData) -> Unit)? = null,
+    ) = Step(
+        TestStepId(urlPathSegment),
+        mock(),
+        handleSubmitAndRedirect = null,
+        isSatisfied = { _, _ -> isSatisfied },
+        nextAction = { journeyData, _ ->
+            customNextActionAddition?.invoke(journeyData)
+            Pair(nextSegment?.let { TestStepId(it) }, null)
+        },
+    )
+
+    fun getDataForStep(urlPathSegment: String): Any? = journeyData[urlPathSegment]
+
+    fun clearJourneyData() = journeyData.clear()
+}


### PR DESCRIPTION
Turns `Journey` into an `Iterable<StepDetails>` by creating an `Iterator`. This massively simplifies functions that need to iterate through the journey, and lets us leverage kotlins built in iterable functionality.

 Draft because `StepDetailsIterator`...
* Should be in its own file
* Have more sensible exceptions
* Have explicit tests

To make `Journey` iterable, however, we need to get journey data from the `JourneyDataService` for each `Iterator` created. That in itself should be no problem, but I was worried about the potential performance hit of accessing data from the session multiple times so I've added an optional additional change to make `JourneyDataService` have a manual in-memory cache of the journey data.