### PR TITLE
Feat/prsd 703 landlord deregistration check for properties

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/DeregisterLandlordController.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/DeregisterLandlordController.kt
@@ -14,14 +14,14 @@ import uk.gov.communities.prsdb.webapp.forms.PageData
 import uk.gov.communities.prsdb.webapp.forms.journeys.LandlordDeregistrationJourney
 import uk.gov.communities.prsdb.webapp.forms.journeys.factories.LandlordDeregistrationJourneyFactory
 import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.LandlordDeregistrationCheckUserPropertiesFormModel.Companion.USER_HAS_REGISTERED_PROPERTIES_JOURNEY_DATA_KEY
-import uk.gov.communities.prsdb.webapp.services.LandlordService
+import uk.gov.communities.prsdb.webapp.services.LandlordDeregistrationService
 import java.security.Principal
 
 @Controller
 @RequestMapping("/$DEREGISTER_LANDLORD_JOURNEY_URL")
 class DeregisterLandlordController(
     private val landlordDeregistrationJourneyFactory: LandlordDeregistrationJourneyFactory,
-    private val landlordService: LandlordService,
+    private val landlordDeregistrationService: LandlordDeregistrationService,
 ) {
     @PreAuthorize("hasRole('LANDLORD')")
     @GetMapping("/${CHECK_FOR_REGISTERED_PROPERTIES_PATH_SEGMENT}")
@@ -31,7 +31,8 @@ class DeregisterLandlordController(
     ): ModelAndView {
         val formData =
             mutableMapOf(
-                USER_HAS_REGISTERED_PROPERTIES_JOURNEY_DATA_KEY to landlordService.getLandlordHasRegisteredProperties(principal.name),
+                USER_HAS_REGISTERED_PROPERTIES_JOURNEY_DATA_KEY
+                    to landlordDeregistrationService.getLandlordHasRegisteredProperties(principal.name),
             )
 
         return landlordDeregistrationJourneyFactory

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/database/repository/LandlordWithListedPropertyCountRepository.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/database/repository/LandlordWithListedPropertyCountRepository.kt
@@ -5,4 +5,7 @@ import uk.gov.communities.prsdb.webapp.database.entity.LandlordWithListedPropert
 
 interface LandlordWithListedPropertyCountRepository : JpaRepository<LandlordWithListedPropertyCount?, Long?> {
     fun findByLandlordIdIn(primaryLandlordId: List<Long>): List<LandlordWithListedPropertyCount>
+
+    @Suppress("ktlint:standard:function-naming")
+    fun findByLandlord_BaseUser_Id(subjectId: String): LandlordWithListedPropertyCount?
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/LandlordDeregistrationService.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/LandlordDeregistrationService.kt
@@ -1,0 +1,17 @@
+package uk.gov.communities.prsdb.webapp.services
+
+import jakarta.persistence.EntityNotFoundException
+import org.springframework.stereotype.Service
+import uk.gov.communities.prsdb.webapp.database.repository.LandlordWithListedPropertyCountRepository
+
+@Service
+class LandlordDeregistrationService(
+    private val landlordWithListedPropertyCountRepository: LandlordWithListedPropertyCountRepository,
+) {
+    fun getLandlordHasRegisteredProperties(baseUserId: String): Boolean {
+        val landlordWithListedPropertyCount =
+            landlordWithListedPropertyCountRepository.findByLandlord_BaseUser_Id(baseUserId)
+                ?: throw EntityNotFoundException("Landlord with baseUserId $baseUserId not found")
+        return landlordWithListedPropertyCount.listedPropertyCount > 0
+    }
+}

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/controllers/DeregisterLandlordControllerTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/controllers/DeregisterLandlordControllerTests.kt
@@ -17,7 +17,7 @@ import uk.gov.communities.prsdb.webapp.controllers.DeregisterLandlordController.
 import uk.gov.communities.prsdb.webapp.forms.journeys.LandlordDeregistrationJourney
 import uk.gov.communities.prsdb.webapp.forms.journeys.factories.LandlordDeregistrationJourneyFactory
 import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.LandlordDeregistrationCheckUserPropertiesFormModel.Companion.USER_HAS_REGISTERED_PROPERTIES_JOURNEY_DATA_KEY
-import uk.gov.communities.prsdb.webapp.services.LandlordService
+import uk.gov.communities.prsdb.webapp.services.LandlordDeregistrationService
 
 @WebMvcTest(DeregisterLandlordController::class)
 class DeregisterLandlordControllerTests(
@@ -27,7 +27,7 @@ class DeregisterLandlordControllerTests(
     private lateinit var landlordDeregistrationJourneyFactory: LandlordDeregistrationJourneyFactory
 
     @MockBean
-    private lateinit var landlordService: LandlordService
+    private lateinit var landlordDeregistrationService: LandlordDeregistrationService
 
     @MockBean
     private lateinit var landlordDeregistrationJourney: LandlordDeregistrationJourney
@@ -56,7 +56,7 @@ class DeregisterLandlordControllerTests(
     fun `checkForRegisteredProperties caches userHasRegisteredProperties then returns a redirect to the are you sure step`() {
         landlordDeregistrationJourney = mock()
         whenever(landlordDeregistrationJourneyFactory.create()).thenReturn(landlordDeregistrationJourney)
-        whenever(landlordService.getLandlordHasRegisteredProperties(anyString())).thenReturn(false)
+        whenever(landlordDeregistrationService.getLandlordHasRegisteredProperties(anyString())).thenReturn(false)
         whenever(
             landlordDeregistrationJourney
                 .completeStep(

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/LandlordDeregistrationJourneyTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/LandlordDeregistrationJourneyTests.kt
@@ -14,16 +14,16 @@ import org.springframework.test.context.jdbc.Sql
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.BaseComponent.Companion.assertThat
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.LandlordDetailsPage
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages.BasePage.Companion.assertPageIs
-import uk.gov.communities.prsdb.webapp.services.LandlordService
+import uk.gov.communities.prsdb.webapp.services.LandlordDeregistrationService
 
 @Sql("/data-local.sql")
 class LandlordDeregistrationJourneyTests : IntegrationTest() {
     @MockBean
-    lateinit var landlordService: LandlordService
+    lateinit var landlordDeregistrationService: LandlordDeregistrationService
 
     @Test
     fun `User with properties can navigate the whole journey`(page: Page) {
-        whenever(landlordService.getLandlordHasRegisteredProperties(anyString())).thenReturn(true)
+        whenever(landlordDeregistrationService.getLandlordHasRegisteredProperties(anyString())).thenReturn(true)
         val areYouSurePage = navigator.goToLandlordDeregistrationAreYouSurePage()
         assertThat(areYouSurePage.form.fieldsetHeading)
             .containsText("Are you sure you want to delete your account and all your properties on the database?")
@@ -35,7 +35,7 @@ class LandlordDeregistrationJourneyTests : IntegrationTest() {
 
     @Test
     fun `User with no properties can navigate the whole journey`(page: Page) {
-        whenever(landlordService.getLandlordHasRegisteredProperties(anyString())).thenReturn(false)
+        whenever(landlordDeregistrationService.getLandlordHasRegisteredProperties(anyString())).thenReturn(false)
 
         val areYouSurePage = navigator.goToLandlordDeregistrationAreYouSurePage()
         assertThat(areYouSurePage.form.fieldsetHeading).containsText("Are you sure you want to delete your account from the database?")
@@ -56,7 +56,7 @@ class LandlordDeregistrationJourneyTests : IntegrationTest() {
         userHasRegisteredProperties: Boolean,
         page: Page,
     ) {
-        whenever(landlordService.getLandlordHasRegisteredProperties(anyString())).thenReturn(userHasRegisteredProperties)
+        whenever(landlordDeregistrationService.getLandlordHasRegisteredProperties(anyString())).thenReturn(userHasRegisteredProperties)
         val areYouSurePage = navigator.goToLandlordDeregistrationAreYouSurePage()
         areYouSurePage.submitDoesNotWantToProceed()
 
@@ -69,7 +69,7 @@ class LandlordDeregistrationJourneyTests : IntegrationTest() {
         userHasRegisteredProperties: Boolean,
         page: Page,
     ) {
-        whenever(landlordService.getLandlordHasRegisteredProperties(anyString())).thenReturn(userHasRegisteredProperties)
+        whenever(landlordDeregistrationService.getLandlordHasRegisteredProperties(anyString())).thenReturn(userHasRegisteredProperties)
         val areYouSurePage = navigator.goToLandlordDeregistrationAreYouSurePage()
         areYouSurePage.backLink.clickAndWait()
         assertPageIs(page, LandlordDetailsPage::class)
@@ -85,7 +85,7 @@ class LandlordDeregistrationJourneyTests : IntegrationTest() {
         expectedErrorMessage: String,
         page: Page,
     ) {
-        whenever(landlordService.getLandlordHasRegisteredProperties(anyString())).thenReturn(userHasRegisteredProperties)
+        whenever(landlordDeregistrationService.getLandlordHasRegisteredProperties(anyString())).thenReturn(userHasRegisteredProperties)
 
         val areYouSurePage = navigator.goToLandlordDeregistrationAreYouSurePage()
         areYouSurePage.form.submit()

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/LandlordDeregistrationServiceTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/LandlordDeregistrationServiceTests.kt
@@ -1,0 +1,53 @@
+package uk.gov.communities.prsdb.webapp.services
+
+import jakarta.persistence.EntityNotFoundException
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.whenever
+import uk.gov.communities.prsdb.webapp.database.repository.LandlordWithListedPropertyCountRepository
+import uk.gov.communities.prsdb.webapp.testHelpers.mockObjects.MockLandlordData.Companion.createLandlordWithListedPropertyCount
+
+@ExtendWith(MockitoExtension::class)
+class LandlordDeregistrationServiceTests {
+    @Mock
+    private lateinit var mockLandlordWithListedPropertyCountRepository: LandlordWithListedPropertyCountRepository
+
+    @InjectMocks
+    private lateinit var landlordDeregistrationService: LandlordDeregistrationService
+
+    @Test
+    fun `getLandlordHasRegisteredProperties throws an error if the landlord is not found`() {
+        val baseUserId = "one-login-id"
+        assertThrows<EntityNotFoundException> { landlordDeregistrationService.getLandlordHasRegisteredProperties(baseUserId) }
+    }
+
+    @Test
+    fun `getLandlordHasRegisteredProperties returns true if listedPropertyCount is greater than 0`() {
+        // Arrange
+        val landlordWithListedPropertyCount = createLandlordWithListedPropertyCount(5)
+        val baseUserId = landlordWithListedPropertyCount.landlord.baseUser.id
+        whenever(mockLandlordWithListedPropertyCountRepository.findByLandlord_BaseUser_Id(baseUserId))
+            .thenReturn(landlordWithListedPropertyCount)
+
+        // Act, Assert
+        assertTrue(landlordDeregistrationService.getLandlordHasRegisteredProperties(baseUserId))
+    }
+
+    @Test
+    fun `getLandlordHasRegisteredProperties returns false true if listedPropertyCount is 0`() {
+        // Arrange
+        val landlordWithListedPropertyCount = createLandlordWithListedPropertyCount(0)
+        val baseUserId = landlordWithListedPropertyCount.landlord.baseUser.id
+        whenever(mockLandlordWithListedPropertyCountRepository.findByLandlord_BaseUser_Id(baseUserId))
+            .thenReturn(landlordWithListedPropertyCount)
+
+        // Act, Assert
+        assertFalse(landlordDeregistrationService.getLandlordHasRegisteredProperties(baseUserId))
+    }
+}

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/testHelpers/mockObjects/MockLandlordData.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/testHelpers/mockObjects/MockLandlordData.kt
@@ -9,6 +9,7 @@ import uk.gov.communities.prsdb.webapp.constants.enums.RegistrationNumberType
 import uk.gov.communities.prsdb.webapp.constants.enums.RegistrationStatus
 import uk.gov.communities.prsdb.webapp.database.entity.Address
 import uk.gov.communities.prsdb.webapp.database.entity.Landlord
+import uk.gov.communities.prsdb.webapp.database.entity.LandlordWithListedPropertyCount
 import uk.gov.communities.prsdb.webapp.database.entity.License
 import uk.gov.communities.prsdb.webapp.database.entity.LocalAuthority
 import uk.gov.communities.prsdb.webapp.database.entity.OneLoginUser
@@ -60,6 +61,15 @@ class MockLandlordData {
             ReflectionTestUtils.setField(landlord, "createdDate", createdDate)
 
             return landlord
+        }
+
+        fun createLandlordWithListedPropertyCount(listedPropertyCount: Int = 0): LandlordWithListedPropertyCount {
+            val landlord = createLandlord()
+            return LandlordWithListedPropertyCount(
+                landlord.id,
+                landlord,
+                listedPropertyCount,
+            )
         }
 
         fun createProperty(


### PR DESCRIPTION
Adds a new service and checks the repository to see whether the landlord has registered properties

(currently branched off prsd-703-landlord-deregistration-are-you-sure)