### PR TITLE
Feat/prsd 797 update landlord phone number

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/database/entity/Landlord.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/database/entity/Landlord.kt
@@ -31,7 +31,6 @@ class Landlord() : ModifiableAuditableEntity() {
 
     @Column(nullable = false)
     lateinit var phoneNumber: String
-        private set
 
     @ManyToOne(optional = false)
     @JoinColumn(

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/UpdateLandlordDetailsJourney.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/UpdateLandlordDetailsJourney.kt
@@ -17,6 +17,7 @@ import uk.gov.communities.prsdb.webapp.models.dataModels.updateModels.LandlordUp
 import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.EmailFormModel
 import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.NameFormModel
 import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.NoInputFormModel
+import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.PhoneNumberFormModel
 import uk.gov.communities.prsdb.webapp.services.JourneyDataService
 import uk.gov.communities.prsdb.webapp.services.LandlordService
 
@@ -79,6 +80,29 @@ class UpdateLandlordDetailsJourney(
                         ),
                 ),
             handleSubmitAndRedirect = { _, _ -> UpdateDetailsStepId.UpdateDetails.urlPathSegment },
+            nextAction = { _, _ -> Pair(UpdateDetailsStepId.UpdatePhoneNumber, null) },
+            saveAfterSubmit = false,
+        )
+
+    private val phoneNumberStep =
+        Step(
+            id = UpdateDetailsStepId.UpdatePhoneNumber,
+            page =
+                Page(
+                    formModel = PhoneNumberFormModel::class,
+                    templateName = "forms/phoneNumberForm",
+                    content =
+                        mapOf(
+                            "title" to "forms.update.title",
+                            "fieldSetHeading" to "forms.update.phoneNumber.fieldSetHeading",
+                            "fieldSetHint" to "forms.phoneNumber.fieldSetHint",
+                            "label" to "forms.phoneNumber.label",
+                            "submitButtonText" to "forms.buttons.continue",
+                            "hint" to "forms.phoneNumber.hint",
+                            BACK_URL_ATTR_NAME to UpdateDetailsStepId.UpdateDetails.urlPathSegment,
+                        ),
+                ),
+            handleSubmitAndRedirect = { _, _ -> UpdateDetailsStepId.UpdateDetails.urlPathSegment },
             nextAction = { _, _ -> Pair(UpdateDetailsStepId.UpdateDetails, null) },
             saveAfterSubmit = false,
         )
@@ -90,6 +114,7 @@ class UpdateLandlordDetailsJourney(
             setOf(
                 emailStep,
                 nameStep,
+                phoneNumberStep,
                 updateDetailsStep,
             ),
         )
