### PR TITLE
PRSD-800: Update Property - Number of Households

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/database/entity/PropertyOwnership.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/database/entity/PropertyOwnership.kt
@@ -36,7 +36,6 @@ class PropertyOwnership(
 
     @Column(nullable = false)
     var currentNumHouseholds: Int = 0
-        private set
 
     @Column(nullable = false)
     var currentNumTenants: Int = 0

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/PropertyDetailsUpdateJourney.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/PropertyDetailsUpdateJourney.kt
@@ -9,10 +9,12 @@ import uk.gov.communities.prsdb.webapp.forms.JourneyData
 import uk.gov.communities.prsdb.webapp.forms.pages.Page
 import uk.gov.communities.prsdb.webapp.forms.steps.Step
 import uk.gov.communities.prsdb.webapp.forms.steps.UpdatePropertyDetailsStepId
+import uk.gov.communities.prsdb.webapp.helpers.extensions.journeyDataExtensions.PropertyDetailsUpdateJourneyDataExtensions.Companion.getNumberOfHouseholdsUpdateIfPresent
 import uk.gov.communities.prsdb.webapp.helpers.extensions.journeyDataExtensions.PropertyDetailsUpdateJourneyDataExtensions.Companion.getNumberOfPeopleUpdateIfPresent
 import uk.gov.communities.prsdb.webapp.helpers.extensions.journeyDataExtensions.PropertyDetailsUpdateJourneyDataExtensions.Companion.getOwnershipTypeUpdateIfPresent
 import uk.gov.communities.prsdb.webapp.models.dataModels.updateModels.PropertyOwnershipUpdateModel
 import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.NoInputFormModel
+import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.NumberOfHouseholdsFormModel
 import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.NumberOfPeopleFormModel
 import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.OwnershipTypeFormModel
 import uk.gov.communities.prsdb.webapp.models.viewModels.formModels.RadiosButtonViewModel
@@ -41,6 +43,8 @@ class PropertyDetailsUpdateJourney(
 
         return mapOf(
             UpdatePropertyDetailsStepId.UpdateOwnershipType.urlPathSegment to mapOf("ownershipType" to propertyOwnership.ownershipType),
+            UpdatePropertyDetailsStepId.UpdateNumberOfHouseholds.urlPathSegment to
+                mapOf("numberOfHouseholds" to propertyOwnership.currentNumHouseholds),
             UpdatePropertyDetailsStepId.UpdateNumberOfPeople.urlPathSegment to
                 mapOf("numberOfPeople" to propertyOwnership.currentNumTenants),
         )
@@ -88,6 +92,26 @@ class PropertyDetailsUpdateJourney(
                         ),
                 ),
             handleSubmitAndRedirect = { _, _ -> UpdatePropertyDetailsStepId.UpdateDetails.urlPathSegment },
+            nextAction = { _, _ -> Pair(UpdatePropertyDetailsStepId.UpdateNumberOfHouseholds, null) },
+            saveAfterSubmit = false,
+        )
+
+    private val numberOfHouseholdsStep =
+        Step(
+            id = UpdatePropertyDetailsStepId.UpdateNumberOfHouseholds,
+            page =
+                Page(
+                    formModel = NumberOfHouseholdsFormModel::class,
+                    templateName = "forms/numberOfHouseholdsForm",
+                    content =
+                        mapOf(
+                            "title" to "propertyDetails.update.title",
+                            "fieldSetHeading" to "forms.update.numberOfHouseholds.fieldSetHeading",
+                            "label" to "forms.numberOfHouseholds.label",
+                            BACK_URL_ATTR_NAME to UpdatePropertyDetailsStepId.UpdateDetails.urlPathSegment,
+                        ),
+                ),
+            handleSubmitAndRedirect = { _, _ -> UpdatePropertyDetailsStepId.UpdateDetails.urlPathSegment },
             nextAction = { _, _ -> Pair(UpdatePropertyDetailsStepId.UpdateNumberOfPeople, null) },
             saveAfterSubmit = false,
         )
