### PR TITLE
PRSD-NONE: Remove completed todos for prsd-405 and prsd-659

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/SearchRegisterController.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/SearchRegisterController.kt
@@ -69,8 +69,7 @@ class SearchRegisterController(
             PaginationViewModel(page, pagedLandlordList.totalPages, httpServletRequest),
         )
         model.addAttribute("baseLandlordDetailsURL", LandlordDetailsController.LANDLORD_DETAILS_ROUTE)
-        // TODO PRSD-659: add LA property search base URL to model
-        model.addAttribute("propertySearchURL", "property")
+        model.addAttribute("propertySearchURL", SEARCH_PROPERTY_URL)
 
         return "searchLandlord"
     }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/dataModels/LocalAuthorityUserDataModel.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/dataModels/LocalAuthorityUserDataModel.kt
@@ -9,6 +9,5 @@ data class LocalAuthorityUserDataModel(
     val localAuthorityName: String,
     val isManager: Boolean,
     val isPending: Boolean = false,
-    // TODO PRSD-405: capture email during registration
     val email: String = "$userName@$localAuthorityName.gov.uk",
 )

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/EditLAUserTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/EditLAUserTests.kt
@@ -28,7 +28,6 @@ class EditLAUserTests : IntegrationTest() {
         manageUsersPage.getChangeLink(rowIndex = 0).clickAndWait()
         var editUserPage = assertPageIs(page, EditLaUserPage::class)
         assertThat(editUserPage.name).containsText("Arthur Dent")
-        // TODO PRSD-405: fix when LA users have email addresses
         assertThat(editUserPage.email).containsText("Arthur Dent@ISLE OF MAN.gov.uk")
         assertFalse(editUserPage.isManagerSelected)
 
@@ -59,7 +58,6 @@ class EditLAUserTests : IntegrationTest() {
         editUserPage.removeAccountButton.clickAndWait()
         val confirmDeletePage = assertPageIs(page, ConfirmDeleteLaUserPage::class)
         assertThat(confirmDeletePage.userDetailsSection).containsText("Arthur Dent")
-        // TODO PRSD-405: fix when LA users have email addresses
         assertThat(confirmDeletePage.userDetailsSection).containsText("Arthur Dent@ISLE OF MAN.gov.uk")
         confirmDeletePage.form.submit()
         val successPage = assertPageIs(page, DeleteLaUserSuccessPage::class)


### PR DESCRIPTION
Removes a couple of stray todos from the codebase