@@ -128,6 +153,7 @@ class UpdateLandlordDetailsJourney(
             LandlordUpdateModel(
                 email = UpdateLandlordDetailsJourneyDataHelper.getEmailUpdateIfPresent(journeyData),
                 fullName = UpdateLandlordDetailsJourneyDataHelper.getNameUpdateIfPresent(journeyData),
+                phoneNumber = UpdateLandlordDetailsJourneyDataHelper.getPhoneNumberIfPresent(journeyData),
             )
 
         landlordService.updateLandlordForBaseUserId(
@@ -153,6 +179,7 @@ class UpdateLandlordDetailsJourney(
         mutableMapOf(
             UpdateDetailsStepId.UpdateEmail.urlPathSegment to mutableMapOf("emailAddress" to landlord.email),
             UpdateDetailsStepId.UpdateName.urlPathSegment to mutableMapOf("name" to landlord.name),
+            UpdateDetailsStepId.UpdatePhoneNumber.urlPathSegment to mutableMapOf("phoneNumber" to landlord.phoneNumber),
         )
 
     companion object {

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/steps/UpdateDetailsStepId.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/steps/UpdateDetailsStepId.kt
@@ -7,5 +7,6 @@ enum class UpdateDetailsStepId(
 ) : StepId {
     UpdateEmail("email"),
     UpdateName("name"),
+    UpdatePhoneNumber("phone-number"),
     UpdateDetails(DETAILS_PATH_SEGMENT),
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/helpers/UpdateLandlordDetailsJourneyDataHelper.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/helpers/UpdateLandlordDetailsJourneyDataHelper.kt
@@ -18,5 +18,12 @@ class UpdateLandlordDetailsJourneyDataHelper : JourneyDataHelper() {
                 UpdateDetailsStepId.UpdateName.urlPathSegment,
                 "name",
             )
+
+        fun getPhoneNumberIfPresent(journeyData: JourneyData) =
+            getFieldStringValue(
+                journeyData,
+                UpdateDetailsStepId.UpdatePhoneNumber.urlPathSegment,
+                "phoneNumber",
+            )
     }
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/dataModels/updateModels/LandlordUpdateModel.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/dataModels/updateModels/LandlordUpdateModel.kt
@@ -3,4 +3,5 @@ package uk.gov.communities.prsdb.webapp.models.dataModels.updateModels
 data class LandlordUpdateModel(
     val email: String?,
     val fullName: String?,
+    val phoneNumber: String?,
 )

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/summaryModels/LandlordViewModel.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/summaryModels/LandlordViewModel.kt
@@ -71,8 +71,7 @@ class LandlordViewModel(
                 SummaryListRowViewModel(
                     "landlordDetails.personalDetails.telephoneNumber",
                     landlord.phoneNumber,
-                    // TODO: PRSD-797 toggleChangeLink("$UPDATE_ROUTE/telephone"),
-                    null,
+                    toggleChangeLink("$UPDATE_ROUTE/phone-number"),
                 ),
                 SummaryListRowViewModel(
                     "landlordDetails.personalDetails.englandOrWalesResident",

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/LandlordService.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/LandlordService.kt
@@ -77,6 +77,7 @@ class LandlordService(
 
         landlordUpdate.email?.let { landlordEntity.email = it }
         landlordUpdate.fullName?.let { landlordEntity.name = it }
+        landlordUpdate.phoneNumber?.let { landlordEntity.phoneNumber = it }
 
         return landlordEntity
     }

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -643,6 +643,7 @@ forms.checkPropertyAnswers.interestedParties.heading=Interested parties
 forms.update.title=Update your details
 forms.update.email.fieldSetHeading=What is your updated email address?
 forms.update.name.fieldSetHeading=Update your name on your landlord record
+forms.update.phoneNumber.fieldSetHeading=What is your updated phone number?
 
 pagination.previousText=Previous
 pagination.pageText=page

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/helpers/UpdateDetailsJourneyDataHelperTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/helpers/UpdateDetailsJourneyDataHelperTests.kt
@@ -51,4 +51,23 @@ class UpdateDetailsJourneyDataHelperTests {
 
         assertEquals(null, nameUpdate)
     }
+
+    @Test
+    fun `getPhoneNumberIfPresent returns a phone number if the phone number page is in journeyData`() {
+        val newPhoneNumber = "new phone number"
+        val testJourneyData = journeyDataBuilder.withPhoneNumber(newPhoneNumber).build()
+
+        val phoneNumberUpdate = UpdateLandlordDetailsJourneyDataHelper.getPhoneNumberIfPresent(testJourneyData)
+
+        assertEquals(newPhoneNumber, phoneNumberUpdate)
+    }
+
+    @Test
+    fun `getPhoneNumberIfPresent returns null if the phone number page is in not journeyData`() {
+        val testJourneyData = journeyDataBuilder.build()
+
+        val phoneNumberUpdate = UpdateLandlordDetailsJourneyDataHelper.getPhoneNumberIfPresent(testJourneyData)
+
+        assertEquals(null, phoneNumberUpdate)
+    }
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/UpdateLandlordDetailsJourneyTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/UpdateLandlordDetailsJourneyTests.kt
@@ -1,18 +1,23 @@
 package uk.gov.communities.prsdb.webapp.integration
 
+import com.google.i18n.phonenumbers.PhoneNumberUtil
 import com.microsoft.playwright.Page
 import com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat
 import org.junit.jupiter.api.Test
 import org.springframework.test.context.jdbc.Sql
+import uk.gov.communities.prsdb.webapp.helpers.getFormattedUkPhoneNumber
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.BaseComponent.Companion.assertThat
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.LandlordDetailsPage
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.LandlordUpdateDetailsPage
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages.BasePage.Companion.assertPageIs
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.updateLandlordDetailsPages.EmailFormPageUpdateLandlordDetails
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.updateLandlordDetailsPages.NameFormPageUpdateLandlordDetails
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.updateLandlordDetailsPages.PhoneNumberFormPageUpdateLandlordDetails
 
 @Sql("/data-local.sql")
 class UpdateLandlordDetailsJourneyTests : IntegrationTest() {
+    private val phoneNumberUtil = PhoneNumberUtil.getInstance()
+
     private fun updateLandlordNameAndReturn(
         detailsPage: LandlordUpdateDetailsPage,
         newName: String,
@@ -39,6 +44,19 @@ class UpdateLandlordDetailsJourneyTests : IntegrationTest() {
         return assertPageIs(page, LandlordUpdateDetailsPage::class)
     }
 
+    private fun updateLandlordPhoneNumberAndReturn(
+        detailsPage: LandlordUpdateDetailsPage,
+        newPhoneNumber: String,
+    ): LandlordUpdateDetailsPage {
+        val page = detailsPage.page
+        detailsPage.personalDetailsSummaryList.phoneNumberRow.actions.actionLink
+            .clickAndWait()
+        val updatePhoneNumberPage = assertPageIs(page, PhoneNumberFormPageUpdateLandlordDetails::class)
+
+        updatePhoneNumberPage.submitPhoneNumber(newPhoneNumber)
+        return assertPageIs(page, LandlordUpdateDetailsPage::class)
+    }
+
     @Test
     fun `A Landlord can update all of their details on the Update Details Journey`(page: Page) {
         // Update details page
@@ -51,6 +69,9 @@ class UpdateLandlordDetailsJourneyTests : IntegrationTest() {
         val landlordEmail = "new@email.test"
         landlordDetailsUpdatePage = updateLandlordEmailAndReturn(landlordDetailsUpdatePage, landlordEmail)
 
+        val landlordPhoneNumber = phoneNumberUtil.getFormattedUkPhoneNumber()
+        landlordDetailsUpdatePage = updateLandlordPhoneNumberAndReturn(landlordDetailsUpdatePage, landlordPhoneNumber)
+
         // Submit changes TODO PRSD-355 add proper submit button and declaration page
         landlordDetailsUpdatePage.submitButton.clickAndWait()
         val landlordDetailsPage = assertPageIs(page, LandlordDetailsPage::class)
@@ -58,6 +79,7 @@ class UpdateLandlordDetailsJourneyTests : IntegrationTest() {
         // Check changes have occurred
         assertThat(landlordDetailsPage.personalDetailsSummaryList.nameRow.value).containsText(landlordName)
         assertThat(landlordDetailsPage.personalDetailsSummaryList.emailRow.value).containsText(landlordEmail)
+        assertThat(landlordDetailsPage.personalDetailsSummaryList.phoneNumberRow.value).containsText(landlordPhoneNumber)
     }
 
     @Test
@@ -66,7 +88,7 @@ class UpdateLandlordDetailsJourneyTests : IntegrationTest() {
         var landlordDetailsUpdatePage = navigator.goToUpdateLandlordDetailsPage()
         assertThat(landlordDetailsUpdatePage.heading).containsText("Alexander Smith")
 
-        val landlordName = "landlord name"
+        val landlordName = phoneNumberUtil.getFormattedUkPhoneNumber()
         landlordDetailsUpdatePage = updateLandlordNameAndReturn(landlordDetailsUpdatePage, landlordName)
 
         // Submit changes TODO PRSD-355 add proper submit button and declaration page
@@ -91,5 +113,21 @@ class UpdateLandlordDetailsJourneyTests : IntegrationTest() {
 
         // Check changes have occurred
         assertThat(landlordDetailsPage.personalDetailsSummaryList.emailRow.value).containsText(landlordEmail)
+    }
+
+    @Test
+    fun `A Landlord can update just their phone number on the Update Details Journey`(page: Page) {
+        // Update details page
+        var landlordDetailsUpdatePage = navigator.goToUpdateLandlordDetailsPage()
+        assertThat(landlordDetailsUpdatePage.heading).containsText("Alexander Smith")
+        val landlordPhoneNumber = phoneNumberUtil.getFormattedUkPhoneNumber()
+        landlordDetailsUpdatePage = updateLandlordPhoneNumberAndReturn(landlordDetailsUpdatePage, landlordPhoneNumber)
+
+        // Submit changes TODO PRSD-355 add proper submit button and declaration page
+        landlordDetailsUpdatePage.submitButton.clickAndWait()
+        val landlordDetailsPage = assertPageIs(page, LandlordDetailsPage::class)
+
+        // Check changes have occurred
+        assertThat(landlordDetailsPage.personalDetailsSummaryList.phoneNumberRow.value).containsText(landlordPhoneNumber)
     }
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/UpdateLandlordDetailsJourneyTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/UpdateLandlordDetailsJourneyTests.kt
@@ -88,7 +88,7 @@ class UpdateLandlordDetailsJourneyTests : IntegrationTest() {
         var landlordDetailsUpdatePage = navigator.goToUpdateLandlordDetailsPage()
         assertThat(landlordDetailsUpdatePage.heading).containsText("Alexander Smith")
 
-        val landlordName = phoneNumberUtil.getFormattedUkPhoneNumber()
+        val landlordName = "landlord name"
         landlordDetailsUpdatePage = updateLandlordNameAndReturn(landlordDetailsUpdatePage, landlordName)
 
         // Submit changes TODO PRSD-355 add proper submit button and declaration page

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/basePages/LandlordDetailsBasePage.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/basePages/LandlordDetailsBasePage.kt
@@ -29,5 +29,6 @@ abstract class LandlordDetailsBasePage(
     ) : SummaryList(page) {
         val nameRow = getRow("Name")
         val emailRow = getRow("Email address")
+        val phoneNumberRow = getRow("Telephone number")
     }
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/basePages/PhoneNumberFormPage.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/basePages/PhoneNumberFormPage.kt
@@ -1,0 +1,23 @@
+package uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages
+
+import com.microsoft.playwright.Page
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.FormWithSectionHeader
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.TextInput
+
+abstract class PhoneNumberFormPage(
+    page: Page,
+    urlSegment: String,
+) : BasePage(page, urlSegment) {
+    val form = PhoneNumberFormLandlord(page)
+
+    fun submitPhoneNumber(phoneNumber: String) {
+        form.phoneNumberInput.fill(phoneNumber)
+        form.submit()
+    }
+
+    class PhoneNumberFormLandlord(
+        page: Page,
+    ) : FormWithSectionHeader(page) {
+        val phoneNumberInput = TextInput.textByFieldName(locator, "phoneNumber")
+    }
+}

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/landlordRegistrationJourneyPages/PhoneNumberFormPageLandlordRegistration.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/landlordRegistrationJourneyPages/PhoneNumberFormPageLandlordRegistration.kt
@@ -3,23 +3,8 @@ package uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.landlordRe
 import com.microsoft.playwright.Page
 import uk.gov.communities.prsdb.webapp.constants.REGISTER_LANDLORD_JOURNEY_URL
 import uk.gov.communities.prsdb.webapp.forms.steps.LandlordRegistrationStepId
-import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.FormWithSectionHeader
-import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.TextInput
-import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages.BasePage
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages.PhoneNumberFormPage
 
 class PhoneNumberFormPageLandlordRegistration(
     page: Page,
-) : BasePage(page, "/$REGISTER_LANDLORD_JOURNEY_URL/${LandlordRegistrationStepId.PhoneNumber.urlPathSegment}") {
-    val form = PhoneNumberFormLandlord(page)
-
-    fun submitPhoneNumber(phoneNumber: String) {
-        form.phoneNumberInput.fill(phoneNumber)
-        form.submit()
-    }
-
-    class PhoneNumberFormLandlord(
-        page: Page,
-    ) : FormWithSectionHeader(page) {
-        val phoneNumberInput = TextInput.textByFieldName(locator, "phoneNumber")
-    }
-}
+) : PhoneNumberFormPage(page, "/$REGISTER_LANDLORD_JOURNEY_URL/${LandlordRegistrationStepId.PhoneNumber.urlPathSegment}")

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/updateLandlordDetailsPages/PhoneNumberFormPageUpdateLandlordDetails.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/updateLandlordDetailsPages/PhoneNumberFormPageUpdateLandlordDetails.kt
@@ -1,0 +1,10 @@
+package uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.updateLandlordDetailsPages
+
+import com.microsoft.playwright.Page
+import uk.gov.communities.prsdb.webapp.constants.UPDATE_LANDLORD_DETAILS_URL
+import uk.gov.communities.prsdb.webapp.forms.steps.UpdateDetailsStepId
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages.PhoneNumberFormPage
+
+class PhoneNumberFormPageUpdateLandlordDetails(
+    page: Page,
+) : PhoneNumberFormPage(page, "$UPDATE_LANDLORD_DETAILS_URL/${UpdateDetailsStepId.UpdatePhoneNumber.urlPathSegment}")

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/summaryModels/LandlordViewModelTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/summaryModels/LandlordViewModelTests.kt
@@ -326,7 +326,12 @@ class LandlordViewModelTests {
     fun `LandlordViewModel populates change links in rows that should have them`() {
         // Arrange
         val testLandlord = MockLandlordData.createLandlord()
-        val changeablePersonalDetailKeys = listOf("landlordDetails.personalDetails.name", "landlordDetails.personalDetails.emailAddress")
+        val changeablePersonalDetailKeys =
+            listOf(
+                "landlordDetails.personalDetails.name",
+                "landlordDetails.personalDetails.emailAddress",
+                "landlordDetails.personalDetails.telephoneNumber",
+            )
 
         // Act
         val viewModel = LandlordViewModel(testLandlord)

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/LandlordServiceTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/LandlordServiceTests.kt
@@ -356,7 +356,8 @@ class LandlordServiceTests {
         val userId = "my id"
         val originalName = "original name"
         val originalEmail = "original email"
-        val landlordEntity = createLandlord(name = originalName, email = originalEmail)
+        val originalPhoneNumber = "original phone number"
+        val landlordEntity = createLandlord(name = originalName, email = originalEmail, phoneNumber = originalPhoneNumber)
         val updateModel = LandlordUpdateModel(null, null, null)
 
         whenever(mockLandlordRepository.findByBaseUser_Id(userId)).thenReturn(landlordEntity)
@@ -367,6 +368,7 @@ class LandlordServiceTests {
         // Assert
         assertEquals(originalName, landlordEntity.name)
         assertEquals(originalEmail, landlordEntity.email)
+        assertEquals(originalPhoneNumber, landlordEntity.phoneNumber)
     }
 
     @Test
@@ -375,8 +377,9 @@ class LandlordServiceTests {
         val userId = "my id"
         val originalName = "original name"
         val originalEmail = "original email"
-        val landlordEntity = createLandlord(name = originalName, email = originalEmail)
-        val updateModel = LandlordUpdateModel("newEmail", "newName")
+        val originalPhoneNumber = "original phone number"
+        val landlordEntity = createLandlord(name = originalName, email = originalEmail, phoneNumber = originalPhoneNumber)
+        val updateModel = LandlordUpdateModel("newEmail", "newName", "new phone number")
 
         whenever(mockLandlordRepository.findByBaseUser_Id(userId)).thenReturn(landlordEntity)
 
@@ -386,5 +389,6 @@ class LandlordServiceTests {
         // Assert
         assertEquals(updateModel.fullName, landlordEntity.name)
         assertEquals(updateModel.email, landlordEntity.email)
+        assertEquals(updateModel.phoneNumber, landlordEntity.phoneNumber)
     }
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/LandlordServiceTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/LandlordServiceTests.kt
@@ -357,7 +357,7 @@ class LandlordServiceTests {
         val originalName = "original name"
         val originalEmail = "original email"
         val landlordEntity = createLandlord(name = originalName, email = originalEmail)
-        val updateModel = LandlordUpdateModel(null, null)
+        val updateModel = LandlordUpdateModel(null, null, null)
 
         whenever(mockLandlordRepository.findByBaseUser_Id(userId)).thenReturn(landlordEntity)
 


### PR DESCRIPTION
Added the change link to the landlord details update page
Added the phone number step to the Update Landlords details journey so that a landlord can input a new phone number and it will be saved to the db on confirmation
Added new tests and updated existing ones

Update phone number page:
![image](https://github.com/user-attachments/assets/d8dcce77-7dda-4ed6-833d-ce3f035baa13)

Landlord details update page:
![image](https://github.com/user-attachments/assets/552c2421-8e10-485f-8e84-c720d11a1b43)

