### PR TITLE
PRSD-670: Update back link from property registration

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/RegisterPropertyController.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/RegisterPropertyController.kt
@@ -34,7 +34,7 @@ class RegisterPropertyController(
             "registerPropertyInitialStep",
             "/$REGISTER_PROPERTY_JOURNEY_URL/task-list",
         )
-        model.addAttribute("backUrl", "/")
+        model.addAttribute("backUrl", LANDLORD_DASHBOARD_URL)
 
         return "registerPropertyStartPage"
     }


### PR DESCRIPTION
Point the back link from the property registration start page to the landlord dashboard