### PR TITLE
PRSD-NONE: Refactors Address Data Service

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/constants/SessionAttributes.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/constants/SessionAttributes.kt
@@ -5,3 +5,5 @@ const val LA_USER_INVITATION_TOKEN: String = "la-user-invitation-token"
 const val LA_USER_ID = "la-user-id"
 
 const val PROPERTY_REGISTRATION_NUMBER = "propertyRegistrationNumber"
+
+const val LOOKED_UP_ADDRESSES_JOURNEY_DATA_KEY = "looked-up-addresses"

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/LandlordRegistrationJourney.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/LandlordRegistrationJourney.kt
@@ -3,6 +3,7 @@ package uk.gov.communities.prsdb.webapp.forms.journeys
 import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.validation.Validator
 import uk.gov.communities.prsdb.webapp.constants.INTERNATIONAL_PLACE_NAMES
+import uk.gov.communities.prsdb.webapp.constants.LOOKED_UP_ADDRESSES_JOURNEY_DATA_KEY
 import uk.gov.communities.prsdb.webapp.constants.NON_ENGLAND_OR_WALES_ADDRESS_MAX_LENGTH
 import uk.gov.communities.prsdb.webapp.constants.REGISTER_LANDLORD_JOURNEY_URL
 import uk.gov.communities.prsdb.webapp.constants.enums.JourneyType
