### PR TITLE
PRSD-670: Replace link to external content

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/constants/ExternalLinks.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/constants/ExternalLinks.kt
@@ -2,4 +2,4 @@ package uk.gov.communities.prsdb.webapp.constants
 
 const val RENTERS_RIGHTS_BILL_URL =
     "https://www.gov.uk/government/publications/" +
-        "guide-to-the-renters-rights-bill/82ffc7fb-64b0-4af5-a72e-c24701a5f12a#private-rented-sector-database"
+        "guide-to-the-renters-rights-bill/guide-to-the-renters-rights-bill#private-rented-sector-database"


### PR DESCRIPTION
The original link contains a uuid (this was a link from a ticket), but clicking on it redirects you to a page without a uuid.
It feels a bit cleaner to just use the link without the uuid!