@@ -117,13 +141,14 @@ class PropertyDetailsUpdateJourney(
     override val sections =
         createSingleSectionWithSingleTaskFromSteps(
             initialStepId,
-            setOf(ownershipTypeStep, numberOfPeopleStep, updateDetailsStep),
+            setOf(ownershipTypeStep, numberOfHouseholdsStep, numberOfPeopleStep, updateDetailsStep),
         )
 
     private fun updatePropertyAndRedirect(journeyData: JourneyData): String {
         val propertyUpdate =
             PropertyOwnershipUpdateModel(
                 ownershipType = journeyData.getOwnershipTypeUpdateIfPresent(),
+                numberOfHouseholds = journeyData.getNumberOfHouseholdsUpdateIfPresent(),
                 numberOfPeople = journeyData.getNumberOfPeopleUpdateIfPresent(),
             )
 

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/steps/UpdatePropertyDetailsStepId.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/steps/UpdatePropertyDetailsStepId.kt
@@ -6,6 +6,7 @@ enum class UpdatePropertyDetailsStepId(
     override val urlPathSegment: String,
 ) : StepId {
     UpdateOwnershipType("ownership-type"),
+    UpdateNumberOfHouseholds("number-of-households"),
     UpdateNumberOfPeople("number-of-people"),
     UpdateDetails(DETAILS_PATH_SEGMENT),
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/helpers/extensions/journeyDataExtensions/PropertyDetailsUpdateJourneyDataExtensions.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/helpers/extensions/journeyDataExtensions/PropertyDetailsUpdateJourneyDataExtensions.kt
@@ -14,6 +14,13 @@ class PropertyDetailsUpdateJourneyDataExtensions {
                 "ownershipType",
             )
 
+        fun JourneyData.getNumberOfHouseholdsUpdateIfPresent() =
+            JourneyDataHelper.getFieldIntegerValue(
+                this,
+                UpdatePropertyDetailsStepId.UpdateNumberOfHouseholds.urlPathSegment,
+                "numberOfHouseholds",
+            )
+
         fun JourneyData.getNumberOfPeopleUpdateIfPresent() =
             JourneyDataHelper.getFieldIntegerValue(
                 this,

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/dataModels/updateModels/PropertyOwnershipUpdateModel.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/dataModels/updateModels/PropertyOwnershipUpdateModel.kt
@@ -4,5 +4,6 @@ import uk.gov.communities.prsdb.webapp.constants.enums.OwnershipType
 
 data class PropertyOwnershipUpdateModel(
     val ownershipType: OwnershipType?,
+    val numberOfHouseholds: Int?,
     val numberOfPeople: Int?,
 )

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/summaryModels/PropertyDetailsViewModel.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/summaryModels/PropertyDetailsViewModel.kt
@@ -84,10 +84,11 @@ class PropertyDetailsViewModel(
                 // TODO PRSD-799: Add update link
                 addRow("propertyDetails.propertyRecord.occupied", isTenantedKey)
                 if (propertyOwnership.currentNumTenants > 0) {
-                    // TODO PRSD-800: Add update link
                     addRow(
                         "propertyDetails.propertyRecord.numberOfHouseholds",
                         propertyOwnership.currentNumHouseholds,
+                        UpdatePropertyDetailsStepId.UpdateNumberOfHouseholds.urlPathSegment,
+                        withChangeLinks,
                     )
                     addRow(
                         "propertyDetails.propertyRecord.numberOfPeople",

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/PropertyOwnershipService.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/PropertyOwnershipService.kt
@@ -156,6 +156,7 @@ class PropertyOwnershipService(
         val propertyOwnership = getPropertyOwnership(id)
 
         update.ownershipType?.let { propertyOwnership.ownershipType = it }
+        update.numberOfHouseholds?.let { propertyOwnership.currentNumHouseholds = it }
         update.numberOfPeople?.let { propertyOwnership.currentNumTenants = it }
     }
 

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -683,6 +683,7 @@ forms.update.lookupAddress.fieldSetHeading=Update your contact address
 forms.update.phoneNumber.fieldSetHeading=What is your updated phone number?
 forms.update.dateOfBirth.fieldSetHeading=Update your date of birth on your landlord record
 forms.update.ownershipType.fieldSetHeading=Update the ownership type for your property
+forms.update.numberOfHouseholds.fieldSetHeading=Update the number of households in the property
 forms.update.numberOfPeople.fieldSetHeading=Update how many people live in your property
 
 forms.areYouSure.propertyDeregistration.radios.error.missing=Select whether you want to delete this property from the database

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/helpers/extensions/journeyDataExtensions/PropertyDetailsUpdateJourneyDataExtensionsTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/helpers/extensions/journeyDataExtensions/PropertyDetailsUpdateJourneyDataExtensionsTests.kt
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.mockito.Mockito.mock
 import uk.gov.communities.prsdb.webapp.constants.enums.OwnershipType
+import uk.gov.communities.prsdb.webapp.helpers.extensions.journeyDataExtensions.PropertyDetailsUpdateJourneyDataExtensions.Companion.getNumberOfHouseholdsUpdateIfPresent
 import uk.gov.communities.prsdb.webapp.helpers.extensions.journeyDataExtensions.PropertyDetailsUpdateJourneyDataExtensions.Companion.getNumberOfPeopleUpdateIfPresent
 import uk.gov.communities.prsdb.webapp.helpers.extensions.journeyDataExtensions.PropertyDetailsUpdateJourneyDataExtensions.Companion.getOwnershipTypeUpdateIfPresent
 import uk.gov.communities.prsdb.webapp.testHelpers.builders.JourneyDataBuilder
@@ -36,6 +37,27 @@ class PropertyDetailsUpdateJourneyDataExtensionsTests {
             testJourneyData.getOwnershipTypeUpdateIfPresent()
 
         assertEquals(null, ownershipTypeUpdate)
+    }
+
+    @Test
+    fun `getNumberOfHouseholdsUpdateIfPresent returns an integer if the corresponding page is in journeyData`() {
+        val newNumberOfHouseholds = 3
+        val testJourneyData = journeyDataBuilder.withNumberOfHouseholdsUpdate(newNumberOfHouseholds).build()
+
+        val numberOfHouseholdsUpdate =
+            testJourneyData.getNumberOfHouseholdsUpdateIfPresent()
+
+        assertEquals(newNumberOfHouseholds, numberOfHouseholdsUpdate)
+    }
+
+    @Test
+    fun `getNumberOfHouseholdsUpdateIfPresent returns null if the corresponding page is in not journeyData`() {
+        val testJourneyData = journeyDataBuilder.build()
+
+        val numberOfHouseholdsUpdate =
+            testJourneyData.getNumberOfHouseholdsUpdateIfPresent()
+
+        assertEquals(null, numberOfHouseholdsUpdate)
     }
 
     @Test

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/PropertyDetailsUpdateJourneyTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/PropertyDetailsUpdateJourneyTests.kt
@@ -7,6 +7,7 @@ import org.springframework.test.context.jdbc.Sql
 import uk.gov.communities.prsdb.webapp.constants.enums.OwnershipType
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.BaseComponent.Companion.assertThat
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages.BasePage.Companion.assertPageIs
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyDetailsUpdateJourneyPages.NumberOfHouseholdsFormPagePropertyDetailsUpdate
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyDetailsUpdateJourneyPages.NumberOfPeopleFormPagePropertyDetailsUpdate
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyDetailsUpdateJourneyPages.OwnershipTypeFormPagePropertyDetailsUpdate
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyDetailsUpdateJourneyPages.PropertyDetailsUpdatePage
@@ -25,6 +26,9 @@ class PropertyDetailsUpdateJourneyTests : IntegrationTest() {
         val newOwnershipType = OwnershipType.LEASEHOLD
         propertyDetailsUpdatePage = updateOwnershipTypeAndReturn(propertyDetailsUpdatePage, newOwnershipType)
 
+        val newNumberOfHouseholds = 2
+        propertyDetailsUpdatePage = updateNumberOfHouseholdsAndReturn(propertyDetailsUpdatePage, newNumberOfHouseholds)
+
         val newNumberOfPeople = 4
         propertyDetailsUpdatePage = updateNumberOfPeopleAndReturn(propertyDetailsUpdatePage, newNumberOfPeople)
 
@@ -34,6 +38,9 @@ class PropertyDetailsUpdateJourneyTests : IntegrationTest() {
 
         // Check changes have occurred
         assertThat(propertyDetailsUpdatePage.propertyDetailsSummaryList.ownershipTypeRow.value).containsText("Leasehold")
+        assertThat(
+            propertyDetailsUpdatePage.propertyDetailsSummaryList.numberOfHouseholdsRow.value,
+        ).containsText(newNumberOfHouseholds.toString())
         assertThat(propertyDetailsUpdatePage.propertyDetailsSummaryList.numberOfPeopleRow.value).containsText(
             newNumberOfPeople.toString(),
         )
@@ -54,6 +61,25 @@ class PropertyDetailsUpdateJourneyTests : IntegrationTest() {
 
         // Check changes have occurred
         assertThat(propertyDetailsUpdatePage.propertyDetailsSummaryList.ownershipTypeRow.value).containsText("Leasehold")
+    }
+
+    @Test
+    fun `A property can have just their number of households updated`(page: Page) {
+        // Update details page
+        var propertyDetailsUpdatePage = navigator.goToPropertyDetailsUpdatePage(propertyOwnershipId)
+        assertThat(propertyDetailsUpdatePage.heading).containsText("1, Example Road, EG")
+
+        val newNumberOfHouseholds = 3
+        propertyDetailsUpdatePage = updateNumberOfHouseholdsAndReturn(propertyDetailsUpdatePage, newNumberOfHouseholds)
+
+        // Submit changes TODO PRSD-355 add proper submit button and declaration page
+        propertyDetailsUpdatePage.submitButton.clickAndWait()
+        propertyDetailsUpdatePage = assertPageIs(page, PropertyDetailsUpdatePage::class, urlArguments)
+
+        // Check changes have occurred
+        assertThat(propertyDetailsUpdatePage.propertyDetailsSummaryList.numberOfHouseholdsRow.value).containsText(
+            newNumberOfHouseholds.toString(),
+        )
     }
 
     @Test
@@ -84,6 +110,19 @@ class PropertyDetailsUpdateJourneyTests : IntegrationTest() {
 
         val updateOwnershipTypePage = assertPageIs(page, OwnershipTypeFormPagePropertyDetailsUpdate::class, urlArguments)
         updateOwnershipTypePage.submitOwnershipType(newOwnershipType)
+
+        return assertPageIs(page, PropertyDetailsUpdatePage::class, urlArguments)
+    }
+
+    private fun updateNumberOfHouseholdsAndReturn(
+        detailsPage: PropertyDetailsUpdatePage,
+        newNumberOfHouseholds: Int,
+    ): PropertyDetailsUpdatePage {
+        val page = detailsPage.page
+        detailsPage.propertyDetailsSummaryList.numberOfHouseholdsRow.clickActionLinkAndWait()
+
+        val updateNumberOfHouseholdsPage = assertPageIs(page, NumberOfHouseholdsFormPagePropertyDetailsUpdate::class, urlArguments)
+        updateNumberOfHouseholdsPage.submitNumberOfHouseholds(newNumberOfHouseholds)
 
         return assertPageIs(page, PropertyDetailsUpdatePage::class, urlArguments)
     }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/PropertyRegistrationJourneyTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/PropertyRegistrationJourneyTests.kt
@@ -27,10 +27,10 @@ import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyReg
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyRegistrationJourneyPages.DeclarationFormPagePropertyRegistration
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyRegistrationJourneyPages.HmoAdditionalLicenceFormPagePropertyRegistration
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyRegistrationJourneyPages.HmoMandatoryLicenceFormPagePropertyRegistration
-import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyRegistrationJourneyPages.HouseholdsFormPagePropertyRegistration
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyRegistrationJourneyPages.LicensingTypeFormPagePropertyRegistration
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyRegistrationJourneyPages.LookupAddressFormPagePropertyRegistration
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyRegistrationJourneyPages.ManualAddressFormPagePropertyRegistration
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyRegistrationJourneyPages.NumberOfHouseholdsFormPagePropertyRegistration
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyRegistrationJourneyPages.NumberOfPeopleFormPagePropertyRegistration
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyRegistrationJourneyPages.OccupancyFormPagePropertyRegistration
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyRegistrationJourneyPages.OwnershipTypeFormPagePropertyRegistration
@@ -151,7 +151,7 @@ class PropertyRegistrationJourneyTests : IntegrationTest() {
         assertThat(occupancyPage.form.sectionHeader).containsText("Section 1 of 2 \u2014 Register your property details")
         // fill in "yes" and submit
         occupancyPage.submitIsOccupied()
-        val householdsPage = assertPageIs(page, HouseholdsFormPagePropertyRegistration::class)
+        val householdsPage = assertPageIs(page, NumberOfHouseholdsFormPagePropertyRegistration::class)
 
         // Number of Households - render page
         assertThat(householdsPage.form.fieldsetHeading).containsText("How many households live in your property?")

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/Navigator.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/Navigator.kt
@@ -58,10 +58,10 @@ import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyReg
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyRegistrationJourneyPages.DeclarationFormPagePropertyRegistration
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyRegistrationJourneyPages.HmoAdditionalLicenceFormPagePropertyRegistration
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyRegistrationJourneyPages.HmoMandatoryLicenceFormPagePropertyRegistration
-import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyRegistrationJourneyPages.HouseholdsFormPagePropertyRegistration
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyRegistrationJourneyPages.LicensingTypeFormPagePropertyRegistration
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyRegistrationJourneyPages.LookupAddressFormPagePropertyRegistration
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyRegistrationJourneyPages.ManualAddressFormPagePropertyRegistration
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyRegistrationJourneyPages.NumberOfHouseholdsFormPagePropertyRegistration
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyRegistrationJourneyPages.NumberOfPeopleFormPagePropertyRegistration
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyRegistrationJourneyPages.OccupancyFormPagePropertyRegistration
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyRegistrationJourneyPages.OwnershipTypeFormPagePropertyRegistration
@@ -342,10 +342,10 @@ class Navigator(
         return createValidPage(page, OccupancyFormPagePropertyRegistration::class)
     }
 
-    fun goToPropertyRegistrationHouseholdsPage(): HouseholdsFormPagePropertyRegistration {
+    fun goToPropertyRegistrationHouseholdsPage(): NumberOfHouseholdsFormPagePropertyRegistration {
         val occupancyPage = goToPropertyRegistrationOccupancyPage()
         occupancyPage.submitIsOccupied()
-        return createValidPage(page, HouseholdsFormPagePropertyRegistration::class)
+        return createValidPage(page, NumberOfHouseholdsFormPagePropertyRegistration::class)
     }
 
     fun goToPropertyRegistrationPeoplePage(): NumberOfPeopleFormPagePropertyRegistration {

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/basePages/NumberOfHouseholdsFormBasePage.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/basePages/NumberOfHouseholdsFormBasePage.kt
@@ -1,19 +1,14 @@
-package uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyRegistrationJourneyPages
+package uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages
 
 import com.microsoft.playwright.Page
-import uk.gov.communities.prsdb.webapp.constants.REGISTER_PROPERTY_JOURNEY_URL
-import uk.gov.communities.prsdb.webapp.forms.steps.RegisterPropertyStepId
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.FormWithSectionHeader
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.TextInput
-import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages.BasePage
 
-class HouseholdsFormPagePropertyRegistration(
+abstract class NumberOfHouseholdsFormBasePage(
     page: Page,
-) : BasePage(
-        page,
-        "/$REGISTER_PROPERTY_JOURNEY_URL/${RegisterPropertyStepId.NumberOfHouseholds.urlPathSegment}",
-    ) {
-    val form = HouseholdsForm(page)
+    urlSegment: String,
+) : BasePage(page, urlSegment) {
+    val form = NumOfHouseholdsForm(page)
 
     fun submitNumberOfHouseholds(num: Int) = submitNumberOfHouseholds(num.toString())
 
@@ -22,7 +17,7 @@ class HouseholdsFormPagePropertyRegistration(
         form.submit()
     }
 
-    class HouseholdsForm(
+    class NumOfHouseholdsForm(
         page: Page,
     ) : FormWithSectionHeader(page) {
         val householdsInput = TextInput.textByFieldName(locator, "numberOfHouseholds")

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/basePages/PropertyDetailsBasePage.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/basePages/PropertyDetailsBasePage.kt
@@ -35,6 +35,7 @@ abstract class PropertyDetailsBasePage(
         page: Page,
     ) : SummaryList(page) {
         val ownershipTypeRow = getRow("Ownership type")
+        val numberOfHouseholdsRow = getRow("Number of households")
         val numberOfPeopleRow = getRow("Number of people")
     }
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/propertyDetailsUpdateJourneyPages/NumberOfHouseholdsFormPagePropertyDetailsUpdate.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/propertyDetailsUpdateJourneyPages/NumberOfHouseholdsFormPagePropertyDetailsUpdate.kt
@@ -1,0 +1,15 @@
+package uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyDetailsUpdateJourneyPages
+
+import com.microsoft.playwright.Page
+import uk.gov.communities.prsdb.webapp.controllers.PropertyDetailsController
+import uk.gov.communities.prsdb.webapp.forms.steps.UpdatePropertyDetailsStepId
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages.NumberOfHouseholdsFormBasePage
+
+class NumberOfHouseholdsFormPagePropertyDetailsUpdate(
+    page: Page,
+    urlArguments: Map<String, String>,
+) : NumberOfHouseholdsFormBasePage(
+        page,
+        PropertyDetailsController.getUpdatePropertyDetailsPath(urlArguments["propertyOwnershipId"]!!.toLong()) +
+            "/${UpdatePropertyDetailsStepId.UpdateNumberOfHouseholds.urlPathSegment}",
+    )

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/propertyRegistrationJourneyPages/NumberOfHouseholdsFormPagePropertyRegistration.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/propertyRegistrationJourneyPages/NumberOfHouseholdsFormPagePropertyRegistration.kt
@@ -1,0 +1,13 @@
+package uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyRegistrationJourneyPages
+
+import com.microsoft.playwright.Page
+import uk.gov.communities.prsdb.webapp.constants.REGISTER_PROPERTY_JOURNEY_URL
+import uk.gov.communities.prsdb.webapp.forms.steps.RegisterPropertyStepId
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages.NumberOfHouseholdsFormBasePage
+
+class NumberOfHouseholdsFormPagePropertyRegistration(
+    page: Page,
+) : NumberOfHouseholdsFormBasePage(
+        page,
+        "/$REGISTER_PROPERTY_JOURNEY_URL/${RegisterPropertyStepId.NumberOfHouseholds.urlPathSegment}",
+    )

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/summaryModels/PropertyDetailsViewModelTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/summaryModels/PropertyDetailsViewModelTests.kt
@@ -248,7 +248,7 @@ class PropertyDetailsViewModelTests {
 
         val changeLinkCount = viewModel.propertyRecord.count { it.changeUrl != null }
 
-        assertEquals(2, changeLinkCount)
+        assertEquals(3, changeLinkCount)
     }
 
     @Test

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/PropertyOwnershipServiceTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/PropertyOwnershipServiceTests.kt
@@ -552,11 +552,14 @@ class PropertyOwnershipServiceTests {
             MockLandlordData.createPropertyOwnership(
                 id = 1,
                 ownershipType = OwnershipType.FREEHOLD,
+                currentNumHouseholds = 2,
                 currentNumTenants = 4,
             )
         val originalOwnershipType = propertyOwnership.ownershipType
+        val originalNumberOfHouseholds = propertyOwnership.currentNumHouseholds
         val originalNumberOfPeople = propertyOwnership.currentNumTenants
-        val updateModel = PropertyOwnershipUpdateModel(ownershipType = null, numberOfPeople = null)
+        val updateModel =
+            PropertyOwnershipUpdateModel(ownershipType = null, numberOfHouseholds = null, numberOfPeople = null)
 
         whenever(mockPropertyOwnershipRepository.findByIdAndIsActiveTrue(propertyOwnership.id)).thenReturn(
             propertyOwnership,
@@ -567,6 +570,7 @@ class PropertyOwnershipServiceTests {
 
         // Assert
         assertEquals(originalOwnershipType, propertyOwnership.ownershipType)
+        assertEquals(originalNumberOfHouseholds, propertyOwnership.currentNumHouseholds)
         assertEquals(originalNumberOfPeople, propertyOwnership.currentNumTenants)
     }
 
@@ -577,9 +581,15 @@ class PropertyOwnershipServiceTests {
             MockLandlordData.createPropertyOwnership(
                 id = 1,
                 ownershipType = OwnershipType.FREEHOLD,
+                currentNumHouseholds = 2,
                 currentNumTenants = 6,
             )
-        val updateModel = PropertyOwnershipUpdateModel(ownershipType = OwnershipType.LEASEHOLD, numberOfPeople = 2)
+        val updateModel =
+            PropertyOwnershipUpdateModel(
+                ownershipType = OwnershipType.LEASEHOLD,
+                numberOfHouseholds = 1,
+                numberOfPeople = 2,
+            )
 
         whenever(mockPropertyOwnershipRepository.findByIdAndIsActiveTrue(propertyOwnership.id)).thenReturn(
             propertyOwnership,
@@ -590,6 +600,7 @@ class PropertyOwnershipServiceTests {
 
         // Assert
         assertEquals(updateModel.ownershipType, propertyOwnership.ownershipType)
+        assertEquals(updateModel.numberOfHouseholds, propertyOwnership.currentNumHouseholds)
         assertEquals(updateModel.numberOfPeople, propertyOwnership.currentNumTenants)
     }
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/testHelpers/builders/JourneyDataBuilder.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/testHelpers/builders/JourneyDataBuilder.kt
@@ -338,6 +338,12 @@ class JourneyDataBuilder(
         return this
     }
 
+    fun withNumberOfHouseholdsUpdate(numberOfHouseholds: Int): JourneyDataBuilder {
+        journeyData[UpdatePropertyDetailsStepId.UpdateNumberOfHouseholds.urlPathSegment] =
+            mutableMapOf("numberOfHouseholds" to numberOfHouseholds)
+        return this
+    }
+
     fun withNumberOfPeopleUpdate(numberOfPeople: Int): JourneyDataBuilder {
         journeyData[UpdatePropertyDetailsStepId.UpdateNumberOfPeople.urlPathSegment] =
             mutableMapOf("numberOfPeople" to numberOfPeople)


### PR DESCRIPTION
### Features
- Adds number of households to `PropertyOwnershipUpdateModel` and `PropertyOwnershipService.updatePropertyOwnership`
- Creates `PropertyDetailsUpdateJourneyDataExtensions.getNumberOfHouseholdsUpdateIfPresent()`
- Adds `NumberOfHouseholds` step to `PropertyDetailsUpdateJourney`

### Tests
- Updates tests for `PropertyOwnershipService.updatePropertyOwnership`
- Adds tests for `PropertyDetailsUpdateJourneyDataExtensions.getNumberOfHouseholdsUpdateIfPresent()`
- Updates `PropertyDetailsUpdateJourneyTests` to include `NumberOfHouseholds` step

### Screenshots
- Update details page
![image](https://github.com/user-attachments/assets/caf134be-4925-490c-a848-b057c4c67249)

- Update number of households page
![image](https://github.com/user-attachments/assets/2e530e97-c165-49a2-a172-9508ba42e7de)