@@ -491,7 +492,9 @@ class LandlordRegistrationJourney(
         }
 
     private fun declarationHandleSubmitAndRedirect(): String {
-        val filteredJourneyData = last().filteredJourneyData
+        val filteredJourneyData =
+            last().filteredJourneyData + journeyDataService.getJourneyDataEntryInSession(LOOKED_UP_ADDRESSES_JOURNEY_DATA_KEY)!!
+
         val landlord =
             landlordService.createLandlord(
                 baseUserId = SecurityContextHolder.getContext().authentication.name,

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/LandlordRegistrationJourney.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/LandlordRegistrationJourney.kt
@@ -39,13 +39,11 @@ import uk.gov.communities.prsdb.webapp.services.AddressLookupService
 import uk.gov.communities.prsdb.webapp.services.EmailNotificationService
 import uk.gov.communities.prsdb.webapp.services.JourneyDataService
 import uk.gov.communities.prsdb.webapp.services.LandlordService
-import uk.gov.communities.prsdb.webapp.services.RegisteredAddressCache
 
 class LandlordRegistrationJourney(
     validator: Validator,
     journeyDataService: JourneyDataService,
     val addressLookupService: AddressLookupService,
-    val registeredAddressCache: RegisteredAddressCache,
     val landlordService: LandlordService,
     val absoluteUrlProvider: AbsoluteUrlProvider,
     val emailNotificationService: EmailNotificationService<LandlordRegistrationConfirmationEmail>,
@@ -305,7 +303,7 @@ class LandlordRegistrationJourney(
                         ),
                     lookupAddressPathSegment = LandlordRegistrationStepId.LookupAddress.urlPathSegment,
                     addressLookupService = addressLookupService,
-                    registeredAddressCache = registeredAddressCache,
+                    journeyDataService = journeyDataService,
                     displaySectionHeader = true,
                 ),
             nextAction = { journeyData, _ -> selectAddressNextAction(journeyData) },
@@ -400,7 +398,7 @@ class LandlordRegistrationJourney(
                         ),
                     lookupAddressPathSegment = LandlordRegistrationStepId.LookupContactAddress.urlPathSegment,
                     addressLookupService = addressLookupService,
-                    registeredAddressCache = registeredAddressCache,
+                    journeyDataService = journeyDataService,
                     displaySectionHeader = true,
                 ),
             nextAction = { journeyData, _ ->
@@ -438,7 +436,7 @@ class LandlordRegistrationJourney(
     private fun checkAnswersStep() =
         Step(
             id = LandlordRegistrationStepId.CheckAnswers,
-            page = LandlordRegistrationCheckAnswersPage(registeredAddressCache, displaySectionHeader = true),
+            page = LandlordRegistrationCheckAnswersPage(journeyDataService, displaySectionHeader = true),
             nextAction = { _, _ -> Pair(LandlordRegistrationStepId.Declaration, null) },
             saveAfterSubmit = false,
         )
@@ -500,12 +498,10 @@ class LandlordRegistrationJourney(
                 name = LandlordRegistrationJourneyDataHelper.getName(filteredJourneyData)!!,
                 email = LandlordRegistrationJourneyDataHelper.getEmail(filteredJourneyData)!!,
                 phoneNumber = LandlordRegistrationJourneyDataHelper.getPhoneNumber(filteredJourneyData)!!,
-                addressDataModel =
-                    LandlordRegistrationJourneyDataHelper.getAddress(filteredJourneyData, registeredAddressCache)!!,
+                addressDataModel = LandlordRegistrationJourneyDataHelper.getAddress(filteredJourneyData)!!,
                 countryOfResidence = LandlordRegistrationJourneyDataHelper.getCountryOfResidence(filteredJourneyData),
                 isVerified = LandlordRegistrationJourneyDataHelper.isIdentityVerified(filteredJourneyData),
-                nonEnglandOrWalesAddress =
-                    LandlordRegistrationJourneyDataHelper.getNonEnglandOrWalesAddress(filteredJourneyData),
+                nonEnglandOrWalesAddress = LandlordRegistrationJourneyDataHelper.getNonEnglandOrWalesAddress(filteredJourneyData),
                 dateOfBirth = LandlordRegistrationJourneyDataHelper.getDOB(filteredJourneyData)!!,
             )
 

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/LandlordRegistrationJourney.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/LandlordRegistrationJourney.kt
@@ -3,7 +3,6 @@ package uk.gov.communities.prsdb.webapp.forms.journeys
 import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.validation.Validator
 import uk.gov.communities.prsdb.webapp.constants.INTERNATIONAL_PLACE_NAMES
-import uk.gov.communities.prsdb.webapp.constants.LOOKED_UP_ADDRESSES_JOURNEY_DATA_KEY
 import uk.gov.communities.prsdb.webapp.constants.NON_ENGLAND_OR_WALES_ADDRESS_MAX_LENGTH
 import uk.gov.communities.prsdb.webapp.constants.REGISTER_LANDLORD_JOURNEY_URL
 import uk.gov.communities.prsdb.webapp.constants.enums.JourneyType
@@ -19,6 +18,7 @@ import uk.gov.communities.prsdb.webapp.forms.steps.Step
 import uk.gov.communities.prsdb.webapp.forms.tasks.JourneySection
 import uk.gov.communities.prsdb.webapp.forms.tasks.JourneyTask
 import uk.gov.communities.prsdb.webapp.helpers.LandlordRegistrationJourneyDataHelper
+import uk.gov.communities.prsdb.webapp.helpers.extensions.JourneyDataExtensions.Companion.getLookedUpAddresses
 import uk.gov.communities.prsdb.webapp.models.dataModels.RegistrationNumberDataModel
 import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.CheckAnswersFormModel
 import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.CountryOfResidenceFormModel
@@ -492,8 +492,8 @@ class LandlordRegistrationJourney(
         }
 
     private fun declarationHandleSubmitAndRedirect(): String {
-        val filteredJourneyData =
-            last().filteredJourneyData + journeyDataService.getJourneyDataEntryInSession(LOOKED_UP_ADDRESSES_JOURNEY_DATA_KEY)!!
+        val filteredJourneyData = last().filteredJourneyData
+        val lookedUpAddresses = journeyDataService.getJourneyDataFromSession().getLookedUpAddresses()
 
         val landlord =
             landlordService.createLandlord(
@@ -501,7 +501,7 @@ class LandlordRegistrationJourney(
                 name = LandlordRegistrationJourneyDataHelper.getName(filteredJourneyData)!!,
                 email = LandlordRegistrationJourneyDataHelper.getEmail(filteredJourneyData)!!,
                 phoneNumber = LandlordRegistrationJourneyDataHelper.getPhoneNumber(filteredJourneyData)!!,
-                addressDataModel = LandlordRegistrationJourneyDataHelper.getAddress(filteredJourneyData)!!,
+                addressDataModel = LandlordRegistrationJourneyDataHelper.getAddress(filteredJourneyData, lookedUpAddresses)!!,
                 countryOfResidence = LandlordRegistrationJourneyDataHelper.getCountryOfResidence(filteredJourneyData),
                 isVerified = LandlordRegistrationJourneyDataHelper.isIdentityVerified(filteredJourneyData),
                 nonEnglandOrWalesAddress = LandlordRegistrationJourneyDataHelper.getNonEnglandOrWalesAddress(filteredJourneyData),

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/LandlordRegistrationJourney.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/LandlordRegistrationJourney.kt
@@ -35,17 +35,17 @@ import uk.gov.communities.prsdb.webapp.models.viewModels.formModels.CheckboxView
 import uk.gov.communities.prsdb.webapp.models.viewModels.formModels.RadiosButtonViewModel
 import uk.gov.communities.prsdb.webapp.models.viewModels.formModels.SelectViewModel
 import uk.gov.communities.prsdb.webapp.services.AbsoluteUrlProvider
-import uk.gov.communities.prsdb.webapp.services.AddressDataService
 import uk.gov.communities.prsdb.webapp.services.AddressLookupService
 import uk.gov.communities.prsdb.webapp.services.EmailNotificationService
 import uk.gov.communities.prsdb.webapp.services.JourneyDataService
 import uk.gov.communities.prsdb.webapp.services.LandlordService
+import uk.gov.communities.prsdb.webapp.services.RegisteredAddressCache
 
 class LandlordRegistrationJourney(
     validator: Validator,
     journeyDataService: JourneyDataService,
     val addressLookupService: AddressLookupService,
-    val addressDataService: AddressDataService,
+    val registeredAddressCache: RegisteredAddressCache,
     val landlordService: LandlordService,
     val absoluteUrlProvider: AbsoluteUrlProvider,
     val emailNotificationService: EmailNotificationService<LandlordRegistrationConfirmationEmail>,
@@ -305,7 +305,7 @@ class LandlordRegistrationJourney(
                         ),
                     lookupAddressPathSegment = LandlordRegistrationStepId.LookupAddress.urlPathSegment,
                     addressLookupService = addressLookupService,
-                    addressDataService = addressDataService,
+                    registeredAddressCache = registeredAddressCache,
                     displaySectionHeader = true,
                 ),
             nextAction = { journeyData, _ -> selectAddressNextAction(journeyData) },
@@ -400,7 +400,7 @@ class LandlordRegistrationJourney(
                         ),
                     lookupAddressPathSegment = LandlordRegistrationStepId.LookupContactAddress.urlPathSegment,
                     addressLookupService = addressLookupService,
-                    addressDataService = addressDataService,
+                    registeredAddressCache = registeredAddressCache,
                     displaySectionHeader = true,
                 ),
             nextAction = { journeyData, _ ->
@@ -438,7 +438,7 @@ class LandlordRegistrationJourney(
     private fun checkAnswersStep() =
         Step(
             id = LandlordRegistrationStepId.CheckAnswers,
-            page = LandlordRegistrationCheckAnswersPage(addressDataService, displaySectionHeader = true),
+            page = LandlordRegistrationCheckAnswersPage(registeredAddressCache, displaySectionHeader = true),
             nextAction = { _, _ -> Pair(LandlordRegistrationStepId.Declaration, null) },
             saveAfterSubmit = false,
         )
@@ -501,7 +501,7 @@ class LandlordRegistrationJourney(
                 email = LandlordRegistrationJourneyDataHelper.getEmail(filteredJourneyData)!!,
                 phoneNumber = LandlordRegistrationJourneyDataHelper.getPhoneNumber(filteredJourneyData)!!,
                 addressDataModel =
-                    LandlordRegistrationJourneyDataHelper.getAddress(filteredJourneyData, addressDataService)!!,
+                    LandlordRegistrationJourneyDataHelper.getAddress(filteredJourneyData, registeredAddressCache)!!,
                 countryOfResidence = LandlordRegistrationJourneyDataHelper.getCountryOfResidence(filteredJourneyData),
                 isVerified = LandlordRegistrationJourneyDataHelper.isIdentityVerified(filteredJourneyData),
                 nonEnglandOrWalesAddress =

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/LandlordRegistrationJourney.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/LandlordRegistrationJourney.kt
@@ -18,7 +18,7 @@ import uk.gov.communities.prsdb.webapp.forms.steps.Step
 import uk.gov.communities.prsdb.webapp.forms.tasks.JourneySection
 import uk.gov.communities.prsdb.webapp.forms.tasks.JourneyTask
 import uk.gov.communities.prsdb.webapp.helpers.LandlordRegistrationJourneyDataHelper
-import uk.gov.communities.prsdb.webapp.helpers.extensions.JourneyDataExtensions.Companion.getLookedUpAddresses
+import uk.gov.communities.prsdb.webapp.helpers.extensions.journeyDataExtensions.JourneyDataExtensions.Companion.getLookedUpAddresses
 import uk.gov.communities.prsdb.webapp.models.dataModels.RegistrationNumberDataModel
 import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.CheckAnswersFormModel
 import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.CountryOfResidenceFormModel

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/PropertyRegistrationJourney.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/PropertyRegistrationJourney.kt
@@ -3,6 +3,7 @@ package uk.gov.communities.prsdb.webapp.forms.journeys
 import jakarta.persistence.EntityExistsException
 import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.validation.Validator
+import uk.gov.communities.prsdb.webapp.constants.LOOKED_UP_ADDRESSES_JOURNEY_DATA_KEY
 import uk.gov.communities.prsdb.webapp.constants.REGISTER_PROPERTY_JOURNEY_URL
 import uk.gov.communities.prsdb.webapp.constants.enums.JourneyType
 import uk.gov.communities.prsdb.webapp.constants.enums.LicensingType
@@ -574,8 +575,10 @@ class PropertyRegistrationJourney(
 
     private fun checkAnswersSubmitAndRedirect(): String {
         try {
-            val filteredJourneyData = last().filteredJourneyData
-            val address = PropertyRegistrationJourneyDataHelper.getAddress(filteredJourneyData, registeredAddressCache)!!
+            val filteredJourneyData =
+                last().filteredJourneyData + journeyDataService.getJourneyDataEntryInSession(LOOKED_UP_ADDRESSES_JOURNEY_DATA_KEY)!!
+
+            val address = PropertyRegistrationJourneyDataHelper.getAddress(filteredJourneyData)!!
             val baseUserId = SecurityContextHolder.getContext().authentication.name
             val propertyRegistrationNumber =
                 propertyRegistrationService.registerPropertyAndReturnPropertyRegistrationNumber(

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/PropertyRegistrationJourney.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/PropertyRegistrationJourney.kt
@@ -20,7 +20,7 @@ import uk.gov.communities.prsdb.webapp.forms.steps.Step
 import uk.gov.communities.prsdb.webapp.forms.tasks.JourneySection
 import uk.gov.communities.prsdb.webapp.forms.tasks.JourneyTask
 import uk.gov.communities.prsdb.webapp.helpers.PropertyRegistrationJourneyDataHelper
-import uk.gov.communities.prsdb.webapp.helpers.extensions.JourneyDataExtensions.Companion.getLookedUpAddresses
+import uk.gov.communities.prsdb.webapp.helpers.extensions.journeyDataExtensions.JourneyDataExtensions.Companion.getLookedUpAddresses
 import uk.gov.communities.prsdb.webapp.models.dataModels.RegistrationNumberDataModel
 import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.DeclarationFormModel
 import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.HmoAdditionalLicenceFormModel

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/UpdateLandlordDetailsJourney.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/UpdateLandlordDetailsJourney.kt
@@ -19,6 +19,8 @@ import uk.gov.communities.prsdb.webapp.forms.steps.UpdateLandlordDetailsStepId
 import uk.gov.communities.prsdb.webapp.helpers.JourneyDataHelper
 import uk.gov.communities.prsdb.webapp.helpers.LandlordRegistrationJourneyDataHelper
 import uk.gov.communities.prsdb.webapp.helpers.UpdateLandlordDetailsJourneyDataHelper
+import uk.gov.communities.prsdb.webapp.helpers.extensions.JourneyDataExtensions.Companion.getSerializedLookedUpAddresses
+import uk.gov.communities.prsdb.webapp.helpers.extensions.JourneyDataExtensions.Companion.updateLookedUpAddresses
 import uk.gov.communities.prsdb.webapp.models.dataModels.AddressDataModel
 import uk.gov.communities.prsdb.webapp.models.dataModels.updateModels.LandlordUpdateModel
 import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.DateOfBirthFormModel
@@ -92,7 +94,9 @@ class UpdateLandlordDetailsJourney(
     override fun initializeJourneyDataIfNotInitialized() {
         if (!isJourneyDataInitialised()) {
             super.initializeJourneyDataIfNotInitialized()
-            journeyDataService.setJourneyDataEntryInSession(LOOKED_UP_ADDRESSES_JOURNEY_DATA_KEY, getOriginalLookedUpAddresses())
+            val journeyData = journeyDataService.getJourneyDataFromSession()
+            val updatedJourneyData = setOriginalLookedUpAddresses(journeyData)
+            journeyDataService.setJourneyDataInSession(updatedJourneyData)
         }
     }
 
@@ -330,10 +334,10 @@ class UpdateLandlordDetailsJourney(
 
     private fun Address.getTownOrCity(): String = townName ?: singleLineAddress
 
-    private fun getOriginalLookedUpAddresses(): String {
-        val journeyData = journeyDataService.getJourneyDataFromSession(journeyDataKey)
+    private fun setOriginalLookedUpAddresses(journeyData: JourneyData): JourneyData {
         val originalJourneyData = JourneyDataHelper.getPageData(journeyData, originalDataKey)!!
-        return JourneyDataHelper.getStringValueByKey(originalJourneyData, LOOKED_UP_ADDRESSES_JOURNEY_DATA_KEY)!!
+        val lookedUpAddresses = originalJourneyData.getSerializedLookedUpAddresses()!!
+        return journeyData.updateLookedUpAddresses(lookedUpAddresses)
     }
 
     companion object {

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/UpdateLandlordDetailsJourney.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/UpdateLandlordDetailsJourney.kt
@@ -94,9 +94,11 @@ class UpdateLandlordDetailsJourney(
     override fun initializeJourneyDataIfNotInitialized() {
         if (!isJourneyDataInitialised()) {
             super.initializeJourneyDataIfNotInitialized()
+
             val journeyData = journeyDataService.getJourneyDataFromSession()
-            val updatedJourneyData = setOriginalLookedUpAddresses(journeyData)
-            journeyDataService.setJourneyDataInSession(updatedJourneyData)
+            val lookedUpAddresses = JourneyDataHelper.getPageData(journeyData, originalDataKey)!!.getSerializedLookedUpAddresses()!!
+            val journeyDataWithLookedUpAddresses = journeyData.withUpdatedLookedUpAddresses(lookedUpAddresses)
+            journeyDataService.setJourneyDataInSession(journeyDataWithLookedUpAddresses)
         }
     }
 
@@ -333,12 +335,6 @@ class UpdateLandlordDetailsJourney(
     private fun Address.getSelectedAddress(): String = if (uprn == null) MANUAL_ADDRESS_CHOSEN else singleLineAddress
 
     private fun Address.getTownOrCity(): String = townName ?: singleLineAddress
-
-    private fun setOriginalLookedUpAddresses(journeyData: JourneyData): JourneyData {
-        val originalJourneyData = JourneyDataHelper.getPageData(journeyData, originalDataKey)!!
-        val lookedUpAddresses = originalJourneyData.getSerializedLookedUpAddresses()!!
-        return journeyData.withUpdatedLookedUpAddresses(lookedUpAddresses)
-    }
 
     companion object {
         const val IS_IDENTITY_VERIFIED_KEY = "isIdentityVerified"

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/UpdateLandlordDetailsJourney.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/UpdateLandlordDetailsJourney.kt
@@ -19,8 +19,8 @@ import uk.gov.communities.prsdb.webapp.forms.steps.UpdateLandlordDetailsStepId
 import uk.gov.communities.prsdb.webapp.helpers.JourneyDataHelper
 import uk.gov.communities.prsdb.webapp.helpers.LandlordRegistrationJourneyDataHelper
 import uk.gov.communities.prsdb.webapp.helpers.UpdateLandlordDetailsJourneyDataHelper
-import uk.gov.communities.prsdb.webapp.helpers.extensions.JourneyDataExtensions.Companion.getSerializedLookedUpAddresses
-import uk.gov.communities.prsdb.webapp.helpers.extensions.JourneyDataExtensions.Companion.updateLookedUpAddresses
+import uk.gov.communities.prsdb.webapp.helpers.extensions.journeyDataExtensions.JourneyDataExtensions.Companion.getSerializedLookedUpAddresses
+import uk.gov.communities.prsdb.webapp.helpers.extensions.journeyDataExtensions.JourneyDataExtensions.Companion.updateLookedUpAddresses
 import uk.gov.communities.prsdb.webapp.models.dataModels.AddressDataModel
 import uk.gov.communities.prsdb.webapp.models.dataModels.updateModels.LandlordUpdateModel
 import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.DateOfBirthFormModel

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/UpdateLandlordDetailsJourney.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/UpdateLandlordDetailsJourney.kt
@@ -20,7 +20,7 @@ import uk.gov.communities.prsdb.webapp.helpers.JourneyDataHelper
 import uk.gov.communities.prsdb.webapp.helpers.LandlordRegistrationJourneyDataHelper
 import uk.gov.communities.prsdb.webapp.helpers.UpdateLandlordDetailsJourneyDataHelper
 import uk.gov.communities.prsdb.webapp.helpers.extensions.journeyDataExtensions.JourneyDataExtensions.Companion.getSerializedLookedUpAddresses
-import uk.gov.communities.prsdb.webapp.helpers.extensions.journeyDataExtensions.JourneyDataExtensions.Companion.updateLookedUpAddresses
+import uk.gov.communities.prsdb.webapp.helpers.extensions.journeyDataExtensions.JourneyDataExtensions.Companion.withUpdatedLookedUpAddresses
 import uk.gov.communities.prsdb.webapp.models.dataModels.AddressDataModel
 import uk.gov.communities.prsdb.webapp.models.dataModels.updateModels.LandlordUpdateModel
 import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.DateOfBirthFormModel
@@ -337,7 +337,7 @@ class UpdateLandlordDetailsJourney(
     private fun setOriginalLookedUpAddresses(journeyData: JourneyData): JourneyData {
         val originalJourneyData = JourneyDataHelper.getPageData(journeyData, originalDataKey)!!
         val lookedUpAddresses = originalJourneyData.getSerializedLookedUpAddresses()!!
-        return journeyData.updateLookedUpAddresses(lookedUpAddresses)
+        return journeyData.withUpdatedLookedUpAddresses(lookedUpAddresses)
     }
 
     companion object {

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/UpdateLandlordDetailsJourney.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/UpdateLandlordDetailsJourney.kt
@@ -314,7 +314,7 @@ class UpdateLandlordDetailsJourney(
                 email = UpdateLandlordDetailsJourneyDataHelper.getEmailUpdateIfPresent(journeyData),
                 name = UpdateLandlordDetailsJourneyDataHelper.getNameUpdateIfPresent(journeyData),
                 phoneNumber = UpdateLandlordDetailsJourneyDataHelper.getPhoneNumberIfPresent(journeyData),
-                address = UpdateLandlordDetailsJourneyDataHelper.getAddressIfPresent(journeyData, registeredAddressCache),
+                address = UpdateLandlordDetailsJourneyDataHelper.getAddressIfPresent(journeyData),
                 dateOfBirth = UpdateLandlordDetailsJourneyDataHelper.getDateOfBirthIfPresent(journeyData),
             )
 

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/UpdateLandlordDetailsJourney.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/UpdateLandlordDetailsJourney.kt
@@ -5,6 +5,7 @@ import kotlinx.serialization.json.Json
 import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.validation.Validator
 import uk.gov.communities.prsdb.webapp.constants.BACK_URL_ATTR_NAME
+import uk.gov.communities.prsdb.webapp.constants.LOOKED_UP_ADDRESSES_JOURNEY_DATA_KEY
 import uk.gov.communities.prsdb.webapp.constants.MANUAL_ADDRESS_CHOSEN
 import uk.gov.communities.prsdb.webapp.constants.UPDATE_LANDLORD_DETAILS_URL
 import uk.gov.communities.prsdb.webapp.constants.enums.JourneyType
@@ -31,14 +32,12 @@ import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.SelectAdd
 import uk.gov.communities.prsdb.webapp.services.AddressLookupService
 import uk.gov.communities.prsdb.webapp.services.JourneyDataService
 import uk.gov.communities.prsdb.webapp.services.LandlordService
-import uk.gov.communities.prsdb.webapp.services.RegisteredAddressCache
 
 class UpdateLandlordDetailsJourney(
     validator: Validator,
     journeyDataService: JourneyDataService,
     addressLookupService: AddressLookupService,
     private val landlordService: LandlordService,
-    private val registeredAddressCache: RegisteredAddressCache,
     private val landlordBaseUserId: String,
 ) : UpdateJourney<UpdateLandlordDetailsStepId>(
         journeyType = JourneyType.LANDLORD_DETAILS_UPDATE,
@@ -98,7 +97,7 @@ class UpdateLandlordDetailsJourney(
     override fun initializeJourneyDataIfNotInitialized() {
         if (!isJourneyDataInitialised()) {
             super.initializeJourneyDataIfNotInitialized()
-            registeredAddressCache.setAddressData(getOriginalAddressData())
+            journeyDataService.setJourneyDataEntryInSession(LOOKED_UP_ADDRESSES_JOURNEY_DATA_KEY, getOriginalLookedUpAddresses())
         }
     }
 
@@ -253,7 +252,7 @@ class UpdateLandlordDetailsJourney(
                         ),
                     lookupAddressPathSegment = UpdateLandlordDetailsStepId.LookupEnglandAndWalesAddress.urlPathSegment,
                     addressLookupService = addressLookupService,
-                    registeredAddressCache = registeredAddressCache,
+                    journeyDataService = journeyDataService,
                     displaySectionHeader = false,
                 ),
             nextAction = { journeyData, _ -> selectAddressNextAction(journeyData) },

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/UpdateLandlordDetailsJourney.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/UpdateLandlordDetailsJourney.kt
@@ -58,6 +58,7 @@ class UpdateLandlordDetailsJourney(
         val originalLandlordData =
             mutableMapOf(
                 IS_IDENTITY_VERIFIED_KEY to landlord.isVerified,
+                LOOKED_UP_ADDRESSES_JOURNEY_DATA_KEY to Json.encodeToString(listOf(AddressDataModel.fromAddress(landlord.address))),
                 UpdateLandlordDetailsStepId.UpdateEmail.urlPathSegment to mapOf("emailAddress" to landlord.email),
                 UpdateLandlordDetailsStepId.UpdateName.urlPathSegment to mapOf("name" to landlord.name),
                 UpdateLandlordDetailsStepId.UpdatePhoneNumber.urlPathSegment to mapOf("phoneNumber" to landlord.phoneNumber),
@@ -67,13 +68,7 @@ class UpdateLandlordDetailsJourney(
                         "houseNameOrNumber" to landlord.address.getHouseNameOrNumber(),
                     ),
                 UpdateLandlordDetailsStepId.SelectEnglandAndWalesAddress.urlPathSegment to
-                    mapOf(
-                        "address" to landlord.address.getSelectedAddress(),
-                    ),
-                ORIGINAL_ADDRESS_DATA_KEY to
-                    mapOf(
-                        "address" to Json.encodeToString(AddressDataModel.fromAddress(landlord.address)),
-                    ),
+                    mapOf("address" to landlord.address.getSelectedAddress()),
                 UpdateLandlordDetailsStepId.UpdateDateOfBirth.urlPathSegment to
                     mapOf(
                         "day" to landlord.dateOfBirth?.dayOfMonth.toString(),
@@ -335,15 +330,13 @@ class UpdateLandlordDetailsJourney(
 
     private fun Address.getTownOrCity(): String = townName ?: singleLineAddress
 
-    private fun getOriginalAddressData(): List<AddressDataModel> {
+    private fun getOriginalLookedUpAddresses(): String {
         val journeyData = journeyDataService.getJourneyDataFromSession(journeyDataKey)
         val originalJourneyData = JourneyDataHelper.getPageData(journeyData, originalDataKey)!!
-        val originalAddressData = JourneyDataHelper.getPageData(originalJourneyData, ORIGINAL_ADDRESS_DATA_KEY)!!
-        return listOf(Json.decodeFromString(originalAddressData["address"] as String))
+        return JourneyDataHelper.getStringValueByKey(originalJourneyData, LOOKED_UP_ADDRESSES_JOURNEY_DATA_KEY)!!
     }
 
     companion object {
-        private const val ORIGINAL_ADDRESS_DATA_KEY = "original-address-data"
         const val IS_IDENTITY_VERIFIED_KEY = "isIdentityVerified"
     }
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/UpdateLandlordDetailsJourney.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/UpdateLandlordDetailsJourney.kt
@@ -28,17 +28,17 @@ import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.NameFormM
 import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.NoInputFormModel
 import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.PhoneNumberFormModel
 import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.SelectAddressFormModel
-import uk.gov.communities.prsdb.webapp.services.AddressDataService
 import uk.gov.communities.prsdb.webapp.services.AddressLookupService
 import uk.gov.communities.prsdb.webapp.services.JourneyDataService
 import uk.gov.communities.prsdb.webapp.services.LandlordService
+import uk.gov.communities.prsdb.webapp.services.RegisteredAddressCache
 
 class UpdateLandlordDetailsJourney(
     validator: Validator,
     journeyDataService: JourneyDataService,
     addressLookupService: AddressLookupService,
     private val landlordService: LandlordService,
-    private val addressDataService: AddressDataService,
+    private val registeredAddressCache: RegisteredAddressCache,
     private val landlordBaseUserId: String,
 ) : UpdateJourney<UpdateLandlordDetailsStepId>(
         journeyType = JourneyType.LANDLORD_DETAILS_UPDATE,
@@ -98,7 +98,7 @@ class UpdateLandlordDetailsJourney(
     override fun initializeJourneyDataIfNotInitialized() {
         if (!isJourneyDataInitialised()) {
             super.initializeJourneyDataIfNotInitialized()
-            addressDataService.setAddressData(getOriginalAddressData())
+            registeredAddressCache.setAddressData(getOriginalAddressData())
         }
     }
 
@@ -253,7 +253,7 @@ class UpdateLandlordDetailsJourney(
                         ),
                     lookupAddressPathSegment = UpdateLandlordDetailsStepId.LookupEnglandAndWalesAddress.urlPathSegment,
                     addressLookupService = addressLookupService,
-                    addressDataService = addressDataService,
+                    registeredAddressCache = registeredAddressCache,
                     displaySectionHeader = false,
                 ),
             nextAction = { journeyData, _ -> selectAddressNextAction(journeyData) },
@@ -314,7 +314,7 @@ class UpdateLandlordDetailsJourney(
                 email = UpdateLandlordDetailsJourneyDataHelper.getEmailUpdateIfPresent(journeyData),
                 name = UpdateLandlordDetailsJourneyDataHelper.getNameUpdateIfPresent(journeyData),
                 phoneNumber = UpdateLandlordDetailsJourneyDataHelper.getPhoneNumberIfPresent(journeyData),
-                address = UpdateLandlordDetailsJourneyDataHelper.getAddressIfPresent(journeyData, addressDataService),
+                address = UpdateLandlordDetailsJourneyDataHelper.getAddressIfPresent(journeyData, registeredAddressCache),
                 dateOfBirth = UpdateLandlordDetailsJourneyDataHelper.getDateOfBirthIfPresent(journeyData),
             )
 

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/factories/LandlordDetailsUpdateJourneyFactory.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/factories/LandlordDetailsUpdateJourneyFactory.kt
@@ -6,7 +6,6 @@ import uk.gov.communities.prsdb.webapp.forms.journeys.UpdateLandlordDetailsJourn
 import uk.gov.communities.prsdb.webapp.services.AddressLookupService
 import uk.gov.communities.prsdb.webapp.services.JourneyDataService
 import uk.gov.communities.prsdb.webapp.services.LandlordService
-import uk.gov.communities.prsdb.webapp.services.RegisteredAddressCache
 
 @Component
 class LandlordDetailsUpdateJourneyFactory(
@@ -14,7 +13,6 @@ class LandlordDetailsUpdateJourneyFactory(
     private val journeyDataService: JourneyDataService,
     private val addressLookupService: AddressLookupService,
     private val landlordService: LandlordService,
-    private val registeredAddressCache: RegisteredAddressCache,
 ) {
     fun create(landlordBaseUserId: String) =
         UpdateLandlordDetailsJourney(
@@ -22,7 +20,6 @@ class LandlordDetailsUpdateJourneyFactory(
             journeyDataService,
             addressLookupService,
             landlordService,
-            registeredAddressCache,
             landlordBaseUserId,
         )
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/factories/LandlordDetailsUpdateJourneyFactory.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/factories/LandlordDetailsUpdateJourneyFactory.kt
@@ -3,10 +3,10 @@ package uk.gov.communities.prsdb.webapp.forms.journeys.factories
 import org.springframework.stereotype.Component
 import org.springframework.validation.Validator
 import uk.gov.communities.prsdb.webapp.forms.journeys.UpdateLandlordDetailsJourney
-import uk.gov.communities.prsdb.webapp.services.AddressDataService
 import uk.gov.communities.prsdb.webapp.services.AddressLookupService
 import uk.gov.communities.prsdb.webapp.services.JourneyDataService
 import uk.gov.communities.prsdb.webapp.services.LandlordService
+import uk.gov.communities.prsdb.webapp.services.RegisteredAddressCache
 
 @Component
 class LandlordDetailsUpdateJourneyFactory(
@@ -14,7 +14,7 @@ class LandlordDetailsUpdateJourneyFactory(
     private val journeyDataService: JourneyDataService,
     private val addressLookupService: AddressLookupService,
     private val landlordService: LandlordService,
-    private val addressDataService: AddressDataService,
+    private val registeredAddressCache: RegisteredAddressCache,
 ) {
     fun create(landlordBaseUserId: String) =
         UpdateLandlordDetailsJourney(
@@ -22,7 +22,7 @@ class LandlordDetailsUpdateJourneyFactory(
             journeyDataService,
             addressLookupService,
             landlordService,
-            addressDataService,
+            registeredAddressCache,
             landlordBaseUserId,
         )
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/factories/LandlordRegistrationJourneyFactory.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/factories/LandlordRegistrationJourneyFactory.kt
@@ -9,14 +9,12 @@ import uk.gov.communities.prsdb.webapp.services.AddressLookupService
 import uk.gov.communities.prsdb.webapp.services.EmailNotificationService
 import uk.gov.communities.prsdb.webapp.services.JourneyDataService
 import uk.gov.communities.prsdb.webapp.services.LandlordService
-import uk.gov.communities.prsdb.webapp.services.RegisteredAddressCache
 
 @Component
 class LandlordRegistrationJourneyFactory(
     private val validator: Validator,
     private val journeyDataService: JourneyDataService,
     private val addressLookupService: AddressLookupService,
-    private val registeredAddressCache: RegisteredAddressCache,
     private val landlordService: LandlordService,
     private val absoluteUrlProvider: AbsoluteUrlProvider,
     private val emailNotificationService: EmailNotificationService<LandlordRegistrationConfirmationEmail>,
@@ -26,7 +24,6 @@ class LandlordRegistrationJourneyFactory(
             validator,
             journeyDataService,
             addressLookupService,
-            registeredAddressCache,
             landlordService,
             absoluteUrlProvider,
             emailNotificationService,

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/factories/LandlordRegistrationJourneyFactory.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/factories/LandlordRegistrationJourneyFactory.kt
@@ -5,18 +5,18 @@ import org.springframework.validation.Validator
 import uk.gov.communities.prsdb.webapp.forms.journeys.LandlordRegistrationJourney
 import uk.gov.communities.prsdb.webapp.models.viewModels.emailModels.LandlordRegistrationConfirmationEmail
 import uk.gov.communities.prsdb.webapp.services.AbsoluteUrlProvider
-import uk.gov.communities.prsdb.webapp.services.AddressDataService
 import uk.gov.communities.prsdb.webapp.services.AddressLookupService
 import uk.gov.communities.prsdb.webapp.services.EmailNotificationService
 import uk.gov.communities.prsdb.webapp.services.JourneyDataService
 import uk.gov.communities.prsdb.webapp.services.LandlordService
+import uk.gov.communities.prsdb.webapp.services.RegisteredAddressCache
 
 @Component
 class LandlordRegistrationJourneyFactory(
     private val validator: Validator,
     private val journeyDataService: JourneyDataService,
     private val addressLookupService: AddressLookupService,
-    private val addressDataService: AddressDataService,
+    private val registeredAddressCache: RegisteredAddressCache,
     private val landlordService: LandlordService,
     private val absoluteUrlProvider: AbsoluteUrlProvider,
     private val emailNotificationService: EmailNotificationService<LandlordRegistrationConfirmationEmail>,
@@ -26,7 +26,7 @@ class LandlordRegistrationJourneyFactory(
             validator,
             journeyDataService,
             addressLookupService,
-            addressDataService,
+            registeredAddressCache,
             landlordService,
             absoluteUrlProvider,
             emailNotificationService,

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/factories/PropertyRegistrationJourneyFactory.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/factories/PropertyRegistrationJourneyFactory.kt
@@ -5,20 +5,20 @@ import org.springframework.validation.Validator
 import uk.gov.communities.prsdb.webapp.forms.journeys.PropertyRegistrationJourney
 import uk.gov.communities.prsdb.webapp.models.viewModels.emailModels.PropertyRegistrationConfirmationEmail
 import uk.gov.communities.prsdb.webapp.services.AbsoluteUrlProvider
-import uk.gov.communities.prsdb.webapp.services.AddressDataService
 import uk.gov.communities.prsdb.webapp.services.AddressLookupService
 import uk.gov.communities.prsdb.webapp.services.EmailNotificationService
 import uk.gov.communities.prsdb.webapp.services.JourneyDataService
 import uk.gov.communities.prsdb.webapp.services.LandlordService
 import uk.gov.communities.prsdb.webapp.services.LocalAuthorityService
 import uk.gov.communities.prsdb.webapp.services.PropertyRegistrationService
+import uk.gov.communities.prsdb.webapp.services.RegisteredAddressCache
 
 @Component
 class PropertyRegistrationJourneyFactory(
     private val validator: Validator,
     private val journeyDataService: JourneyDataService,
     private val addressLookupService: AddressLookupService,
-    private val addressDataService: AddressDataService,
+    private val registeredAddressCache: RegisteredAddressCache,
     private val propertyRegistrationService: PropertyRegistrationService,
     private val localAuthorityService: LocalAuthorityService,
     private val landlordService: LandlordService,
@@ -30,7 +30,7 @@ class PropertyRegistrationJourneyFactory(
             validator,
             journeyDataService,
             addressLookupService,
-            addressDataService,
+            registeredAddressCache,
             propertyRegistrationService,
             localAuthorityService,
             landlordService,

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/factories/PropertyRegistrationJourneyFactory.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/factories/PropertyRegistrationJourneyFactory.kt
@@ -11,14 +11,12 @@ import uk.gov.communities.prsdb.webapp.services.JourneyDataService
 import uk.gov.communities.prsdb.webapp.services.LandlordService
 import uk.gov.communities.prsdb.webapp.services.LocalAuthorityService
 import uk.gov.communities.prsdb.webapp.services.PropertyRegistrationService
-import uk.gov.communities.prsdb.webapp.services.RegisteredAddressCache
 
 @Component
 class PropertyRegistrationJourneyFactory(
     private val validator: Validator,
     private val journeyDataService: JourneyDataService,
     private val addressLookupService: AddressLookupService,
-    private val registeredAddressCache: RegisteredAddressCache,
     private val propertyRegistrationService: PropertyRegistrationService,
     private val localAuthorityService: LocalAuthorityService,
     private val landlordService: LandlordService,
@@ -30,7 +28,6 @@ class PropertyRegistrationJourneyFactory(
             validator,
             journeyDataService,
             addressLookupService,
-            registeredAddressCache,
             propertyRegistrationService,
             localAuthorityService,
             landlordService,

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/pages/LandlordRegistrationCheckAnswersPage.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/pages/LandlordRegistrationCheckAnswersPage.kt
@@ -6,10 +6,10 @@ import uk.gov.communities.prsdb.webapp.forms.steps.LandlordRegistrationStepId
 import uk.gov.communities.prsdb.webapp.helpers.LandlordRegistrationJourneyDataHelper
 import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.CheckAnswersFormModel
 import uk.gov.communities.prsdb.webapp.models.viewModels.summaryModels.SummaryListRowViewModel
-import uk.gov.communities.prsdb.webapp.services.AddressDataService
+import uk.gov.communities.prsdb.webapp.services.RegisteredAddressCache
 
 class LandlordRegistrationCheckAnswersPage(
-    private val addressDataService: AddressDataService,
+    private val registeredAddressCache: RegisteredAddressCache,
     displaySectionHeader: Boolean = false,
 ) : AbstractPage(
         formModel = CheckAnswersFormModel::class,
@@ -72,7 +72,7 @@ class LandlordRegistrationCheckAnswersPage(
 
         return getLivesInEnglandOrWalesFormData(livesInEnglandOrWales) +
             (if (!livesInEnglandOrWales) getNonEnglandOrWalesAddressFormData(journeyData) else emptyList()) +
-            getContactAddressFormData(journeyData, addressDataService, livesInEnglandOrWales)
+            getContactAddressFormData(journeyData, registeredAddressCache, livesInEnglandOrWales)
     }
 
     private fun getLivesInEnglandOrWalesFormData(livesInEnglandOrWales: Boolean): List<SummaryListRowViewModel> =
@@ -100,7 +100,7 @@ class LandlordRegistrationCheckAnswersPage(
 
     private fun getContactAddressFormData(
         journeyData: JourneyData,
-        addressDataService: AddressDataService,
+        registeredAddressCache: RegisteredAddressCache,
         livesInEnglandOrWales: Boolean,
     ): SummaryListRowViewModel =
         SummaryListRowViewModel(
@@ -109,7 +109,7 @@ class LandlordRegistrationCheckAnswersPage(
             } else {
                 "registerAsALandlord.checkAnswers.rowHeading.englandOrWalesContactAddress"
             },
-            LandlordRegistrationJourneyDataHelper.getAddress(journeyData, addressDataService)!!.singleLineAddress,
+            LandlordRegistrationJourneyDataHelper.getAddress(journeyData, registeredAddressCache)!!.singleLineAddress,
             getContactAddressChangeURLPathSegment(journeyData, livesInEnglandOrWales),
         )
 

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/pages/LandlordRegistrationCheckAnswersPage.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/pages/LandlordRegistrationCheckAnswersPage.kt
@@ -6,10 +6,10 @@ import uk.gov.communities.prsdb.webapp.forms.steps.LandlordRegistrationStepId
 import uk.gov.communities.prsdb.webapp.helpers.LandlordRegistrationJourneyDataHelper
 import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.CheckAnswersFormModel
 import uk.gov.communities.prsdb.webapp.models.viewModels.summaryModels.SummaryListRowViewModel
-import uk.gov.communities.prsdb.webapp.services.RegisteredAddressCache
+import uk.gov.communities.prsdb.webapp.services.JourneyDataService
 
 class LandlordRegistrationCheckAnswersPage(
-    private val registeredAddressCache: RegisteredAddressCache,
+    private val journeyDataService: JourneyDataService,
     displaySectionHeader: Boolean = false,
 ) : AbstractPage(
         formModel = CheckAnswersFormModel::class,
@@ -72,7 +72,7 @@ class LandlordRegistrationCheckAnswersPage(
 
         return getLivesInEnglandOrWalesFormData(livesInEnglandOrWales) +
             (if (!livesInEnglandOrWales) getNonEnglandOrWalesAddressFormData(journeyData) else emptyList()) +
-            getContactAddressFormData(journeyData, registeredAddressCache, livesInEnglandOrWales)
+            getContactAddressFormData(journeyData, livesInEnglandOrWales)
     }
 
     private fun getLivesInEnglandOrWalesFormData(livesInEnglandOrWales: Boolean): List<SummaryListRowViewModel> =
@@ -100,7 +100,6 @@ class LandlordRegistrationCheckAnswersPage(
 
     private fun getContactAddressFormData(
         journeyData: JourneyData,
-        registeredAddressCache: RegisteredAddressCache,
         livesInEnglandOrWales: Boolean,
     ): SummaryListRowViewModel =
         SummaryListRowViewModel(
@@ -109,7 +108,7 @@ class LandlordRegistrationCheckAnswersPage(
             } else {
                 "registerAsALandlord.checkAnswers.rowHeading.englandOrWalesContactAddress"
             },
-            LandlordRegistrationJourneyDataHelper.getAddress(journeyData, registeredAddressCache)!!.singleLineAddress,
+            LandlordRegistrationJourneyDataHelper.getAddress(journeyData)!!.singleLineAddress,
             getContactAddressChangeURLPathSegment(journeyData, livesInEnglandOrWales),
         )
 

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/pages/LandlordRegistrationCheckAnswersPage.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/pages/LandlordRegistrationCheckAnswersPage.kt
@@ -1,6 +1,7 @@
 package uk.gov.communities.prsdb.webapp.forms.pages
 
 import org.springframework.web.servlet.ModelAndView
+import uk.gov.communities.prsdb.webapp.constants.LOOKED_UP_ADDRESSES_JOURNEY_DATA_KEY
 import uk.gov.communities.prsdb.webapp.forms.JourneyData
 import uk.gov.communities.prsdb.webapp.forms.steps.LandlordRegistrationStepId
 import uk.gov.communities.prsdb.webapp.helpers.LandlordRegistrationJourneyDataHelper
@@ -26,12 +27,13 @@ class LandlordRegistrationCheckAnswersPage(
         modelAndView: ModelAndView,
         filteredJourneyData: JourneyData?,
     ) {
-        filteredJourneyData!!
+        val filteredJourneyDataWithLookedUpAddresses =
+            filteredJourneyData!! + journeyDataService.getJourneyDataEntryInSession(LOOKED_UP_ADDRESSES_JOURNEY_DATA_KEY)!!
 
         val formData =
-            getIdentityFormData(filteredJourneyData) +
-                getEmailAndPhoneFormData(filteredJourneyData) +
-                getAddressFormData(filteredJourneyData)
+            getIdentityFormData(filteredJourneyDataWithLookedUpAddresses) +
+                getEmailAndPhoneFormData(filteredJourneyDataWithLookedUpAddresses) +
+                getAddressFormData(filteredJourneyDataWithLookedUpAddresses)
 
         modelAndView.addObject("formData", formData)
     }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/pages/LandlordRegistrationCheckAnswersPage.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/pages/LandlordRegistrationCheckAnswersPage.kt
@@ -4,7 +4,7 @@ import org.springframework.web.servlet.ModelAndView
 import uk.gov.communities.prsdb.webapp.forms.JourneyData
 import uk.gov.communities.prsdb.webapp.forms.steps.LandlordRegistrationStepId
 import uk.gov.communities.prsdb.webapp.helpers.LandlordRegistrationJourneyDataHelper
-import uk.gov.communities.prsdb.webapp.helpers.extensions.JourneyDataExtensions.Companion.getLookedUpAddresses
+import uk.gov.communities.prsdb.webapp.helpers.extensions.journeyDataExtensions.JourneyDataExtensions.Companion.getLookedUpAddresses
 import uk.gov.communities.prsdb.webapp.models.dataModels.AddressDataModel
 import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.CheckAnswersFormModel
 import uk.gov.communities.prsdb.webapp.models.viewModels.summaryModels.SummaryListRowViewModel

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/pages/PropertyRegistrationCheckAnswersPage.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/pages/PropertyRegistrationCheckAnswersPage.kt
@@ -8,13 +8,13 @@ import uk.gov.communities.prsdb.webapp.forms.steps.RegisterPropertyStepId
 import uk.gov.communities.prsdb.webapp.models.dataModels.AddressDataModel
 import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.NoInputFormModel
 import uk.gov.communities.prsdb.webapp.models.viewModels.summaryModels.SummaryListRowViewModel
+import uk.gov.communities.prsdb.webapp.services.JourneyDataService
 import uk.gov.communities.prsdb.webapp.services.LocalAuthorityService
-import uk.gov.communities.prsdb.webapp.services.RegisteredAddressCache
 import uk.gov.communities.prsdb.webapp.helpers.PropertyRegistrationJourneyDataHelper as DataHelper
 
 class PropertyRegistrationCheckAnswersPage(
-    private val registeredAddressCache: RegisteredAddressCache,
     private val localAuthorityService: LocalAuthorityService,
+    private val journeyDataService: JourneyDataService,
     displaySectionHeader: Boolean = false,
 ) : AbstractPage(
         NoInputFormModel::class,
@@ -45,7 +45,7 @@ class PropertyRegistrationCheckAnswersPage(
         modelAndView.addObject("showUprnDetail", !DataHelper.isManualAddressChosen(journeyData))
     }
 
-    private fun getPropertyName(journeyData: JourneyData) = DataHelper.getAddress(journeyData, registeredAddressCache)!!.singleLineAddress
+    private fun getPropertyName(journeyData: JourneyData) = DataHelper.getAddress(journeyData)!!.singleLineAddress
 
     private fun getPropertyDetailsSummary(journeyData: JourneyData): List<SummaryListRowViewModel> =
         getAddressDetails(journeyData) +
@@ -55,7 +55,7 @@ class PropertyRegistrationCheckAnswersPage(
             getTenancyDetails(journeyData)
 
     private fun getAddressDetails(journeyData: JourneyData): List<SummaryListRowViewModel> {
-        val address = DataHelper.getAddress(journeyData, registeredAddressCache)!!
+        val address = DataHelper.getAddress(journeyData)!!
         return if (DataHelper.isManualAddressChosen(journeyData)) {
             getManualAddressDetails(address)
         } else {

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/pages/PropertyRegistrationCheckAnswersPage.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/pages/PropertyRegistrationCheckAnswersPage.kt
@@ -8,12 +8,12 @@ import uk.gov.communities.prsdb.webapp.forms.steps.RegisterPropertyStepId
 import uk.gov.communities.prsdb.webapp.models.dataModels.AddressDataModel
 import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.NoInputFormModel
 import uk.gov.communities.prsdb.webapp.models.viewModels.summaryModels.SummaryListRowViewModel
-import uk.gov.communities.prsdb.webapp.services.AddressDataService
 import uk.gov.communities.prsdb.webapp.services.LocalAuthorityService
+import uk.gov.communities.prsdb.webapp.services.RegisteredAddressCache
 import uk.gov.communities.prsdb.webapp.helpers.PropertyRegistrationJourneyDataHelper as DataHelper
 
 class PropertyRegistrationCheckAnswersPage(
-    private val addressDataService: AddressDataService,
+    private val registeredAddressCache: RegisteredAddressCache,
     private val localAuthorityService: LocalAuthorityService,
     displaySectionHeader: Boolean = false,
 ) : AbstractPage(
@@ -45,7 +45,7 @@ class PropertyRegistrationCheckAnswersPage(
         modelAndView.addObject("showUprnDetail", !DataHelper.isManualAddressChosen(journeyData))
     }
 
-    private fun getPropertyName(journeyData: JourneyData) = DataHelper.getAddress(journeyData, addressDataService)!!.singleLineAddress
+    private fun getPropertyName(journeyData: JourneyData) = DataHelper.getAddress(journeyData, registeredAddressCache)!!.singleLineAddress
 
     private fun getPropertyDetailsSummary(journeyData: JourneyData): List<SummaryListRowViewModel> =
         getAddressDetails(journeyData) +
@@ -55,7 +55,7 @@ class PropertyRegistrationCheckAnswersPage(
             getTenancyDetails(journeyData)
 
     private fun getAddressDetails(journeyData: JourneyData): List<SummaryListRowViewModel> {
-        val address = DataHelper.getAddress(journeyData, addressDataService)!!
+        val address = DataHelper.getAddress(journeyData, registeredAddressCache)!!
         return if (DataHelper.isManualAddressChosen(journeyData)) {
             getManualAddressDetails(address)
         } else {

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/pages/PropertyRegistrationCheckAnswersPage.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/pages/PropertyRegistrationCheckAnswersPage.kt
@@ -5,7 +5,7 @@ import uk.gov.communities.prsdb.webapp.constants.enums.LicensingType
 import uk.gov.communities.prsdb.webapp.constants.enums.PropertyType
 import uk.gov.communities.prsdb.webapp.forms.JourneyData
 import uk.gov.communities.prsdb.webapp.forms.steps.RegisterPropertyStepId
-import uk.gov.communities.prsdb.webapp.helpers.extensions.JourneyDataExtensions.Companion.getLookedUpAddresses
+import uk.gov.communities.prsdb.webapp.helpers.extensions.journeyDataExtensions.JourneyDataExtensions.Companion.getLookedUpAddresses
 import uk.gov.communities.prsdb.webapp.models.dataModels.AddressDataModel
 import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.NoInputFormModel
 import uk.gov.communities.prsdb.webapp.models.viewModels.summaryModels.SummaryListRowViewModel

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/pages/PropertyRegistrationCheckAnswersPage.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/pages/PropertyRegistrationCheckAnswersPage.kt
@@ -1,6 +1,7 @@
 package uk.gov.communities.prsdb.webapp.forms.pages
 
 import org.springframework.web.servlet.ModelAndView
+import uk.gov.communities.prsdb.webapp.constants.LOOKED_UP_ADDRESSES_JOURNEY_DATA_KEY
 import uk.gov.communities.prsdb.webapp.constants.enums.LicensingType
 import uk.gov.communities.prsdb.webapp.constants.enums.PropertyType
 import uk.gov.communities.prsdb.webapp.forms.JourneyData
@@ -29,8 +30,9 @@ class PropertyRegistrationCheckAnswersPage(
         modelAndView: ModelAndView,
         filteredJourneyData: JourneyData?,
     ) {
-        filteredJourneyData!!
-        addPropertyDetailsToModel(modelAndView, filteredJourneyData)
+        val filteredJourneyDataWithLookedUpAddresses =
+            filteredJourneyData!! + journeyDataService.getJourneyDataEntryInSession(LOOKED_UP_ADDRESSES_JOURNEY_DATA_KEY)!!
+        addPropertyDetailsToModel(modelAndView, filteredJourneyDataWithLookedUpAddresses)
     }
 
     private fun addPropertyDetailsToModel(

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/pages/PropertyRegistrationCheckAnswersPage.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/pages/PropertyRegistrationCheckAnswersPage.kt
@@ -1,11 +1,11 @@
 package uk.gov.communities.prsdb.webapp.forms.pages
 
 import org.springframework.web.servlet.ModelAndView
-import uk.gov.communities.prsdb.webapp.constants.LOOKED_UP_ADDRESSES_JOURNEY_DATA_KEY
 import uk.gov.communities.prsdb.webapp.constants.enums.LicensingType
 import uk.gov.communities.prsdb.webapp.constants.enums.PropertyType
 import uk.gov.communities.prsdb.webapp.forms.JourneyData
 import uk.gov.communities.prsdb.webapp.forms.steps.RegisterPropertyStepId
+import uk.gov.communities.prsdb.webapp.helpers.extensions.JourneyDataExtensions.Companion.getLookedUpAddresses
 import uk.gov.communities.prsdb.webapp.models.dataModels.AddressDataModel
 import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.NoInputFormModel
 import uk.gov.communities.prsdb.webapp.models.viewModels.summaryModels.SummaryListRowViewModel
@@ -30,34 +30,43 @@ class PropertyRegistrationCheckAnswersPage(
         modelAndView: ModelAndView,
         filteredJourneyData: JourneyData?,
     ) {
-        val filteredJourneyDataWithLookedUpAddresses =
-            filteredJourneyData!! + journeyDataService.getJourneyDataEntryInSession(LOOKED_UP_ADDRESSES_JOURNEY_DATA_KEY)!!
-        addPropertyDetailsToModel(modelAndView, filteredJourneyDataWithLookedUpAddresses)
+        val lookedUpAddresses = journeyDataService.getJourneyDataFromSession().getLookedUpAddresses()
+        addPropertyDetailsToModel(modelAndView, filteredJourneyData!!, lookedUpAddresses)
     }
 
     private fun addPropertyDetailsToModel(
         modelAndView: ModelAndView,
         journeyData: JourneyData,
+        lookedUpAddresses: List<AddressDataModel>,
     ) {
-        val propertyName = getPropertyName(journeyData)
-        val propertyDetails = getPropertyDetailsSummary(journeyData)
+        val propertyName = getPropertyName(journeyData, lookedUpAddresses)
+        val propertyDetails = getPropertyDetailsSummary(journeyData, lookedUpAddresses)
 
         modelAndView.addObject("propertyDetails", propertyDetails)
         modelAndView.addObject("propertyName", propertyName)
         modelAndView.addObject("showUprnDetail", !DataHelper.isManualAddressChosen(journeyData))
     }
 
-    private fun getPropertyName(journeyData: JourneyData) = DataHelper.getAddress(journeyData)!!.singleLineAddress
+    private fun getPropertyName(
+        journeyData: JourneyData,
+        lookedUpAddresses: List<AddressDataModel>,
+    ) = DataHelper.getAddress(journeyData, lookedUpAddresses)!!.singleLineAddress
 
-    private fun getPropertyDetailsSummary(journeyData: JourneyData): List<SummaryListRowViewModel> =
-        getAddressDetails(journeyData) +
+    private fun getPropertyDetailsSummary(
+        journeyData: JourneyData,
+        lookedUpAddresses: List<AddressDataModel>,
+    ): List<SummaryListRowViewModel> =
+        getAddressDetails(journeyData, lookedUpAddresses) +
             getPropertyTypeDetails(journeyData) +
             getOwnershipTypeDetails(journeyData) +
             getLicensingTypeDetails(journeyData) +
             getTenancyDetails(journeyData)
 
-    private fun getAddressDetails(journeyData: JourneyData): List<SummaryListRowViewModel> {
-        val address = DataHelper.getAddress(journeyData)!!
+    private fun getAddressDetails(
+        journeyData: JourneyData,
+        lookedUpAddresses: List<AddressDataModel>,
+    ): List<SummaryListRowViewModel> {
+        val address = DataHelper.getAddress(journeyData, lookedUpAddresses)!!
         return if (DataHelper.isManualAddressChosen(journeyData)) {
             getManualAddressDetails(address)
         } else {

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/pages/SelectAddressPage.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/pages/SelectAddressPage.kt
@@ -7,7 +7,7 @@ import uk.gov.communities.prsdb.webapp.forms.JourneyData
 import uk.gov.communities.prsdb.webapp.forms.PageData
 import uk.gov.communities.prsdb.webapp.helpers.JourneyDataHelper
 import uk.gov.communities.prsdb.webapp.helpers.extensions.journeyDataExtensions.JourneyDataExtensions.Companion.getLookedUpAddress
-import uk.gov.communities.prsdb.webapp.helpers.extensions.journeyDataExtensions.JourneyDataExtensions.Companion.updateLookedUpAddresses
+import uk.gov.communities.prsdb.webapp.helpers.extensions.journeyDataExtensions.JourneyDataExtensions.Companion.withUpdatedLookedUpAddresses
 import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.FormModel
 import uk.gov.communities.prsdb.webapp.models.viewModels.formModels.RadiosButtonViewModel
 import uk.gov.communities.prsdb.webapp.models.viewModels.formModels.RadiosDividerViewModel
@@ -40,7 +40,7 @@ class SelectAddressPage(
         val addressLookupResults = addressLookupService.search(houseNameOrNumber, postcode)
 
         val journeyData = journeyDataService.getJourneyDataFromSession()
-        val updatedJourneyData = journeyData.updateLookedUpAddresses(addressLookupResults)
+        val updatedJourneyData = journeyData.withUpdatedLookedUpAddresses(addressLookupResults)
         journeyDataService.setJourneyDataInSession(updatedJourneyData)
 
         var addressRadiosViewModel: List<RadiosViewModel> =

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/pages/SelectAddressPage.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/pages/SelectAddressPage.kt
@@ -6,12 +6,13 @@ import uk.gov.communities.prsdb.webapp.constants.MANUAL_ADDRESS_CHOSEN
 import uk.gov.communities.prsdb.webapp.forms.JourneyData
 import uk.gov.communities.prsdb.webapp.forms.PageData
 import uk.gov.communities.prsdb.webapp.helpers.JourneyDataHelper
+import uk.gov.communities.prsdb.webapp.helpers.extensions.JourneyDataExtensions.Companion.getLookedUpAddress
 import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.FormModel
 import uk.gov.communities.prsdb.webapp.models.viewModels.formModels.RadiosButtonViewModel
 import uk.gov.communities.prsdb.webapp.models.viewModels.formModels.RadiosDividerViewModel
 import uk.gov.communities.prsdb.webapp.models.viewModels.formModels.RadiosViewModel
 import uk.gov.communities.prsdb.webapp.services.AddressLookupService
-import uk.gov.communities.prsdb.webapp.services.RegisteredAddressCache
+import uk.gov.communities.prsdb.webapp.services.JourneyDataService
 import kotlin.reflect.KClass
 
 class SelectAddressPage(
@@ -21,7 +22,7 @@ class SelectAddressPage(
     displaySectionHeader: Boolean = false,
     private val lookupAddressPathSegment: String,
     private val addressLookupService: AddressLookupService,
-    private val registeredAddressCache: RegisteredAddressCache,
+    private val journeyDataService: JourneyDataService,
 ) : AbstractPage(formModel, templateName, content, displaySectionHeader) {
     override fun enrichModel(
         modelAndView: ModelAndView,
@@ -64,6 +65,8 @@ class SelectAddressPage(
         formData: PageData,
     ): Boolean {
         val selectedAddress = formData["address"].toString()
-        return selectedAddress == MANUAL_ADDRESS_CHOSEN || registeredAddressCache.getAddressData(selectedAddress) != null
+        val journeyData = journeyDataService.getJourneyDataFromSession()
+
+        return selectedAddress == MANUAL_ADDRESS_CHOSEN || journeyData.getLookedUpAddress(selectedAddress) != null
     }
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/pages/SelectAddressPage.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/pages/SelectAddressPage.kt
@@ -10,8 +10,8 @@ import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.FormModel
 import uk.gov.communities.prsdb.webapp.models.viewModels.formModels.RadiosButtonViewModel
 import uk.gov.communities.prsdb.webapp.models.viewModels.formModels.RadiosDividerViewModel
 import uk.gov.communities.prsdb.webapp.models.viewModels.formModels.RadiosViewModel
-import uk.gov.communities.prsdb.webapp.services.AddressDataService
 import uk.gov.communities.prsdb.webapp.services.AddressLookupService
+import uk.gov.communities.prsdb.webapp.services.RegisteredAddressCache
 import kotlin.reflect.KClass
 
 class SelectAddressPage(
@@ -21,7 +21,7 @@ class SelectAddressPage(
     displaySectionHeader: Boolean = false,
     private val lookupAddressPathSegment: String,
     private val addressLookupService: AddressLookupService,
-    private val addressDataService: AddressDataService,
+    private val registeredAddressCache: RegisteredAddressCache,
 ) : AbstractPage(formModel, templateName, content, displaySectionHeader) {
     override fun enrichModel(
         modelAndView: ModelAndView,
@@ -36,7 +36,7 @@ class SelectAddressPage(
             )!!
 
         val addressLookupResults = addressLookupService.search(houseNameOrNumber, postcode)
-        addressDataService.setAddressData(addressLookupResults)
+        registeredAddressCache.setAddressData(addressLookupResults)
 
         var addressRadiosViewModel: List<RadiosViewModel> =
             addressLookupResults.mapIndexed { index, address ->
@@ -64,6 +64,6 @@ class SelectAddressPage(
         formData: PageData,
     ): Boolean {
         val selectedAddress = formData["address"].toString()
-        return selectedAddress == MANUAL_ADDRESS_CHOSEN || addressDataService.getAddressData(selectedAddress) != null
+        return selectedAddress == MANUAL_ADDRESS_CHOSEN || registeredAddressCache.getAddressData(selectedAddress) != null
     }
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/pages/SelectAddressPage.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/pages/SelectAddressPage.kt
@@ -1,7 +1,10 @@
 package uk.gov.communities.prsdb.webapp.forms.pages
 
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
 import org.springframework.validation.Validator
 import org.springframework.web.servlet.ModelAndView
+import uk.gov.communities.prsdb.webapp.constants.LOOKED_UP_ADDRESSES_JOURNEY_DATA_KEY
 import uk.gov.communities.prsdb.webapp.constants.MANUAL_ADDRESS_CHOSEN
 import uk.gov.communities.prsdb.webapp.forms.JourneyData
 import uk.gov.communities.prsdb.webapp.forms.PageData
@@ -37,7 +40,7 @@ class SelectAddressPage(
             )!!
 
         val addressLookupResults = addressLookupService.search(houseNameOrNumber, postcode)
-        registeredAddressCache.setAddressData(addressLookupResults)
+        journeyDataService.setJourneyDataEntryInSession(LOOKED_UP_ADDRESSES_JOURNEY_DATA_KEY, Json.encodeToString(addressLookupResults))
 
         var addressRadiosViewModel: List<RadiosViewModel> =
             addressLookupResults.mapIndexed { index, address ->

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/pages/SelectAddressPage.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/pages/SelectAddressPage.kt
@@ -6,8 +6,8 @@ import uk.gov.communities.prsdb.webapp.constants.MANUAL_ADDRESS_CHOSEN
 import uk.gov.communities.prsdb.webapp.forms.JourneyData
 import uk.gov.communities.prsdb.webapp.forms.PageData
 import uk.gov.communities.prsdb.webapp.helpers.JourneyDataHelper
-import uk.gov.communities.prsdb.webapp.helpers.extensions.JourneyDataExtensions.Companion.getLookedUpAddress
-import uk.gov.communities.prsdb.webapp.helpers.extensions.JourneyDataExtensions.Companion.updateLookedUpAddresses
+import uk.gov.communities.prsdb.webapp.helpers.extensions.journeyDataExtensions.JourneyDataExtensions.Companion.getLookedUpAddress
+import uk.gov.communities.prsdb.webapp.helpers.extensions.journeyDataExtensions.JourneyDataExtensions.Companion.updateLookedUpAddresses
 import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.FormModel
 import uk.gov.communities.prsdb.webapp.models.viewModels.formModels.RadiosButtonViewModel
 import uk.gov.communities.prsdb.webapp.models.viewModels.formModels.RadiosDividerViewModel

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/pages/SelectAddressPage.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/pages/SelectAddressPage.kt
@@ -1,15 +1,13 @@
 package uk.gov.communities.prsdb.webapp.forms.pages
 
-import kotlinx.serialization.encodeToString
-import kotlinx.serialization.json.Json
 import org.springframework.validation.Validator
 import org.springframework.web.servlet.ModelAndView
-import uk.gov.communities.prsdb.webapp.constants.LOOKED_UP_ADDRESSES_JOURNEY_DATA_KEY
 import uk.gov.communities.prsdb.webapp.constants.MANUAL_ADDRESS_CHOSEN
 import uk.gov.communities.prsdb.webapp.forms.JourneyData
 import uk.gov.communities.prsdb.webapp.forms.PageData
 import uk.gov.communities.prsdb.webapp.helpers.JourneyDataHelper
 import uk.gov.communities.prsdb.webapp.helpers.extensions.JourneyDataExtensions.Companion.getLookedUpAddress
+import uk.gov.communities.prsdb.webapp.helpers.extensions.JourneyDataExtensions.Companion.updateLookedUpAddresses
 import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.FormModel
 import uk.gov.communities.prsdb.webapp.models.viewModels.formModels.RadiosButtonViewModel
 import uk.gov.communities.prsdb.webapp.models.viewModels.formModels.RadiosDividerViewModel
@@ -40,7 +38,10 @@ class SelectAddressPage(
             )!!
 
         val addressLookupResults = addressLookupService.search(houseNameOrNumber, postcode)
-        journeyDataService.setJourneyDataEntryInSession(LOOKED_UP_ADDRESSES_JOURNEY_DATA_KEY, Json.encodeToString(addressLookupResults))
+
+        val journeyData = journeyDataService.getJourneyDataFromSession()
+        val updatedJourneyData = journeyData.updateLookedUpAddresses(addressLookupResults)
+        journeyDataService.setJourneyDataInSession(updatedJourneyData)
 
         var addressRadiosViewModel: List<RadiosViewModel> =
             addressLookupResults.mapIndexed { index, address ->

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/helpers/LandlordRegistrationJourneyDataHelper.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/helpers/LandlordRegistrationJourneyDataHelper.kt
@@ -4,7 +4,6 @@ import uk.gov.communities.prsdb.webapp.constants.ENGLAND_OR_WALES
 import uk.gov.communities.prsdb.webapp.constants.MANUAL_ADDRESS_CHOSEN
 import uk.gov.communities.prsdb.webapp.forms.JourneyData
 import uk.gov.communities.prsdb.webapp.forms.steps.LandlordRegistrationStepId
-import uk.gov.communities.prsdb.webapp.helpers.extensions.JourneyDataExtensions.Companion.getLookedUpAddress
 import uk.gov.communities.prsdb.webapp.models.dataModels.AddressDataModel
 import java.time.LocalDate
 
@@ -92,14 +91,17 @@ class LandlordRegistrationJourneyDataHelper : JourneyDataHelper() {
                 )
             }
 
-        fun getAddress(journeyData: JourneyData): AddressDataModel? {
+        fun getAddress(
+            journeyData: JourneyData,
+            lookedUpAddresses: List<AddressDataModel>,
+        ): AddressDataModel? {
             val livesInEnglandOrWales = getLivesInEnglandOrWales(journeyData) ?: return null
 
             return if (isManualAddressChosen(journeyData, !livesInEnglandOrWales)) {
                 getManualAddress(journeyData, !livesInEnglandOrWales)
             } else {
                 val selectedAddress = getSelectedAddress(journeyData, !livesInEnglandOrWales) ?: return null
-                journeyData.getLookedUpAddress(selectedAddress)
+                lookedUpAddresses.singleOrNull { it.singleLineAddress == selectedAddress }
             }
         }
 

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/helpers/LandlordRegistrationJourneyDataHelper.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/helpers/LandlordRegistrationJourneyDataHelper.kt
@@ -5,7 +5,7 @@ import uk.gov.communities.prsdb.webapp.constants.MANUAL_ADDRESS_CHOSEN
 import uk.gov.communities.prsdb.webapp.forms.JourneyData
 import uk.gov.communities.prsdb.webapp.forms.steps.LandlordRegistrationStepId
 import uk.gov.communities.prsdb.webapp.models.dataModels.AddressDataModel
-import uk.gov.communities.prsdb.webapp.services.AddressDataService
+import uk.gov.communities.prsdb.webapp.services.RegisteredAddressCache
 import java.time.LocalDate
 
 class LandlordRegistrationJourneyDataHelper : JourneyDataHelper() {
@@ -94,7 +94,7 @@ class LandlordRegistrationJourneyDataHelper : JourneyDataHelper() {
 
         fun getAddress(
             journeyData: JourneyData,
-            addressDataService: AddressDataService,
+            registeredAddressCache: RegisteredAddressCache,
         ): AddressDataModel? {
             val livesInEnglandOrWales = getLivesInEnglandOrWales(journeyData) ?: return null
 
@@ -102,7 +102,7 @@ class LandlordRegistrationJourneyDataHelper : JourneyDataHelper() {
                 getManualAddress(journeyData, !livesInEnglandOrWales)
             } else {
                 val selectedAddress = getSelectedAddress(journeyData, !livesInEnglandOrWales) ?: return null
-                addressDataService.getAddressData(selectedAddress)
+                registeredAddressCache.getAddressData(selectedAddress)
             }
         }
 

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/helpers/LandlordRegistrationJourneyDataHelper.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/helpers/LandlordRegistrationJourneyDataHelper.kt
@@ -4,8 +4,8 @@ import uk.gov.communities.prsdb.webapp.constants.ENGLAND_OR_WALES
 import uk.gov.communities.prsdb.webapp.constants.MANUAL_ADDRESS_CHOSEN
 import uk.gov.communities.prsdb.webapp.forms.JourneyData
 import uk.gov.communities.prsdb.webapp.forms.steps.LandlordRegistrationStepId
+import uk.gov.communities.prsdb.webapp.helpers.extensions.JourneyDataExtensions.Companion.getLookedUpAddress
 import uk.gov.communities.prsdb.webapp.models.dataModels.AddressDataModel
-import uk.gov.communities.prsdb.webapp.services.RegisteredAddressCache
 import java.time.LocalDate
 
 class LandlordRegistrationJourneyDataHelper : JourneyDataHelper() {
@@ -92,17 +92,14 @@ class LandlordRegistrationJourneyDataHelper : JourneyDataHelper() {
                 )
             }
 
-        fun getAddress(
-            journeyData: JourneyData,
-            registeredAddressCache: RegisteredAddressCache,
-        ): AddressDataModel? {
+        fun getAddress(journeyData: JourneyData): AddressDataModel? {
             val livesInEnglandOrWales = getLivesInEnglandOrWales(journeyData) ?: return null
 
             return if (isManualAddressChosen(journeyData, !livesInEnglandOrWales)) {
                 getManualAddress(journeyData, !livesInEnglandOrWales)
             } else {
                 val selectedAddress = getSelectedAddress(journeyData, !livesInEnglandOrWales) ?: return null
-                registeredAddressCache.getAddressData(selectedAddress)
+                journeyData.getLookedUpAddress(selectedAddress)
             }
         }
 

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/helpers/PropertyRegistrationJourneyDataHelper.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/helpers/PropertyRegistrationJourneyDataHelper.kt
@@ -6,23 +6,24 @@ import uk.gov.communities.prsdb.webapp.constants.enums.OwnershipType
 import uk.gov.communities.prsdb.webapp.constants.enums.PropertyType
 import uk.gov.communities.prsdb.webapp.forms.JourneyData
 import uk.gov.communities.prsdb.webapp.forms.steps.RegisterPropertyStepId
-import uk.gov.communities.prsdb.webapp.helpers.extensions.JourneyDataExtensions.Companion.getLookedUpAddress
 import uk.gov.communities.prsdb.webapp.models.dataModels.AddressDataModel
 
 class PropertyRegistrationJourneyDataHelper : JourneyDataHelper() {
     companion object {
-        fun getAddress(journeyData: JourneyData): AddressDataModel? {
-            return if (isManualAddressChosen(journeyData)) {
+        fun getAddress(
+            journeyData: JourneyData,
+            lookedUpAddresses: List<AddressDataModel>,
+        ): AddressDataModel? =
+            if (isManualAddressChosen(journeyData)) {
                 getManualAddress(
                     journeyData,
                     RegisterPropertyStepId.ManualAddress.urlPathSegment,
                     RegisterPropertyStepId.LocalAuthority.urlPathSegment,
                 )
             } else {
-                val selectedAddress = getSelectedAddress(journeyData) ?: return null
-                journeyData.getLookedUpAddress(selectedAddress)
+                val selectedAddress = getSelectedAddress(journeyData)
+                lookedUpAddresses.singleOrNull { it.singleLineAddress == selectedAddress }
             }
-        }
 
         fun getPropertyType(journeyData: JourneyData): PropertyType? =
             getFieldEnumValue<PropertyType>(

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/helpers/PropertyRegistrationJourneyDataHelper.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/helpers/PropertyRegistrationJourneyDataHelper.kt
@@ -6,15 +6,12 @@ import uk.gov.communities.prsdb.webapp.constants.enums.OwnershipType
 import uk.gov.communities.prsdb.webapp.constants.enums.PropertyType
 import uk.gov.communities.prsdb.webapp.forms.JourneyData
 import uk.gov.communities.prsdb.webapp.forms.steps.RegisterPropertyStepId
+import uk.gov.communities.prsdb.webapp.helpers.extensions.JourneyDataExtensions.Companion.getLookedUpAddress
 import uk.gov.communities.prsdb.webapp.models.dataModels.AddressDataModel
-import uk.gov.communities.prsdb.webapp.services.RegisteredAddressCache
 
 class PropertyRegistrationJourneyDataHelper : JourneyDataHelper() {
     companion object {
-        fun getAddress(
-            journeyData: JourneyData,
-            registeredAddressCache: RegisteredAddressCache,
-        ): AddressDataModel? {
+        fun getAddress(journeyData: JourneyData): AddressDataModel? {
             return if (isManualAddressChosen(journeyData)) {
                 getManualAddress(
                     journeyData,
@@ -23,7 +20,7 @@ class PropertyRegistrationJourneyDataHelper : JourneyDataHelper() {
                 )
             } else {
                 val selectedAddress = getSelectedAddress(journeyData) ?: return null
-                registeredAddressCache.getAddressData(selectedAddress)
+                journeyData.getLookedUpAddress(selectedAddress)
             }
         }
 

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/helpers/PropertyRegistrationJourneyDataHelper.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/helpers/PropertyRegistrationJourneyDataHelper.kt
@@ -7,13 +7,13 @@ import uk.gov.communities.prsdb.webapp.constants.enums.PropertyType
 import uk.gov.communities.prsdb.webapp.forms.JourneyData
 import uk.gov.communities.prsdb.webapp.forms.steps.RegisterPropertyStepId
 import uk.gov.communities.prsdb.webapp.models.dataModels.AddressDataModel
-import uk.gov.communities.prsdb.webapp.services.AddressDataService
+import uk.gov.communities.prsdb.webapp.services.RegisteredAddressCache
 
 class PropertyRegistrationJourneyDataHelper : JourneyDataHelper() {
     companion object {
         fun getAddress(
             journeyData: JourneyData,
-            addressDataService: AddressDataService,
+            registeredAddressCache: RegisteredAddressCache,
         ): AddressDataModel? {
             return if (isManualAddressChosen(journeyData)) {
                 getManualAddress(
@@ -23,7 +23,7 @@ class PropertyRegistrationJourneyDataHelper : JourneyDataHelper() {
                 )
             } else {
                 val selectedAddress = getSelectedAddress(journeyData) ?: return null
-                addressDataService.getAddressData(selectedAddress)
+                registeredAddressCache.getAddressData(selectedAddress)
             }
         }
 

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/helpers/UpdateLandlordDetailsJourneyDataHelper.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/helpers/UpdateLandlordDetailsJourneyDataHelper.kt
@@ -4,7 +4,7 @@ import uk.gov.communities.prsdb.webapp.constants.MANUAL_ADDRESS_CHOSEN
 import uk.gov.communities.prsdb.webapp.forms.JourneyData
 import uk.gov.communities.prsdb.webapp.forms.journeys.UpdateLandlordDetailsJourney
 import uk.gov.communities.prsdb.webapp.forms.steps.UpdateLandlordDetailsStepId
-import uk.gov.communities.prsdb.webapp.helpers.extensions.JourneyDataExtensions.Companion.getLookedUpAddress
+import uk.gov.communities.prsdb.webapp.helpers.extensions.journeyDataExtensions.JourneyDataExtensions.Companion.getLookedUpAddress
 import uk.gov.communities.prsdb.webapp.models.dataModels.AddressDataModel
 import java.time.LocalDate
 

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/helpers/UpdateLandlordDetailsJourneyDataHelper.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/helpers/UpdateLandlordDetailsJourneyDataHelper.kt
@@ -4,8 +4,8 @@ import uk.gov.communities.prsdb.webapp.constants.MANUAL_ADDRESS_CHOSEN
 import uk.gov.communities.prsdb.webapp.forms.JourneyData
 import uk.gov.communities.prsdb.webapp.forms.journeys.UpdateLandlordDetailsJourney
 import uk.gov.communities.prsdb.webapp.forms.steps.UpdateLandlordDetailsStepId
+import uk.gov.communities.prsdb.webapp.helpers.extensions.JourneyDataExtensions.Companion.getLookedUpAddress
 import uk.gov.communities.prsdb.webapp.models.dataModels.AddressDataModel
-import uk.gov.communities.prsdb.webapp.services.RegisteredAddressCache
 import java.time.LocalDate
 
 class UpdateLandlordDetailsJourneyDataHelper : JourneyDataHelper() {
@@ -34,10 +34,7 @@ class UpdateLandlordDetailsJourneyDataHelper : JourneyDataHelper() {
                 "phoneNumber",
             )
 
-        fun getAddressIfPresent(
-            journeyData: JourneyData,
-            registeredAddressCache: RegisteredAddressCache,
-        ): AddressDataModel? {
+        fun getAddressIfPresent(journeyData: JourneyData): AddressDataModel? {
             val selectedAddress =
                 getFieldStringValue(
                     journeyData,
@@ -48,7 +45,7 @@ class UpdateLandlordDetailsJourneyDataHelper : JourneyDataHelper() {
             return if (selectedAddress == MANUAL_ADDRESS_CHOSEN) {
                 getManualAddress(journeyData, UpdateLandlordDetailsStepId.ManualEnglandAndWalesAddress.urlPathSegment)
             } else if (selectedAddress != null) {
-                registeredAddressCache.getAddressData(selectedAddress)
+                journeyData.getLookedUpAddress(selectedAddress)
             } else {
                 null
             }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/helpers/UpdateLandlordDetailsJourneyDataHelper.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/helpers/UpdateLandlordDetailsJourneyDataHelper.kt
@@ -5,7 +5,7 @@ import uk.gov.communities.prsdb.webapp.forms.JourneyData
 import uk.gov.communities.prsdb.webapp.forms.journeys.UpdateLandlordDetailsJourney
 import uk.gov.communities.prsdb.webapp.forms.steps.UpdateLandlordDetailsStepId
 import uk.gov.communities.prsdb.webapp.models.dataModels.AddressDataModel
-import uk.gov.communities.prsdb.webapp.services.AddressDataService
+import uk.gov.communities.prsdb.webapp.services.RegisteredAddressCache
 import java.time.LocalDate
 
 class UpdateLandlordDetailsJourneyDataHelper : JourneyDataHelper() {
@@ -36,7 +36,7 @@ class UpdateLandlordDetailsJourneyDataHelper : JourneyDataHelper() {
 
         fun getAddressIfPresent(
             journeyData: JourneyData,
-            addressDataService: AddressDataService,
+            registeredAddressCache: RegisteredAddressCache,
         ): AddressDataModel? {
             val selectedAddress =
                 getFieldStringValue(
@@ -48,7 +48,7 @@ class UpdateLandlordDetailsJourneyDataHelper : JourneyDataHelper() {
             return if (selectedAddress == MANUAL_ADDRESS_CHOSEN) {
                 getManualAddress(journeyData, UpdateLandlordDetailsStepId.ManualEnglandAndWalesAddress.urlPathSegment)
             } else if (selectedAddress != null) {
-                addressDataService.getAddressData(selectedAddress)
+                registeredAddressCache.getAddressData(selectedAddress)
             } else {
                 null
             }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/helpers/extensions/JourneyDataExtensions.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/helpers/extensions/JourneyDataExtensions.kt
@@ -1,5 +1,6 @@
 package uk.gov.communities.prsdb.webapp.helpers.extensions
 
+import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import uk.gov.communities.prsdb.webapp.constants.LOOKED_UP_ADDRESSES_JOURNEY_DATA_KEY
 import uk.gov.communities.prsdb.webapp.forms.JourneyData
@@ -9,11 +10,20 @@ import uk.gov.communities.prsdb.webapp.models.dataModels.AddressDataModel
 class JourneyDataExtensions {
     companion object {
         fun JourneyData.getLookedUpAddress(selectedAddress: String): AddressDataModel? {
-            val serializedLookedUpAddresses =
-                JourneyDataHelper.getStringValueByKey(this, LOOKED_UP_ADDRESSES_JOURNEY_DATA_KEY)
-                    ?: return null
+            val serializedLookedUpAddresses = this.getSerializedLookedUpAddresses() ?: return null
             val lookedUpAddresses = Json.decodeFromString<List<AddressDataModel>>(serializedLookedUpAddresses)
             return lookedUpAddresses.singleOrNull { it.singleLineAddress == selectedAddress }
         }
+
+        fun JourneyData.getSerializedLookedUpAddresses(): String? =
+            JourneyDataHelper.getStringValueByKey(this, LOOKED_UP_ADDRESSES_JOURNEY_DATA_KEY)
+
+        fun JourneyData.updateLookedUpAddresses(lookedUpAddresses: String): JourneyData {
+            val updatedJourneyData = this + (LOOKED_UP_ADDRESSES_JOURNEY_DATA_KEY to lookedUpAddresses)
+            return updatedJourneyData
+        }
+
+        fun JourneyData.updateLookedUpAddresses(lookedUpAddresses: List<AddressDataModel>): JourneyData =
+            this.updateLookedUpAddresses(Json.encodeToString(lookedUpAddresses))
     }
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/helpers/extensions/JourneyDataExtensions.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/helpers/extensions/JourneyDataExtensions.kt
@@ -9,10 +9,12 @@ import uk.gov.communities.prsdb.webapp.models.dataModels.AddressDataModel
 
 class JourneyDataExtensions {
     companion object {
-        fun JourneyData.getLookedUpAddress(selectedAddress: String): AddressDataModel? {
-            val serializedLookedUpAddresses = this.getSerializedLookedUpAddresses() ?: return null
-            val lookedUpAddresses = Json.decodeFromString<List<AddressDataModel>>(serializedLookedUpAddresses)
-            return lookedUpAddresses.singleOrNull { it.singleLineAddress == selectedAddress }
+        fun JourneyData.getLookedUpAddress(selectedAddress: String): AddressDataModel? =
+            this.getLookedUpAddresses().singleOrNull { it.singleLineAddress == selectedAddress }
+
+        fun JourneyData.getLookedUpAddresses(): List<AddressDataModel> {
+            val serializedLookedUpAddresses = this.getSerializedLookedUpAddresses() ?: return emptyList()
+            return Json.decodeFromString<List<AddressDataModel>>(serializedLookedUpAddresses)
         }
 
         fun JourneyData.getSerializedLookedUpAddresses(): String? =

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/helpers/extensions/JourneyDataExtensions.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/helpers/extensions/JourneyDataExtensions.kt
@@ -1,0 +1,19 @@
+package uk.gov.communities.prsdb.webapp.helpers.extensions
+
+import kotlinx.serialization.json.Json
+import uk.gov.communities.prsdb.webapp.constants.LOOKED_UP_ADDRESSES_JOURNEY_DATA_KEY
+import uk.gov.communities.prsdb.webapp.forms.JourneyData
+import uk.gov.communities.prsdb.webapp.helpers.JourneyDataHelper
+import uk.gov.communities.prsdb.webapp.models.dataModels.AddressDataModel
+
+class JourneyDataExtensions {
+    companion object {
+        fun JourneyData.getLookedUpAddress(selectedAddress: String): AddressDataModel? {
+            val serializedLookedUpAddresses =
+                JourneyDataHelper.getStringValueByKey(this, LOOKED_UP_ADDRESSES_JOURNEY_DATA_KEY)
+                    ?: return null
+            val lookedUpAddresses = Json.decodeFromString<List<AddressDataModel>>(serializedLookedUpAddresses)
+            return lookedUpAddresses.singleOrNull { it.singleLineAddress == selectedAddress }
+        }
+    }
+}

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/helpers/extensions/SummaryListViewModelExtensionHelper.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/helpers/extensions/SummaryListViewModelExtensionHelper.kt
@@ -1,4 +1,4 @@
-package uk.gov.communities.prsdb.webapp.helpers.extenstions
+package uk.gov.communities.prsdb.webapp.helpers.extensions
 
 import uk.gov.communities.prsdb.webapp.models.viewModels.summaryModels.SummaryListRowViewModel
 

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/helpers/extensions/journeyDataExtensions/JourneyDataExtensions.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/helpers/extensions/journeyDataExtensions/JourneyDataExtensions.kt
@@ -1,4 +1,4 @@
-package uk.gov.communities.prsdb.webapp.helpers.extensions
+package uk.gov.communities.prsdb.webapp.helpers.extensions.journeyDataExtensions
 
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/helpers/extensions/journeyDataExtensions/JourneyDataExtensions.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/helpers/extensions/journeyDataExtensions/JourneyDataExtensions.kt
@@ -20,12 +20,12 @@ class JourneyDataExtensions {
         fun JourneyData.getSerializedLookedUpAddresses(): String? =
             JourneyDataHelper.getStringValueByKey(this, LOOKED_UP_ADDRESSES_JOURNEY_DATA_KEY)
 
-        fun JourneyData.updateLookedUpAddresses(lookedUpAddresses: String): JourneyData {
+        fun JourneyData.withUpdatedLookedUpAddresses(lookedUpAddresses: String): JourneyData {
             val updatedJourneyData = this + (LOOKED_UP_ADDRESSES_JOURNEY_DATA_KEY to lookedUpAddresses)
             return updatedJourneyData
         }
 
-        fun JourneyData.updateLookedUpAddresses(lookedUpAddresses: List<AddressDataModel>): JourneyData =
-            this.updateLookedUpAddresses(Json.encodeToString(lookedUpAddresses))
+        fun JourneyData.withUpdatedLookedUpAddresses(lookedUpAddresses: List<AddressDataModel>): JourneyData =
+            this.withUpdatedLookedUpAddresses(Json.encodeToString(lookedUpAddresses))
     }
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/summaryModels/LandlordViewModel.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/summaryModels/LandlordViewModel.kt
@@ -5,7 +5,7 @@ import uk.gov.communities.prsdb.webapp.controllers.LandlordDetailsController.Com
 import uk.gov.communities.prsdb.webapp.database.entity.Landlord
 import uk.gov.communities.prsdb.webapp.helpers.DateTimeHelper
 import uk.gov.communities.prsdb.webapp.helpers.converters.MessageKeyConverter
-import uk.gov.communities.prsdb.webapp.helpers.extenstions.addRow
+import uk.gov.communities.prsdb.webapp.helpers.extensions.addRow
 import uk.gov.communities.prsdb.webapp.models.dataModels.RegistrationNumberDataModel
 
 class LandlordViewModel(

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/summaryModels/PropertyDetailsLandlordViewModel.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/summaryModels/PropertyDetailsLandlordViewModel.kt
@@ -3,7 +3,7 @@ package uk.gov.communities.prsdb.webapp.models.viewModels.summaryModels
 import uk.gov.communities.prsdb.webapp.controllers.LandlordDetailsController
 import uk.gov.communities.prsdb.webapp.database.entity.Landlord
 import uk.gov.communities.prsdb.webapp.helpers.converters.MessageKeyConverter
-import uk.gov.communities.prsdb.webapp.helpers.extenstions.addRow
+import uk.gov.communities.prsdb.webapp.helpers.extensions.addRow
 
 class PropertyDetailsLandlordViewModel(
     private val landlord: Landlord,

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/summaryModels/PropertyDetailsViewModel.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/summaryModels/PropertyDetailsViewModel.kt
@@ -6,7 +6,7 @@ import uk.gov.communities.prsdb.webapp.controllers.LandlordDetailsController
 import uk.gov.communities.prsdb.webapp.database.entity.PropertyOwnership
 import uk.gov.communities.prsdb.webapp.helpers.DateTimeHelper
 import uk.gov.communities.prsdb.webapp.helpers.converters.MessageKeyConverter
-import uk.gov.communities.prsdb.webapp.helpers.extenstions.addRow
+import uk.gov.communities.prsdb.webapp.helpers.extensions.addRow
 import uk.gov.communities.prsdb.webapp.models.dataModels.RegistrationNumberDataModel
 
 class PropertyDetailsViewModel(

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/JourneyDataService.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/JourneyDataService.kt
@@ -40,8 +40,6 @@ class JourneyDataService(
             objectToStringKeyedMap(session.getAttribute(journeyDataKey)) ?: mapOf()
         }
 
-    fun getJourneyDataEntryInSession(key: String) = getJourneyDataFromSession().entries.find { it.key == key }?.toPair()
-
     fun setJourneyDataInSession(journeyData: JourneyData) {
         if (!this::journeyDataKey.isInitialized) {
             throw PrsdbWebException("journeyDataKey has not been set")

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/JourneyDataService.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/JourneyDataService.kt
@@ -50,19 +50,6 @@ class JourneyDataService(
         }
     }
 
-    fun setJourneyDataEntryInSession(
-        key: String,
-        value: Any,
-    ) {
-        if (!this::journeyDataKey.isInitialized) {
-            throw PrsdbWebException("journeyDataKey has not been set")
-        } else {
-            val journeyData = getJourneyDataFromSession()
-            val updatedJourneyData = journeyData + (key to value)
-            setJourneyDataInSession(updatedJourneyData)
-        }
-    }
-
     fun clearJourneyDataFromSession() {
         if (!this::journeyDataKey.isInitialized) {
             throw PrsdbWebException("journeyDataKey has not been set")

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/JourneyDataService.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/JourneyDataService.kt
@@ -40,6 +40,8 @@ class JourneyDataService(
             objectToStringKeyedMap(session.getAttribute(journeyDataKey)) ?: mapOf()
         }
 
+    fun getJourneyDataEntryInSession(key: String) = getJourneyDataFromSession().entries.find { it.key == key }?.toPair()
+
     fun setJourneyDataInSession(journeyData: JourneyData) {
         if (!this::journeyDataKey.isInitialized) {
             throw PrsdbWebException("journeyDataKey has not been set")

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/JourneyDataService.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/JourneyDataService.kt
@@ -50,6 +50,19 @@ class JourneyDataService(
         }
     }
 
+    fun setJourneyDataEntryInSession(
+        key: String,
+        value: Any,
+    ) {
+        if (!this::journeyDataKey.isInitialized) {
+            throw PrsdbWebException("journeyDataKey has not been set")
+        } else {
+            val journeyData = getJourneyDataFromSession()
+            val updatedJourneyData = journeyData + (key to value)
+            setJourneyDataInSession(updatedJourneyData)
+        }
+    }
+
     fun clearJourneyDataFromSession() {
         if (!this::journeyDataKey.isInitialized) {
             throw PrsdbWebException("journeyDataKey has not been set")

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/PropertyRegistrationService.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/PropertyRegistrationService.kt
@@ -20,7 +20,7 @@ class PropertyRegistrationService(
     private val propertyRepository: PropertyRepository,
     private val propertyOwnershipRepository: PropertyOwnershipRepository,
     private val landlordRepository: LandlordRepository,
-    private val addressDataService: AddressDataService,
+    private val registeredAddressCache: RegisteredAddressCache,
     private val propertyService: PropertyService,
     private val licenseService: LicenseService,
     private val propertyOwnershipService: PropertyOwnershipService,
@@ -31,18 +31,18 @@ class PropertyRegistrationService(
         ignoreCache: Boolean = false,
     ): Boolean {
         if (!ignoreCache) {
-            val cachedResult = addressDataService.getCachedAddressRegisteredResult(uprn)
+            val cachedResult = registeredAddressCache.getCachedAddressRegisteredResult(uprn)
             if (cachedResult != null) return cachedResult
         }
 
         val property = propertyRepository.findByAddress_Uprn(uprn)
         if (property == null || !property.isActive) {
-            addressDataService.setCachedAddressRegisteredResult(uprn, false)
+            registeredAddressCache.setCachedAddressRegisteredResult(uprn, false)
             return false
         }
 
         val databaseResult = propertyOwnershipRepository.existsByIsActiveTrueAndProperty_Id(property.id)
-        addressDataService.setCachedAddressRegisteredResult(uprn, databaseResult)
+        registeredAddressCache.setCachedAddressRegisteredResult(uprn, databaseResult)
         return databaseResult
     }
 
@@ -84,7 +84,7 @@ class PropertyRegistrationService(
                 license = license,
             )
 
-        address.uprn?.let { addressDataService.setCachedAddressRegisteredResult(it, true) }
+        address.uprn?.let { registeredAddressCache.setCachedAddressRegisteredResult(it, true) }
 
         return propertyOwnership.registrationNumber
     }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/RegisteredAddressCache.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/RegisteredAddressCache.kt
@@ -1,24 +1,13 @@
 package uk.gov.communities.prsdb.webapp.services
 
 import jakarta.servlet.http.HttpSession
-import kotlinx.serialization.encodeToString
-import kotlinx.serialization.json.Json
 import org.springframework.stereotype.Service
 import uk.gov.communities.prsdb.webapp.forms.objectToStringKeyedMap
-import uk.gov.communities.prsdb.webapp.models.dataModels.AddressDataModel
 
 @Service
 class RegisteredAddressCache(
     private val session: HttpSession,
-    private val journeyDataService: JourneyDataService,
 ) {
-    fun setAddressData(addressDataList: List<AddressDataModel>) {
-        val journeyData = journeyDataService.getJourneyDataFromSession()
-        val newJourneyData =
-            journeyData + ("address-data" to Json.encodeToString(addressDataList.associateBy { it.singleLineAddress }))
-        journeyDataService.setJourneyDataInSession(newJourneyData)
-    }
-
     fun getCachedAddressRegisteredResult(uprn: Long): Boolean? {
         val cachedResults = objectToStringKeyedMap(session.getAttribute("addressRegisteredResults")) ?: mapOf()
         return cachedResults[uprn.toString()].toString().toBooleanStrictOrNull()

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/RegisteredAddressCache.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/RegisteredAddressCache.kt
@@ -12,16 +12,6 @@ class RegisteredAddressCache(
     private val session: HttpSession,
     private val journeyDataService: JourneyDataService,
 ) {
-    fun getAddressData(singleLineAddress: String): AddressDataModel? {
-        val journeyData = journeyDataService.getJourneyDataFromSession()
-        val addressData = journeyData["address-data"] as String?
-        if (addressData == null) {
-            return null
-        } else {
-            return Json.decodeFromString<Map<String, AddressDataModel>>(addressData)[singleLineAddress]
-        }
-    }
-
     fun setAddressData(addressDataList: List<AddressDataModel>) {
         val journeyData = journeyDataService.getJourneyDataFromSession()
         val newJourneyData =

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/RegisteredAddressCache.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/RegisteredAddressCache.kt
@@ -8,7 +8,7 @@ import uk.gov.communities.prsdb.webapp.forms.objectToStringKeyedMap
 import uk.gov.communities.prsdb.webapp.models.dataModels.AddressDataModel
 
 @Service
-class AddressDataService(
+class RegisteredAddressCache(
     private val session: HttpSession,
     private val journeyDataService: JourneyDataService,
 ) {

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/LandlordRegistrationJourneyTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/LandlordRegistrationJourneyTests.kt
@@ -18,11 +18,11 @@ import uk.gov.communities.prsdb.webapp.forms.PageData
 import uk.gov.communities.prsdb.webapp.forms.steps.LandlordRegistrationStepId
 import uk.gov.communities.prsdb.webapp.models.viewModels.emailModels.LandlordRegistrationConfirmationEmail
 import uk.gov.communities.prsdb.webapp.services.AbsoluteUrlProvider
-import uk.gov.communities.prsdb.webapp.services.AddressDataService
 import uk.gov.communities.prsdb.webapp.services.AddressLookupService
 import uk.gov.communities.prsdb.webapp.services.EmailNotificationService
 import uk.gov.communities.prsdb.webapp.services.JourneyDataService
 import uk.gov.communities.prsdb.webapp.services.LandlordService
+import uk.gov.communities.prsdb.webapp.services.RegisteredAddressCache
 import uk.gov.communities.prsdb.webapp.testHelpers.builders.JourneyDataBuilder
 import uk.gov.communities.prsdb.webapp.testHelpers.mockObjects.AlwaysTrueValidator
 import uk.gov.communities.prsdb.webapp.testHelpers.mockObjects.MockLandlordData
@@ -33,7 +33,7 @@ class LandlordRegistrationJourneyTests {
     lateinit var mockJourneyDataService: JourneyDataService
 
     @Mock
-    lateinit var addressDataService: AddressDataService
+    lateinit var registeredAddressCache: RegisteredAddressCache
 
     @Mock
     lateinit var landlordService: LandlordService
@@ -52,7 +52,7 @@ class LandlordRegistrationJourneyTests {
     @BeforeEach
     fun setup() {
         mockJourneyDataService = mock()
-        addressDataService = mock()
+        registeredAddressCache = mock()
         landlordService = mock()
         addressLookupService = mock()
         confirmationEmailSender = mock()
@@ -85,7 +85,7 @@ class LandlordRegistrationJourneyTests {
                     validator = alwaysTrueValidator,
                     journeyDataService = mockJourneyDataService,
                     addressLookupService = addressLookupService,
-                    addressDataService = addressDataService,
+                    registeredAddressCache = registeredAddressCache,
                     landlordService = landlordService,
                     emailNotificationService = confirmationEmailSender,
                     absoluteUrlProvider = urlProvider,
@@ -109,7 +109,7 @@ class LandlordRegistrationJourneyTests {
             val journeyData =
                 JourneyDataBuilder
                     .landlordDefault(
-                        addressDataService,
+                        registeredAddressCache,
                         localAuthorityService = mock(),
                     ).withNonEnglandOrWalesAndSelectedContactAddress(
                         "Angola",

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/LandlordRegistrationJourneyTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/LandlordRegistrationJourneyTests.kt
@@ -13,7 +13,6 @@ import org.mockito.kotlin.whenever
 import org.springframework.security.core.Authentication
 import org.springframework.security.core.context.SecurityContext
 import org.springframework.security.core.context.SecurityContextHolder
-import uk.gov.communities.prsdb.webapp.constants.LOOKED_UP_ADDRESSES_JOURNEY_DATA_KEY
 import uk.gov.communities.prsdb.webapp.database.entity.LocalAuthority
 import uk.gov.communities.prsdb.webapp.forms.steps.LandlordRegistrationStepId
 import uk.gov.communities.prsdb.webapp.models.viewModels.emailModels.LandlordRegistrationConfirmationEmail
@@ -114,7 +113,6 @@ class LandlordRegistrationJourneyTests {
                     ).build()
 
             whenever(mockJourneyDataService.getJourneyDataFromSession()).thenReturn(journeyData)
-            whenever(mockJourneyDataService.getJourneyDataEntryInSession(LOOKED_UP_ADDRESSES_JOURNEY_DATA_KEY)).thenCallRealMethod()
 
             // Act
             testJourney.completeStep(

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/LandlordRegistrationJourneyTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/LandlordRegistrationJourneyTests.kt
@@ -13,6 +13,7 @@ import org.mockito.kotlin.whenever
 import org.springframework.security.core.Authentication
 import org.springframework.security.core.context.SecurityContext
 import org.springframework.security.core.context.SecurityContextHolder
+import uk.gov.communities.prsdb.webapp.constants.LOOKED_UP_ADDRESSES_JOURNEY_DATA_KEY
 import uk.gov.communities.prsdb.webapp.database.entity.LocalAuthority
 import uk.gov.communities.prsdb.webapp.forms.steps.LandlordRegistrationStepId
 import uk.gov.communities.prsdb.webapp.models.viewModels.emailModels.LandlordRegistrationConfirmationEmail
@@ -113,6 +114,7 @@ class LandlordRegistrationJourneyTests {
                     ).build()
 
             whenever(mockJourneyDataService.getJourneyDataFromSession()).thenReturn(journeyData)
+            whenever(mockJourneyDataService.getJourneyDataEntryInSession(LOOKED_UP_ADDRESSES_JOURNEY_DATA_KEY)).thenCallRealMethod()
 
             // Act
             testJourney.completeStep(

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/PropertyRegistrationJourneyTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/PropertyRegistrationJourneyTests.kt
@@ -26,7 +26,6 @@ import uk.gov.communities.prsdb.webapp.services.JourneyDataService
 import uk.gov.communities.prsdb.webapp.services.LandlordService
 import uk.gov.communities.prsdb.webapp.services.LocalAuthorityService
 import uk.gov.communities.prsdb.webapp.services.PropertyRegistrationService
-import uk.gov.communities.prsdb.webapp.services.RegisteredAddressCache
 import uk.gov.communities.prsdb.webapp.testHelpers.builders.JourneyDataBuilder
 import uk.gov.communities.prsdb.webapp.testHelpers.mockObjects.AlwaysTrueValidator
 import uk.gov.communities.prsdb.webapp.testHelpers.mockObjects.MockLandlordData
@@ -38,9 +37,6 @@ class PropertyRegistrationJourneyTests {
 
     @Mock
     lateinit var mockPropertyRegistrationService: PropertyRegistrationService
-
-    @Mock
-    lateinit var registeredAddressCache: RegisteredAddressCache
 
     @Mock
     lateinit var localAuthorityService: LocalAuthorityService
@@ -63,7 +59,6 @@ class PropertyRegistrationJourneyTests {
     fun setup() {
         mockJourneyDataService = mock()
         mockPropertyRegistrationService = mock()
-        registeredAddressCache = mock()
         localAuthorityService = mock()
         landlordService = mock()
         addressLookupService = mock()
@@ -100,7 +95,6 @@ class PropertyRegistrationJourneyTests {
                     validator = alwaysTrueValidator,
                     journeyDataService = mockJourneyDataService,
                     addressLookupService = addressLookupService,
-                    registeredAddressCache = registeredAddressCache,
                     propertyRegistrationService = mockPropertyRegistrationService,
                     localAuthorityService = localAuthorityService,
                     landlordService = landlordService,
@@ -124,11 +118,12 @@ class PropertyRegistrationJourneyTests {
             // Arrange
             val journeyData =
                 JourneyDataBuilder
-                    .propertyDefault(registeredAddressCache, localAuthorityService)
+                    .propertyDefault(localAuthorityService)
                     .withTenants(3, 7)
                     .withOccupiedSetToFalse()
+                    .build()
 
-            whenever(mockJourneyDataService.getJourneyDataFromSession()).thenReturn(journeyData.build())
+            whenever(mockJourneyDataService.getJourneyDataFromSession()).thenReturn(journeyData)
 
             // Act
             completeStep(RegisterPropertyStepId.Declaration)
@@ -151,11 +146,12 @@ class PropertyRegistrationJourneyTests {
             // Arrange
             val journeyData =
                 JourneyDataBuilder
-                    .propertyDefault(registeredAddressCache, localAuthorityService)
+                    .propertyDefault(localAuthorityService)
                     .withPropertyType(PropertyType.OTHER, "Bungalow")
                     .withPropertyType(PropertyType.FLAT)
+                    .build()
 
-            whenever(mockJourneyDataService.getJourneyDataFromSession()).thenReturn(journeyData.build())
+            whenever(mockJourneyDataService.getJourneyDataFromSession()).thenReturn(journeyData)
 
             // Act
             completeStep(RegisterPropertyStepId.Declaration)
@@ -178,14 +174,14 @@ class PropertyRegistrationJourneyTests {
             // Arrange
             val journeyData =
                 JourneyDataBuilder
-                    .propertyDefault(registeredAddressCache, localAuthorityService)
+                    .propertyDefault(localAuthorityService)
                     .withLicensingType(LicensingType.SELECTIVE_LICENCE, LicensingType.SELECTIVE_LICENCE.toString())
                     .withLicensingType(
                         LicensingType.HMO_MANDATORY_LICENCE,
                         LicensingType.HMO_MANDATORY_LICENCE.toString(),
-                    )
+                    ).build()
 
-            whenever(mockJourneyDataService.getJourneyDataFromSession()).thenReturn(journeyData.build())
+            whenever(mockJourneyDataService.getJourneyDataFromSession()).thenReturn(journeyData)
 
             // Act
             completeStep(RegisterPropertyStepId.Declaration)
@@ -208,11 +204,12 @@ class PropertyRegistrationJourneyTests {
             // Arrange
             val journeyData =
                 JourneyDataBuilder
-                    .propertyDefault(registeredAddressCache, localAuthorityService)
+                    .propertyDefault(localAuthorityService)
                     .withLicensingType(LicensingType.SELECTIVE_LICENCE, LicensingType.SELECTIVE_LICENCE.toString())
                     .withLicensingType(LicensingType.NO_LICENSING)
+                    .build()
 
-            whenever(mockJourneyDataService.getJourneyDataFromSession()).thenReturn(journeyData.build())
+            whenever(mockJourneyDataService.getJourneyDataFromSession()).thenReturn(journeyData)
 
             // Act
             completeStep(RegisterPropertyStepId.Declaration)

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/PropertyRegistrationJourneyTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/PropertyRegistrationJourneyTests.kt
@@ -12,6 +12,7 @@ import org.mockito.kotlin.whenever
 import org.springframework.security.core.Authentication
 import org.springframework.security.core.context.SecurityContext
 import org.springframework.security.core.context.SecurityContextHolder
+import uk.gov.communities.prsdb.webapp.constants.LOOKED_UP_ADDRESSES_JOURNEY_DATA_KEY
 import uk.gov.communities.prsdb.webapp.constants.enums.LicensingType
 import uk.gov.communities.prsdb.webapp.constants.enums.PropertyType
 import uk.gov.communities.prsdb.webapp.constants.enums.RegistrationNumberType
@@ -124,6 +125,7 @@ class PropertyRegistrationJourneyTests {
                     .build()
 
             whenever(mockJourneyDataService.getJourneyDataFromSession()).thenReturn(journeyData)
+            whenever(mockJourneyDataService.getJourneyDataEntryInSession(LOOKED_UP_ADDRESSES_JOURNEY_DATA_KEY)).thenCallRealMethod()
 
             // Act
             completeStep(RegisterPropertyStepId.Declaration)
@@ -152,6 +154,7 @@ class PropertyRegistrationJourneyTests {
                     .build()
 
             whenever(mockJourneyDataService.getJourneyDataFromSession()).thenReturn(journeyData)
+            whenever(mockJourneyDataService.getJourneyDataEntryInSession(LOOKED_UP_ADDRESSES_JOURNEY_DATA_KEY)).thenCallRealMethod()
 
             // Act
             completeStep(RegisterPropertyStepId.Declaration)
@@ -182,6 +185,7 @@ class PropertyRegistrationJourneyTests {
                     ).build()
 
             whenever(mockJourneyDataService.getJourneyDataFromSession()).thenReturn(journeyData)
+            whenever(mockJourneyDataService.getJourneyDataEntryInSession(LOOKED_UP_ADDRESSES_JOURNEY_DATA_KEY)).thenCallRealMethod()
 
             // Act
             completeStep(RegisterPropertyStepId.Declaration)
@@ -210,6 +214,7 @@ class PropertyRegistrationJourneyTests {
                     .build()
 
             whenever(mockJourneyDataService.getJourneyDataFromSession()).thenReturn(journeyData)
+            whenever(mockJourneyDataService.getJourneyDataEntryInSession(LOOKED_UP_ADDRESSES_JOURNEY_DATA_KEY)).thenCallRealMethod()
 
             // Act
             completeStep(RegisterPropertyStepId.Declaration)

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/PropertyRegistrationJourneyTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/PropertyRegistrationJourneyTests.kt
@@ -12,7 +12,6 @@ import org.mockito.kotlin.whenever
 import org.springframework.security.core.Authentication
 import org.springframework.security.core.context.SecurityContext
 import org.springframework.security.core.context.SecurityContextHolder
-import uk.gov.communities.prsdb.webapp.constants.LOOKED_UP_ADDRESSES_JOURNEY_DATA_KEY
 import uk.gov.communities.prsdb.webapp.constants.enums.LicensingType
 import uk.gov.communities.prsdb.webapp.constants.enums.PropertyType
 import uk.gov.communities.prsdb.webapp.constants.enums.RegistrationNumberType
@@ -125,7 +124,6 @@ class PropertyRegistrationJourneyTests {
                     .build()
 
             whenever(mockJourneyDataService.getJourneyDataFromSession()).thenReturn(journeyData)
-            whenever(mockJourneyDataService.getJourneyDataEntryInSession(LOOKED_UP_ADDRESSES_JOURNEY_DATA_KEY)).thenCallRealMethod()
 
             // Act
             completeStep(RegisterPropertyStepId.Declaration)
@@ -154,7 +152,6 @@ class PropertyRegistrationJourneyTests {
                     .build()
 
             whenever(mockJourneyDataService.getJourneyDataFromSession()).thenReturn(journeyData)
-            whenever(mockJourneyDataService.getJourneyDataEntryInSession(LOOKED_UP_ADDRESSES_JOURNEY_DATA_KEY)).thenCallRealMethod()
 
             // Act
             completeStep(RegisterPropertyStepId.Declaration)
@@ -185,7 +182,6 @@ class PropertyRegistrationJourneyTests {
                     ).build()
 
             whenever(mockJourneyDataService.getJourneyDataFromSession()).thenReturn(journeyData)
-            whenever(mockJourneyDataService.getJourneyDataEntryInSession(LOOKED_UP_ADDRESSES_JOURNEY_DATA_KEY)).thenCallRealMethod()
 
             // Act
             completeStep(RegisterPropertyStepId.Declaration)
@@ -214,7 +210,6 @@ class PropertyRegistrationJourneyTests {
                     .build()
 
             whenever(mockJourneyDataService.getJourneyDataFromSession()).thenReturn(journeyData)
-            whenever(mockJourneyDataService.getJourneyDataEntryInSession(LOOKED_UP_ADDRESSES_JOURNEY_DATA_KEY)).thenCallRealMethod()
 
             // Act
             completeStep(RegisterPropertyStepId.Declaration)

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/PropertyRegistrationJourneyTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/PropertyRegistrationJourneyTests.kt
@@ -20,13 +20,13 @@ import uk.gov.communities.prsdb.webapp.forms.PageData
 import uk.gov.communities.prsdb.webapp.forms.steps.RegisterPropertyStepId
 import uk.gov.communities.prsdb.webapp.models.viewModels.emailModels.PropertyRegistrationConfirmationEmail
 import uk.gov.communities.prsdb.webapp.services.AbsoluteUrlProvider
-import uk.gov.communities.prsdb.webapp.services.AddressDataService
 import uk.gov.communities.prsdb.webapp.services.AddressLookupService
 import uk.gov.communities.prsdb.webapp.services.EmailNotificationService
 import uk.gov.communities.prsdb.webapp.services.JourneyDataService
 import uk.gov.communities.prsdb.webapp.services.LandlordService
 import uk.gov.communities.prsdb.webapp.services.LocalAuthorityService
 import uk.gov.communities.prsdb.webapp.services.PropertyRegistrationService
+import uk.gov.communities.prsdb.webapp.services.RegisteredAddressCache
 import uk.gov.communities.prsdb.webapp.testHelpers.builders.JourneyDataBuilder
 import uk.gov.communities.prsdb.webapp.testHelpers.mockObjects.AlwaysTrueValidator
 import uk.gov.communities.prsdb.webapp.testHelpers.mockObjects.MockLandlordData
@@ -40,7 +40,7 @@ class PropertyRegistrationJourneyTests {
     lateinit var mockPropertyRegistrationService: PropertyRegistrationService
 
     @Mock
-    lateinit var addressDataService: AddressDataService
+    lateinit var registeredAddressCache: RegisteredAddressCache
 
     @Mock
     lateinit var localAuthorityService: LocalAuthorityService
@@ -63,7 +63,7 @@ class PropertyRegistrationJourneyTests {
     fun setup() {
         mockJourneyDataService = mock()
         mockPropertyRegistrationService = mock()
-        addressDataService = mock()
+        registeredAddressCache = mock()
         localAuthorityService = mock()
         landlordService = mock()
         addressLookupService = mock()
@@ -100,7 +100,7 @@ class PropertyRegistrationJourneyTests {
                     validator = alwaysTrueValidator,
                     journeyDataService = mockJourneyDataService,
                     addressLookupService = addressLookupService,
-                    addressDataService = addressDataService,
+                    registeredAddressCache = registeredAddressCache,
                     propertyRegistrationService = mockPropertyRegistrationService,
                     localAuthorityService = localAuthorityService,
                     landlordService = landlordService,
@@ -124,7 +124,7 @@ class PropertyRegistrationJourneyTests {
             // Arrange
             val journeyData =
                 JourneyDataBuilder
-                    .propertyDefault(addressDataService, localAuthorityService)
+                    .propertyDefault(registeredAddressCache, localAuthorityService)
                     .withTenants(3, 7)
                     .withOccupiedSetToFalse()
 
@@ -151,7 +151,7 @@ class PropertyRegistrationJourneyTests {
             // Arrange
             val journeyData =
                 JourneyDataBuilder
-                    .propertyDefault(addressDataService, localAuthorityService)
+                    .propertyDefault(registeredAddressCache, localAuthorityService)
                     .withPropertyType(PropertyType.OTHER, "Bungalow")
                     .withPropertyType(PropertyType.FLAT)
 
@@ -178,7 +178,7 @@ class PropertyRegistrationJourneyTests {
             // Arrange
             val journeyData =
                 JourneyDataBuilder
-                    .propertyDefault(addressDataService, localAuthorityService)
+                    .propertyDefault(registeredAddressCache, localAuthorityService)
                     .withLicensingType(LicensingType.SELECTIVE_LICENCE, LicensingType.SELECTIVE_LICENCE.toString())
                     .withLicensingType(
                         LicensingType.HMO_MANDATORY_LICENCE,
@@ -208,7 +208,7 @@ class PropertyRegistrationJourneyTests {
             // Arrange
             val journeyData =
                 JourneyDataBuilder
-                    .propertyDefault(addressDataService, localAuthorityService)
+                    .propertyDefault(registeredAddressCache, localAuthorityService)
                     .withLicensingType(LicensingType.SELECTIVE_LICENCE, LicensingType.SELECTIVE_LICENCE.toString())
                     .withLicensingType(LicensingType.NO_LICENSING)
 

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/forms/pages/LandlordRegistrationCheckAnswersPageTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/forms/pages/LandlordRegistrationCheckAnswersPageTests.kt
@@ -8,7 +8,6 @@ import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 import org.springframework.validation.Validator
-import uk.gov.communities.prsdb.webapp.constants.LOOKED_UP_ADDRESSES_JOURNEY_DATA_KEY
 import uk.gov.communities.prsdb.webapp.forms.JourneyData
 import uk.gov.communities.prsdb.webapp.forms.PageData
 import uk.gov.communities.prsdb.webapp.forms.steps.LandlordRegistrationStepId
@@ -41,12 +40,10 @@ class LandlordRegistrationCheckAnswersPageTests {
         journeyDataBuilder = JourneyDataBuilder.landlordDefault(localAuthorityService)
     }
 
-    private fun getFormData(filteredJourneyData: JourneyData): List<SummaryListRowViewModel> {
-        whenever(journeyDataService.getJourneyDataEntryInSession(LOOKED_UP_ADDRESSES_JOURNEY_DATA_KEY)).thenReturn(
-            LOOKED_UP_ADDRESSES_JOURNEY_DATA_KEY to filteredJourneyData[LOOKED_UP_ADDRESSES_JOURNEY_DATA_KEY],
-        )
+    private fun getFormData(journeyData: JourneyData): List<SummaryListRowViewModel> {
+        whenever(journeyDataService.getJourneyDataFromSession()).thenReturn(journeyData)
 
-        val result = page.getModelAndView(validator, pageData, prevStepUrl, filteredJourneyData, null)
+        val result = page.getModelAndView(validator, pageData, prevStepUrl, journeyData, null)
 
         val formData = result.model["formData"] as List<*>
         return formData.filterIsInstance<SummaryListRowViewModel>()

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/forms/pages/LandlordRegistrationCheckAnswersPageTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/forms/pages/LandlordRegistrationCheckAnswersPageTests.kt
@@ -13,16 +13,16 @@ import uk.gov.communities.prsdb.webapp.forms.PageData
 import uk.gov.communities.prsdb.webapp.forms.steps.LandlordRegistrationStepId
 import uk.gov.communities.prsdb.webapp.models.dataModels.AddressDataModel
 import uk.gov.communities.prsdb.webapp.models.viewModels.summaryModels.SummaryListRowViewModel
+import uk.gov.communities.prsdb.webapp.services.JourneyDataService
 import uk.gov.communities.prsdb.webapp.services.LocalAuthorityService
-import uk.gov.communities.prsdb.webapp.services.RegisteredAddressCache
 import uk.gov.communities.prsdb.webapp.testHelpers.builders.JourneyDataBuilder
 import uk.gov.communities.prsdb.webapp.testHelpers.builders.JourneyDataBuilder.Companion.DEFAULT_ADDRESS
 import java.time.LocalDate
 
 class LandlordRegistrationCheckAnswersPageTests {
     private lateinit var page: LandlordRegistrationCheckAnswersPage
-    private lateinit var addressService: RegisteredAddressCache
     private lateinit var localAuthorityService: LocalAuthorityService
+    private lateinit var journeyDataService: JourneyDataService
     private lateinit var validator: Validator
     private lateinit var pageData: PageData
     private lateinit var prevStepUrl: String
@@ -30,14 +30,14 @@ class LandlordRegistrationCheckAnswersPageTests {
 
     @BeforeEach
     fun setup() {
-        addressService = mock()
         localAuthorityService = mock()
-        page = LandlordRegistrationCheckAnswersPage(addressService)
+        journeyDataService = mock()
+        page = LandlordRegistrationCheckAnswersPage(journeyDataService)
         validator = mock()
         whenever(validator.supports(any<Class<*>>())).thenReturn(true)
         pageData = mock()
         prevStepUrl = "mock"
-        journeyDataBuilder = JourneyDataBuilder.landlordDefault(addressService, localAuthorityService)
+        journeyDataBuilder = JourneyDataBuilder.landlordDefault(localAuthorityService)
     }
 
     private fun getFormData(filteredJourneyData: JourneyData): List<SummaryListRowViewModel> {

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/forms/pages/LandlordRegistrationCheckAnswersPageTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/forms/pages/LandlordRegistrationCheckAnswersPageTests.kt
@@ -8,6 +8,7 @@ import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 import org.springframework.validation.Validator
+import uk.gov.communities.prsdb.webapp.constants.LOOKED_UP_ADDRESSES_JOURNEY_DATA_KEY
 import uk.gov.communities.prsdb.webapp.forms.JourneyData
 import uk.gov.communities.prsdb.webapp.forms.PageData
 import uk.gov.communities.prsdb.webapp.forms.steps.LandlordRegistrationStepId
@@ -41,6 +42,10 @@ class LandlordRegistrationCheckAnswersPageTests {
     }
 
     private fun getFormData(filteredJourneyData: JourneyData): List<SummaryListRowViewModel> {
+        whenever(journeyDataService.getJourneyDataEntryInSession(LOOKED_UP_ADDRESSES_JOURNEY_DATA_KEY)).thenReturn(
+            LOOKED_UP_ADDRESSES_JOURNEY_DATA_KEY to filteredJourneyData[LOOKED_UP_ADDRESSES_JOURNEY_DATA_KEY],
+        )
+
         val result = page.getModelAndView(validator, pageData, prevStepUrl, filteredJourneyData, null)
 
         val formData = result.model["formData"] as List<*>

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/forms/pages/LandlordRegistrationCheckAnswersPageTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/forms/pages/LandlordRegistrationCheckAnswersPageTests.kt
@@ -13,15 +13,15 @@ import uk.gov.communities.prsdb.webapp.forms.PageData
 import uk.gov.communities.prsdb.webapp.forms.steps.LandlordRegistrationStepId
 import uk.gov.communities.prsdb.webapp.models.dataModels.AddressDataModel
 import uk.gov.communities.prsdb.webapp.models.viewModels.summaryModels.SummaryListRowViewModel
-import uk.gov.communities.prsdb.webapp.services.AddressDataService
 import uk.gov.communities.prsdb.webapp.services.LocalAuthorityService
+import uk.gov.communities.prsdb.webapp.services.RegisteredAddressCache
 import uk.gov.communities.prsdb.webapp.testHelpers.builders.JourneyDataBuilder
 import uk.gov.communities.prsdb.webapp.testHelpers.builders.JourneyDataBuilder.Companion.DEFAULT_ADDRESS
 import java.time.LocalDate
 
 class LandlordRegistrationCheckAnswersPageTests {
     private lateinit var page: LandlordRegistrationCheckAnswersPage
-    private lateinit var addressService: AddressDataService
+    private lateinit var addressService: RegisteredAddressCache
     private lateinit var localAuthorityService: LocalAuthorityService
     private lateinit var validator: Validator
     private lateinit var pageData: PageData

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/forms/pages/PropertyRegistrationCheckAnswersPageTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/forms/pages/PropertyRegistrationCheckAnswersPageTests.kt
@@ -16,15 +16,15 @@ import uk.gov.communities.prsdb.webapp.forms.PageData
 import uk.gov.communities.prsdb.webapp.forms.steps.RegisterPropertyStepId
 import uk.gov.communities.prsdb.webapp.models.dataModels.AddressDataModel
 import uk.gov.communities.prsdb.webapp.models.viewModels.summaryModels.SummaryListRowViewModel
+import uk.gov.communities.prsdb.webapp.services.JourneyDataService
 import uk.gov.communities.prsdb.webapp.services.LocalAuthorityService
-import uk.gov.communities.prsdb.webapp.services.RegisteredAddressCache
 import uk.gov.communities.prsdb.webapp.testHelpers.builders.JourneyDataBuilder
 import uk.gov.communities.prsdb.webapp.testHelpers.mockObjects.MockLocalAuthorityData.Companion.createLocalAuthority
 
 class PropertyRegistrationCheckAnswersPageTests {
     private lateinit var page: PropertyRegistrationCheckAnswersPage
-    private lateinit var addressService: RegisteredAddressCache
     private lateinit var localAuthorityService: LocalAuthorityService
+    private lateinit var journeyDataService: JourneyDataService
     private lateinit var validator: Validator
     private lateinit var pageData: PageData
     private lateinit var prevStepUrl: String
@@ -32,14 +32,14 @@ class PropertyRegistrationCheckAnswersPageTests {
 
     @BeforeEach
     fun setup() {
-        addressService = mock()
         localAuthorityService = mock()
-        page = PropertyRegistrationCheckAnswersPage(addressService, localAuthorityService)
+        journeyDataService = mock()
+        page = PropertyRegistrationCheckAnswersPage(localAuthorityService, journeyDataService)
         validator = mock()
         whenever(validator.supports(any<Class<*>>())).thenReturn(true)
         pageData = mock()
         prevStepUrl = "mock"
-        journeyDataBuilder = JourneyDataBuilder.propertyDefault(addressService, localAuthorityService)
+        journeyDataBuilder = JourneyDataBuilder.propertyDefault(localAuthorityService)
     }
 
     private fun getPropertyDetails(filteredJourneyData: JourneyData): List<SummaryListRowViewModel> {

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/forms/pages/PropertyRegistrationCheckAnswersPageTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/forms/pages/PropertyRegistrationCheckAnswersPageTests.kt
@@ -8,7 +8,6 @@ import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 import org.springframework.validation.Validator
-import uk.gov.communities.prsdb.webapp.constants.LOOKED_UP_ADDRESSES_JOURNEY_DATA_KEY
 import uk.gov.communities.prsdb.webapp.constants.enums.LicensingType
 import uk.gov.communities.prsdb.webapp.constants.enums.OwnershipType
 import uk.gov.communities.prsdb.webapp.constants.enums.PropertyType
@@ -43,12 +42,10 @@ class PropertyRegistrationCheckAnswersPageTests {
         journeyDataBuilder = JourneyDataBuilder.propertyDefault(localAuthorityService)
     }
 
-    private fun getPropertyDetails(filteredJourneyData: JourneyData): List<SummaryListRowViewModel> {
-        whenever(journeyDataService.getJourneyDataEntryInSession(LOOKED_UP_ADDRESSES_JOURNEY_DATA_KEY)).thenReturn(
-            LOOKED_UP_ADDRESSES_JOURNEY_DATA_KEY to filteredJourneyData[LOOKED_UP_ADDRESSES_JOURNEY_DATA_KEY],
-        )
+    private fun getPropertyDetails(journeyData: JourneyData): List<SummaryListRowViewModel> {
+        whenever(journeyDataService.getJourneyDataFromSession()).thenReturn(journeyData)
 
-        val result = page.getModelAndView(validator, pageData, prevStepUrl, filteredJourneyData, null)
+        val result = page.getModelAndView(validator, pageData, prevStepUrl, journeyData, null)
 
         val propertyDetails = result.model["propertyDetails"] as List<*>
         return propertyDetails.filterIsInstance<SummaryListRowViewModel>()

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/forms/pages/PropertyRegistrationCheckAnswersPageTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/forms/pages/PropertyRegistrationCheckAnswersPageTests.kt
@@ -16,14 +16,14 @@ import uk.gov.communities.prsdb.webapp.forms.PageData
 import uk.gov.communities.prsdb.webapp.forms.steps.RegisterPropertyStepId
 import uk.gov.communities.prsdb.webapp.models.dataModels.AddressDataModel
 import uk.gov.communities.prsdb.webapp.models.viewModels.summaryModels.SummaryListRowViewModel
-import uk.gov.communities.prsdb.webapp.services.AddressDataService
 import uk.gov.communities.prsdb.webapp.services.LocalAuthorityService
+import uk.gov.communities.prsdb.webapp.services.RegisteredAddressCache
 import uk.gov.communities.prsdb.webapp.testHelpers.builders.JourneyDataBuilder
 import uk.gov.communities.prsdb.webapp.testHelpers.mockObjects.MockLocalAuthorityData.Companion.createLocalAuthority
 
 class PropertyRegistrationCheckAnswersPageTests {
     private lateinit var page: PropertyRegistrationCheckAnswersPage
-    private lateinit var addressService: AddressDataService
+    private lateinit var addressService: RegisteredAddressCache
     private lateinit var localAuthorityService: LocalAuthorityService
     private lateinit var validator: Validator
     private lateinit var pageData: PageData

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/forms/pages/PropertyRegistrationCheckAnswersPageTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/forms/pages/PropertyRegistrationCheckAnswersPageTests.kt
@@ -8,6 +8,7 @@ import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 import org.springframework.validation.Validator
+import uk.gov.communities.prsdb.webapp.constants.LOOKED_UP_ADDRESSES_JOURNEY_DATA_KEY
 import uk.gov.communities.prsdb.webapp.constants.enums.LicensingType
 import uk.gov.communities.prsdb.webapp.constants.enums.OwnershipType
 import uk.gov.communities.prsdb.webapp.constants.enums.PropertyType
@@ -43,6 +44,10 @@ class PropertyRegistrationCheckAnswersPageTests {
     }
 
     private fun getPropertyDetails(filteredJourneyData: JourneyData): List<SummaryListRowViewModel> {
+        whenever(journeyDataService.getJourneyDataEntryInSession(LOOKED_UP_ADDRESSES_JOURNEY_DATA_KEY)).thenReturn(
+            LOOKED_UP_ADDRESSES_JOURNEY_DATA_KEY to filteredJourneyData[LOOKED_UP_ADDRESSES_JOURNEY_DATA_KEY],
+        )
+
         val result = page.getModelAndView(validator, pageData, prevStepUrl, filteredJourneyData, null)
 
         val propertyDetails = result.model["propertyDetails"] as List<*>

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/helpers/JourneyDataHelperTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/helpers/JourneyDataHelperTests.kt
@@ -6,23 +6,23 @@ import org.junit.jupiter.api.Test
 import org.mockito.Mockito.mock
 import uk.gov.communities.prsdb.webapp.forms.JourneyData
 import uk.gov.communities.prsdb.webapp.models.dataModels.AddressDataModel
-import uk.gov.communities.prsdb.webapp.services.AddressDataService
 import uk.gov.communities.prsdb.webapp.services.LocalAuthorityService
+import uk.gov.communities.prsdb.webapp.services.RegisteredAddressCache
 import uk.gov.communities.prsdb.webapp.testHelpers.builders.JourneyDataBuilder
 import uk.gov.communities.prsdb.webapp.testHelpers.mockObjects.MockLocalAuthorityData.Companion.createLocalAuthority
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
 
 class JourneyDataHelperTests {
-    private lateinit var mockAddressDataService: AddressDataService
+    private lateinit var mockRegisteredAddressCache: RegisteredAddressCache
     private lateinit var mockLocalAuthorityService: LocalAuthorityService
     private lateinit var journeyDataBuilder: JourneyDataBuilder
 
     @BeforeEach
     fun setup() {
-        mockAddressDataService = mock()
+        mockRegisteredAddressCache = mock()
         mockLocalAuthorityService = mock()
-        journeyDataBuilder = JourneyDataBuilder.landlordDefault(mockAddressDataService, mockLocalAuthorityService)
+        journeyDataBuilder = JourneyDataBuilder.landlordDefault(mockRegisteredAddressCache, mockLocalAuthorityService)
     }
 
     @Test

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/helpers/JourneyDataHelperTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/helpers/JourneyDataHelperTests.kt
@@ -7,22 +7,19 @@ import org.mockito.Mockito.mock
 import uk.gov.communities.prsdb.webapp.forms.JourneyData
 import uk.gov.communities.prsdb.webapp.models.dataModels.AddressDataModel
 import uk.gov.communities.prsdb.webapp.services.LocalAuthorityService
-import uk.gov.communities.prsdb.webapp.services.RegisteredAddressCache
 import uk.gov.communities.prsdb.webapp.testHelpers.builders.JourneyDataBuilder
 import uk.gov.communities.prsdb.webapp.testHelpers.mockObjects.MockLocalAuthorityData.Companion.createLocalAuthority
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
 
 class JourneyDataHelperTests {
-    private lateinit var mockRegisteredAddressCache: RegisteredAddressCache
     private lateinit var mockLocalAuthorityService: LocalAuthorityService
     private lateinit var journeyDataBuilder: JourneyDataBuilder
 
     @BeforeEach
     fun setup() {
-        mockRegisteredAddressCache = mock()
         mockLocalAuthorityService = mock()
-        journeyDataBuilder = JourneyDataBuilder.landlordDefault(mockRegisteredAddressCache, mockLocalAuthorityService)
+        journeyDataBuilder = JourneyDataBuilder.landlordDefault(mockLocalAuthorityService)
     }
 
     @Test

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/helpers/LandlordRegistrationJourneyDataHelperTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/helpers/LandlordRegistrationJourneyDataHelperTests.kt
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
 import org.mockito.Mockito.mock
+import uk.gov.communities.prsdb.webapp.helpers.extensions.JourneyDataExtensions.Companion.getLookedUpAddresses
 import uk.gov.communities.prsdb.webapp.models.dataModels.AddressDataModel
 import uk.gov.communities.prsdb.webapp.services.LocalAuthorityService
 import uk.gov.communities.prsdb.webapp.testHelpers.builders.JourneyDataBuilder
@@ -106,7 +107,7 @@ class LandlordRegistrationJourneyDataHelperTests {
                 ).build()
         val expectedAddressDataModel = AddressDataModel(selectedAddress)
 
-        val addressDataModel = LandlordRegistrationJourneyDataHelper.getAddress(mockJourneyData)
+        val addressDataModel = LandlordRegistrationJourneyDataHelper.getAddress(mockJourneyData, mockJourneyData.getLookedUpAddresses())
 
         assertEquals(expectedAddressDataModel, addressDataModel)
     }
@@ -128,8 +129,7 @@ class LandlordRegistrationJourneyDataHelperTests {
                 ).build()
         val expectedAddressDataModel = AddressDataModel.fromManualAddressData(addressLineOne, townOrCity, postcode)
 
-        val addressDataModel =
-            LandlordRegistrationJourneyDataHelper.getAddress(mockJourneyData)
+        val addressDataModel = LandlordRegistrationJourneyDataHelper.getAddress(mockJourneyData, mockJourneyData.getLookedUpAddresses())
 
         assertEquals(expectedAddressDataModel, addressDataModel)
     }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/helpers/LandlordRegistrationJourneyDataHelperTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/helpers/LandlordRegistrationJourneyDataHelperTests.kt
@@ -8,22 +8,22 @@ import org.junit.jupiter.params.provider.ValueSource
 import org.mockito.Mockito.mock
 import org.mockito.kotlin.whenever
 import uk.gov.communities.prsdb.webapp.models.dataModels.AddressDataModel
-import uk.gov.communities.prsdb.webapp.services.AddressDataService
 import uk.gov.communities.prsdb.webapp.services.LocalAuthorityService
+import uk.gov.communities.prsdb.webapp.services.RegisteredAddressCache
 import uk.gov.communities.prsdb.webapp.testHelpers.builders.JourneyDataBuilder
 import java.time.LocalDate
 import kotlin.test.assertEquals
 
 class LandlordRegistrationJourneyDataHelperTests {
-    private lateinit var mockAddressDataService: AddressDataService
+    private lateinit var mockRegisteredAddressCache: RegisteredAddressCache
     private lateinit var mockLocalAuthorityService: LocalAuthorityService
     private lateinit var journeyDataBuilder: JourneyDataBuilder
 
     @BeforeEach
     fun setup() {
-        mockAddressDataService = mock()
+        mockRegisteredAddressCache = mock()
         mockLocalAuthorityService = mock()
-        journeyDataBuilder = JourneyDataBuilder.landlordDefault(mockAddressDataService, mockLocalAuthorityService)
+        journeyDataBuilder = JourneyDataBuilder.landlordDefault(mockRegisteredAddressCache, mockLocalAuthorityService)
     }
 
     @Test
@@ -110,9 +110,9 @@ class LandlordRegistrationJourneyDataHelperTests {
                 ).build()
         val expectedAddressDataModel = AddressDataModel(selectedAddress)
 
-        whenever(mockAddressDataService.getAddressData(selectedAddress)).thenReturn(expectedAddressDataModel)
+        whenever(mockRegisteredAddressCache.getAddressData(selectedAddress)).thenReturn(expectedAddressDataModel)
 
-        val addressDataModel = LandlordRegistrationJourneyDataHelper.getAddress(mockJourneyData, mockAddressDataService)
+        val addressDataModel = LandlordRegistrationJourneyDataHelper.getAddress(mockJourneyData, mockRegisteredAddressCache)
 
         assertEquals(expectedAddressDataModel, addressDataModel)
     }
@@ -135,7 +135,7 @@ class LandlordRegistrationJourneyDataHelperTests {
         val expectedAddressDataModel = AddressDataModel.fromManualAddressData(addressLineOne, townOrCity, postcode)
 
         val addressDataModel =
-            LandlordRegistrationJourneyDataHelper.getAddress(mockJourneyData, mockAddressDataService)
+            LandlordRegistrationJourneyDataHelper.getAddress(mockJourneyData, mockRegisteredAddressCache)
 
         assertEquals(expectedAddressDataModel, addressDataModel)
     }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/helpers/LandlordRegistrationJourneyDataHelperTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/helpers/LandlordRegistrationJourneyDataHelperTests.kt
@@ -6,7 +6,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
 import org.mockito.Mockito.mock
-import uk.gov.communities.prsdb.webapp.helpers.extensions.JourneyDataExtensions.Companion.getLookedUpAddresses
+import uk.gov.communities.prsdb.webapp.helpers.extensions.journeyDataExtensions.JourneyDataExtensions.Companion.getLookedUpAddresses
 import uk.gov.communities.prsdb.webapp.models.dataModels.AddressDataModel
 import uk.gov.communities.prsdb.webapp.services.LocalAuthorityService
 import uk.gov.communities.prsdb.webapp.testHelpers.builders.JourneyDataBuilder

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/helpers/LandlordRegistrationJourneyDataHelperTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/helpers/LandlordRegistrationJourneyDataHelperTests.kt
@@ -6,24 +6,20 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.ValueSource
 import org.mockito.Mockito.mock
-import org.mockito.kotlin.whenever
 import uk.gov.communities.prsdb.webapp.models.dataModels.AddressDataModel
 import uk.gov.communities.prsdb.webapp.services.LocalAuthorityService
-import uk.gov.communities.prsdb.webapp.services.RegisteredAddressCache
 import uk.gov.communities.prsdb.webapp.testHelpers.builders.JourneyDataBuilder
 import java.time.LocalDate
 import kotlin.test.assertEquals
 
 class LandlordRegistrationJourneyDataHelperTests {
-    private lateinit var mockRegisteredAddressCache: RegisteredAddressCache
     private lateinit var mockLocalAuthorityService: LocalAuthorityService
     private lateinit var journeyDataBuilder: JourneyDataBuilder
 
     @BeforeEach
     fun setup() {
-        mockRegisteredAddressCache = mock()
         mockLocalAuthorityService = mock()
-        journeyDataBuilder = JourneyDataBuilder.landlordDefault(mockRegisteredAddressCache, mockLocalAuthorityService)
+        journeyDataBuilder = JourneyDataBuilder.landlordDefault(mockLocalAuthorityService)
     }
 
     @Test
@@ -110,9 +106,7 @@ class LandlordRegistrationJourneyDataHelperTests {
                 ).build()
         val expectedAddressDataModel = AddressDataModel(selectedAddress)
 
-        whenever(mockRegisteredAddressCache.getAddressData(selectedAddress)).thenReturn(expectedAddressDataModel)
-
-        val addressDataModel = LandlordRegistrationJourneyDataHelper.getAddress(mockJourneyData, mockRegisteredAddressCache)
+        val addressDataModel = LandlordRegistrationJourneyDataHelper.getAddress(mockJourneyData)
 
         assertEquals(expectedAddressDataModel, addressDataModel)
     }
@@ -135,7 +129,7 @@ class LandlordRegistrationJourneyDataHelperTests {
         val expectedAddressDataModel = AddressDataModel.fromManualAddressData(addressLineOne, townOrCity, postcode)
 
         val addressDataModel =
-            LandlordRegistrationJourneyDataHelper.getAddress(mockJourneyData, mockRegisteredAddressCache)
+            LandlordRegistrationJourneyDataHelper.getAddress(mockJourneyData)
 
         assertEquals(expectedAddressDataModel, addressDataModel)
     }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/helpers/PropertyRegistrationJourneyDataHelperTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/helpers/PropertyRegistrationJourneyDataHelperTests.kt
@@ -10,22 +10,22 @@ import uk.gov.communities.prsdb.webapp.constants.enums.LicensingType
 import uk.gov.communities.prsdb.webapp.constants.enums.OwnershipType
 import uk.gov.communities.prsdb.webapp.constants.enums.PropertyType
 import uk.gov.communities.prsdb.webapp.models.dataModels.AddressDataModel
-import uk.gov.communities.prsdb.webapp.services.AddressDataService
 import uk.gov.communities.prsdb.webapp.services.LocalAuthorityService
+import uk.gov.communities.prsdb.webapp.services.RegisteredAddressCache
 import uk.gov.communities.prsdb.webapp.testHelpers.builders.JourneyDataBuilder
 import uk.gov.communities.prsdb.webapp.testHelpers.mockObjects.MockLocalAuthorityData.Companion.createLocalAuthority
 import kotlin.test.assertEquals
 
 class PropertyRegistrationJourneyDataHelperTests {
-    private lateinit var mockAddressDataService: AddressDataService
+    private lateinit var mockRegisteredAddressCache: RegisteredAddressCache
     private lateinit var mockLocalAuthorityService: LocalAuthorityService
     private lateinit var journeyDataBuilder: JourneyDataBuilder
 
     @BeforeEach
     fun setup() {
-        mockAddressDataService = mock()
+        mockRegisteredAddressCache = mock()
         mockLocalAuthorityService = mock()
-        journeyDataBuilder = JourneyDataBuilder.propertyDefault(mockAddressDataService, mockLocalAuthorityService)
+        journeyDataBuilder = JourneyDataBuilder.propertyDefault(mockRegisteredAddressCache, mockLocalAuthorityService)
     }
 
     @Test
@@ -36,12 +36,12 @@ class PropertyRegistrationJourneyDataHelperTests {
             journeyDataBuilder.withSelectedAddress(selectedAddress, localAuthority = localAuthority).build()
         val expectedAddressDataModel = AddressDataModel(selectedAddress, localAuthorityId = localAuthority.id)
 
-        whenever(mockAddressDataService.getAddressData(selectedAddress)).thenReturn(expectedAddressDataModel)
+        whenever(mockRegisteredAddressCache.getAddressData(selectedAddress)).thenReturn(expectedAddressDataModel)
 
         val addressDataModel =
             PropertyRegistrationJourneyDataHelper.getAddress(
                 mockJourneyData,
-                mockAddressDataService,
+                mockRegisteredAddressCache,
             )
 
         assertEquals(expectedAddressDataModel, addressDataModel)
@@ -72,7 +72,7 @@ class PropertyRegistrationJourneyDataHelperTests {
         val addressDataModel =
             PropertyRegistrationJourneyDataHelper.getAddress(
                 mockJourneyData,
-                mockAddressDataService,
+                mockRegisteredAddressCache,
             )
         assertEquals(expectedAddressDataModel, addressDataModel)
     }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/helpers/PropertyRegistrationJourneyDataHelperTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/helpers/PropertyRegistrationJourneyDataHelperTests.kt
@@ -9,7 +9,7 @@ import org.mockito.kotlin.whenever
 import uk.gov.communities.prsdb.webapp.constants.enums.LicensingType
 import uk.gov.communities.prsdb.webapp.constants.enums.OwnershipType
 import uk.gov.communities.prsdb.webapp.constants.enums.PropertyType
-import uk.gov.communities.prsdb.webapp.helpers.extensions.JourneyDataExtensions.Companion.getLookedUpAddresses
+import uk.gov.communities.prsdb.webapp.helpers.extensions.journeyDataExtensions.JourneyDataExtensions.Companion.getLookedUpAddresses
 import uk.gov.communities.prsdb.webapp.models.dataModels.AddressDataModel
 import uk.gov.communities.prsdb.webapp.services.LocalAuthorityService
 import uk.gov.communities.prsdb.webapp.testHelpers.builders.JourneyDataBuilder

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/helpers/PropertyRegistrationJourneyDataHelperTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/helpers/PropertyRegistrationJourneyDataHelperTests.kt
@@ -9,6 +9,7 @@ import org.mockito.kotlin.whenever
 import uk.gov.communities.prsdb.webapp.constants.enums.LicensingType
 import uk.gov.communities.prsdb.webapp.constants.enums.OwnershipType
 import uk.gov.communities.prsdb.webapp.constants.enums.PropertyType
+import uk.gov.communities.prsdb.webapp.helpers.extensions.JourneyDataExtensions.Companion.getLookedUpAddresses
 import uk.gov.communities.prsdb.webapp.models.dataModels.AddressDataModel
 import uk.gov.communities.prsdb.webapp.services.LocalAuthorityService
 import uk.gov.communities.prsdb.webapp.testHelpers.builders.JourneyDataBuilder
@@ -33,7 +34,7 @@ class PropertyRegistrationJourneyDataHelperTests {
             journeyDataBuilder.withSelectedAddress(selectedAddress, localAuthority = localAuthority).build()
         val expectedAddressDataModel = AddressDataModel(selectedAddress, localAuthorityId = localAuthority.id)
 
-        val addressDataModel = PropertyRegistrationJourneyDataHelper.getAddress(mockJourneyData)
+        val addressDataModel = PropertyRegistrationJourneyDataHelper.getAddress(mockJourneyData, mockJourneyData.getLookedUpAddresses())
 
         assertEquals(expectedAddressDataModel, addressDataModel)
     }
@@ -60,7 +61,7 @@ class PropertyRegistrationJourneyDataHelperTests {
             localAuthority,
         )
 
-        val addressDataModel = PropertyRegistrationJourneyDataHelper.getAddress(mockJourneyData)
+        val addressDataModel = PropertyRegistrationJourneyDataHelper.getAddress(mockJourneyData, mockJourneyData.getLookedUpAddresses())
         assertEquals(expectedAddressDataModel, addressDataModel)
     }
 

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/helpers/PropertyRegistrationJourneyDataHelperTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/helpers/PropertyRegistrationJourneyDataHelperTests.kt
@@ -11,21 +11,18 @@ import uk.gov.communities.prsdb.webapp.constants.enums.OwnershipType
 import uk.gov.communities.prsdb.webapp.constants.enums.PropertyType
 import uk.gov.communities.prsdb.webapp.models.dataModels.AddressDataModel
 import uk.gov.communities.prsdb.webapp.services.LocalAuthorityService
-import uk.gov.communities.prsdb.webapp.services.RegisteredAddressCache
 import uk.gov.communities.prsdb.webapp.testHelpers.builders.JourneyDataBuilder
 import uk.gov.communities.prsdb.webapp.testHelpers.mockObjects.MockLocalAuthorityData.Companion.createLocalAuthority
 import kotlin.test.assertEquals
 
 class PropertyRegistrationJourneyDataHelperTests {
-    private lateinit var mockRegisteredAddressCache: RegisteredAddressCache
     private lateinit var mockLocalAuthorityService: LocalAuthorityService
     private lateinit var journeyDataBuilder: JourneyDataBuilder
 
     @BeforeEach
     fun setup() {
-        mockRegisteredAddressCache = mock()
         mockLocalAuthorityService = mock()
-        journeyDataBuilder = JourneyDataBuilder.propertyDefault(mockRegisteredAddressCache, mockLocalAuthorityService)
+        journeyDataBuilder = JourneyDataBuilder.propertyDefault(mockLocalAuthorityService)
     }
 
     @Test
@@ -36,13 +33,7 @@ class PropertyRegistrationJourneyDataHelperTests {
             journeyDataBuilder.withSelectedAddress(selectedAddress, localAuthority = localAuthority).build()
         val expectedAddressDataModel = AddressDataModel(selectedAddress, localAuthorityId = localAuthority.id)
 
-        whenever(mockRegisteredAddressCache.getAddressData(selectedAddress)).thenReturn(expectedAddressDataModel)
-
-        val addressDataModel =
-            PropertyRegistrationJourneyDataHelper.getAddress(
-                mockJourneyData,
-                mockRegisteredAddressCache,
-            )
+        val addressDataModel = PropertyRegistrationJourneyDataHelper.getAddress(mockJourneyData)
 
         assertEquals(expectedAddressDataModel, addressDataModel)
     }
@@ -69,11 +60,7 @@ class PropertyRegistrationJourneyDataHelperTests {
             localAuthority,
         )
 
-        val addressDataModel =
-            PropertyRegistrationJourneyDataHelper.getAddress(
-                mockJourneyData,
-                mockRegisteredAddressCache,
-            )
+        val addressDataModel = PropertyRegistrationJourneyDataHelper.getAddress(mockJourneyData)
         assertEquals(expectedAddressDataModel, addressDataModel)
     }
 

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/helpers/UpdateLandlordDetailsJourneyDataHelperTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/helpers/UpdateLandlordDetailsJourneyDataHelperTests.kt
@@ -6,19 +6,19 @@ import org.junit.jupiter.api.Test
 import org.mockito.Mockito.mock
 import uk.gov.communities.prsdb.webapp.database.entity.LocalAuthority
 import uk.gov.communities.prsdb.webapp.models.dataModels.AddressDataModel
-import uk.gov.communities.prsdb.webapp.services.AddressDataService
+import uk.gov.communities.prsdb.webapp.services.RegisteredAddressCache
 import uk.gov.communities.prsdb.webapp.testHelpers.builders.JourneyDataBuilder
 import java.time.LocalDate
 import kotlin.test.assertEquals
 
 class UpdateLandlordDetailsJourneyDataHelperTests {
     private lateinit var journeyDataBuilder: JourneyDataBuilder
-    private lateinit var addressDataService: AddressDataService
+    private lateinit var registeredAddressCache: RegisteredAddressCache
 
     @BeforeEach
     fun setup() {
-        addressDataService = mock()
-        journeyDataBuilder = JourneyDataBuilder(addressDataService, mock())
+        registeredAddressCache = mock()
+        journeyDataBuilder = JourneyDataBuilder(registeredAddressCache, mock())
     }
 
     @Test
@@ -67,7 +67,7 @@ class UpdateLandlordDetailsJourneyDataHelperTests {
         val testJourneyData = journeyDataBuilder.withSelectedAddress(singleLineAddress, uprn, authority).build()
 
         val addressUpdate =
-            UpdateLandlordDetailsJourneyDataHelper.getAddressIfPresent(testJourneyData, addressDataService)
+            UpdateLandlordDetailsJourneyDataHelper.getAddressIfPresent(testJourneyData, registeredAddressCache)
 
         assertEquals(AddressDataModel(singleLineAddress, uprn = uprn, localAuthorityId = authority.id), addressUpdate)
     }
@@ -80,7 +80,7 @@ class UpdateLandlordDetailsJourneyDataHelperTests {
         val testJourneyData = journeyDataBuilder.withManualAddress(lineOne, locality, postcode).build()
 
         val addressUpdate =
-            UpdateLandlordDetailsJourneyDataHelper.getAddressIfPresent(testJourneyData, addressDataService)
+            UpdateLandlordDetailsJourneyDataHelper.getAddressIfPresent(testJourneyData, registeredAddressCache)
 
         assertEquals(
             AddressDataModel(
@@ -97,7 +97,7 @@ class UpdateLandlordDetailsJourneyDataHelperTests {
         val testJourneyData = journeyDataBuilder.build()
 
         val addressUpdate =
-            UpdateLandlordDetailsJourneyDataHelper.getAddressIfPresent(testJourneyData, addressDataService)
+            UpdateLandlordDetailsJourneyDataHelper.getAddressIfPresent(testJourneyData, registeredAddressCache)
 
         assertNull(addressUpdate)
     }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/helpers/UpdateLandlordDetailsJourneyDataHelperTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/helpers/UpdateLandlordDetailsJourneyDataHelperTests.kt
@@ -6,19 +6,16 @@ import org.junit.jupiter.api.Test
 import org.mockito.Mockito.mock
 import uk.gov.communities.prsdb.webapp.database.entity.LocalAuthority
 import uk.gov.communities.prsdb.webapp.models.dataModels.AddressDataModel
-import uk.gov.communities.prsdb.webapp.services.RegisteredAddressCache
 import uk.gov.communities.prsdb.webapp.testHelpers.builders.JourneyDataBuilder
 import java.time.LocalDate
 import kotlin.test.assertEquals
 
 class UpdateLandlordDetailsJourneyDataHelperTests {
     private lateinit var journeyDataBuilder: JourneyDataBuilder
-    private lateinit var registeredAddressCache: RegisteredAddressCache
 
     @BeforeEach
     fun setup() {
-        registeredAddressCache = mock()
-        journeyDataBuilder = JourneyDataBuilder(registeredAddressCache, mock())
+        journeyDataBuilder = JourneyDataBuilder(mock())
     }
 
     @Test
@@ -66,8 +63,7 @@ class UpdateLandlordDetailsJourneyDataHelperTests {
         val authority = LocalAuthority()
         val testJourneyData = journeyDataBuilder.withSelectedAddress(singleLineAddress, uprn, authority).build()
 
-        val addressUpdate =
-            UpdateLandlordDetailsJourneyDataHelper.getAddressIfPresent(testJourneyData, registeredAddressCache)
+        val addressUpdate = UpdateLandlordDetailsJourneyDataHelper.getAddressIfPresent(testJourneyData)
 
         assertEquals(AddressDataModel(singleLineAddress, uprn = uprn, localAuthorityId = authority.id), addressUpdate)
     }
@@ -79,8 +75,7 @@ class UpdateLandlordDetailsJourneyDataHelperTests {
         val postcode = "EG1 9ZY"
         val testJourneyData = journeyDataBuilder.withManualAddress(lineOne, locality, postcode).build()
 
-        val addressUpdate =
-            UpdateLandlordDetailsJourneyDataHelper.getAddressIfPresent(testJourneyData, registeredAddressCache)
+        val addressUpdate = UpdateLandlordDetailsJourneyDataHelper.getAddressIfPresent(testJourneyData)
 
         assertEquals(
             AddressDataModel(
@@ -96,8 +91,7 @@ class UpdateLandlordDetailsJourneyDataHelperTests {
     fun `getAddressUpdateIfPresent returns null if the address pages are not journeyData`() {
         val testJourneyData = journeyDataBuilder.build()
 
-        val addressUpdate =
-            UpdateLandlordDetailsJourneyDataHelper.getAddressIfPresent(testJourneyData, registeredAddressCache)
+        val addressUpdate = UpdateLandlordDetailsJourneyDataHelper.getAddressIfPresent(testJourneyData)
 
         assertNull(addressUpdate)
     }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/helpers/extensions/JourneyDataExtensionsTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/helpers/extensions/JourneyDataExtensionsTests.kt
@@ -1,0 +1,48 @@
+package uk.gov.communities.prsdb.webapp.helpers.extensions
+
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import org.junit.jupiter.api.Test
+import uk.gov.communities.prsdb.webapp.constants.LOOKED_UP_ADDRESSES_JOURNEY_DATA_KEY
+import uk.gov.communities.prsdb.webapp.helpers.extensions.JourneyDataExtensions.Companion.getLookedUpAddress
+import uk.gov.communities.prsdb.webapp.models.dataModels.AddressDataModel
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class JourneyDataExtensionsTests {
+    @Test
+    fun `getLookedUpAddress retrieves the requested AddressDataModel from journeyData`() {
+        val requestedAddress = AddressDataModel("1, Example Road, EG", 1, 1234, buildingNumber = "1", postcode = "EG")
+
+        val lookedUpAddresses =
+            listOf(
+                requestedAddress,
+                AddressDataModel("2, Example Road, EG", 2, buildingNumber = "2", postcode = "EG"),
+                AddressDataModel("Main, Example Road, EG", 3, buildingName = "Main", postcode = "EG"),
+            )
+
+        val journeyData = mapOf(LOOKED_UP_ADDRESSES_JOURNEY_DATA_KEY to Json.encodeToString(lookedUpAddresses))
+
+        val retrievedAddress = journeyData.getLookedUpAddress(requestedAddress.singleLineAddress)
+
+        assertEquals(requestedAddress, retrievedAddress)
+    }
+
+    @Test
+    fun `getLookedUpAddress returns null when the requested AddressDataModel is not in journeyData`() {
+        val requestedSingleLineAddress = "address not in journeyData"
+
+        val lookedUpAddresses =
+            listOf(
+                AddressDataModel("1, Example Road, EG", 1, 1234, buildingNumber = "1", postcode = "EG"),
+                AddressDataModel("2, Example Road, EG", 2, buildingNumber = "2", postcode = "EG"),
+                AddressDataModel("Main, Example Road, EG", 3, buildingName = "Main", postcode = "EG"),
+            )
+
+        val journeyData = mapOf(LOOKED_UP_ADDRESSES_JOURNEY_DATA_KEY to Json.encodeToString(lookedUpAddresses))
+
+        val retrievedAddress = journeyData.getLookedUpAddress(requestedSingleLineAddress)
+
+        assertNull(retrievedAddress)
+    }
+}

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/helpers/extensions/JourneyDataExtensionsTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/helpers/extensions/JourneyDataExtensionsTests.kt
@@ -5,6 +5,8 @@ import kotlinx.serialization.json.Json
 import org.junit.jupiter.api.Test
 import uk.gov.communities.prsdb.webapp.constants.LOOKED_UP_ADDRESSES_JOURNEY_DATA_KEY
 import uk.gov.communities.prsdb.webapp.helpers.extensions.JourneyDataExtensions.Companion.getLookedUpAddress
+import uk.gov.communities.prsdb.webapp.helpers.extensions.JourneyDataExtensions.Companion.getSerializedLookedUpAddresses
+import uk.gov.communities.prsdb.webapp.helpers.extensions.JourneyDataExtensions.Companion.updateLookedUpAddresses
 import uk.gov.communities.prsdb.webapp.models.dataModels.AddressDataModel
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
@@ -44,5 +46,51 @@ class JourneyDataExtensionsTests {
         val retrievedAddress = journeyData.getLookedUpAddress(requestedSingleLineAddress)
 
         assertNull(retrievedAddress)
+    }
+
+    @Test
+    fun `getSerializedLookedUpAddresses returns the serialized looked-up addresses in journeyData`() {
+        val serializedAddresses = "serialized-looked-up-addresses"
+        val journeyData = mapOf(LOOKED_UP_ADDRESSES_JOURNEY_DATA_KEY to serializedAddresses)
+
+        val retrievedSerializedAddresses = journeyData.getSerializedLookedUpAddresses()
+
+        assertEquals(serializedAddresses, retrievedSerializedAddresses)
+    }
+
+    @Test
+    fun `getSerializedLookedUpAddresses returns null when there aren't serialized looked-up addresses in journeyData`() {
+        val journeyData = mapOf("other-key" to "other-value")
+
+        val retrievedSerializedAddresses = journeyData.getSerializedLookedUpAddresses()
+
+        assertNull(retrievedSerializedAddresses)
+    }
+
+    @Test
+    fun `updateLookedUpAddresses returns journeyData updated with the given serialized addresses`() {
+        val serializedAddresses = "serialized-looked-up-addresses"
+        val journeyData = mapOf("other-key" to "other-value")
+        val expectedUpdatedJourneyData = journeyData + (LOOKED_UP_ADDRESSES_JOURNEY_DATA_KEY to serializedAddresses)
+
+        val updatedJourneyData = journeyData.updateLookedUpAddresses(serializedAddresses)
+
+        assertEquals(expectedUpdatedJourneyData, updatedJourneyData)
+    }
+
+    @Test
+    fun `updateLookedUpAddresses returns journeyData updated with the given addresses`() {
+        val addresses =
+            listOf(
+                AddressDataModel("1, Example Road, EG", 1, 1234, buildingNumber = "1", postcode = "EG"),
+                AddressDataModel("2, Example Road, EG", 2, buildingNumber = "2", postcode = "EG"),
+                AddressDataModel("Main, Example Road, EG", 3, buildingName = "Main", postcode = "EG"),
+            )
+        val journeyData = mapOf("other-key" to "other-value")
+        val expectedUpdatedJourneyData = journeyData + (LOOKED_UP_ADDRESSES_JOURNEY_DATA_KEY to Json.encodeToString(addresses))
+
+        val updatedJourneyData = journeyData.updateLookedUpAddresses(addresses)
+
+        assertEquals(expectedUpdatedJourneyData, updatedJourneyData)
     }
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/helpers/extensions/JourneyDataExtensionsTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/helpers/extensions/JourneyDataExtensionsTests.kt
@@ -5,6 +5,7 @@ import kotlinx.serialization.json.Json
 import org.junit.jupiter.api.Test
 import uk.gov.communities.prsdb.webapp.constants.LOOKED_UP_ADDRESSES_JOURNEY_DATA_KEY
 import uk.gov.communities.prsdb.webapp.helpers.extensions.JourneyDataExtensions.Companion.getLookedUpAddress
+import uk.gov.communities.prsdb.webapp.helpers.extensions.JourneyDataExtensions.Companion.getLookedUpAddresses
 import uk.gov.communities.prsdb.webapp.helpers.extensions.JourneyDataExtensions.Companion.getSerializedLookedUpAddresses
 import uk.gov.communities.prsdb.webapp.helpers.extensions.JourneyDataExtensions.Companion.updateLookedUpAddresses
 import uk.gov.communities.prsdb.webapp.models.dataModels.AddressDataModel
@@ -46,6 +47,31 @@ class JourneyDataExtensionsTests {
         val retrievedAddress = journeyData.getLookedUpAddress(requestedSingleLineAddress)
 
         assertNull(retrievedAddress)
+    }
+
+    @Test
+    fun `getLookedUpAddresses returns the looked-up AddressDataModels from journeyData`() {
+        val lookedUpAddresses =
+            listOf(
+                AddressDataModel("1, Example Road, EG", 1, 1234, buildingNumber = "1", postcode = "EG"),
+                AddressDataModel("2, Example Road, EG", 2, buildingNumber = "2", postcode = "EG"),
+                AddressDataModel("Main, Example Road, EG", 3, buildingName = "Main", postcode = "EG"),
+            )
+
+        val journeyData = mapOf(LOOKED_UP_ADDRESSES_JOURNEY_DATA_KEY to Json.encodeToString(lookedUpAddresses))
+
+        val retrievedAddresses = journeyData.getLookedUpAddresses()
+
+        assertEquals(lookedUpAddresses, retrievedAddresses)
+    }
+
+    @Test
+    fun `getLookedUpAddresses returns an empty list when there aren't looked-up addresses in journeyData`() {
+        val journeyData = mapOf("other-key" to "other-value")
+
+        val retrievedAddresses = journeyData.getLookedUpAddresses()
+
+        assertEquals(emptyList(), retrievedAddresses)
     }
 
     @Test

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/helpers/extensions/JourneyDataExtensionsTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/helpers/extensions/JourneyDataExtensionsTests.kt
@@ -7,7 +7,7 @@ import uk.gov.communities.prsdb.webapp.constants.LOOKED_UP_ADDRESSES_JOURNEY_DAT
 import uk.gov.communities.prsdb.webapp.helpers.extensions.journeyDataExtensions.JourneyDataExtensions.Companion.getLookedUpAddress
 import uk.gov.communities.prsdb.webapp.helpers.extensions.journeyDataExtensions.JourneyDataExtensions.Companion.getLookedUpAddresses
 import uk.gov.communities.prsdb.webapp.helpers.extensions.journeyDataExtensions.JourneyDataExtensions.Companion.getSerializedLookedUpAddresses
-import uk.gov.communities.prsdb.webapp.helpers.extensions.journeyDataExtensions.JourneyDataExtensions.Companion.updateLookedUpAddresses
+import uk.gov.communities.prsdb.webapp.helpers.extensions.journeyDataExtensions.JourneyDataExtensions.Companion.withUpdatedLookedUpAddresses
 import uk.gov.communities.prsdb.webapp.models.dataModels.AddressDataModel
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
@@ -99,7 +99,7 @@ class JourneyDataExtensionsTests {
         val journeyData = mapOf("other-key" to "other-value")
         val expectedUpdatedJourneyData = journeyData + (LOOKED_UP_ADDRESSES_JOURNEY_DATA_KEY to serializedAddresses)
 
-        val updatedJourneyData = journeyData.updateLookedUpAddresses(serializedAddresses)
+        val updatedJourneyData = journeyData.withUpdatedLookedUpAddresses(serializedAddresses)
 
         assertEquals(expectedUpdatedJourneyData, updatedJourneyData)
     }
@@ -115,7 +115,7 @@ class JourneyDataExtensionsTests {
         val journeyData = mapOf("other-key" to "other-value")
         val expectedUpdatedJourneyData = journeyData + (LOOKED_UP_ADDRESSES_JOURNEY_DATA_KEY to Json.encodeToString(addresses))
 
-        val updatedJourneyData = journeyData.updateLookedUpAddresses(addresses)
+        val updatedJourneyData = journeyData.withUpdatedLookedUpAddresses(addresses)
 
         assertEquals(expectedUpdatedJourneyData, updatedJourneyData)
     }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/helpers/extensions/JourneyDataExtensionsTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/helpers/extensions/JourneyDataExtensionsTests.kt
@@ -4,10 +4,10 @@ import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import org.junit.jupiter.api.Test
 import uk.gov.communities.prsdb.webapp.constants.LOOKED_UP_ADDRESSES_JOURNEY_DATA_KEY
-import uk.gov.communities.prsdb.webapp.helpers.extensions.JourneyDataExtensions.Companion.getLookedUpAddress
-import uk.gov.communities.prsdb.webapp.helpers.extensions.JourneyDataExtensions.Companion.getLookedUpAddresses
-import uk.gov.communities.prsdb.webapp.helpers.extensions.JourneyDataExtensions.Companion.getSerializedLookedUpAddresses
-import uk.gov.communities.prsdb.webapp.helpers.extensions.JourneyDataExtensions.Companion.updateLookedUpAddresses
+import uk.gov.communities.prsdb.webapp.helpers.extensions.journeyDataExtensions.JourneyDataExtensions.Companion.getLookedUpAddress
+import uk.gov.communities.prsdb.webapp.helpers.extensions.journeyDataExtensions.JourneyDataExtensions.Companion.getLookedUpAddresses
+import uk.gov.communities.prsdb.webapp.helpers.extensions.journeyDataExtensions.JourneyDataExtensions.Companion.getSerializedLookedUpAddresses
+import uk.gov.communities.prsdb.webapp.helpers.extensions.journeyDataExtensions.JourneyDataExtensions.Companion.updateLookedUpAddresses
 import uk.gov.communities.prsdb.webapp.models.dataModels.AddressDataModel
 import kotlin.test.assertEquals
 import kotlin.test.assertNull

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/JourneyDataServiceTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/JourneyDataServiceTests.kt
@@ -27,6 +27,7 @@ import java.security.Principal
 import java.util.Optional
 import kotlin.test.assertContains
 import kotlin.test.assertEquals
+import kotlin.test.assertNull
 
 @ExtendWith(MockitoExtension::class)
 class JourneyDataServiceTests {
@@ -98,6 +99,39 @@ class JourneyDataServiceTests {
         @Test
         fun `getJourneyDataFromSession throws an error if the journeyDataKey is not initialized`() {
             val exception = assertThrows<PrsdbWebException> { journeyDataService.getJourneyDataFromSession() }
+            assertContains(exception.message!!, "journeyDataKey has not been set")
+        }
+
+        @Test
+        fun `getJourneyDataEntryInSession returns the requested journey data entry in session if journeyDataKey is initialized`() {
+            val journeyDataKey = "journeyDataKey"
+            val journeyDataEntry = ("key" to "value")
+            val journeyData = mapOf(journeyDataEntry)
+
+            whenever(mockHttpSession.getAttribute(journeyDataKey)).thenReturn(journeyData)
+            journeyDataService.getJourneyDataFromSession(journeyDataKey)
+
+            val returnedJourneyDataEntry = journeyDataService.getJourneyDataEntryInSession(journeyDataEntry.first)
+
+            assertEquals(journeyDataEntry, returnedJourneyDataEntry)
+        }
+
+        @Test
+        fun `getJourneyDataEntryInSession returns null when the given key is invalid and journeyDataKey is initialized`() {
+            val journeyDataKey = "journeyDataKey"
+            val journeyData = mapOf("key" to "value")
+
+            whenever(mockHttpSession.getAttribute(journeyDataKey)).thenReturn(journeyData)
+            journeyDataService.getJourneyDataFromSession(journeyDataKey)
+
+            val returnedJourneyDataEntry = journeyDataService.getJourneyDataEntryInSession("not-a-entry-key")
+
+            assertNull(returnedJourneyDataEntry)
+        }
+
+        @Test
+        fun `getJourneyDataEntryInSession throws an error if the journeyDataKey is not initialized`() {
+            val exception = assertThrows<PrsdbWebException> { journeyDataService.getJourneyDataEntryInSession("any-entry-key") }
             assertContains(exception.message!!, "journeyDataKey has not been set")
         }
 

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/JourneyDataServiceTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/JourneyDataServiceTests.kt
@@ -154,28 +154,6 @@ class JourneyDataServiceTests {
         }
 
         @Test
-        fun `setJourneyDataEntryInSession sets the given journey data entry in session if journeyDataKey is initialized`() {
-            val journeyDataKey = "journeyDataKey"
-            val journeyData = mapOf("key" to "value")
-            val newJourneyDataEntry = ("new-key" to "new-value")
-            val updatedJourneyData = journeyData + newJourneyDataEntry
-
-            whenever(mockHttpSession.getAttribute(journeyDataKey)).thenReturn(journeyData)
-            journeyDataService.getJourneyDataFromSession(journeyDataKey)
-
-            journeyDataService.setJourneyDataEntryInSession(newJourneyDataEntry.first, newJourneyDataEntry.second)
-
-            verify(mockHttpSession).setAttribute(journeyDataKey, updatedJourneyData)
-        }
-
-        @Test
-        fun `setJourneyDataEntryInSession throws an error if the journeyDataKey is not initialized`() {
-            val exception =
-                assertThrows<PrsdbWebException> { journeyDataService.setJourneyDataEntryInSession("any-entry-key", "any-value") }
-            assertContains(exception.message!!, "journeyDataKey has not been set")
-        }
-
-        @Test
         fun `clearJourneyDataFromSession clears the journey data from session if journeyDataKey is initialized`() {
             val journeyDataKey = "journeyDataKey"
 

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/JourneyDataServiceTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/JourneyDataServiceTests.kt
@@ -154,6 +154,28 @@ class JourneyDataServiceTests {
         }
 
         @Test
+        fun `setJourneyDataEntryInSession sets the given journey data entry in session if journeyDataKey is initialized`() {
+            val journeyDataKey = "journeyDataKey"
+            val journeyData = mapOf("key" to "value")
+            val newJourneyDataEntry = ("new-key" to "new-value")
+            val updatedJourneyData = journeyData + newJourneyDataEntry
+
+            whenever(mockHttpSession.getAttribute(journeyDataKey)).thenReturn(journeyData)
+            journeyDataService.getJourneyDataFromSession(journeyDataKey)
+
+            journeyDataService.setJourneyDataEntryInSession(newJourneyDataEntry.first, newJourneyDataEntry.second)
+
+            verify(mockHttpSession).setAttribute(journeyDataKey, updatedJourneyData)
+        }
+
+        @Test
+        fun `setJourneyDataEntryInSession throws an error if the journeyDataKey is not initialized`() {
+            val exception =
+                assertThrows<PrsdbWebException> { journeyDataService.setJourneyDataEntryInSession("any-entry-key", "any-value") }
+            assertContains(exception.message!!, "journeyDataKey has not been set")
+        }
+
+        @Test
         fun `clearJourneyDataFromSession clears the journey data from session if journeyDataKey is initialized`() {
             val journeyDataKey = "journeyDataKey"
 

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/JourneyDataServiceTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/JourneyDataServiceTests.kt
@@ -27,7 +27,6 @@ import java.security.Principal
 import java.util.Optional
 import kotlin.test.assertContains
 import kotlin.test.assertEquals
-import kotlin.test.assertNull
 
 @ExtendWith(MockitoExtension::class)
 class JourneyDataServiceTests {
@@ -99,39 +98,6 @@ class JourneyDataServiceTests {
         @Test
         fun `getJourneyDataFromSession throws an error if the journeyDataKey is not initialized`() {
             val exception = assertThrows<PrsdbWebException> { journeyDataService.getJourneyDataFromSession() }
-            assertContains(exception.message!!, "journeyDataKey has not been set")
-        }
-
-        @Test
-        fun `getJourneyDataEntryInSession returns the requested journey data entry in session if journeyDataKey is initialized`() {
-            val journeyDataKey = "journeyDataKey"
-            val journeyDataEntry = ("key" to "value")
-            val journeyData = mapOf(journeyDataEntry)
-
-            whenever(mockHttpSession.getAttribute(journeyDataKey)).thenReturn(journeyData)
-            journeyDataService.getJourneyDataFromSession(journeyDataKey)
-
-            val returnedJourneyDataEntry = journeyDataService.getJourneyDataEntryInSession(journeyDataEntry.first)
-
-            assertEquals(journeyDataEntry, returnedJourneyDataEntry)
-        }
-
-        @Test
-        fun `getJourneyDataEntryInSession returns null when the given key is invalid and journeyDataKey is initialized`() {
-            val journeyDataKey = "journeyDataKey"
-            val journeyData = mapOf("key" to "value")
-
-            whenever(mockHttpSession.getAttribute(journeyDataKey)).thenReturn(journeyData)
-            journeyDataService.getJourneyDataFromSession(journeyDataKey)
-
-            val returnedJourneyDataEntry = journeyDataService.getJourneyDataEntryInSession("not-a-entry-key")
-
-            assertNull(returnedJourneyDataEntry)
-        }
-
-        @Test
-        fun `getJourneyDataEntryInSession throws an error if the journeyDataKey is not initialized`() {
-            val exception = assertThrows<PrsdbWebException> { journeyDataService.getJourneyDataEntryInSession("any-entry-key") }
             assertContains(exception.message!!, "journeyDataKey has not been set")
         }
 

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/PropertyRegistrationServiceTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/PropertyRegistrationServiceTests.kt
@@ -44,7 +44,7 @@ class PropertyRegistrationServiceTests {
     private lateinit var mockLandlordRepository: LandlordRepository
 
     @Mock
-    private lateinit var mockAddressDataService: AddressDataService
+    private lateinit var mockRegisteredAddressCache: RegisteredAddressCache
 
     @Mock
     private lateinit var mockPropertyService: PropertyService
@@ -66,7 +66,7 @@ class PropertyRegistrationServiceTests {
     fun `getIsAddressRegistered returns the expected value when the given uprn is cached`(expectedValue: Boolean) {
         val uprn = 0L
 
-        whenever(mockAddressDataService.getCachedAddressRegisteredResult(uprn)).thenReturn(expectedValue)
+        whenever(mockRegisteredAddressCache.getCachedAddressRegisteredResult(uprn)).thenReturn(expectedValue)
 
         val result = propertyRegistrationService.getIsAddressRegistered(uprn)
 
@@ -77,12 +77,12 @@ class PropertyRegistrationServiceTests {
     fun `getIsAddressRegistered caches and returns false when there's no property associated with the given uprn`() {
         val uprn = 0L
 
-        whenever(mockAddressDataService.getCachedAddressRegisteredResult(uprn)).thenReturn(null)
+        whenever(mockRegisteredAddressCache.getCachedAddressRegisteredResult(uprn)).thenReturn(null)
         whenever(mockPropertyRepository.findByAddress_Uprn(uprn)).thenReturn(null)
 
         val result = propertyRegistrationService.getIsAddressRegistered(uprn)
 
-        verify(mockAddressDataService).setCachedAddressRegisteredResult(uprn, false)
+        verify(mockRegisteredAddressCache).setCachedAddressRegisteredResult(uprn, false)
         assertFalse(result)
     }
 
@@ -91,12 +91,12 @@ class PropertyRegistrationServiceTests {
         val uprn = 0L
         val inactiveProperty = Property()
 
-        whenever(mockAddressDataService.getCachedAddressRegisteredResult(uprn)).thenReturn(null)
+        whenever(mockRegisteredAddressCache.getCachedAddressRegisteredResult(uprn)).thenReturn(null)
         whenever(mockPropertyRepository.findByAddress_Uprn(uprn)).thenReturn(inactiveProperty)
 
         val result = propertyRegistrationService.getIsAddressRegistered(uprn)
 
-        verify(mockAddressDataService).setCachedAddressRegisteredResult(uprn, false)
+        verify(mockRegisteredAddressCache).setCachedAddressRegisteredResult(uprn, false)
         assertFalse(result)
     }
 
@@ -108,14 +108,14 @@ class PropertyRegistrationServiceTests {
         val uprn = 0L
         val activeProperty = Property(id = 1, address = Address(), isActive = true)
 
-        whenever(mockAddressDataService.getCachedAddressRegisteredResult(uprn)).thenReturn(null)
+        whenever(mockRegisteredAddressCache.getCachedAddressRegisteredResult(uprn)).thenReturn(null)
         whenever(mockPropertyRepository.findByAddress_Uprn(uprn)).thenReturn(activeProperty)
         whenever(mockPropertyOwnershipRepository.existsByIsActiveTrueAndProperty_Id(activeProperty.id))
             .thenReturn(expectedValue)
 
         val result = propertyRegistrationService.getIsAddressRegistered(uprn)
 
-        verify(mockAddressDataService).setCachedAddressRegisteredResult(uprn, result)
+        verify(mockRegisteredAddressCache).setCachedAddressRegisteredResult(uprn, result)
         assertEquals(expectedValue, result)
     }
 
@@ -132,7 +132,7 @@ class PropertyRegistrationServiceTests {
 
         val result = propertyRegistrationService.getIsAddressRegistered(uprn, ignoreCache = true)
 
-        verify(mockAddressDataService, never()).getCachedAddressRegisteredResult(uprn)
+        verify(mockRegisteredAddressCache, never()).getCachedAddressRegisteredResult(uprn)
         assertEquals(expectedValue, result)
     }
 

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/RegisteredAddressCacheTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/RegisteredAddressCacheTests.kt
@@ -1,8 +1,6 @@
 package uk.gov.communities.prsdb.webapp.services
 
 import jakarta.servlet.http.HttpSession
-import kotlinx.serialization.encodeToString
-import kotlinx.serialization.json.Json
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
@@ -15,9 +13,6 @@ import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.whenever
-import uk.gov.communities.prsdb.webapp.forms.JourneyData
-import uk.gov.communities.prsdb.webapp.models.dataModels.AddressDataModel
-import kotlin.test.assertEquals
 import kotlin.test.assertNull
 
 @ExtendWith(MockitoExtension::class)
@@ -25,33 +20,11 @@ class RegisteredAddressCacheTests {
     @Mock
     private lateinit var mockHttpSession: HttpSession
 
-    @Mock
-    private lateinit var mockJourneyDataService: JourneyDataService
-
     private lateinit var registeredAddressCache: RegisteredAddressCache
 
     @BeforeEach
     fun setup() {
-        registeredAddressCache = RegisteredAddressCache(mockHttpSession, mockJourneyDataService)
-    }
-
-    @Test
-    fun `setAddressData stores the given address data as a serialized map`() {
-        val addressDataList =
-            listOf(
-                AddressDataModel("1, Example Road, EG", 1, 1234, buildingNumber = "1", postcode = "EG"),
-                AddressDataModel("2, Example Road, EG", 2, buildingNumber = "2", postcode = "EG"),
-                AddressDataModel("Main, Example Road, EG", 3, buildingName = "Main", postcode = "EG"),
-            )
-        val expectedAddressDataString = Json.encodeToString(addressDataList.associateBy { it.singleLineAddress })
-
-        whenever(mockJourneyDataService.getJourneyDataFromSession()).thenReturn(mapOf())
-
-        registeredAddressCache.setAddressData(addressDataList)
-
-        val addressDataStringCaptor = argumentCaptor<JourneyData>()
-        verify(mockJourneyDataService).setJourneyDataInSession(addressDataStringCaptor.capture())
-        Assertions.assertEquals(expectedAddressDataString, addressDataStringCaptor.firstValue["address-data"])
+        registeredAddressCache = RegisteredAddressCache(mockHttpSession)
     }
 
     @Test

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/RegisteredAddressCacheTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/RegisteredAddressCacheTests.kt
@@ -21,18 +21,18 @@ import kotlin.test.assertEquals
 import kotlin.test.assertNull
 
 @ExtendWith(MockitoExtension::class)
-class AddressDataServiceTests {
+class RegisteredAddressCacheTests {
     @Mock
     private lateinit var mockHttpSession: HttpSession
 
     @Mock
     private lateinit var mockJourneyDataService: JourneyDataService
 
-    private lateinit var addressDataService: AddressDataService
+    private lateinit var registeredAddressCache: RegisteredAddressCache
 
     @BeforeEach
     fun setup() {
-        addressDataService = AddressDataService(mockHttpSession, mockJourneyDataService)
+        registeredAddressCache = RegisteredAddressCache(mockHttpSession, mockJourneyDataService)
     }
 
     @Test
@@ -50,7 +50,7 @@ class AddressDataServiceTests {
 
         whenever(mockJourneyDataService.getJourneyDataFromSession()).thenReturn(mapOf("address-data" to addressDataJSON))
 
-        val addressData = addressDataService.getAddressData("1, Example Road, EG")
+        val addressData = registeredAddressCache.getAddressData("1, Example Road, EG")
 
         assertEquals(expectedAddressData, addressData)
     }
@@ -68,7 +68,7 @@ class AddressDataServiceTests {
 
         whenever(mockJourneyDataService.getJourneyDataFromSession()).thenReturn(mapOf("address-data" to addressDataJSON))
 
-        val addressData = addressDataService.getAddressData("invalid address")
+        val addressData = registeredAddressCache.getAddressData("invalid address")
 
         assertNull(addressData)
     }
@@ -85,7 +85,7 @@ class AddressDataServiceTests {
 
         whenever(mockJourneyDataService.getJourneyDataFromSession()).thenReturn(mapOf())
 
-        addressDataService.setAddressData(addressDataList)
+        registeredAddressCache.setAddressData(addressDataList)
 
         val addressDataStringCaptor = argumentCaptor<JourneyData>()
         verify(mockJourneyDataService).setJourneyDataInSession(addressDataStringCaptor.capture())
@@ -96,28 +96,28 @@ class AddressDataServiceTests {
     fun `getCachedAddressRegisteredResult returns null if no results are cached`() {
         val uprn = 1234.toLong()
         whenever(mockHttpSession.getAttribute("addressRegisteredResults")).thenReturn(null)
-        assertNull(addressDataService.getCachedAddressRegisteredResult(uprn))
+        assertNull(registeredAddressCache.getCachedAddressRegisteredResult(uprn))
     }
 
     @Test
     fun `getCachedAddressRegisteredResult returns null if no matching result is cached`() {
         val uprn = 1234.toLong()
         whenever(mockHttpSession.getAttribute("addressRegisteredResults")).thenReturn(mapOf(5678.toString() to true))
-        assertNull(addressDataService.getCachedAddressRegisteredResult(uprn))
+        assertNull(registeredAddressCache.getCachedAddressRegisteredResult(uprn))
     }
 
     @Test
     fun `getCachedAddressRegisteredResult returns true if the cached result is true`() {
         val uprn = 1234.toLong()
         whenever(mockHttpSession.getAttribute("addressRegisteredResults")).thenReturn(mapOf(uprn.toString() to true))
-        assertTrue(addressDataService.getCachedAddressRegisteredResult(uprn) ?: false)
+        assertTrue(registeredAddressCache.getCachedAddressRegisteredResult(uprn) ?: false)
     }
 
     @Test
     fun `getCachedAddressRegisteredResult returns false if the cached result is false`() {
         val uprn = 1234.toLong()
         whenever(mockHttpSession.getAttribute("addressRegisteredResults")).thenReturn(mapOf(uprn.toString() to false))
-        assertFalse(addressDataService.getCachedAddressRegisteredResult(uprn) ?: true)
+        assertFalse(registeredAddressCache.getCachedAddressRegisteredResult(uprn) ?: true)
     }
 
     @Test
@@ -128,7 +128,7 @@ class AddressDataServiceTests {
 
         val expectedNewCache = mapOf(5678.toString() to true, uprn.toString() to false)
 
-        addressDataService.setCachedAddressRegisteredResult(uprn, false)
+        registeredAddressCache.setCachedAddressRegisteredResult(uprn, false)
         val addressRegisteredResultCaptor = argumentCaptor<MutableMap<String, Boolean>>()
         verify(mockHttpSession).setAttribute(eq("addressRegisteredResults"), addressRegisteredResultCaptor.capture())
         Assertions.assertEquals(expectedNewCache, addressRegisteredResultCaptor.firstValue)

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/RegisteredAddressCacheTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/RegisteredAddressCacheTests.kt
@@ -36,44 +36,6 @@ class RegisteredAddressCacheTests {
     }
 
     @Test
-    fun `getAddressData returns the AddressDataModel that corresponds with the given address`() {
-        val addressDataJSON =
-            Json.encodeToString(
-                listOf(
-                    AddressDataModel("1, Example Road, EG", 1, 1234, buildingNumber = "1", postcode = "EG"),
-                    AddressDataModel("2, Example Road, EG", 2, buildingNumber = "2", postcode = "EG"),
-                    AddressDataModel("Main, Example Road, EG", 3, buildingName = "Main", postcode = "EG"),
-                ).associateBy { it.singleLineAddress },
-            )
-        val expectedAddressData =
-            AddressDataModel("1, Example Road, EG", 1, 1234, buildingNumber = "1", postcode = "EG")
-
-        whenever(mockJourneyDataService.getJourneyDataFromSession()).thenReturn(mapOf("address-data" to addressDataJSON))
-
-        val addressData = registeredAddressCache.getAddressData("1, Example Road, EG")
-
-        assertEquals(expectedAddressData, addressData)
-    }
-
-    @Test
-    fun `getAddressData returns null when given an invalid address`() {
-        val addressDataJSON =
-            Json.encodeToString(
-                listOf(
-                    AddressDataModel("1, Example Road, EG", 1, 1234, buildingNumber = "1", postcode = "EG"),
-                    AddressDataModel("2, Example Road, EG", 2, buildingNumber = "2", postcode = "EG"),
-                    AddressDataModel("Main, Example Road, EG", 3, buildingName = "Main", postcode = "EG"),
-                ).associateBy { it.singleLineAddress },
-            )
-
-        whenever(mockJourneyDataService.getJourneyDataFromSession()).thenReturn(mapOf("address-data" to addressDataJSON))
-
-        val addressData = registeredAddressCache.getAddressData("invalid address")
-
-        assertNull(addressData)
-    }
-
-    @Test
     fun `setAddressData stores the given address data as a serialized map`() {
         val addressDataList =
             listOf(

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/testHelpers/builders/JourneyDataBuilder.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/testHelpers/builders/JourneyDataBuilder.kt
@@ -10,13 +10,13 @@ import uk.gov.communities.prsdb.webapp.forms.JourneyData
 import uk.gov.communities.prsdb.webapp.forms.steps.LandlordRegistrationStepId
 import uk.gov.communities.prsdb.webapp.forms.steps.UpdateLandlordDetailsStepId
 import uk.gov.communities.prsdb.webapp.models.dataModels.AddressDataModel
-import uk.gov.communities.prsdb.webapp.services.AddressDataService
 import uk.gov.communities.prsdb.webapp.services.LocalAuthorityService
+import uk.gov.communities.prsdb.webapp.services.RegisteredAddressCache
 import uk.gov.communities.prsdb.webapp.testHelpers.mockObjects.MockLocalAuthorityData.Companion.createLocalAuthority
 import java.time.LocalDate
 
 class JourneyDataBuilder(
-    private val mockAddressDataService: AddressDataService,
+    private val mockRegisteredAddressCache: RegisteredAddressCache,
     private val mockLocalAuthorityService: LocalAuthorityService,
     initialJourneyData: JourneyData? = null,
 ) {
@@ -70,7 +70,7 @@ class JourneyDataBuilder(
             )
 
         fun propertyDefault(
-            addressService: AddressDataService,
+            addressService: RegisteredAddressCache,
             localAuthorityService: LocalAuthorityService,
         ) = JourneyDataBuilder(addressService, localAuthorityService, defaultPropertyJourneyData).withSelectedAddress(
             DEFAULT_ADDRESS,
@@ -96,7 +96,7 @@ class JourneyDataBuilder(
             )
 
         fun landlordDefault(
-            addressService: AddressDataService,
+            addressService: RegisteredAddressCache,
             localAuthorityService: LocalAuthorityService,
         ) = JourneyDataBuilder(addressService, localAuthorityService, defaultLandlordJourneyData).withSelectedAddress(
             DEFAULT_ADDRESS,
@@ -121,7 +121,7 @@ class JourneyDataBuilder(
         localAuthority: LocalAuthority,
         isContactAddress: Boolean = false,
     ): JourneyDataBuilder {
-        whenever(mockAddressDataService.getAddressData(singleLineAddress)).thenReturn(
+        whenever(mockRegisteredAddressCache.getAddressData(singleLineAddress)).thenReturn(
             AddressDataModel(
                 singleLineAddress,
                 localAuthorityId = localAuthority.id,

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/testHelpers/builders/JourneyDataBuilder.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/testHelpers/builders/JourneyDataBuilder.kt
@@ -1,6 +1,9 @@
 package uk.gov.communities.prsdb.webapp.testHelpers.builders
 
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
 import org.mockito.kotlin.whenever
+import uk.gov.communities.prsdb.webapp.constants.LOOKED_UP_ADDRESSES_JOURNEY_DATA_KEY
 import uk.gov.communities.prsdb.webapp.constants.MANUAL_ADDRESS_CHOSEN
 import uk.gov.communities.prsdb.webapp.constants.enums.LicensingType
 import uk.gov.communities.prsdb.webapp.constants.enums.OwnershipType
@@ -11,12 +14,10 @@ import uk.gov.communities.prsdb.webapp.forms.steps.LandlordRegistrationStepId
 import uk.gov.communities.prsdb.webapp.forms.steps.UpdateLandlordDetailsStepId
 import uk.gov.communities.prsdb.webapp.models.dataModels.AddressDataModel
 import uk.gov.communities.prsdb.webapp.services.LocalAuthorityService
-import uk.gov.communities.prsdb.webapp.services.RegisteredAddressCache
 import uk.gov.communities.prsdb.webapp.testHelpers.mockObjects.MockLocalAuthorityData.Companion.createLocalAuthority
 import java.time.LocalDate
 
 class JourneyDataBuilder(
-    private val mockRegisteredAddressCache: RegisteredAddressCache,
     private val mockLocalAuthorityService: LocalAuthorityService,
     initialJourneyData: JourneyData? = null,
 ) {
@@ -69,14 +70,12 @@ class JourneyDataBuilder(
                     ),
             )
 
-        fun propertyDefault(
-            addressService: RegisteredAddressCache,
-            localAuthorityService: LocalAuthorityService,
-        ) = JourneyDataBuilder(addressService, localAuthorityService, defaultPropertyJourneyData).withSelectedAddress(
-            DEFAULT_ADDRESS,
-            709902,
-            createLocalAuthority(),
-        )
+        fun propertyDefault(localAuthorityService: LocalAuthorityService) =
+            JourneyDataBuilder(localAuthorityService, defaultPropertyJourneyData).withSelectedAddress(
+                DEFAULT_ADDRESS,
+                709902,
+                createLocalAuthority(),
+            )
 
         private val defaultLandlordJourneyData: JourneyData =
             mapOf(
@@ -95,14 +94,12 @@ class JourneyDataBuilder(
                 LandlordRegistrationStepId.SelectAddress.urlPathSegment to mapOf("address" to DEFAULT_ADDRESS),
             )
 
-        fun landlordDefault(
-            addressService: RegisteredAddressCache,
-            localAuthorityService: LocalAuthorityService,
-        ) = JourneyDataBuilder(addressService, localAuthorityService, defaultLandlordJourneyData).withSelectedAddress(
-            DEFAULT_ADDRESS,
-            709902,
-            createLocalAuthority(),
-        )
+        fun landlordDefault(localAuthorityService: LocalAuthorityService) =
+            JourneyDataBuilder(localAuthorityService, defaultLandlordJourneyData).withSelectedAddress(
+                DEFAULT_ADDRESS,
+                709902,
+                createLocalAuthority(),
+            )
     }
 
     fun withLookupAddress(
@@ -118,22 +115,19 @@ class JourneyDataBuilder(
     fun withSelectedAddress(
         singleLineAddress: String,
         uprn: Long? = null,
-        localAuthority: LocalAuthority,
+        localAuthority: LocalAuthority? = null,
         isContactAddress: Boolean = false,
     ): JourneyDataBuilder {
-        whenever(mockRegisteredAddressCache.getAddressData(singleLineAddress)).thenReturn(
-            AddressDataModel(
-                singleLineAddress,
-                localAuthorityId = localAuthority.id,
-                uprn = uprn,
-            ),
-        )
-
-        whenever(mockLocalAuthorityService.retrieveLocalAuthorityById(localAuthority.id)).thenReturn(localAuthority)
+        localAuthority?.let {
+            whenever(mockLocalAuthorityService.retrieveLocalAuthorityById(localAuthority.id)).thenReturn(localAuthority)
+        }
 
         if (!isContactAddress) {
             withEnglandOrWalesResidence()
         }
+
+        journeyData[LOOKED_UP_ADDRESSES_JOURNEY_DATA_KEY] =
+            Json.encodeToString(listOf(AddressDataModel(singleLineAddress, localAuthorityId = localAuthority?.id, uprn = uprn)))
 
         val selectAddressKey = if (isContactAddress) "select-contact-address" else "select-address"
         journeyData[selectAddressKey] = mapOf("address" to singleLineAddress)
@@ -294,7 +288,7 @@ class JourneyDataBuilder(
     ): JourneyDataBuilder =
         this
             .withNonEnglandOrWalesAddress(countryOfResidence, nonEnglandOrWalesAddress)
-            .withSelectedAddress(selectedAddress, localAuthority = createLocalAuthority(), isContactAddress = true)
+            .withSelectedAddress(selectedAddress, isContactAddress = true)
 
     fun withNonEnglandOrWalesAndManualContactAddress(
         countryOfResidence: String,

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/urlProviders/LandlordDashboardUrlTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/urlProviders/LandlordDashboardUrlTests.kt
@@ -14,6 +14,7 @@ import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequ
 import org.springframework.test.web.servlet.get
 import org.springframework.test.web.servlet.post
 import org.springframework.web.context.WebApplicationContext
+import uk.gov.communities.prsdb.webapp.constants.LOOKED_UP_ADDRESSES_JOURNEY_DATA_KEY
 import uk.gov.communities.prsdb.webapp.constants.REGISTER_LANDLORD_JOURNEY_URL
 import uk.gov.communities.prsdb.webapp.constants.REGISTER_PROPERTY_JOURNEY_URL
 import uk.gov.communities.prsdb.webapp.controllers.ControllerTest
@@ -38,7 +39,6 @@ import uk.gov.communities.prsdb.webapp.services.LocalAuthorityService
 import uk.gov.communities.prsdb.webapp.services.OneLoginIdentityService
 import uk.gov.communities.prsdb.webapp.services.PropertyOwnershipService
 import uk.gov.communities.prsdb.webapp.services.PropertyRegistrationService
-import uk.gov.communities.prsdb.webapp.services.RegisteredAddressCache
 import uk.gov.communities.prsdb.webapp.testHelpers.builders.JourneyDataBuilder
 import uk.gov.communities.prsdb.webapp.testHelpers.mockObjects.MockLandlordData.Companion.createLandlord
 import uk.gov.communities.prsdb.webapp.testHelpers.mockObjects.MockLandlordData.Companion.createPropertyOwnership
@@ -73,9 +73,6 @@ class LandlordDashboardUrlTests(
     private lateinit var mockAddressLookupService: AddressLookupService
 
     @MockBean
-    private lateinit var mockRegisteredAddressCache: RegisteredAddressCache
-
-    @MockBean
     private lateinit var mockLocalAuthorityService: LocalAuthorityService
 
     @MockBean
@@ -90,9 +87,11 @@ class LandlordDashboardUrlTests(
         // Arrange
         val landlord = createLandlord()
 
-        val mockJourneyData =
-            JourneyDataBuilder.landlordDefault(mockRegisteredAddressCache, mockLocalAuthorityService).build()
+        val mockJourneyData = JourneyDataBuilder.landlordDefault(mockLocalAuthorityService).build()
         whenever(mockJourneyDataService.getJourneyDataFromSession()).thenReturn(mockJourneyData)
+        whenever(mockJourneyDataService.getJourneyDataEntryInSession(LOOKED_UP_ADDRESSES_JOURNEY_DATA_KEY)).thenReturn(
+            LOOKED_UP_ADDRESSES_JOURNEY_DATA_KEY to mockJourneyData[LOOKED_UP_ADDRESSES_JOURNEY_DATA_KEY],
+        )
 
         whenever(
             mockLandlordService.createLandlord(
@@ -139,9 +138,11 @@ class LandlordDashboardUrlTests(
         val propertyOwnership = createPropertyOwnership()
         val landlord = createLandlord()
 
-        val mockJourneyData =
-            JourneyDataBuilder.propertyDefault(mockRegisteredAddressCache, mockLocalAuthorityService).build()
+        val mockJourneyData = JourneyDataBuilder.propertyDefault(mockLocalAuthorityService).build()
         whenever(mockJourneyDataService.getJourneyDataFromSession()).thenReturn(mockJourneyData)
+        whenever(mockJourneyDataService.getJourneyDataEntryInSession(LOOKED_UP_ADDRESSES_JOURNEY_DATA_KEY)).thenReturn(
+            LOOKED_UP_ADDRESSES_JOURNEY_DATA_KEY to mockJourneyData[LOOKED_UP_ADDRESSES_JOURNEY_DATA_KEY],
+        )
 
         whenever(
             mockPropertyRegistrationService.registerPropertyAndReturnPropertyRegistrationNumber(

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/urlProviders/LandlordDashboardUrlTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/urlProviders/LandlordDashboardUrlTests.kt
@@ -14,7 +14,6 @@ import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequ
 import org.springframework.test.web.servlet.get
 import org.springframework.test.web.servlet.post
 import org.springframework.web.context.WebApplicationContext
-import uk.gov.communities.prsdb.webapp.constants.LOOKED_UP_ADDRESSES_JOURNEY_DATA_KEY
 import uk.gov.communities.prsdb.webapp.constants.REGISTER_LANDLORD_JOURNEY_URL
 import uk.gov.communities.prsdb.webapp.constants.REGISTER_PROPERTY_JOURNEY_URL
 import uk.gov.communities.prsdb.webapp.controllers.ControllerTest
@@ -89,9 +88,6 @@ class LandlordDashboardUrlTests(
 
         val mockJourneyData = JourneyDataBuilder.landlordDefault(mockLocalAuthorityService).build()
         whenever(mockJourneyDataService.getJourneyDataFromSession()).thenReturn(mockJourneyData)
-        whenever(mockJourneyDataService.getJourneyDataEntryInSession(LOOKED_UP_ADDRESSES_JOURNEY_DATA_KEY)).thenReturn(
-            LOOKED_UP_ADDRESSES_JOURNEY_DATA_KEY to mockJourneyData[LOOKED_UP_ADDRESSES_JOURNEY_DATA_KEY],
-        )
 
         whenever(
             mockLandlordService.createLandlord(
@@ -140,9 +136,6 @@ class LandlordDashboardUrlTests(
 
         val mockJourneyData = JourneyDataBuilder.propertyDefault(mockLocalAuthorityService).build()
         whenever(mockJourneyDataService.getJourneyDataFromSession()).thenReturn(mockJourneyData)
-        whenever(mockJourneyDataService.getJourneyDataEntryInSession(LOOKED_UP_ADDRESSES_JOURNEY_DATA_KEY)).thenReturn(
-            LOOKED_UP_ADDRESSES_JOURNEY_DATA_KEY to mockJourneyData[LOOKED_UP_ADDRESSES_JOURNEY_DATA_KEY],
-        )
 
         whenever(
             mockPropertyRegistrationService.registerPropertyAndReturnPropertyRegistrationNumber(

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/urlProviders/LandlordDashboardUrlTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/urlProviders/LandlordDashboardUrlTests.kt
@@ -30,7 +30,6 @@ import uk.gov.communities.prsdb.webapp.models.viewModels.emailModels.EmailTempla
 import uk.gov.communities.prsdb.webapp.models.viewModels.emailModels.LandlordRegistrationConfirmationEmail
 import uk.gov.communities.prsdb.webapp.models.viewModels.emailModels.PropertyRegistrationConfirmationEmail
 import uk.gov.communities.prsdb.webapp.services.AbsoluteUrlProvider
-import uk.gov.communities.prsdb.webapp.services.AddressDataService
 import uk.gov.communities.prsdb.webapp.services.AddressLookupService
 import uk.gov.communities.prsdb.webapp.services.EmailNotificationService
 import uk.gov.communities.prsdb.webapp.services.JourneyDataService
@@ -39,6 +38,7 @@ import uk.gov.communities.prsdb.webapp.services.LocalAuthorityService
 import uk.gov.communities.prsdb.webapp.services.OneLoginIdentityService
 import uk.gov.communities.prsdb.webapp.services.PropertyOwnershipService
 import uk.gov.communities.prsdb.webapp.services.PropertyRegistrationService
+import uk.gov.communities.prsdb.webapp.services.RegisteredAddressCache
 import uk.gov.communities.prsdb.webapp.testHelpers.builders.JourneyDataBuilder
 import uk.gov.communities.prsdb.webapp.testHelpers.mockObjects.MockLandlordData.Companion.createLandlord
 import uk.gov.communities.prsdb.webapp.testHelpers.mockObjects.MockLandlordData.Companion.createPropertyOwnership
@@ -73,7 +73,7 @@ class LandlordDashboardUrlTests(
     private lateinit var mockAddressLookupService: AddressLookupService
 
     @MockBean
-    private lateinit var mockAddressDataService: AddressDataService
+    private lateinit var mockRegisteredAddressCache: RegisteredAddressCache
 
     @MockBean
     private lateinit var mockLocalAuthorityService: LocalAuthorityService
@@ -91,7 +91,7 @@ class LandlordDashboardUrlTests(
         val landlord = createLandlord()
 
         val mockJourneyData =
-            JourneyDataBuilder.landlordDefault(mockAddressDataService, mockLocalAuthorityService).build()
+            JourneyDataBuilder.landlordDefault(mockRegisteredAddressCache, mockLocalAuthorityService).build()
         whenever(mockJourneyDataService.getJourneyDataFromSession()).thenReturn(mockJourneyData)
 
         whenever(
@@ -140,7 +140,7 @@ class LandlordDashboardUrlTests(
         val landlord = createLandlord()
 
         val mockJourneyData =
-            JourneyDataBuilder.propertyDefault(mockAddressDataService, mockLocalAuthorityService).build()
+            JourneyDataBuilder.propertyDefault(mockRegisteredAddressCache, mockLocalAuthorityService).build()
         whenever(mockJourneyDataService.getJourneyDataFromSession()).thenReturn(mockJourneyData)
 
         whenever(


### PR DESCRIPTION
- Removes interactions with `JourneyDataService` from `AddressDataService` 
  - Getting looked-up addresses now done via `JourneyDataExtensions.getLookedUpAddress` (`JourneyDataService.getJourneyDataEntryInSession` used to add looked-up address data to `filteredJourneyData` before calling the extension)
  - Setting looked-up addresses now done via `JourneyDataService.setJourneyDataEntryInSession`
- Renames `AddressDataService` as `RegisteredAddressCache`
- Tests
  - `JourneyDataExtensions.getLookedUpAddress`
  - `JourneyDataService.getJourneyDataEntryInSession` and `setJourneyDataEntryInSession`
  - Removes redundant tests from `RegisteredAddressCache`
  - Updates affected tests