### PR TITLE
chore/PRSD-932 create gradle task test excluding integration

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -119,6 +119,11 @@ tasks.register<JavaExec>("playwright") {
     mainClass.set("com.microsoft.playwright.CLI")
 }
 
+tasks.register<Test>("testWithoutIntegration") {
+    group = "verification"
+    exclude("uk/gov/communities/prsdb/webapp/integration/**")
+}
+
 buildscript {
     repositories {
         mavenCentral()


### PR DESCRIPTION
Added a task to `build.gradle.kts` to run all the tests except those in the integration folder.

In Gradle the test can be found in the `verification` folder under `Tasks`