### PR TITLE
feat/PRSD-638 remove united kingdom from place names

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/constants/PlaceNamesConstants.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/constants/PlaceNamesConstants.kt
@@ -10,6 +10,8 @@ val internationalPlaceNameCSVFiles =
         "classpath:data/place_names/overseas_territory_names.csv",
     )
 
-val INTERNATIONAL_PLACE_NAMES = DataLoader.loadPlaceNames(internationalPlaceNameCSVFiles)
+val INTERNATIONAL_PLACE_NAMES = DataLoader.loadPlaceNames(internationalPlaceNameCSVFiles).filterNot { it.name == UNITED_KINGDOM }
 
 const val ENGLAND_OR_WALES = "England or Wales"
+
+const val UNITED_KINGDOM = "United Kingdom"


### PR DESCRIPTION
Removed United Kingdom from the list of international place names

![image](https://github.com/user-attachments/assets/926e6878-e114-4015-9cbe-51c1d6749677)
