### PR TITLE
PRSD-697: Add hint text to property deregistration reason page

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/PropertyDeregistrationJourney.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/PropertyDeregistrationJourney.kt
@@ -87,6 +87,7 @@ class PropertyDeregistrationJourney(
                         mapOf(
                             "title" to "deregisterProperty.title",
                             "fieldSetHeading" to "forms.reason.propertyDeregistration.fieldSetHeading",
+                            "fieldSetHint" to "forms.reason.propertyDeregistration.fieldSetHint",
                             "limit" to DEREGISTRATION_REASON_MAX_LENGTH,
                             "submitButtonText" to "forms.buttons.continue",
                         ),

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -688,6 +688,7 @@ forms.update.numberOfPeople.fieldSetHeading=Update how many people live in your 
 forms.areYouSure.propertyDeregistration.fieldSetHeading=Are you sure you want to delete {0,,address} from the database?
 forms.areYouSure.propertyDeregistration.radios.error.missing=Select whether you want to delete this property from the database
 forms.reason.propertyDeregistration.fieldSetHeading=Why are you deleting this property? (optional)
+forms.reason.propertyDeregistration.fieldSetHint=This will help us understand why landlords might want to remove a property from the database
 forms.reason.propertyDeregistration.error.tooLong=Your reason for deleting this property must be 200 characters or fewer.
 
 pagination.previousText=Previous

--- a/src/main/resources/templates/forms/deregistrationReasonForm.html
+++ b/src/main/resources/templates/forms/deregistrationReasonForm.html
@@ -8,7 +8,7 @@
 <html th:replace="~{fragments/forms/questionPage :: questionPage(#{${title}}, ${formModel}, ~{::#form-content}, ${backUrl}, null)}">
 <th:block id="form-content">
     <th:block id="fieldset-content"
-              th:replace="~{fragments/forms/fieldSet :: fieldSet(~{::#fieldset-content/content()}, 'reason', #{${fieldSetHeading}}, null)}">
+              th:replace="~{fragments/forms/fieldSet :: fieldSet(~{::#fieldset-content/content()}, 'reason', #{${fieldSetHeading}}, #{${fieldSetHint}})}">
         <div th:replace="~{fragments/forms/textArea :: textArea(null, 'reason', null, ${limit})}">
         </div>
     </th:block>


### PR DESCRIPTION
Adds hint text to the property deregistration reason page

![image](https://github.com/user-attachments/assets/7132b7d0-6679-46de-b629-faf742563e55)
