### PR TITLE
Feat/prsd 999 example file upload template

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/ExampleFileUploadController.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/ExampleFileUploadController.kt
@@ -1,0 +1,33 @@
+package uk.gov.communities.prsdb.webapp.controllers
+
+import org.springframework.http.MediaType
+import org.springframework.stereotype.Controller
+import org.springframework.ui.Model
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.multipart.MultipartFile
+
+@Controller
+@RequestMapping("example/file-upload")
+class ExampleFileUploadController {
+    @GetMapping
+    fun getFileUploadForm() = "example/fileUpload"
+
+    @PostMapping(produces = [MediaType.APPLICATION_JSON_VALUE])
+    fun postmappedvalue(
+        @RequestParam("file") file: MultipartFile,
+        model: Model,
+    ): String {
+        model.addAttribute(
+            "fileUploadResponse",
+            mapOf(
+                "name" to file.originalFilename,
+                "size" to file.size,
+                "contentType" to file.contentType,
+            ),
+        )
+        return "example/fileUpload"
+    }
+}

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/examples/ExampleFileUploadController.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/examples/ExampleFileUploadController.kt
@@ -16,7 +16,7 @@ class ExampleFileUploadController {
     fun getFileUploadForm() = "example/fileUpload"
 
     @PostMapping(produces = [MediaType.APPLICATION_JSON_VALUE])
-    fun postmappedvalue(
+    fun uploadFile(
         @RequestParam("uploaded-file") file: MultipartFile,
         model: Model,
     ): String {

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/examples/ExampleFileUploadController.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/examples/ExampleFileUploadController.kt
@@ -1,4 +1,4 @@
-package uk.gov.communities.prsdb.webapp.controllers
+package uk.gov.communities.prsdb.webapp.examples
 
 import org.springframework.http.MediaType
 import org.springframework.stereotype.Controller

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/examples/ExampleFileUploadController.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/examples/ExampleFileUploadController.kt
@@ -1,6 +1,5 @@
 package uk.gov.communities.prsdb.webapp.examples
 
-import org.springframework.http.MediaType
 import org.springframework.stereotype.Controller
 import org.springframework.ui.Model
 import org.springframework.web.bind.annotation.GetMapping
@@ -15,7 +14,7 @@ class ExampleFileUploadController {
     @GetMapping
     fun getFileUploadForm() = "example/fileUpload"
 
-    @PostMapping(produces = [MediaType.APPLICATION_JSON_VALUE])
+    @PostMapping
     fun uploadFile(
         @RequestParam("uploaded-file") file: MultipartFile,
         model: Model,

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/examples/ExampleFileUploadController.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/examples/ExampleFileUploadController.kt
@@ -17,7 +17,7 @@ class ExampleFileUploadController {
 
     @PostMapping(produces = [MediaType.APPLICATION_JSON_VALUE])
     fun postmappedvalue(
-        @RequestParam("file") file: MultipartFile,
+        @RequestParam("uploaded-file") file: MultipartFile,
         model: Model,
     ): String {
         model.addAttribute(

--- a/src/main/resources/templates/example/fileUpload.html
+++ b/src/main/resources/templates/example/fileUpload.html
@@ -1,0 +1,9 @@
+<th:block id="main-content" th:replace="~{fragments/layout :: layout('Example Form Page', ~{::#main-content/content()}, null)}">
+    <form th:action="@{''}" novalidate method="post" enctype="multipart/form-data">
+        <input type="file" name="file">
+        <input type="submit" value="Upload">
+    </form>
+    <div th:unless="${fileUploadResponse} == null">
+        <div th:text="${fileUploadResponse}"></div>
+    </div>
+</th:block>

--- a/src/main/resources/templates/example/fileUpload.html
+++ b/src/main/resources/templates/example/fileUpload.html
@@ -1,6 +1,6 @@
 <th:block id="main-content" th:replace="~{fragments/layout :: layout('Example Form Page', ~{::#main-content/content()}, null)}">
     <form th:action="@{''}" novalidate method="post" enctype="multipart/form-data">
-        <input type="file" name="file">
+        <input type="file" name="uploaded-file">
         <input type="submit" value="Upload">
     </form>
     <div th:unless="${fileUploadResponse} == null">


### PR DESCRIPTION
Creates the file upload page and an endpoint that accepts the file, but no streaming currently occurs. (Will be in a future PR, I expect)