### PR TITLE
feat/PRSD-896 update number of households validation

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/requestModels/formModels/NumberOfHouseholdsFormModel.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/requestModels/formModels/NumberOfHouseholdsFormModel.kt
@@ -3,7 +3,7 @@ package uk.gov.communities.prsdb.webapp.models.requestModels.formModels
 import uk.gov.communities.prsdb.webapp.validation.ConstraintDescriptor
 import uk.gov.communities.prsdb.webapp.validation.IsValidPrioritised
 import uk.gov.communities.prsdb.webapp.validation.NotBlankConstraintValidator
-import uk.gov.communities.prsdb.webapp.validation.PositiveOrZeroIntegerValidator
+import uk.gov.communities.prsdb.webapp.validation.PositiveIntegerValidator
 import uk.gov.communities.prsdb.webapp.validation.ValidatedBy
 
 @IsValidPrioritised
@@ -16,7 +16,7 @@ class NumberOfHouseholdsFormModel : FormModel {
             ),
             ConstraintDescriptor(
                 messageKey = "forms.numberOfHouseholds.input.error.invalidFormat",
-                validatorType = PositiveOrZeroIntegerValidator::class,
+                validatorType = PositiveIntegerValidator::class,
             ),
         ],
     )

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/validation/DateValidator.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/validation/DateValidator.kt
@@ -23,26 +23,11 @@ class DateValidator {
         year: String,
     ): Boolean = isBlank(day) || isBlank(month) || isBlank(year)
 
-    fun isValidDay(day: String): Boolean =
-        try {
-            day.toInt() in 1..31
-        } catch (e: NumberFormatException) {
-            false
-        }
+    fun isValidDay(day: String): Boolean = day.toIntOrNull() in 1..31
 
-    fun isValidMonth(month: String): Boolean =
-        try {
-            month.toInt() in 1..12
-        } catch (e: NumberFormatException) {
-            false
-        }
+    fun isValidMonth(month: String): Boolean = month.toIntOrNull() in 1..12
 
-    fun isValidYear(year: String): Boolean =
-        try {
-            year.toInt() in 1900..2099
-        } catch (e: NumberFormatException) {
-            false
-        }
+    fun isValidYear(year: String): Boolean = year.toIntOrNull() in 1900..2099
 
     fun isValidDate(
         day: String,

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/validation/PositiveIntegerValidator.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/validation/PositiveIntegerValidator.kt
@@ -4,11 +4,7 @@ import org.hibernate.validator.internal.constraintvalidators.bv.number.sign.Posi
 
 class PositiveIntegerValidator : PropertyConstraintValidator {
     override fun isValid(value: Any?): Boolean {
-        try {
-            val integerValue = value.toString().toInt()
-            return PositiveValidatorForInteger().isValid(integerValue, null)
-        } catch (e: NumberFormatException) {
-            return false
-        }
+        val integerValue = value.toString().toIntOrNull() ?: return false
+        return PositiveValidatorForInteger().isValid(integerValue, null)
     }
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/validation/PositiveIntegerValidator.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/validation/PositiveIntegerValidator.kt
@@ -1,0 +1,14 @@
+package uk.gov.communities.prsdb.webapp.validation
+
+import org.hibernate.validator.internal.constraintvalidators.bv.number.sign.PositiveValidatorForInteger
+
+class PositiveIntegerValidator : PropertyConstraintValidator {
+    override fun isValid(value: Any?): Boolean {
+        try {
+            val integerValue = value.toString().toInt()
+            return PositiveValidatorForInteger().isValid(integerValue, null)
+        } catch (e: NumberFormatException) {
+            return false
+        }
+    }
+}

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/validation/PositiveOrZeroIntegerValidator.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/validation/PositiveOrZeroIntegerValidator.kt
@@ -4,11 +4,7 @@ import org.hibernate.validator.internal.constraintvalidators.bv.number.sign.Posi
 
 class PositiveOrZeroIntegerValidator : PropertyConstraintValidator {
     override fun isValid(value: Any?): Boolean {
-        try {
-            val integerValue = value.toString().toInt()
-            return PositiveOrZeroValidatorForInteger().isValid(integerValue, null)
-        } catch (e: NumberFormatException) {
-            return false
-        }
+        val integerValue = value.toString().toIntOrNull() ?: return false
+        return PositiveOrZeroValidatorForInteger().isValid(integerValue, null)
     }
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/PropertyRegistrationJourneyTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/PropertyRegistrationJourneyTests.kt
@@ -399,6 +399,14 @@ class PropertyRegistrationJourneyTests : IntegrationTest() {
             assertThat(householdsPage.form.getErrorMessage())
                 .containsText("Number of households in your property must be a positive, whole number, like 3")
         }
+
+        @Test
+        fun `Submitting with a zero integer in the numberOfHouseholds field returns an error`(page: Page) {
+            val householdsPage = navigator.goToPropertyRegistrationHouseholdsPage()
+            householdsPage.submitNumberOfHouseholds(0)
+            assertThat(householdsPage.form.getErrorMessage())
+                .containsText("Number of households in your property must be a positive, whole number, like 3")
+        }
     }
 
     @Nested


### PR DESCRIPTION
changed the validation on number of household for the property registration to be a positive-integer validator rather than a positive-or-zero-integer validator

Note: the message key does not need to be updated

![image](https://github.com/user-attachments/assets/1b99fd6a-7ae1-4e90-9c41-220115a1e5e4)
