### PR TITLE
PRSD-799: Update Property - Occupation Status

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/database/entity/PropertyOwnership.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/database/entity/PropertyOwnership.kt
@@ -116,4 +116,7 @@ class PropertyOwnership(
         this.property = property
         this.license = license
     }
+
+    val isOccupied: Boolean
+        get() = currentNumTenants > 0
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/PropertyDetailsUpdateJourney.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/PropertyDetailsUpdateJourney.kt
@@ -44,11 +44,10 @@ class PropertyDetailsUpdateJourney(
 
     override fun createOriginalJourneyData(): JourneyData {
         val propertyOwnership = propertyOwnershipService.getPropertyOwnership(propertyOwnershipId)
-        val isOccupied = propertyOwnership.currentNumTenants > 0
 
         return mapOf(
             UpdatePropertyDetailsStepId.UpdateOwnershipType.urlPathSegment to mapOf("ownershipType" to propertyOwnership.ownershipType),
-            UpdatePropertyDetailsStepId.UpdateOccupancy.urlPathSegment to mapOf("occupied" to isOccupied),
+            UpdatePropertyDetailsStepId.UpdateOccupancy.urlPathSegment to mapOf("occupied" to propertyOwnership.isOccupied),
             UpdatePropertyDetailsStepId.UpdateNumberOfHouseholds.urlPathSegment to
                 mapOf("numberOfHouseholds" to propertyOwnership.currentNumHouseholds),
             UpdatePropertyDetailsStepId.UpdateNumberOfPeople.urlPathSegment to

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/steps/UpdatePropertyDetailsStepId.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/steps/UpdatePropertyDetailsStepId.kt
@@ -6,6 +6,7 @@ enum class UpdatePropertyDetailsStepId(
     override val urlPathSegment: String,
 ) : StepId {
     UpdateOwnershipType("ownership-type"),
+    UpdateOccupancy("occupancy"),
     UpdateNumberOfHouseholds("number-of-households"),
     UpdateNumberOfPeople("number-of-people"),
     UpdateDetails(DETAILS_PATH_SEGMENT),

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/helpers/extensions/journeyDataExtensions/PropertyDetailsUpdateJourneyDataExtensions.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/helpers/extensions/journeyDataExtensions/PropertyDetailsUpdateJourneyDataExtensions.kt
@@ -15,14 +15,9 @@ class PropertyDetailsUpdateJourneyDataExtensions {
             )
 
         fun JourneyData.getOriginalIsOccupied(originalJourneyKey: String) =
-            JourneyDataHelper.getPageData(this, originalJourneyKey)?.getIsOccupiedUpdateIfPresent()
+            JourneyDataHelper.getPageData(this, originalJourneyKey)?.getIsOccupied()
 
-        fun JourneyData.getIsOccupiedUpdateIfPresent() =
-            JourneyDataHelper.getFieldBooleanValue(
-                this,
-                UpdatePropertyDetailsStepId.UpdateOccupancy.urlPathSegment,
-                "occupied",
-            )
+        fun JourneyData.getIsOccupiedUpdateIfPresent() = this.getIsOccupied()
 
         fun JourneyData.getNumberOfHouseholdsUpdateIfPresent() =
             if (this.getIsOccupiedUpdateIfPresent() == false) {
@@ -45,5 +40,12 @@ class PropertyDetailsUpdateJourneyDataExtensions {
                     "numberOfPeople",
                 )
             }
+
+        private fun JourneyData.getIsOccupied() =
+            JourneyDataHelper.getFieldBooleanValue(
+                this,
+                UpdatePropertyDetailsStepId.UpdateOccupancy.urlPathSegment,
+                "occupied",
+            )
     }
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/helpers/extensions/journeyDataExtensions/PropertyDetailsUpdateJourneyDataExtensions.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/helpers/extensions/journeyDataExtensions/PropertyDetailsUpdateJourneyDataExtensions.kt
@@ -14,6 +14,13 @@ class PropertyDetailsUpdateJourneyDataExtensions {
                 "ownershipType",
             )
 
+        fun JourneyData.getIsOccupiedUpdateIfPresent() =
+            JourneyDataHelper.getFieldBooleanValue(
+                this,
+                UpdatePropertyDetailsStepId.UpdateOccupancy.urlPathSegment,
+                "occupied",
+            )
+
         fun JourneyData.getNumberOfHouseholdsUpdateIfPresent() =
             JourneyDataHelper.getFieldIntegerValue(
                 this,

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/helpers/extensions/journeyDataExtensions/PropertyDetailsUpdateJourneyDataExtensions.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/helpers/extensions/journeyDataExtensions/PropertyDetailsUpdateJourneyDataExtensions.kt
@@ -22,17 +22,25 @@ class PropertyDetailsUpdateJourneyDataExtensions {
             )
 
         fun JourneyData.getNumberOfHouseholdsUpdateIfPresent() =
-            JourneyDataHelper.getFieldIntegerValue(
-                this,
-                UpdatePropertyDetailsStepId.UpdateNumberOfHouseholds.urlPathSegment,
-                "numberOfHouseholds",
-            )
+            if (this.getIsOccupiedUpdateIfPresent() == false) {
+                0
+            } else {
+                JourneyDataHelper.getFieldIntegerValue(
+                    this,
+                    UpdatePropertyDetailsStepId.UpdateNumberOfHouseholds.urlPathSegment,
+                    "numberOfHouseholds",
+                )
+            }
 
         fun JourneyData.getNumberOfPeopleUpdateIfPresent() =
-            JourneyDataHelper.getFieldIntegerValue(
-                this,
-                UpdatePropertyDetailsStepId.UpdateNumberOfPeople.urlPathSegment,
-                "numberOfPeople",
-            )
+            if (this.getIsOccupiedUpdateIfPresent() == false) {
+                0
+            } else {
+                JourneyDataHelper.getFieldIntegerValue(
+                    this,
+                    UpdatePropertyDetailsStepId.UpdateNumberOfPeople.urlPathSegment,
+                    "numberOfPeople",
+                )
+            }
     }
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/helpers/extensions/journeyDataExtensions/PropertyDetailsUpdateJourneyDataExtensions.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/helpers/extensions/journeyDataExtensions/PropertyDetailsUpdateJourneyDataExtensions.kt
@@ -14,6 +14,9 @@ class PropertyDetailsUpdateJourneyDataExtensions {
                 "ownershipType",
             )
 
+        fun JourneyData.getOriginalIsOccupied(originalJourneyKey: String) =
+            JourneyDataHelper.getPageData(this, originalJourneyKey)?.getIsOccupiedUpdateIfPresent()
+
         fun JourneyData.getIsOccupiedUpdateIfPresent() =
             JourneyDataHelper.getFieldBooleanValue(
                 this,

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/summaryModels/PropertyDetailsViewModel.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/summaryModels/PropertyDetailsViewModel.kt
@@ -81,8 +81,12 @@ class PropertyDetailsViewModel(
                     } ?: MessageKeyConverter.convert(LicensingType.NO_LICENSING),
                     // TODO PRSD-798: Add update link
                 )
-                // TODO PRSD-799: Add update link
-                addRow("propertyDetails.propertyRecord.occupied", isTenantedKey)
+                addRow(
+                    "propertyDetails.propertyRecord.occupied",
+                    isTenantedKey,
+                    UpdatePropertyDetailsStepId.UpdateOccupancy.urlPathSegment,
+                    withChangeLinks,
+                )
                 if (propertyOwnership.currentNumTenants > 0) {
                     addRow(
                         "propertyDetails.propertyRecord.numberOfHouseholds",

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/summaryModels/PropertyDetailsViewModel.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/summaryModels/PropertyDetailsViewModel.kt
@@ -18,7 +18,7 @@ class PropertyDetailsViewModel(
 ) {
     val address: String = propertyOwnership.property.address.singleLineAddress
 
-    val isTenantedKey: String = MessageKeyConverter.convert(propertyOwnership.currentNumTenants > 0)
+    val isTenantedKey: String = MessageKeyConverter.convert(propertyOwnership.isOccupied)
 
     val keyDetails: List<SummaryListRowViewModel> =
         listOf(
@@ -87,7 +87,7 @@ class PropertyDetailsViewModel(
                     UpdatePropertyDetailsStepId.UpdateOccupancy.urlPathSegment,
                     withChangeLinks,
                 )
-                if (propertyOwnership.currentNumTenants > 0) {
+                if (propertyOwnership.isOccupied) {
                     addRow(
                         "propertyDetails.propertyRecord.numberOfHouseholds",
                         propertyOwnership.currentNumHouseholds,

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/summaryModels/RegisteredPropertyViewModel.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/summaryModels/RegisteredPropertyViewModel.kt
@@ -33,7 +33,7 @@ data class RegisteredPropertyViewModel(
                     MessageKeyConverter.convert(
                         propertyOwnership.license?.licenseType ?: LicensingType.NO_LICENSING,
                     ),
-                isTenantedMessageKey = MessageKeyConverter.convert(propertyOwnership.currentNumTenants > 0),
+                isTenantedMessageKey = MessageKeyConverter.convert(propertyOwnership.isOccupied),
                 recordLink = PropertyDetailsController.getPropertyDetailsPath(propertyOwnership.id, isLaView),
             )
     }

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -682,6 +682,7 @@ forms.update.lookupAddress.fieldSetHeading=Update your contact address
 forms.update.phoneNumber.fieldSetHeading=What is your updated phone number?
 forms.update.dateOfBirth.fieldSetHeading=Update your date of birth on your landlord record
 forms.update.ownershipType.fieldSetHeading=Update the ownership type for your property
+forms.update.occupancy.fieldSetHeading=Is your property still occupied by tenants?
 forms.update.numberOfHouseholds.fieldSetHeading=Update the number of households in the property
 forms.update.numberOfPeople.fieldSetHeading=Update how many people live in your property
 

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -682,7 +682,7 @@ forms.update.lookupAddress.fieldSetHeading=Update your contact address
 forms.update.phoneNumber.fieldSetHeading=What is your updated phone number?
 forms.update.dateOfBirth.fieldSetHeading=Update your date of birth on your landlord record
 forms.update.ownershipType.fieldSetHeading=Update the ownership type for your property
-forms.update.occupancy.fieldSetHeading=Is your property still occupied by tenants?
+forms.update.occupancy.occupied.fieldSetHeading=Is your property still occupied by tenants?
 forms.update.numberOfHouseholds.fieldSetHeading=Update the number of households in the property
 forms.update.numberOfPeople.fieldSetHeading=Update how many people live in your property
 

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/helpers/extensions/journeyDataExtensions/PropertyDetailsUpdateJourneyDataExtensionsTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/helpers/extensions/journeyDataExtensions/PropertyDetailsUpdateJourneyDataExtensionsTests.kt
@@ -59,6 +59,25 @@ class PropertyDetailsUpdateJourneyDataExtensionsTests {
     }
 
     @Test
+    fun `getNumberOfHouseholdsUpdateIfPresent returns 0 if the occupancy has been updated to false`() {
+        val testJourneyData = journeyDataBuilder.withIsOccupiedUpdate(false).build()
+
+        val numberOfHouseholdsUpdate = testJourneyData.getNumberOfHouseholdsUpdateIfPresent()
+
+        assertEquals(0, numberOfHouseholdsUpdate)
+    }
+
+    @Test
+    fun `getNumberOfHouseholdsUpdateIfPresent returns an integer if the occupancy has been updated to true`() {
+        val newNumberOfHouseholds = 3
+        val testJourneyData = journeyDataBuilder.withIsOccupiedUpdate(true).withNumberOfHouseholdsUpdate(newNumberOfHouseholds).build()
+
+        val numberOfHouseholdsUpdate = testJourneyData.getNumberOfHouseholdsUpdateIfPresent()
+
+        assertEquals(newNumberOfHouseholds, numberOfHouseholdsUpdate)
+    }
+
+    @Test
     fun `getNumberOfHouseholdsUpdateIfPresent returns an integer if the corresponding page is in journeyData`() {
         val newNumberOfHouseholds = 3
         val testJourneyData = journeyDataBuilder.withNumberOfHouseholdsUpdate(newNumberOfHouseholds).build()
@@ -75,6 +94,25 @@ class PropertyDetailsUpdateJourneyDataExtensionsTests {
         val numberOfHouseholdsUpdate = testJourneyData.getNumberOfHouseholdsUpdateIfPresent()
 
         assertNull(numberOfHouseholdsUpdate)
+    }
+
+    @Test
+    fun `getNumberOfPeopleUpdateIfPresent returns 0 if the occupancy has been updated to false`() {
+        val testJourneyData = journeyDataBuilder.withIsOccupiedUpdate(false).build()
+
+        val numberOfPeopleUpdate = testJourneyData.getNumberOfPeopleUpdateIfPresent()
+
+        assertEquals(0, numberOfPeopleUpdate)
+    }
+
+    @Test
+    fun `getNumberOfPeopleUpdateIfPresent returns an integer if the occupancy has been updated to true`() {
+        val newNumberOfPeople = 10
+        val testJourneyData = journeyDataBuilder.withIsOccupiedUpdate(true).withNumberOfPeopleUpdate(newNumberOfPeople).build()
+
+        val numberOfPeopleUpdate = testJourneyData.getNumberOfPeopleUpdateIfPresent()
+
+        assertEquals(newNumberOfPeople, numberOfPeopleUpdate)
     }
 
     @Test

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/helpers/extensions/journeyDataExtensions/PropertyDetailsUpdateJourneyDataExtensionsTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/helpers/extensions/journeyDataExtensions/PropertyDetailsUpdateJourneyDataExtensionsTests.kt
@@ -7,9 +7,11 @@ import uk.gov.communities.prsdb.webapp.constants.enums.OwnershipType
 import uk.gov.communities.prsdb.webapp.helpers.extensions.journeyDataExtensions.PropertyDetailsUpdateJourneyDataExtensions.Companion.getIsOccupiedUpdateIfPresent
 import uk.gov.communities.prsdb.webapp.helpers.extensions.journeyDataExtensions.PropertyDetailsUpdateJourneyDataExtensions.Companion.getNumberOfHouseholdsUpdateIfPresent
 import uk.gov.communities.prsdb.webapp.helpers.extensions.journeyDataExtensions.PropertyDetailsUpdateJourneyDataExtensions.Companion.getNumberOfPeopleUpdateIfPresent
+import uk.gov.communities.prsdb.webapp.helpers.extensions.journeyDataExtensions.PropertyDetailsUpdateJourneyDataExtensions.Companion.getOriginalIsOccupied
 import uk.gov.communities.prsdb.webapp.helpers.extensions.journeyDataExtensions.PropertyDetailsUpdateJourneyDataExtensions.Companion.getOwnershipTypeUpdateIfPresent
 import uk.gov.communities.prsdb.webapp.testHelpers.builders.JourneyDataBuilder
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
@@ -38,6 +40,37 @@ class PropertyDetailsUpdateJourneyDataExtensionsTests {
         val ownershipTypeUpdate = testJourneyData.getOwnershipTypeUpdateIfPresent()
 
         assertNull(ownershipTypeUpdate)
+    }
+
+    @Test
+    fun `getOriginalIsOccupied returns a boolean if the corresponding page is in original journeyData`() {
+        val originalJourneyKey = "original-key"
+        val originalJourneyData = journeyDataBuilder.withIsOccupiedUpdate(false).build()
+        val testJourneyData = mapOf(originalJourneyKey to originalJourneyData)
+
+        val originalOccupancy = testJourneyData.getOriginalIsOccupied(originalJourneyKey)!!
+
+        assertFalse(originalOccupancy)
+    }
+
+    @Test
+    fun `getOriginalIsOccupied returns null if the corresponding page is not in original journeyData`() {
+        val originalJourneyKey = "original-key"
+        val originalJourneyData = journeyDataBuilder.build()
+        val testJourneyData = mapOf(originalJourneyKey to originalJourneyData)
+
+        val originalOccupancy = testJourneyData.getOriginalIsOccupied(originalJourneyKey)
+
+        assertNull(originalOccupancy)
+    }
+
+    @Test
+    fun `getOriginalIsOccupied returns null if the original journeyData is in not journeyData`() {
+        val testJourneyData = journeyDataBuilder.build()
+
+        val occupancyUpdate = testJourneyData.getOriginalIsOccupied("original-key-not-in-journey-data")
+
+        assertNull(occupancyUpdate)
     }
 
     @Test

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/helpers/extensions/journeyDataExtensions/PropertyDetailsUpdateJourneyDataExtensionsTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/helpers/extensions/journeyDataExtensions/PropertyDetailsUpdateJourneyDataExtensionsTests.kt
@@ -4,18 +4,21 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.mockito.Mockito.mock
 import uk.gov.communities.prsdb.webapp.constants.enums.OwnershipType
+import uk.gov.communities.prsdb.webapp.helpers.extensions.journeyDataExtensions.PropertyDetailsUpdateJourneyDataExtensions.Companion.getIsOccupiedUpdateIfPresent
 import uk.gov.communities.prsdb.webapp.helpers.extensions.journeyDataExtensions.PropertyDetailsUpdateJourneyDataExtensions.Companion.getNumberOfHouseholdsUpdateIfPresent
 import uk.gov.communities.prsdb.webapp.helpers.extensions.journeyDataExtensions.PropertyDetailsUpdateJourneyDataExtensions.Companion.getNumberOfPeopleUpdateIfPresent
 import uk.gov.communities.prsdb.webapp.helpers.extensions.journeyDataExtensions.PropertyDetailsUpdateJourneyDataExtensions.Companion.getOwnershipTypeUpdateIfPresent
 import uk.gov.communities.prsdb.webapp.testHelpers.builders.JourneyDataBuilder
 import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
 
 class PropertyDetailsUpdateJourneyDataExtensionsTests {
     private lateinit var journeyDataBuilder: JourneyDataBuilder
 
     @BeforeEach
     fun setup() {
-        journeyDataBuilder = JourneyDataBuilder(mock(), mock())
+        journeyDataBuilder = JourneyDataBuilder(mock())
     }
 
     @Test
@@ -23,8 +26,7 @@ class PropertyDetailsUpdateJourneyDataExtensionsTests {
         val newOwnershipType = OwnershipType.LEASEHOLD
         val testJourneyData = journeyDataBuilder.withOwnershipTypeUpdate(newOwnershipType).build()
 
-        val ownershipTypeUpdate =
-            testJourneyData.getOwnershipTypeUpdateIfPresent()
+        val ownershipTypeUpdate = testJourneyData.getOwnershipTypeUpdateIfPresent()
 
         assertEquals(newOwnershipType, ownershipTypeUpdate)
     }
@@ -33,10 +35,27 @@ class PropertyDetailsUpdateJourneyDataExtensionsTests {
     fun `getOwnershipTypeUpdateIfPresent returns null if the corresponding page is in not journeyData`() {
         val testJourneyData = journeyDataBuilder.build()
 
-        val ownershipTypeUpdate =
-            testJourneyData.getOwnershipTypeUpdateIfPresent()
+        val ownershipTypeUpdate = testJourneyData.getOwnershipTypeUpdateIfPresent()
 
-        assertEquals(null, ownershipTypeUpdate)
+        assertNull(ownershipTypeUpdate)
+    }
+
+    @Test
+    fun `getIsOccupiedUpdateIfPresent returns a boolean if the corresponding page is in journeyData`() {
+        val testJourneyData = journeyDataBuilder.withIsOccupiedUpdate(true).build()
+
+        val occupancyUpdate = testJourneyData.getIsOccupiedUpdateIfPresent()!!
+
+        assertTrue(occupancyUpdate)
+    }
+
+    @Test
+    fun `getIsOccupiedUpdateIfPresent returns null if the corresponding page is in not journeyData`() {
+        val testJourneyData = journeyDataBuilder.build()
+
+        val occupancyUpdate = testJourneyData.getIsOccupiedUpdateIfPresent()
+
+        assertNull(occupancyUpdate)
     }
 
     @Test
@@ -44,8 +63,7 @@ class PropertyDetailsUpdateJourneyDataExtensionsTests {
         val newNumberOfHouseholds = 3
         val testJourneyData = journeyDataBuilder.withNumberOfHouseholdsUpdate(newNumberOfHouseholds).build()
 
-        val numberOfHouseholdsUpdate =
-            testJourneyData.getNumberOfHouseholdsUpdateIfPresent()
+        val numberOfHouseholdsUpdate = testJourneyData.getNumberOfHouseholdsUpdateIfPresent()
 
         assertEquals(newNumberOfHouseholds, numberOfHouseholdsUpdate)
     }
@@ -54,10 +72,9 @@ class PropertyDetailsUpdateJourneyDataExtensionsTests {
     fun `getNumberOfHouseholdsUpdateIfPresent returns null if the corresponding page is in not journeyData`() {
         val testJourneyData = journeyDataBuilder.build()
 
-        val numberOfHouseholdsUpdate =
-            testJourneyData.getNumberOfHouseholdsUpdateIfPresent()
+        val numberOfHouseholdsUpdate = testJourneyData.getNumberOfHouseholdsUpdateIfPresent()
 
-        assertEquals(null, numberOfHouseholdsUpdate)
+        assertNull(numberOfHouseholdsUpdate)
     }
 
     @Test
@@ -65,8 +82,7 @@ class PropertyDetailsUpdateJourneyDataExtensionsTests {
         val newNumberOfPeople = 10
         val testJourneyData = journeyDataBuilder.withNumberOfPeopleUpdate(newNumberOfPeople).build()
 
-        val numberOfPeopleUpdate =
-            testJourneyData.getNumberOfPeopleUpdateIfPresent()
+        val numberOfPeopleUpdate = testJourneyData.getNumberOfPeopleUpdateIfPresent()
 
         assertEquals(newNumberOfPeople, numberOfPeopleUpdate)
     }
@@ -75,9 +91,8 @@ class PropertyDetailsUpdateJourneyDataExtensionsTests {
     fun `getNumberOfPeopleUpdateIfPresent returns null if the corresponding page is in not journeyData`() {
         val testJourneyData = journeyDataBuilder.build()
 
-        val numberOfPeopleUpdate =
-            testJourneyData.getNumberOfPeopleUpdateIfPresent()
+        val numberOfPeopleUpdate = testJourneyData.getNumberOfPeopleUpdateIfPresent()
 
-        assertEquals(null, numberOfPeopleUpdate)
+        assertNull(numberOfPeopleUpdate)
     }
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/Navigator.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/Navigator.kt
@@ -412,6 +412,20 @@ class Navigator(
         return createValidPage(page, PropertyDetailsUpdatePage::class, mapOf("propertyOwnershipId" to propertyOwnershipId.toString()))
     }
 
+    fun skipToPropertyDetailsUpdateNumberOfHouseholdsPage(propertyOwnershipId: Long) {
+        navigate(
+            PropertyDetailsController.getUpdatePropertyDetailsPath(propertyOwnershipId) +
+                "/${UpdatePropertyDetailsStepId.UpdateNumberOfHouseholds.urlPathSegment}",
+        )
+    }
+
+    fun skipToPropertyDetailsUpdateNumberOfPeoplePage(propertyOwnershipId: Long) {
+        navigate(
+            PropertyDetailsController.getUpdatePropertyDetailsPath(propertyOwnershipId) +
+                "/${UpdatePropertyDetailsStepId.UpdateNumberOfPeople.urlPathSegment}",
+        )
+    }
+
     fun goToPropertyDeregistrationAreYouSurePage(propertyOwnershipId: Long): AreYouSureFormPagePropertyDeregistration {
         navigate("/$DEREGISTER_PROPERTY_JOURNEY_URL/$propertyOwnershipId/${DeregisterPropertyStepId.AreYouSure.urlPathSegment}")
         return createValidPage(

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/basePages/OccupancyFormPage.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/basePages/OccupancyFormPage.kt
@@ -1,0 +1,28 @@
+package uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages
+
+import com.microsoft.playwright.Page
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.FormWithSectionHeader
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.Radios
+
+abstract class OccupancyFormPage(
+    page: Page,
+    urlSegment: String,
+) : BasePage(page, urlSegment) {
+    val form = OccupancyForm(page)
+
+    fun submitIsOccupied() {
+        form.occupancyRadios.selectValue("true")
+        form.submit()
+    }
+
+    fun submitIsVacant() {
+        form.occupancyRadios.selectValue("false")
+        form.submit()
+    }
+
+    class OccupancyForm(
+        page: Page,
+    ) : FormWithSectionHeader(page) {
+        val occupancyRadios = Radios(locator)
+    }
+}

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/basePages/PropertyDetailsBasePage.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/basePages/PropertyDetailsBasePage.kt
@@ -35,6 +35,7 @@ abstract class PropertyDetailsBasePage(
         page: Page,
     ) : SummaryList(page) {
         val ownershipTypeRow = getRow("Ownership type")
+        val occupancyRow = getRow("Occupied by tenants")
         val numberOfHouseholdsRow = getRow("Number of households")
         val numberOfPeopleRow = getRow("Number of people")
     }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/propertyDetailsUpdateJourneyPages/OccupancyFormPagePropertyDetailsUpdate.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/propertyDetailsUpdateJourneyPages/OccupancyFormPagePropertyDetailsUpdate.kt
@@ -1,0 +1,15 @@
+package uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyDetailsUpdateJourneyPages
+
+import com.microsoft.playwright.Page
+import uk.gov.communities.prsdb.webapp.controllers.PropertyDetailsController
+import uk.gov.communities.prsdb.webapp.forms.steps.UpdatePropertyDetailsStepId
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages.OccupancyFormPage
+
+class OccupancyFormPagePropertyDetailsUpdate(
+    page: Page,
+    urlArguments: Map<String, String>,
+) : OccupancyFormPage(
+        page,
+        PropertyDetailsController.getUpdatePropertyDetailsPath(urlArguments["propertyOwnershipId"]!!.toLong()) +
+            "/${UpdatePropertyDetailsStepId.UpdateOccupancy.urlPathSegment}",
+    )

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/propertyRegistrationJourneyPages/OccupancyFormPagePropertyRegistration.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/propertyRegistrationJourneyPages/OccupancyFormPagePropertyRegistration.kt
@@ -3,28 +3,8 @@ package uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyRe
 import com.microsoft.playwright.Page
 import uk.gov.communities.prsdb.webapp.constants.REGISTER_PROPERTY_JOURNEY_URL
 import uk.gov.communities.prsdb.webapp.forms.steps.RegisterPropertyStepId
-import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.FormWithSectionHeader
-import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.Radios
-import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages.BasePage
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages.OccupancyFormPage
 
 class OccupancyFormPagePropertyRegistration(
     page: Page,
-) : BasePage(page, "/$REGISTER_PROPERTY_JOURNEY_URL/${RegisterPropertyStepId.Occupancy.urlPathSegment}") {
-    val form = OccupancyForm(page)
-
-    fun submitIsOccupied() {
-        form.occupancyRadios.selectValue("true")
-        form.submit()
-    }
-
-    fun submitIsVacant() {
-        form.occupancyRadios.selectValue("false")
-        form.submit()
-    }
-
-    class OccupancyForm(
-        page: Page,
-    ) : FormWithSectionHeader(page) {
-        val occupancyRadios = Radios(locator)
-    }
-}
+) : OccupancyFormPage(page, "/$REGISTER_PROPERTY_JOURNEY_URL/${RegisterPropertyStepId.Occupancy.urlPathSegment}")

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/summaryModels/PropertyDetailsViewModelTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/summaryModels/PropertyDetailsViewModelTests.kt
@@ -248,7 +248,7 @@ class PropertyDetailsViewModelTests {
 
         val changeLinkCount = viewModel.propertyRecord.count { it.changeUrl != null }
 
-        assertEquals(3, changeLinkCount)
+        assertEquals(4, changeLinkCount)
     }
 
     @Test

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/testHelpers/builders/JourneyDataBuilder.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/testHelpers/builders/JourneyDataBuilder.kt
@@ -338,6 +338,12 @@ class JourneyDataBuilder(
         return this
     }
 
+    fun withIsOccupiedUpdate(isOccupied: Boolean): JourneyDataBuilder {
+        journeyData[UpdatePropertyDetailsStepId.UpdateOccupancy.urlPathSegment] =
+            mutableMapOf("occupied" to isOccupied)
+        return this
+    }
+
     fun withNumberOfHouseholdsUpdate(numberOfHouseholds: Int): JourneyDataBuilder {
         journeyData[UpdatePropertyDetailsStepId.UpdateNumberOfHouseholds.urlPathSegment] =
             mutableMapOf("numberOfHouseholds" to numberOfHouseholds)


### PR DESCRIPTION
### Features
- Adds `PropertyDetailsUpdateJourneyDataExtensions` methods for retrieving the original and updated occupation statuses
- Updates `PropertyDetailsUpdateJourneyDataExtensions` households and people number retrieval methods to return 0 if the property's occupation status has been updated to vacant
- Updates `PropertyDetailsUpdateJourney`
  - Adds occupation step 
  - Makes the number of people step follow the number of households one
  - Updates the pages of the number of people and households steps to determine their `fieldSetHeading` via the original occupation status and their `backUrl` via the updated one.

### Tests
- Adds tests for the new/updated `PropertyDetailsUpdateJourneyDataExtensions` methods
- Adds integration tests for new `PropertyDetailsUpdateJourney` functionality

### Screenshots
- Update details page
![image](https://github.com/user-attachments/assets/05fff6a0-99d5-406c-9fc2-66f648508cc7)

- Update occupancy page (originally occupied)
![image](https://github.com/user-attachments/assets/a0aca7af-fa5b-409b-9337-e2c84779f92c)

- Update occupancy page (originally vacant)
![image](https://github.com/user-attachments/assets/bbb9b0d2-272a-4794-abaa-349d9e0da4da)