### PR TITLE
Feat/prsd 798 update property licensing

### DIFF
--- a/.run/local.run.xml
+++ b/.run/local.run.xml
@@ -5,7 +5,7 @@
       <option value="$PROJECT_DIR$/.env" />
     </option>
     <option name="FRAME_DEACTIVATION_UPDATE_POLICY" value="UpdateClassesAndResources" />
-    <module name="uk.gov.communities.prsdb.prsdb-webapp.main" />
+    <module name="prsdb-webapp.main" />
     <selectedOptions>
       <option name="environmentVariables" />
     </selectedOptions>

--- a/.run/local.run.xml
+++ b/.run/local.run.xml
@@ -5,7 +5,7 @@
       <option value="$PROJECT_DIR$/.env" />
     </option>
     <option name="FRAME_DEACTIVATION_UPDATE_POLICY" value="UpdateClassesAndResources" />
-    <module name="prsdb-webapp.main" />
+    <module name="uk.gov.communities.prsdb.prsdb-webapp.main" />
     <selectedOptions>
       <option name="environmentVariables" />
     </selectedOptions>

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/database/entity/License.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/database/entity/License.kt
@@ -15,11 +15,9 @@ class License(
 ) : ModifiableAuditableEntity() {
     @Column(nullable = false)
     lateinit var licenseType: LicensingType
-        private set
 
     @Column(nullable = false)
     lateinit var licenseNumber: String
-        private set
 
     constructor(licenseType: LicensingType, licenseNumber: String) : this() {
         this.licenseType = licenseType

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/database/entity/PropertyOwnership.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/database/entity/PropertyOwnership.kt
@@ -70,7 +70,6 @@ class PropertyOwnership(
     @OneToOne
     @JoinColumn(name = "license_id", nullable = true, foreignKey = ForeignKey(name = "FK_PROPERTY_OWNERSHIP_LICENSE"))
     var license: License? = null
-        private set
 
     constructor(
         occupancyType: OccupancyType,

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/PropertyDetailsUpdateJourney.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/PropertyDetailsUpdateJourney.kt
@@ -13,8 +13,8 @@ import uk.gov.communities.prsdb.webapp.forms.steps.Step
 import uk.gov.communities.prsdb.webapp.forms.steps.UpdatePropertyDetailsStepId
 import uk.gov.communities.prsdb.webapp.helpers.extensions.journeyDataExtensions.PropertyDetailsUpdateJourneyDataExtensions
 import uk.gov.communities.prsdb.webapp.helpers.extensions.journeyDataExtensions.PropertyDetailsUpdateJourneyDataExtensions.Companion.getIsOccupiedUpdateIfPresent
-import uk.gov.communities.prsdb.webapp.helpers.extensions.journeyDataExtensions.PropertyDetailsUpdateJourneyDataExtensions.Companion.getLicenceNumberIfPresent
-import uk.gov.communities.prsdb.webapp.helpers.extensions.journeyDataExtensions.PropertyDetailsUpdateJourneyDataExtensions.Companion.getLicensingTypeIfPresent
+import uk.gov.communities.prsdb.webapp.helpers.extensions.journeyDataExtensions.PropertyDetailsUpdateJourneyDataExtensions.Companion.getLicenceNumberUpdateIfPresent
+import uk.gov.communities.prsdb.webapp.helpers.extensions.journeyDataExtensions.PropertyDetailsUpdateJourneyDataExtensions.Companion.getLicensingTypeUpdateIfPresent
 import uk.gov.communities.prsdb.webapp.helpers.extensions.journeyDataExtensions.PropertyDetailsUpdateJourneyDataExtensions.Companion.getNumberOfHouseholdsUpdateIfPresent
 import uk.gov.communities.prsdb.webapp.helpers.extensions.journeyDataExtensions.PropertyDetailsUpdateJourneyDataExtensions.Companion.getNumberOfPeopleUpdateIfPresent
 import uk.gov.communities.prsdb.webapp.helpers.extensions.journeyDataExtensions.PropertyDetailsUpdateJourneyDataExtensions.Companion.getOriginalIsOccupied
@@ -70,8 +70,8 @@ class PropertyDetailsUpdateJourney(
                 UpdatePropertyDetailsStepId.UpdateLicensingType.urlPathSegment to mapOf("licensingType" to licensingType),
             )
 
-        val licenceNumberTypeKey = PropertyDetailsUpdateJourneyDataExtensions.getUpdateStepUrlPathSegmentForLicensingType(licensingType)
-        licenceNumberTypeKey?.let {
+        val licenceNumberUpdateStepId = PropertyDetailsUpdateJourneyDataExtensions.getLicenceNumberUpdateStepId(licensingType)
+        licenceNumberUpdateStepId?.let {
             originalPropertyData[it.urlPathSegment] =
                 mapOf("licenceNumber" to propertyOwnership.license?.licenseNumber!!)
         }
@@ -122,79 +122,6 @@ class PropertyDetailsUpdateJourney(
                 ),
             handleSubmitAndRedirect = { _, _ -> UpdatePropertyDetailsStepId.UpdateDetails.urlPathSegment },
             nextAction = { _, _ -> Pair(UpdatePropertyDetailsStepId.UpdateLicensingType, null) },
-            saveAfterSubmit = false,
-        )
-
-    private val occupancyStep =
-        Step(
-            id = UpdatePropertyDetailsStepId.UpdateOccupancy,
-            page =
-                Page(
-                    formModel = OccupancyFormModel::class,
-                    templateName = "forms/propertyOccupancyForm",
-                    content =
-                        mapOf(
-                            "title" to "propertyDetails.update.title",
-                            "fieldSetHeading" to getOccupancyStepFieldSetHeading(),
-                            "radioOptions" to
-                                listOf(
-                                    RadiosButtonViewModel(
-                                        value = true,
-                                        valueStr = "yes",
-                                        labelMsgKey = "forms.radios.option.yes.label",
-                                        hintMsgKey = "forms.occupancy.radios.option.yes.hint",
-                                    ),
-                                    RadiosButtonViewModel(
-                                        value = false,
-                                        valueStr = "no",
-                                        labelMsgKey = "forms.radios.option.no.label",
-                                        hintMsgKey = "forms.occupancy.radios.option.no.hint",
-                                    ),
-                                ),
-                            BACK_URL_ATTR_NAME to UpdatePropertyDetailsStepId.UpdateDetails.urlPathSegment,
-                        ),
-                ),
-            nextAction = { journeyData, _ -> occupancyNextAction(journeyData) },
-            saveAfterSubmit = false,
-        )
-
-    private val numberOfHouseholdsStep =
-        Step(
-            id = UpdatePropertyDetailsStepId.UpdateNumberOfHouseholds,
-            page =
-                Page(
-                    formModel = NumberOfHouseholdsFormModel::class,
-                    templateName = "forms/numberOfHouseholdsForm",
-                    content =
-                        mapOf(
-                            "title" to "propertyDetails.update.title",
-                            "fieldSetHeading" to getNumberOfHouseholdsStepFieldSetHeading(),
-                            "label" to "forms.numberOfHouseholds.label",
-                            BACK_URL_ATTR_NAME to getNumberOfHouseholdsStepBackUrl(),
-                        ),
-                ),
-            nextAction = { _, _ -> Pair(UpdatePropertyDetailsStepId.UpdateNumberOfPeople, null) },
-            saveAfterSubmit = false,
-        )
-
-    private val numberOfPeopleStep =
-        Step(
-            id = UpdatePropertyDetailsStepId.UpdateNumberOfPeople,
-            page =
-                PropertyRegistrationNumberOfPeoplePage(
-                    formModel = NumberOfPeopleFormModel::class,
-                    templateName = "forms/numberOfPeopleForm",
-                    content =
-                        mapOf(
-                            "title" to "propertyDetails.update.title",
-                            "fieldSetHeading" to getNumberOfPeopleStepFieldSetHeading(),
-                            "fieldSetHint" to "forms.numberOfPeople.fieldSetHint",
-                            "label" to "forms.numberOfPeople.label",
-                            BACK_URL_ATTR_NAME to getNumberOfPeopleStepBackUrl(),
-                        ),
-                    journeyDataService = journeyDataService,
-                ),
-            nextAction = { _, _ -> Pair(UpdatePropertyDetailsStepId.UpdateDetails, null) },
             saveAfterSubmit = false,
         )
 
@@ -313,6 +240,79 @@ class PropertyDetailsUpdateJourney(
             saveAfterSubmit = false,
         )
 
+    private val occupancyStep =
+        Step(
+            id = UpdatePropertyDetailsStepId.UpdateOccupancy,
+            page =
+                Page(
+                    formModel = OccupancyFormModel::class,
+                    templateName = "forms/propertyOccupancyForm",
+                    content =
+                        mapOf(
+                            "title" to "propertyDetails.update.title",
+                            "fieldSetHeading" to getOccupancyStepFieldSetHeading(),
+                            "radioOptions" to
+                                listOf(
+                                    RadiosButtonViewModel(
+                                        value = true,
+                                        valueStr = "yes",
+                                        labelMsgKey = "forms.radios.option.yes.label",
+                                        hintMsgKey = "forms.occupancy.radios.option.yes.hint",
+                                    ),
+                                    RadiosButtonViewModel(
+                                        value = false,
+                                        valueStr = "no",
+                                        labelMsgKey = "forms.radios.option.no.label",
+                                        hintMsgKey = "forms.occupancy.radios.option.no.hint",
+                                    ),
+                                ),
+                            BACK_URL_ATTR_NAME to UpdatePropertyDetailsStepId.UpdateDetails.urlPathSegment,
+                        ),
+                ),
+            nextAction = { journeyData, _ -> occupancyNextAction(journeyData) },
+            saveAfterSubmit = false,
+        )
+
+    private val numberOfHouseholdsStep =
+        Step(
+            id = UpdatePropertyDetailsStepId.UpdateNumberOfHouseholds,
+            page =
+                Page(
+                    formModel = NumberOfHouseholdsFormModel::class,
+                    templateName = "forms/numberOfHouseholdsForm",
+                    content =
+                        mapOf(
+                            "title" to "propertyDetails.update.title",
+                            "fieldSetHeading" to getNumberOfHouseholdsStepFieldSetHeading(),
+                            "label" to "forms.numberOfHouseholds.label",
+                            BACK_URL_ATTR_NAME to getNumberOfHouseholdsStepBackUrl(),
+                        ),
+                ),
+            nextAction = { _, _ -> Pair(UpdatePropertyDetailsStepId.UpdateNumberOfPeople, null) },
+            saveAfterSubmit = false,
+        )
+
+    private val numberOfPeopleStep =
+        Step(
+            id = UpdatePropertyDetailsStepId.UpdateNumberOfPeople,
+            page =
+                PropertyRegistrationNumberOfPeoplePage(
+                    formModel = NumberOfPeopleFormModel::class,
+                    templateName = "forms/numberOfPeopleForm",
+                    content =
+                        mapOf(
+                            "title" to "propertyDetails.update.title",
+                            "fieldSetHeading" to getNumberOfPeopleStepFieldSetHeading(),
+                            "fieldSetHint" to "forms.numberOfPeople.fieldSetHint",
+                            "label" to "forms.numberOfPeople.label",
+                            BACK_URL_ATTR_NAME to getNumberOfPeopleStepBackUrl(),
+                        ),
+                    journeyDataService = journeyDataService,
+                ),
+            nextAction = { _, _ -> Pair(UpdatePropertyDetailsStepId.UpdateDetails, null) },
+            saveAfterSubmit = false,
+        )
+
     // The next action flow must have the `updateDetailsStep` after all data changing steps to ensure that validation for all of them is run
     override val sections =
         createSingleSectionWithSingleTaskFromSteps(
@@ -378,8 +378,8 @@ class PropertyDetailsUpdateJourney(
                 ownershipType = journeyData.getOwnershipTypeUpdateIfPresent(),
                 numberOfHouseholds = journeyData.getNumberOfHouseholdsUpdateIfPresent(),
                 numberOfPeople = journeyData.getNumberOfPeopleUpdateIfPresent(),
-                licensingType = journeyData.getLicensingTypeIfPresent(),
-                licenceNumber = journeyData.getLicenceNumberIfPresent(originalDataKey),
+                licensingType = journeyData.getLicensingTypeUpdateIfPresent(),
+                licenceNumber = journeyData.getLicenceNumberUpdateIfPresent(originalDataKey),
             )
 
         propertyOwnershipService.updatePropertyOwnership(propertyOwnershipId, propertyUpdate)
@@ -394,22 +394,22 @@ class PropertyDetailsUpdateJourney(
     private fun hasPropertyOccupancyBeenUpdated() = journeyDataService.getJourneyDataFromSession().getIsOccupiedUpdateIfPresent() != null
 
     private fun licensingTypeNextAction(journeyData: JourneyData): Pair<UpdatePropertyDetailsStepId, Int?> {
-        val licensingType = journeyData.getLicensingTypeIfPresent()!!
+        val licensingType = journeyData.getLicensingTypeUpdateIfPresent()!!
 
         val nextActionStepId =
-            PropertyDetailsUpdateJourneyDataExtensions.getUpdateStepUrlPathSegmentForLicensingType(licensingType)
+            PropertyDetailsUpdateJourneyDataExtensions.getLicenceNumberUpdateStepId(licensingType)
                 ?: UpdatePropertyDetailsStepId.UpdateOccupancy
 
         return Pair(nextActionStepId, null)
     }
 
     private fun licensingTypeHandleSubmitAndRedirect(journeyData: JourneyData): String {
-        val licensingType = journeyData.getLicensingTypeIfPresent()!!
+        val licensingType = journeyData.getLicensingTypeUpdateIfPresent()!!
 
-        val redirectUrlSegment =
-            PropertyDetailsUpdateJourneyDataExtensions.getUpdateStepUrlPathSegmentForLicensingType(licensingType)
+        val redirectStepId =
+            PropertyDetailsUpdateJourneyDataExtensions.getLicenceNumberUpdateStepId(licensingType)
                 ?: UpdatePropertyDetailsStepId.UpdateDetails
 
-        return redirectUrlSegment.urlPathSegment
+        return redirectStepId.urlPathSegment
     }
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/PropertyDetailsUpdateJourney.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/PropertyDetailsUpdateJourney.kt
@@ -3,6 +3,7 @@ package uk.gov.communities.prsdb.webapp.forms.journeys
 import org.springframework.validation.Validator
 import uk.gov.communities.prsdb.webapp.constants.BACK_URL_ATTR_NAME
 import uk.gov.communities.prsdb.webapp.constants.enums.JourneyType
+import uk.gov.communities.prsdb.webapp.constants.enums.LicensingType
 import uk.gov.communities.prsdb.webapp.constants.enums.OwnershipType
 import uk.gov.communities.prsdb.webapp.controllers.PropertyDetailsController
 import uk.gov.communities.prsdb.webapp.forms.JourneyData
@@ -10,18 +11,27 @@ import uk.gov.communities.prsdb.webapp.forms.pages.Page
 import uk.gov.communities.prsdb.webapp.forms.pages.PropertyRegistrationNumberOfPeoplePage
 import uk.gov.communities.prsdb.webapp.forms.steps.Step
 import uk.gov.communities.prsdb.webapp.forms.steps.UpdatePropertyDetailsStepId
+import uk.gov.communities.prsdb.webapp.helpers.PropertyRegistrationJourneyDataHelper
+import uk.gov.communities.prsdb.webapp.helpers.extensions.journeyDataExtensions.PropertyDetailsUpdateJourneyDataExtensions
 import uk.gov.communities.prsdb.webapp.helpers.extensions.journeyDataExtensions.PropertyDetailsUpdateJourneyDataExtensions.Companion.getIsOccupiedUpdateIfPresent
+import uk.gov.communities.prsdb.webapp.helpers.extensions.journeyDataExtensions.PropertyDetailsUpdateJourneyDataExtensions.Companion.getLicenceNumberIfPresent
+import uk.gov.communities.prsdb.webapp.helpers.extensions.journeyDataExtensions.PropertyDetailsUpdateJourneyDataExtensions.Companion.getLicensingTypeIfPresent
 import uk.gov.communities.prsdb.webapp.helpers.extensions.journeyDataExtensions.PropertyDetailsUpdateJourneyDataExtensions.Companion.getNumberOfHouseholdsUpdateIfPresent
 import uk.gov.communities.prsdb.webapp.helpers.extensions.journeyDataExtensions.PropertyDetailsUpdateJourneyDataExtensions.Companion.getNumberOfPeopleUpdateIfPresent
 import uk.gov.communities.prsdb.webapp.helpers.extensions.journeyDataExtensions.PropertyDetailsUpdateJourneyDataExtensions.Companion.getOriginalIsOccupied
 import uk.gov.communities.prsdb.webapp.helpers.extensions.journeyDataExtensions.PropertyDetailsUpdateJourneyDataExtensions.Companion.getOwnershipTypeUpdateIfPresent
 import uk.gov.communities.prsdb.webapp.models.dataModels.updateModels.PropertyOwnershipUpdateModel
+import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.HmoAdditionalLicenceFormModel
+import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.HmoMandatoryLicenceFormModel
+import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.LicensingTypeFormModel
 import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.NoInputFormModel
 import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.NumberOfHouseholdsFormModel
 import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.NumberOfPeopleFormModel
 import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.OccupancyFormModel
 import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.OwnershipTypeFormModel
+import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.SelectiveLicenceFormModel
 import uk.gov.communities.prsdb.webapp.models.viewModels.formModels.RadiosButtonViewModel
+import uk.gov.communities.prsdb.webapp.models.viewModels.formModels.RadiosDividerViewModel
 import uk.gov.communities.prsdb.webapp.services.JourneyDataService
 import uk.gov.communities.prsdb.webapp.services.PropertyOwnershipService
 
@@ -45,17 +55,26 @@ class PropertyDetailsUpdateJourney(
     override fun createOriginalJourneyData(): JourneyData {
         val propertyOwnership = propertyOwnershipService.getPropertyOwnership(propertyOwnershipId)
 
-        return mapOf(
-            UpdatePropertyDetailsStepId.UpdateOwnershipType.urlPathSegment to mapOf("ownershipType" to propertyOwnership.ownershipType),
-            UpdatePropertyDetailsStepId.UpdateOccupancy.urlPathSegment to mapOf("occupied" to propertyOwnership.isOccupied),
-            UpdatePropertyDetailsStepId.UpdateNumberOfHouseholds.urlPathSegment to
-                mapOf("numberOfHouseholds" to propertyOwnership.currentNumHouseholds),
-            UpdatePropertyDetailsStepId.UpdateNumberOfPeople.urlPathSegment to
-                mapOf(
-                    "numberOfPeople" to propertyOwnership.currentNumTenants,
-                    "numberOfHouseholds" to propertyOwnership.currentNumHouseholds,
-                ),
-        )
+        val licenceType = propertyOwnership.license?.licenseType ?: LicensingType.NO_LICENSING
+
+        val originalPropertyData =
+            mutableMapOf(
+                UpdatePropertyDetailsStepId.UpdateOwnershipType.urlPathSegment to mapOf("ownershipType" to propertyOwnership.ownershipType),
+                UpdatePropertyDetailsStepId.UpdateOccupancy.urlPathSegment to mapOf("occupied" to propertyOwnership.isOccupied),
+                UpdatePropertyDetailsStepId.UpdateNumberOfHouseholds.urlPathSegment to
+                    mapOf("numberOfHouseholds" to propertyOwnership.currentNumHouseholds),
+                UpdatePropertyDetailsStepId.UpdateNumberOfPeople.urlPathSegment to
+                    mapOf(
+                        "numberOfPeople" to propertyOwnership.currentNumTenants,
+                        "numberOfHouseholds" to propertyOwnership.currentNumHouseholds,
+                    ),
+                UpdatePropertyDetailsStepId.UpdateLicensingType.urlPathSegment to mapOf("licensingType" to licenceType),
+            )
+
+        val licenceNumberTypeKey = PropertyDetailsUpdateJourneyDataExtensions.getLicenceNumberKey(licenceType)
+        licenceNumberTypeKey?.let { originalPropertyData[it] = mapOf("licenceNumber" to propertyOwnership.license?.licenseNumber!!) }
+
+        return originalPropertyData
     }
 
     private val updateDetailsStep =
@@ -173,6 +192,117 @@ class PropertyDetailsUpdateJourney(
                         ),
                     journeyDataService = journeyDataService,
                 ),
+            nextAction = { _, _ -> Pair(UpdatePropertyDetailsStepId.UpdateLicensingType, null) },
+            saveAfterSubmit = false,
+        )
+
+    private val licensingTypeStep =
+        Step(
+            id = UpdatePropertyDetailsStepId.UpdateLicensingType,
+            page =
+                Page(
+                    formModel = LicensingTypeFormModel::class,
+                    templateName = "forms/licensingTypeForm",
+                    content =
+                        mapOf(
+                            "title" to "propertyDetails.update.title",
+                            "fieldSetHeading" to "forms.update.licensingType.fieldSetHeading",
+                            "fieldSetHint" to "forms.licensingType.fieldSetHint",
+                            "radioOptions" to
+                                listOf(
+                                    RadiosButtonViewModel(
+                                        value = LicensingType.SELECTIVE_LICENCE,
+                                        labelMsgKey = "forms.licensingType.radios.option.selectiveLicence.label",
+                                        hintMsgKey = "forms.licensingType.radios.option.selectiveLicence.hint",
+                                    ),
+                                    RadiosButtonViewModel(
+                                        value = LicensingType.HMO_MANDATORY_LICENCE,
+                                        labelMsgKey = "forms.licensingType.radios.option.hmoMandatory.label",
+                                        hintMsgKey = "forms.licensingType.radios.option.hmoMandatory.hint",
+                                    ),
+                                    RadiosButtonViewModel(
+                                        value = LicensingType.HMO_ADDITIONAL_LICENCE,
+                                        labelMsgKey = "forms.licensingType.radios.option.hmoAdditional.label",
+                                        hintMsgKey = "forms.licensingType.radios.option.hmoAdditional.hint",
+                                    ),
+                                    RadiosDividerViewModel("forms.radios.dividerText"),
+                                    RadiosButtonViewModel(
+                                        value = LicensingType.NO_LICENSING,
+                                        labelMsgKey = "forms.licensingType.radios.option.noLicensing.label",
+                                    ),
+                                ),
+                            BACK_URL_ATTR_NAME to UpdatePropertyDetailsStepId.UpdateDetails.urlPathSegment,
+                        ),
+                ),
+            nextAction = { journeyData, _ -> licensingTypeNextAction(journeyData) },
+            saveAfterSubmit = false,
+        )
+
+    private val selectiveLicenceStep =
+        Step(
+            id = UpdatePropertyDetailsStepId.UpdateSelectiveLicence,
+            page =
+                Page(
+                    formModel = SelectiveLicenceFormModel::class,
+                    templateName = "forms/licenceNumberForm",
+                    content =
+                        mapOf(
+                            "title" to "registerProperty.title",
+                            "fieldSetHeading" to "forms.selectiveLicence.fieldSetHeading",
+                            "label" to "forms.selectiveLicence.label",
+                            "detailSummary" to "forms.selectiveLicence.detail.summary",
+                            "detailMainText" to "forms.selectiveLicence.detail.text",
+                            BACK_URL_ATTR_NAME to UpdatePropertyDetailsStepId.UpdateLicensingType.urlPathSegment,
+                        ),
+                ),
+            nextAction = { _, _ -> Pair(UpdatePropertyDetailsStepId.UpdateDetails, null) },
+            saveAfterSubmit = false,
+        )
+
+    private val hmoMandatoryLicenceStep =
+        Step(
+            id = UpdatePropertyDetailsStepId.UpdateHmoMandatoryLicence,
+            page =
+                Page(
+                    formModel = HmoMandatoryLicenceFormModel::class,
+                    templateName = "forms/licenceNumberForm",
+                    content =
+                        mapOf(
+                            "title" to "registerProperty.title",
+                            "fieldSetHeading" to "forms.hmoMandatoryLicence.fieldSetHeading",
+                            "label" to "forms.hmoMandatoryLicence.label",
+                            "detailSummary" to "forms.hmoMandatoryLicence.detail.summary",
+                            "detailMainText" to "forms.hmoMandatoryLicence.detail.paragraph.one",
+                            "detailAdditionalContent" to
+                                mapOf(
+                                    "bulletOne" to "forms.hmoMandatoryLicence.detail.bullet.one",
+                                    "bulletTwo" to "forms.hmoMandatoryLicence.detail.bullet.two",
+                                    "text" to "forms.hmoMandatoryLicence.detail.paragraph.two",
+                                ),
+                            BACK_URL_ATTR_NAME to UpdatePropertyDetailsStepId.UpdateLicensingType.urlPathSegment,
+                        ),
+                ),
+            nextAction = { _, _ -> Pair(UpdatePropertyDetailsStepId.UpdateDetails, null) },
+            saveAfterSubmit = false,
+        )
+
+    private val hmoAdditionalLicenceStep =
+        Step(
+            id = UpdatePropertyDetailsStepId.UpdateHmoAdditionalLicence,
+            page =
+                Page(
+                    formModel = HmoAdditionalLicenceFormModel::class,
+                    templateName = "forms/licenceNumberForm",
+                    content =
+                        mapOf(
+                            "title" to "registerProperty.title",
+                            "fieldSetHeading" to "forms.hmoAdditionalLicence.fieldSetHeading",
+                            "label" to "forms.hmoAdditionalLicence.label",
+                            "detailSummary" to "forms.hmoAdditionalLicence.detail.summary",
+                            "detailMainText" to "forms.hmoAdditionalLicence.detail.text",
+                            BACK_URL_ATTR_NAME to UpdatePropertyDetailsStepId.UpdateLicensingType.urlPathSegment,
+                        ),
+                ),
             nextAction = { _, _ -> Pair(UpdatePropertyDetailsStepId.UpdateDetails, null) },
             saveAfterSubmit = false,
         )
@@ -181,7 +311,17 @@ class PropertyDetailsUpdateJourney(
     override val sections =
         createSingleSectionWithSingleTaskFromSteps(
             initialStepId,
-            setOf(ownershipTypeStep, occupancyStep, numberOfHouseholdsStep, numberOfPeopleStep, updateDetailsStep),
+            setOf(
+                ownershipTypeStep,
+                occupancyStep,
+                numberOfHouseholdsStep,
+                numberOfPeopleStep,
+                licensingTypeStep,
+                selectiveLicenceStep,
+                hmoMandatoryLicenceStep,
+                hmoAdditionalLicenceStep,
+                updateDetailsStep,
+            ),
         )
 
     private fun getOccupancyStepFieldSetHeading() =
@@ -223,7 +363,7 @@ class PropertyDetailsUpdateJourney(
         if (journeyData.getIsOccupiedUpdateIfPresent()!!) {
             Pair(UpdatePropertyDetailsStepId.UpdateNumberOfHouseholds, null)
         } else {
-            Pair(UpdatePropertyDetailsStepId.UpdateDetails, null)
+            Pair(UpdatePropertyDetailsStepId.UpdateLicensingType, null)
         }
 
     private fun updatePropertyAndRedirect(journeyData: JourneyData): String {
@@ -232,6 +372,8 @@ class PropertyDetailsUpdateJourney(
                 ownershipType = journeyData.getOwnershipTypeUpdateIfPresent(),
                 numberOfHouseholds = journeyData.getNumberOfHouseholdsUpdateIfPresent(),
                 numberOfPeople = journeyData.getNumberOfPeopleUpdateIfPresent(),
+                licenceType = journeyData.getLicensingTypeIfPresent(),
+                licenceNumber = journeyData.getLicenceNumberIfPresent(originalDataKey),
             )
 
         propertyOwnershipService.updatePropertyOwnership(propertyOwnershipId, propertyUpdate)
@@ -244,4 +386,12 @@ class PropertyDetailsUpdateJourney(
     private fun wasPropertyOriginallyOccupied() = journeyDataService.getJourneyDataFromSession().getOriginalIsOccupied(originalDataKey)!!
 
     private fun hasPropertyOccupancyBeenUpdated() = journeyDataService.getJourneyDataFromSession().getIsOccupiedUpdateIfPresent() != null
+
+    private fun licensingTypeNextAction(journeyData: JourneyData): Pair<UpdatePropertyDetailsStepId, Int?> =
+        when (PropertyRegistrationJourneyDataHelper.getLicensingType(journeyData)!!) {
+            LicensingType.SELECTIVE_LICENCE -> Pair(UpdatePropertyDetailsStepId.UpdateSelectiveLicence, null)
+            LicensingType.HMO_MANDATORY_LICENCE -> Pair(UpdatePropertyDetailsStepId.UpdateHmoMandatoryLicence, null)
+            LicensingType.HMO_ADDITIONAL_LICENCE -> Pair(UpdatePropertyDetailsStepId.UpdateHmoAdditionalLicence, null)
+            LicensingType.NO_LICENSING -> Pair(UpdatePropertyDetailsStepId.UpdateDetails, null)
+        }
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/PropertyDetailsUpdateJourney.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/PropertyDetailsUpdateJourney.kt
@@ -54,7 +54,7 @@ class PropertyDetailsUpdateJourney(
     override fun createOriginalJourneyData(): JourneyData {
         val propertyOwnership = propertyOwnershipService.getPropertyOwnership(propertyOwnershipId)
 
-        val licenceType = propertyOwnership.license?.licenseType ?: LicensingType.NO_LICENSING
+        val licensingType = propertyOwnership.license?.licenseType ?: LicensingType.NO_LICENSING
 
         val originalPropertyData =
             mutableMapOf(
@@ -67,10 +67,10 @@ class PropertyDetailsUpdateJourney(
                         "numberOfPeople" to propertyOwnership.currentNumTenants,
                         "numberOfHouseholds" to propertyOwnership.currentNumHouseholds,
                     ),
-                UpdatePropertyDetailsStepId.UpdateLicensingType.urlPathSegment to mapOf("licensingType" to licenceType),
+                UpdatePropertyDetailsStepId.UpdateLicensingType.urlPathSegment to mapOf("licensingType" to licensingType),
             )
 
-        val licenceNumberTypeKey = PropertyDetailsUpdateJourneyDataExtensions.getLicenceNumberKey(licenceType)
+        val licenceNumberTypeKey = PropertyDetailsUpdateJourneyDataExtensions.getLicenceNumberKey(licensingType)
         licenceNumberTypeKey?.let { originalPropertyData[it] = mapOf("licenceNumber" to propertyOwnership.license?.licenseNumber!!) }
 
         return originalPropertyData
@@ -375,7 +375,7 @@ class PropertyDetailsUpdateJourney(
                 ownershipType = journeyData.getOwnershipTypeUpdateIfPresent(),
                 numberOfHouseholds = journeyData.getNumberOfHouseholdsUpdateIfPresent(),
                 numberOfPeople = journeyData.getNumberOfPeopleUpdateIfPresent(),
-                licenceType = journeyData.getLicensingTypeIfPresent(),
+                licensingType = journeyData.getLicensingTypeIfPresent(),
                 licenceNumber = journeyData.getLicenceNumberIfPresent(originalDataKey),
             )
 

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/PropertyDetailsUpdateJourney.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/PropertyDetailsUpdateJourney.kt
@@ -11,7 +11,6 @@ import uk.gov.communities.prsdb.webapp.forms.pages.Page
 import uk.gov.communities.prsdb.webapp.forms.pages.PropertyRegistrationNumberOfPeoplePage
 import uk.gov.communities.prsdb.webapp.forms.steps.Step
 import uk.gov.communities.prsdb.webapp.forms.steps.UpdatePropertyDetailsStepId
-import uk.gov.communities.prsdb.webapp.helpers.PropertyRegistrationJourneyDataHelper
 import uk.gov.communities.prsdb.webapp.helpers.extensions.journeyDataExtensions.PropertyDetailsUpdateJourneyDataExtensions
 import uk.gov.communities.prsdb.webapp.helpers.extensions.journeyDataExtensions.PropertyDetailsUpdateJourneyDataExtensions.Companion.getIsOccupiedUpdateIfPresent
 import uk.gov.communities.prsdb.webapp.helpers.extensions.journeyDataExtensions.PropertyDetailsUpdateJourneyDataExtensions.Companion.getLicenceNumberIfPresent
@@ -119,7 +118,7 @@ class PropertyDetailsUpdateJourney(
                         ),
                 ),
             handleSubmitAndRedirect = { _, _ -> UpdatePropertyDetailsStepId.UpdateDetails.urlPathSegment },
-            nextAction = { _, _ -> Pair(UpdatePropertyDetailsStepId.UpdateOccupancy, null) },
+            nextAction = { _, _ -> Pair(UpdatePropertyDetailsStepId.UpdateLicensingType, null) },
             saveAfterSubmit = false,
         )
 
@@ -192,7 +191,7 @@ class PropertyDetailsUpdateJourney(
                         ),
                     journeyDataService = journeyDataService,
                 ),
-            nextAction = { _, _ -> Pair(UpdatePropertyDetailsStepId.UpdateLicensingType, null) },
+            nextAction = { _, _ -> Pair(UpdatePropertyDetailsStepId.UpdateDetails, null) },
             saveAfterSubmit = false,
         )
 
@@ -234,6 +233,7 @@ class PropertyDetailsUpdateJourney(
                             BACK_URL_ATTR_NAME to UpdatePropertyDetailsStepId.UpdateDetails.urlPathSegment,
                         ),
                 ),
+            handleSubmitAndRedirect = { journeyData, _ -> licensingTypeHandleSubmitAndRedirect(journeyData) },
             nextAction = { journeyData, _ -> licensingTypeNextAction(journeyData) },
             saveAfterSubmit = false,
         )
@@ -255,7 +255,8 @@ class PropertyDetailsUpdateJourney(
                             BACK_URL_ATTR_NAME to UpdatePropertyDetailsStepId.UpdateLicensingType.urlPathSegment,
                         ),
                 ),
-            nextAction = { _, _ -> Pair(UpdatePropertyDetailsStepId.UpdateDetails, null) },
+            handleSubmitAndRedirect = { _, _ -> UpdatePropertyDetailsStepId.UpdateDetails.urlPathSegment },
+            nextAction = { _, _ -> Pair(UpdatePropertyDetailsStepId.UpdateOccupancy, null) },
             saveAfterSubmit = false,
         )
 
@@ -282,7 +283,8 @@ class PropertyDetailsUpdateJourney(
                             BACK_URL_ATTR_NAME to UpdatePropertyDetailsStepId.UpdateLicensingType.urlPathSegment,
                         ),
                 ),
-            nextAction = { _, _ -> Pair(UpdatePropertyDetailsStepId.UpdateDetails, null) },
+            handleSubmitAndRedirect = { _, _ -> UpdatePropertyDetailsStepId.UpdateDetails.urlPathSegment },
+            nextAction = { _, _ -> Pair(UpdatePropertyDetailsStepId.UpdateOccupancy, null) },
             saveAfterSubmit = false,
         )
 
@@ -303,7 +305,8 @@ class PropertyDetailsUpdateJourney(
                             BACK_URL_ATTR_NAME to UpdatePropertyDetailsStepId.UpdateLicensingType.urlPathSegment,
                         ),
                 ),
-            nextAction = { _, _ -> Pair(UpdatePropertyDetailsStepId.UpdateDetails, null) },
+            handleSubmitAndRedirect = { _, _ -> UpdatePropertyDetailsStepId.UpdateDetails.urlPathSegment },
+            nextAction = { _, _ -> Pair(UpdatePropertyDetailsStepId.UpdateOccupancy, null) },
             saveAfterSubmit = false,
         )
 
@@ -313,13 +316,13 @@ class PropertyDetailsUpdateJourney(
             initialStepId,
             setOf(
                 ownershipTypeStep,
-                occupancyStep,
-                numberOfHouseholdsStep,
-                numberOfPeopleStep,
                 licensingTypeStep,
                 selectiveLicenceStep,
                 hmoMandatoryLicenceStep,
                 hmoAdditionalLicenceStep,
+                occupancyStep,
+                numberOfHouseholdsStep,
+                numberOfPeopleStep,
                 updateDetailsStep,
             ),
         )
@@ -363,7 +366,7 @@ class PropertyDetailsUpdateJourney(
         if (journeyData.getIsOccupiedUpdateIfPresent()!!) {
             Pair(UpdatePropertyDetailsStepId.UpdateNumberOfHouseholds, null)
         } else {
-            Pair(UpdatePropertyDetailsStepId.UpdateLicensingType, null)
+            Pair(UpdatePropertyDetailsStepId.UpdateDetails, null)
         }
 
     private fun updatePropertyAndRedirect(journeyData: JourneyData): String {
@@ -388,10 +391,18 @@ class PropertyDetailsUpdateJourney(
     private fun hasPropertyOccupancyBeenUpdated() = journeyDataService.getJourneyDataFromSession().getIsOccupiedUpdateIfPresent() != null
 
     private fun licensingTypeNextAction(journeyData: JourneyData): Pair<UpdatePropertyDetailsStepId, Int?> =
-        when (PropertyRegistrationJourneyDataHelper.getLicensingType(journeyData)!!) {
+        when (journeyData.getLicensingTypeIfPresent()!!) {
             LicensingType.SELECTIVE_LICENCE -> Pair(UpdatePropertyDetailsStepId.UpdateSelectiveLicence, null)
             LicensingType.HMO_MANDATORY_LICENCE -> Pair(UpdatePropertyDetailsStepId.UpdateHmoMandatoryLicence, null)
             LicensingType.HMO_ADDITIONAL_LICENCE -> Pair(UpdatePropertyDetailsStepId.UpdateHmoAdditionalLicence, null)
-            LicensingType.NO_LICENSING -> Pair(UpdatePropertyDetailsStepId.UpdateDetails, null)
+            LicensingType.NO_LICENSING -> Pair(UpdatePropertyDetailsStepId.UpdateOccupancy, null)
+        }
+
+    private fun licensingTypeHandleSubmitAndRedirect(journeyData: JourneyData): String =
+        when (journeyData.getLicensingTypeIfPresent()!!) {
+            LicensingType.SELECTIVE_LICENCE -> UpdatePropertyDetailsStepId.UpdateSelectiveLicence.urlPathSegment
+            LicensingType.HMO_MANDATORY_LICENCE -> UpdatePropertyDetailsStepId.UpdateHmoMandatoryLicence.urlPathSegment
+            LicensingType.HMO_ADDITIONAL_LICENCE -> UpdatePropertyDetailsStepId.UpdateHmoAdditionalLicence.urlPathSegment
+            LicensingType.NO_LICENSING -> UpdatePropertyDetailsStepId.UpdateDetails.urlPathSegment
         }
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/PropertyRegistrationJourney.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/PropertyRegistrationJourney.kt
@@ -332,74 +332,6 @@ class PropertyRegistrationJourney(
             nextAction = { _, _ -> Pair(RegisterPropertyStepId.LicensingType, null) },
         )
 
-    private fun occupancyStep() =
-        Step(
-            id = RegisterPropertyStepId.Occupancy,
-            page =
-                Page(
-                    formModel = OccupancyFormModel::class,
-                    templateName = "forms/propertyOccupancyForm",
-                    content =
-                        mapOf(
-                            "title" to "registerProperty.title",
-                            "fieldSetHeading" to "forms.occupancy.fieldSetHeading",
-                            "radioOptions" to
-                                listOf(
-                                    RadiosButtonViewModel(
-                                        value = true,
-                                        labelMsgKey = "forms.radios.option.yes.label",
-                                        hintMsgKey = "forms.occupancy.radios.option.yes.hint",
-                                    ),
-                                    RadiosButtonViewModel(
-                                        value = false,
-                                        labelMsgKey = "forms.radios.option.no.label",
-                                        hintMsgKey = "forms.occupancy.radios.option.no.hint",
-                                    ),
-                                ),
-                        ),
-                    shouldDisplaySectionHeader = true,
-                ),
-            nextAction = { journeyData, _ -> occupancyNextAction(journeyData) },
-        )
-
-    private fun numberOfHouseholdsStep() =
-        Step(
-            id = RegisterPropertyStepId.NumberOfHouseholds,
-            page =
-                Page(
-                    formModel = NumberOfHouseholdsFormModel::class,
-                    templateName = "forms/numberOfHouseholdsForm",
-                    content =
-                        mapOf(
-                            "title" to "registerProperty.title",
-                            "fieldSetHeading" to "forms.numberOfHouseholds.fieldSetHeading",
-                            "label" to "forms.numberOfHouseholds.label",
-                        ),
-                    shouldDisplaySectionHeader = true,
-                ),
-            nextAction = { _, _ -> Pair(RegisterPropertyStepId.NumberOfPeople, null) },
-        )
-
-    private fun numberOfPeopleStep() =
-        Step(
-            id = RegisterPropertyStepId.NumberOfPeople,
-            page =
-                PropertyRegistrationNumberOfPeoplePage(
-                    formModel = NumberOfPeopleFormModel::class,
-                    templateName = "forms/numberOfPeopleForm",
-                    content =
-                        mapOf(
-                            "title" to "registerProperty.title",
-                            "fieldSetHeading" to "forms.numberOfPeople.fieldSetHeading",
-                            "fieldSetHint" to "forms.numberOfPeople.fieldSetHint",
-                            "label" to "forms.numberOfPeople.label",
-                        ),
-                    shouldDisplaySectionHeader = true,
-                    journeyDataService = journeyDataService,
-                ),
-            nextAction = { _, _ -> Pair(RegisterPropertyStepId.CheckAnswers, null) },
-        )
-
     private fun licensingTypeStep() =
         Step(
             id = RegisterPropertyStepId.LicensingType,
@@ -505,6 +437,74 @@ class PropertyRegistrationJourney(
                     shouldDisplaySectionHeader = true,
                 ),
             nextAction = { _, _ -> Pair(RegisterPropertyStepId.Occupancy, null) },
+        )
+
+    private fun occupancyStep() =
+        Step(
+            id = RegisterPropertyStepId.Occupancy,
+            page =
+                Page(
+                    formModel = OccupancyFormModel::class,
+                    templateName = "forms/propertyOccupancyForm",
+                    content =
+                        mapOf(
+                            "title" to "registerProperty.title",
+                            "fieldSetHeading" to "forms.occupancy.fieldSetHeading",
+                            "radioOptions" to
+                                listOf(
+                                    RadiosButtonViewModel(
+                                        value = true,
+                                        labelMsgKey = "forms.radios.option.yes.label",
+                                        hintMsgKey = "forms.occupancy.radios.option.yes.hint",
+                                    ),
+                                    RadiosButtonViewModel(
+                                        value = false,
+                                        labelMsgKey = "forms.radios.option.no.label",
+                                        hintMsgKey = "forms.occupancy.radios.option.no.hint",
+                                    ),
+                                ),
+                        ),
+                    shouldDisplaySectionHeader = true,
+                ),
+            nextAction = { journeyData, _ -> occupancyNextAction(journeyData) },
+        )
+
+    private fun numberOfHouseholdsStep() =
+        Step(
+            id = RegisterPropertyStepId.NumberOfHouseholds,
+            page =
+                Page(
+                    formModel = NumberOfHouseholdsFormModel::class,
+                    templateName = "forms/numberOfHouseholdsForm",
+                    content =
+                        mapOf(
+                            "title" to "registerProperty.title",
+                            "fieldSetHeading" to "forms.numberOfHouseholds.fieldSetHeading",
+                            "label" to "forms.numberOfHouseholds.label",
+                        ),
+                    shouldDisplaySectionHeader = true,
+                ),
+            nextAction = { _, _ -> Pair(RegisterPropertyStepId.NumberOfPeople, null) },
+        )
+
+    private fun numberOfPeopleStep() =
+        Step(
+            id = RegisterPropertyStepId.NumberOfPeople,
+            page =
+                PropertyRegistrationNumberOfPeoplePage(
+                    formModel = NumberOfPeopleFormModel::class,
+                    templateName = "forms/numberOfPeopleForm",
+                    content =
+                        mapOf(
+                            "title" to "registerProperty.title",
+                            "fieldSetHeading" to "forms.numberOfPeople.fieldSetHeading",
+                            "fieldSetHint" to "forms.numberOfPeople.fieldSetHint",
+                            "label" to "forms.numberOfPeople.label",
+                        ),
+                    shouldDisplaySectionHeader = true,
+                    journeyDataService = journeyDataService,
+                ),
+            nextAction = { _, _ -> Pair(RegisterPropertyStepId.CheckAnswers, null) },
         )
 
     private fun checkAnswersStep() =

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/steps/UpdatePropertyDetailsStepId.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/steps/UpdatePropertyDetailsStepId.kt
@@ -9,5 +9,9 @@ enum class UpdatePropertyDetailsStepId(
     UpdateOccupancy("occupancy"),
     UpdateNumberOfHouseholds("number-of-households"),
     UpdateNumberOfPeople("number-of-people"),
+    UpdateLicensingType("licensing-type"),
+    UpdateSelectiveLicence("selective-licence"),
+    UpdateHmoMandatoryLicence("hmo-mandatory-licence"),
+    UpdateHmoAdditionalLicence("hmo-additional-licence"),
     UpdateDetails(DETAILS_PATH_SEGMENT),
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/helpers/extensions/journeyDataExtensions/PropertyDetailsUpdateJourneyDataExtensions.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/helpers/extensions/journeyDataExtensions/PropertyDetailsUpdateJourneyDataExtensions.kt
@@ -5,8 +5,6 @@ import uk.gov.communities.prsdb.webapp.constants.enums.OwnershipType
 import uk.gov.communities.prsdb.webapp.forms.JourneyData
 import uk.gov.communities.prsdb.webapp.forms.steps.UpdatePropertyDetailsStepId
 import uk.gov.communities.prsdb.webapp.helpers.JourneyDataHelper
-import uk.gov.communities.prsdb.webapp.helpers.JourneyDataHelper.Companion.getFieldEnumValue
-import uk.gov.communities.prsdb.webapp.helpers.JourneyDataHelper.Companion.getFieldStringValue
 
 class PropertyDetailsUpdateJourneyDataExtensions {
     companion object {
@@ -45,7 +43,7 @@ class PropertyDetailsUpdateJourneyDataExtensions {
             }
 
         fun JourneyData.getLicensingTypeUpdateIfPresent(): LicensingType? =
-            getFieldEnumValue<LicensingType>(
+            JourneyDataHelper.getFieldEnumValue<LicensingType>(
                 this,
                 UpdatePropertyDetailsStepId.UpdateLicensingType.urlPathSegment,
                 "licensingType",
@@ -57,7 +55,7 @@ class PropertyDetailsUpdateJourneyDataExtensions {
                 return null
             } else {
                 val licenseNumberUpdateStepId = getLicenceNumberUpdateStepId(licensingType)
-                return getFieldStringValue(this, licenseNumberUpdateStepId!!.urlPathSegment, "licenceNumber")
+                return JourneyDataHelper.getFieldStringValue(this, licenseNumberUpdateStepId!!.urlPathSegment, "licenceNumber")
             }
         }
 

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/helpers/extensions/journeyDataExtensions/PropertyDetailsUpdateJourneyDataExtensions.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/helpers/extensions/journeyDataExtensions/PropertyDetailsUpdateJourneyDataExtensions.kt
@@ -44,22 +44,24 @@ class PropertyDetailsUpdateJourneyDataExtensions {
                 )
             }
 
-        fun JourneyData.getLicensingTypeIfPresent(): LicensingType? =
+        fun JourneyData.getLicensingTypeUpdateIfPresent(): LicensingType? =
             getFieldEnumValue<LicensingType>(
                 this,
                 UpdatePropertyDetailsStepId.UpdateLicensingType.urlPathSegment,
                 "licensingType",
             )
 
-        fun JourneyData.getLicenceNumberIfPresent(originalJourneyKey: String): String? {
-            val licensingType = getLicensingTypeIfPresent() ?: this.getOriginalLicensingType(originalJourneyKey)
-
-            val licenseNumberPathSegment = getUpdateStepUrlPathSegmentForLicensingType(licensingType)
-
-            return licenseNumberPathSegment?.let { getFieldStringValue(this, it.urlPathSegment, "licenceNumber") }
+        fun JourneyData.getLicenceNumberUpdateIfPresent(originalJourneyKey: String): String? {
+            val licensingType = this.getLicensingTypeUpdateIfPresent() ?: this.getOriginalLicensingType(originalJourneyKey) ?: return null
+            if (licensingType == LicensingType.NO_LICENSING) {
+                return null
+            } else {
+                val licenseNumberUpdateStepId = getLicenceNumberUpdateStepId(licensingType)
+                return getFieldStringValue(this, licenseNumberUpdateStepId!!.urlPathSegment, "licenceNumber")
+            }
         }
 
-        fun getUpdateStepUrlPathSegmentForLicensingType(licensingType: LicensingType?): UpdatePropertyDetailsStepId? =
+        fun getLicenceNumberUpdateStepId(licensingType: LicensingType?): UpdatePropertyDetailsStepId? =
             when (licensingType) {
                 LicensingType.SELECTIVE_LICENCE -> UpdatePropertyDetailsStepId.UpdateSelectiveLicence
                 LicensingType.HMO_MANDATORY_LICENCE -> UpdatePropertyDetailsStepId.UpdateHmoMandatoryLicence
@@ -75,6 +77,6 @@ class PropertyDetailsUpdateJourneyDataExtensions {
             )
 
         private fun JourneyData.getOriginalLicensingType(originalJourneyKey: String) =
-            JourneyDataHelper.getPageData(this, originalJourneyKey)?.getLicensingTypeIfPresent()
+            JourneyDataHelper.getPageData(this, originalJourneyKey)?.getLicensingTypeUpdateIfPresent()
     }
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/helpers/extensions/journeyDataExtensions/PropertyDetailsUpdateJourneyDataExtensions.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/helpers/extensions/journeyDataExtensions/PropertyDetailsUpdateJourneyDataExtensions.kt
@@ -54,16 +54,16 @@ class PropertyDetailsUpdateJourneyDataExtensions {
         fun JourneyData.getLicenceNumberIfPresent(originalJourneyKey: String): String? {
             val licensingType = getLicensingTypeIfPresent() ?: this.getOriginalLicensingType(originalJourneyKey)
 
-            val licenseNumberPathSegment = getLicenceNumberKey(licensingType)
+            val licenseNumberPathSegment = getUpdateStepUrlPathSegmentForLicensingType(licensingType)
 
-            return licenseNumberPathSegment?.let { getFieldStringValue(this, it, "licenceNumber") }
+            return licenseNumberPathSegment?.let { getFieldStringValue(this, it.urlPathSegment, "licenceNumber") }
         }
 
-        fun getLicenceNumberKey(licensingType: LicensingType?): String? =
+        fun getUpdateStepUrlPathSegmentForLicensingType(licensingType: LicensingType?): UpdatePropertyDetailsStepId? =
             when (licensingType) {
-                LicensingType.SELECTIVE_LICENCE -> UpdatePropertyDetailsStepId.UpdateSelectiveLicence.urlPathSegment
-                LicensingType.HMO_MANDATORY_LICENCE -> UpdatePropertyDetailsStepId.UpdateHmoMandatoryLicence.urlPathSegment
-                LicensingType.HMO_ADDITIONAL_LICENCE -> UpdatePropertyDetailsStepId.UpdateHmoAdditionalLicence.urlPathSegment
+                LicensingType.SELECTIVE_LICENCE -> UpdatePropertyDetailsStepId.UpdateSelectiveLicence
+                LicensingType.HMO_MANDATORY_LICENCE -> UpdatePropertyDetailsStepId.UpdateHmoMandatoryLicence
+                LicensingType.HMO_ADDITIONAL_LICENCE -> UpdatePropertyDetailsStepId.UpdateHmoAdditionalLicence
                 else -> null
             }
 

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/dataModels/updateModels/PropertyOwnershipUpdateModel.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/dataModels/updateModels/PropertyOwnershipUpdateModel.kt
@@ -10,7 +10,5 @@ data class PropertyOwnershipUpdateModel(
     val licensingType: LicensingType?,
     val licenceNumber: String?,
 ) {
-    companion object {
-        fun PropertyOwnershipUpdateModel.isLicenceUpdatable(): Boolean = this.licensingType != null || this.licenceNumber != null
-    }
+    fun isLicenceUpdatable(): Boolean = this.licensingType != null || this.licenceNumber != null
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/dataModels/updateModels/PropertyOwnershipUpdateModel.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/dataModels/updateModels/PropertyOwnershipUpdateModel.kt
@@ -7,6 +7,6 @@ data class PropertyOwnershipUpdateModel(
     val ownershipType: OwnershipType?,
     val numberOfHouseholds: Int?,
     val numberOfPeople: Int?,
-    val licenceType: LicensingType?,
+    val licensingType: LicensingType?,
     val licenceNumber: String?,
 )

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/dataModels/updateModels/PropertyOwnershipUpdateModel.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/dataModels/updateModels/PropertyOwnershipUpdateModel.kt
@@ -9,4 +9,8 @@ data class PropertyOwnershipUpdateModel(
     val numberOfPeople: Int?,
     val licensingType: LicensingType?,
     val licenceNumber: String?,
-)
+) {
+    companion object {
+        fun PropertyOwnershipUpdateModel.isLicenceUpdatable(): Boolean = this.licensingType != null || this.licenceNumber != null
+    }
+}

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/dataModels/updateModels/PropertyOwnershipUpdateModel.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/dataModels/updateModels/PropertyOwnershipUpdateModel.kt
@@ -1,9 +1,12 @@
 package uk.gov.communities.prsdb.webapp.models.dataModels.updateModels
 
+import uk.gov.communities.prsdb.webapp.constants.enums.LicensingType
 import uk.gov.communities.prsdb.webapp.constants.enums.OwnershipType
 
 data class PropertyOwnershipUpdateModel(
     val ownershipType: OwnershipType?,
     val numberOfHouseholds: Int?,
     val numberOfPeople: Int?,
+    val licenceType: LicensingType?,
+    val licenceNumber: String?,
 )

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/summaryModels/PropertyDetailsViewModel.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/summaryModels/PropertyDetailsViewModel.kt
@@ -79,7 +79,8 @@ class PropertyDetailsViewModel(
                             listOf(MessageKeyConverter.convert(it.licenseType), it.licenseNumber)
                         }
                     } ?: MessageKeyConverter.convert(LicensingType.NO_LICENSING),
-                    // TODO PRSD-798: Add update link
+                    UpdatePropertyDetailsStepId.UpdateLicensingType.urlPathSegment,
+                    withChangeLinks,
                 )
                 addRow(
                     "propertyDetails.propertyRecord.occupied",

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/LicenseService.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/LicenseService.kt
@@ -1,5 +1,6 @@
 package uk.gov.communities.prsdb.webapp.services
 
+import jakarta.transaction.Transactional
 import org.springframework.stereotype.Service
 import uk.gov.communities.prsdb.webapp.constants.enums.LicensingType
 import uk.gov.communities.prsdb.webapp.database.entity.License
@@ -24,13 +25,20 @@ class LicenseService(
         licenseRepository.delete(license)
     }
 
+    @Transactional
     fun updateLicence(
-        license: License,
+        license: License?,
         updateLicenceType: LicensingType?,
         updateLicenceNumber: String?,
-    ): License {
-        updateLicenceType?.let { license.licenseType = it }
-        updateLicenceNumber?.let { license.licenseNumber = it }
-        return license
-    }
+    ): License? =
+        if (updateLicenceType == LicensingType.NO_LICENSING) {
+            license?.let { deleteLicence(license) }
+            null
+        } else if (license == null) {
+            createLicense(updateLicenceType!!, updateLicenceNumber!!)
+        } else {
+            updateLicenceType?.let { license.licenseType = it }
+            updateLicenceNumber?.let { license.licenseNumber = it }
+            license
+        }
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/LicenseService.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/LicenseService.kt
@@ -19,4 +19,18 @@ class LicenseService(
                 licenceNumber,
             ),
         )
+
+    fun deleteLicence(license: License) {
+        licenseRepository.delete(license)
+    }
+
+    fun updateLicence(
+        license: License,
+        updateLicenceType: LicensingType?,
+        updateLicenceNumber: String?,
+    ): License {
+        updateLicenceType?.let { license.licenseType = it }
+        updateLicenceNumber?.let { license.licenseNumber = it }
+        return license
+    }
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/PropertyOwnershipService.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/PropertyOwnershipService.kt
@@ -20,6 +20,7 @@ import uk.gov.communities.prsdb.webapp.database.repository.PropertyOwnershipRepo
 import uk.gov.communities.prsdb.webapp.helpers.AddressHelper
 import uk.gov.communities.prsdb.webapp.models.dataModels.RegistrationNumberDataModel
 import uk.gov.communities.prsdb.webapp.models.dataModels.updateModels.PropertyOwnershipUpdateModel
+import uk.gov.communities.prsdb.webapp.models.dataModels.updateModels.PropertyOwnershipUpdateModel.Companion.isLicenceUpdatable
 import uk.gov.communities.prsdb.webapp.models.viewModels.searchResultModels.PropertySearchResultViewModel
 import uk.gov.communities.prsdb.webapp.models.viewModels.summaryModels.RegisteredPropertyViewModel
 
@@ -165,7 +166,7 @@ class PropertyOwnershipService(
         update.numberOfHouseholds?.let { propertyOwnership.currentNumHouseholds = it }
         update.numberOfPeople?.let { propertyOwnership.currentNumTenants = it }
 
-        if (update.licensingType != null || update.licenceNumber != null) {
+        if (update.isLicenceUpdatable()) {
             val updatedLicence =
                 getUpdatedLicenceOrNull(
                     propertyOwnership.license,

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/PropertyOwnershipService.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/PropertyOwnershipService.kt
@@ -181,8 +181,8 @@ class PropertyOwnershipService(
         updateLicenceType: LicensingType?,
         updateLicenceNumber: String?,
     ): License? =
-        if (license != null && updateLicenceType == LicensingType.NO_LICENSING) {
-            licenseService.deleteLicence(license)
+        if (updateLicenceType == LicensingType.NO_LICENSING) {
+            license?.let { licenseService.deleteLicence(license) }
             null
         } else if (license == null) {
             licenseService.createLicense(updateLicenceType!!, updateLicenceNumber!!)

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/PropertyOwnershipService.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/PropertyOwnershipService.kt
@@ -165,11 +165,11 @@ class PropertyOwnershipService(
         update.numberOfHouseholds?.let { propertyOwnership.currentNumHouseholds = it }
         update.numberOfPeople?.let { propertyOwnership.currentNumTenants = it }
 
-        if (update.licenceType != null || update.licenceNumber != null) {
+        if (update.licensingType != null || update.licenceNumber != null) {
             val updatedLicence =
                 getUpdatedLicenceOrNull(
                     propertyOwnership.license,
-                    update.licenceType,
+                    update.licensingType,
                     update.licenceNumber,
                 )
             propertyOwnership.license = updatedLicence

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/PropertyOwnershipService.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/PropertyOwnershipService.kt
@@ -20,7 +20,6 @@ import uk.gov.communities.prsdb.webapp.database.repository.PropertyOwnershipRepo
 import uk.gov.communities.prsdb.webapp.helpers.AddressHelper
 import uk.gov.communities.prsdb.webapp.models.dataModels.RegistrationNumberDataModel
 import uk.gov.communities.prsdb.webapp.models.dataModels.updateModels.PropertyOwnershipUpdateModel
-import uk.gov.communities.prsdb.webapp.models.dataModels.updateModels.PropertyOwnershipUpdateModel.Companion.isLicenceUpdatable
 import uk.gov.communities.prsdb.webapp.models.viewModels.searchResultModels.PropertySearchResultViewModel
 import uk.gov.communities.prsdb.webapp.models.viewModels.summaryModels.RegisteredPropertyViewModel
 
@@ -168,7 +167,7 @@ class PropertyOwnershipService(
 
         if (update.isLicenceUpdatable()) {
             val updatedLicence =
-                getUpdatedLicenceOrNull(
+                licenseService.updateLicence(
                     propertyOwnership.license,
                     update.licensingType,
                     update.licenceNumber,
@@ -176,20 +175,6 @@ class PropertyOwnershipService(
             propertyOwnership.license = updatedLicence
         }
     }
-
-    private fun getUpdatedLicenceOrNull(
-        license: License?,
-        updateLicenceType: LicensingType?,
-        updateLicenceNumber: String?,
-    ): License? =
-        if (updateLicenceType == LicensingType.NO_LICENSING) {
-            license?.let { licenseService.deleteLicence(license) }
-            null
-        } else if (license == null) {
-            licenseService.createLicense(updateLicenceType!!, updateLicenceNumber!!)
-        } else {
-            licenseService.updateLicence(license, updateLicenceType, updateLicenceNumber)
-        }
 
     private fun retrieveAllRegisteredPropertiesForLandlord(baseUserId: String): List<PropertyOwnership> =
         propertyOwnershipRepository.findAllByPrimaryLandlord_BaseUser_IdAndIsActiveTrueAndProperty_Status(

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -656,7 +656,7 @@ forms.licensingType.radios.option.hmoMandatory.label=HMO mandatory licence
 forms.licensingType.radios.option.hmoMandatory.hint=A House in Multiple Occupation (HMO) must have a licence if it's occupied by 5 or more people.
 forms.licensingType.radios.option.hmoAdditional.label=HMO additional licence
 forms.licensingType.radios.option.hmoAdditional.hint=A local authority can also include other types of HMOs for licensing.
-forms.licensingType.radios.option.noLicensing.label=I don't have any licensing for my property
+forms.licensingType.radios.option.noLicensing.label=I do not have any licensing for my property
 
 forms.licenceNumber.error.tooLong=The licensing number is too long
 
@@ -708,6 +708,7 @@ forms.update.ownershipType.fieldSetHeading=Update the ownership type for your pr
 forms.update.occupancy.occupied.fieldSetHeading=Is your property still occupied by tenants?
 forms.update.numberOfHouseholds.fieldSetHeading=Update the number of households in the property
 forms.update.numberOfPeople.fieldSetHeading=Update how many people live in your property
+forms.update.licensingType.fieldSetHeading=Update the type of licensing you have for your property
 
 forms.areYouSure.propertyDeregistration.fieldSetHeading=Are you sure you want to delete {0,,address} from the database?
 forms.areYouSure.landlordDeregistration.noProperties.fieldSetHeading=Are you sure you want to delete your account from the database?

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/helpers/extensions/journeyDataExtensions/PropertyDetailsUpdateJourneyDataExtensionsTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/helpers/extensions/journeyDataExtensions/PropertyDetailsUpdateJourneyDataExtensionsTests.kt
@@ -174,19 +174,19 @@ class PropertyDetailsUpdateJourneyDataExtensionsTests {
     fun `getLicensingTypeIfPresent return null if the corresponding page is in not journeyData`() {
         val testJourneyData = journeyDataBuilder.build()
 
-        val licenceTypeUpdate = testJourneyData.getLicensingTypeIfPresent()
+        val licensingTypeUpdate = testJourneyData.getLicensingTypeIfPresent()
 
-        assertNull(licenceTypeUpdate)
+        assertNull(licensingTypeUpdate)
     }
 
     @Test
     fun `getLicensingTypeIfPresent return a licence type if corresponding page is in journeyData`() {
-        val newLicenceType = LicensingType.SELECTIVE_LICENCE
-        val testJourneyData = journeyDataBuilder.withLicensingType(newLicenceType).build()
+        val newLicensingType = LicensingType.SELECTIVE_LICENCE
+        val testJourneyData = journeyDataBuilder.withLicensingType(newLicensingType).build()
 
-        val licenceTypeUpdate = testJourneyData.getLicensingTypeIfPresent()
+        val licensingTypeUpdate = testJourneyData.getLicensingTypeIfPresent()
 
-        assertEquals(newLicenceType, licenceTypeUpdate)
+        assertEquals(newLicensingType, licensingTypeUpdate)
     }
 
     @Test

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/helpers/extensions/journeyDataExtensions/PropertyDetailsUpdateJourneyDataExtensionsTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/helpers/extensions/journeyDataExtensions/PropertyDetailsUpdateJourneyDataExtensionsTests.kt
@@ -3,8 +3,11 @@ package uk.gov.communities.prsdb.webapp.helpers.extensions.journeyDataExtensions
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.mockito.Mockito.mock
+import uk.gov.communities.prsdb.webapp.constants.enums.LicensingType
 import uk.gov.communities.prsdb.webapp.constants.enums.OwnershipType
 import uk.gov.communities.prsdb.webapp.helpers.extensions.journeyDataExtensions.PropertyDetailsUpdateJourneyDataExtensions.Companion.getIsOccupiedUpdateIfPresent
+import uk.gov.communities.prsdb.webapp.helpers.extensions.journeyDataExtensions.PropertyDetailsUpdateJourneyDataExtensions.Companion.getLicenceNumberIfPresent
+import uk.gov.communities.prsdb.webapp.helpers.extensions.journeyDataExtensions.PropertyDetailsUpdateJourneyDataExtensions.Companion.getLicensingTypeIfPresent
 import uk.gov.communities.prsdb.webapp.helpers.extensions.journeyDataExtensions.PropertyDetailsUpdateJourneyDataExtensions.Companion.getNumberOfHouseholdsUpdateIfPresent
 import uk.gov.communities.prsdb.webapp.helpers.extensions.journeyDataExtensions.PropertyDetailsUpdateJourneyDataExtensions.Companion.getNumberOfPeopleUpdateIfPresent
 import uk.gov.communities.prsdb.webapp.helpers.extensions.journeyDataExtensions.PropertyDetailsUpdateJourneyDataExtensions.Companion.getOriginalIsOccupied
@@ -165,5 +168,75 @@ class PropertyDetailsUpdateJourneyDataExtensionsTests {
         val numberOfPeopleUpdate = testJourneyData.getNumberOfPeopleUpdateIfPresent()
 
         assertNull(numberOfPeopleUpdate)
+    }
+
+    @Test
+    fun `getLicensingTypeIfPresent return null if the corresponding page is in not journeyData`() {
+        val testJourneyData = journeyDataBuilder.build()
+
+        val licenceTypeUpdate = testJourneyData.getLicensingTypeIfPresent()
+
+        assertNull(licenceTypeUpdate)
+    }
+
+    @Test
+    fun `getLicensingTypeIfPresent return a licence type if corresponding page is in journeyData`() {
+        val newLicenceType = LicensingType.SELECTIVE_LICENCE
+        val testJourneyData = journeyDataBuilder.withLicensingType(newLicenceType).build()
+
+        val licenceTypeUpdate = testJourneyData.getLicensingTypeIfPresent()
+
+        assertEquals(newLicenceType, licenceTypeUpdate)
+    }
+
+    @Test
+    fun `getLicenceNumberIfPresent return null if the corresponding page is in not journeyData`() {
+        val testJourneyData = journeyDataBuilder.build()
+
+        val licenceNumberUpdate = testJourneyData.getLicenceNumberIfPresent("originalJourneyKey")
+
+        assertNull(licenceNumberUpdate)
+    }
+
+    @Test
+    fun `getLicenceNumberIfPresent return null if the licence type is NO_LICENSING in the journeyData`() {
+        val testJourneyData = journeyDataBuilder.withLicensingType(LicensingType.NO_LICENSING).build()
+
+        val licenceNumberUpdate = testJourneyData.getLicenceNumberIfPresent("originalJourneyKey")
+
+        assertNull(licenceNumberUpdate)
+    }
+
+    @Test
+    fun `getLicensingTypeIfPresent return a licence number if corresponding page is in journeyData`() {
+        val newLicenceNumber = "LN123456"
+        val testJourneyData = journeyDataBuilder.withLicensingType(LicensingType.SELECTIVE_LICENCE, newLicenceNumber).build()
+
+        val licenceNumberUpdate = testJourneyData.getLicenceNumberIfPresent("originalJourneyKey")
+
+        assertEquals(newLicenceNumber, licenceNumberUpdate)
+    }
+
+    @Test
+    fun `getLicensingTypeIfPresent return a licence number if licence type is in the original journey data`() {
+        val originalJourneyKey = "originalJourneyKey"
+        val originalJourneyData =
+            mapOf(
+                "licensing-type" to mapOf("licensingType" to LicensingType.SELECTIVE_LICENCE),
+                "selective-licence" to mapOf("licenceNumber" to "LN00000000"),
+            )
+
+        val newLicenceNumber = "LN123456"
+        val testJourneyData =
+            journeyDataBuilder
+                .withLicenceNumber(
+                    "selective-licence",
+                    newLicenceNumber,
+                ).withOriginalData(originalJourneyKey, originalJourneyData)
+                .build()
+
+        val licenceNumberUpdate = testJourneyData.getLicenceNumberIfPresent(originalJourneyKey)
+
+        assertEquals(newLicenceNumber, licenceNumberUpdate)
     }
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/helpers/extensions/journeyDataExtensions/PropertyDetailsUpdateJourneyDataExtensionsTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/helpers/extensions/journeyDataExtensions/PropertyDetailsUpdateJourneyDataExtensionsTests.kt
@@ -6,8 +6,8 @@ import org.mockito.Mockito.mock
 import uk.gov.communities.prsdb.webapp.constants.enums.LicensingType
 import uk.gov.communities.prsdb.webapp.constants.enums.OwnershipType
 import uk.gov.communities.prsdb.webapp.helpers.extensions.journeyDataExtensions.PropertyDetailsUpdateJourneyDataExtensions.Companion.getIsOccupiedUpdateIfPresent
-import uk.gov.communities.prsdb.webapp.helpers.extensions.journeyDataExtensions.PropertyDetailsUpdateJourneyDataExtensions.Companion.getLicenceNumberIfPresent
-import uk.gov.communities.prsdb.webapp.helpers.extensions.journeyDataExtensions.PropertyDetailsUpdateJourneyDataExtensions.Companion.getLicensingTypeIfPresent
+import uk.gov.communities.prsdb.webapp.helpers.extensions.journeyDataExtensions.PropertyDetailsUpdateJourneyDataExtensions.Companion.getLicenceNumberUpdateIfPresent
+import uk.gov.communities.prsdb.webapp.helpers.extensions.journeyDataExtensions.PropertyDetailsUpdateJourneyDataExtensions.Companion.getLicensingTypeUpdateIfPresent
 import uk.gov.communities.prsdb.webapp.helpers.extensions.journeyDataExtensions.PropertyDetailsUpdateJourneyDataExtensions.Companion.getNumberOfHouseholdsUpdateIfPresent
 import uk.gov.communities.prsdb.webapp.helpers.extensions.journeyDataExtensions.PropertyDetailsUpdateJourneyDataExtensions.Companion.getNumberOfPeopleUpdateIfPresent
 import uk.gov.communities.prsdb.webapp.helpers.extensions.journeyDataExtensions.PropertyDetailsUpdateJourneyDataExtensions.Companion.getOriginalIsOccupied
@@ -37,7 +37,7 @@ class PropertyDetailsUpdateJourneyDataExtensionsTests {
     }
 
     @Test
-    fun `getOwnershipTypeUpdateIfPresent returns null if the corresponding page is in not journeyData`() {
+    fun `getOwnershipTypeUpdateIfPresent returns null if the corresponding page is not in journeyData`() {
         val testJourneyData = journeyDataBuilder.build()
 
         val ownershipTypeUpdate = testJourneyData.getOwnershipTypeUpdateIfPresent()
@@ -171,71 +171,72 @@ class PropertyDetailsUpdateJourneyDataExtensionsTests {
     }
 
     @Test
-    fun `getLicensingTypeIfPresent return null if the corresponding page is in not journeyData`() {
+    fun `getLicensingTypeUpdateIfPresent returns null if the corresponding page is not in journeyData`() {
         val testJourneyData = journeyDataBuilder.build()
 
-        val licensingTypeUpdate = testJourneyData.getLicensingTypeIfPresent()
+        val licensingTypeUpdate = testJourneyData.getLicensingTypeUpdateIfPresent()
 
         assertNull(licensingTypeUpdate)
     }
 
     @Test
-    fun `getLicensingTypeIfPresent return a licence type if corresponding page is in journeyData`() {
+    fun `getLicensingTypeUpdateIfPresent returns a licence type if corresponding page is in journeyData`() {
         val newLicensingType = LicensingType.SELECTIVE_LICENCE
-        val testJourneyData = journeyDataBuilder.withLicensingType(newLicensingType).build()
+        val testJourneyData = journeyDataBuilder.withLicensingTypeUpdate(newLicensingType).build()
 
-        val licensingTypeUpdate = testJourneyData.getLicensingTypeIfPresent()
+        val licensingTypeUpdate = testJourneyData.getLicensingTypeUpdateIfPresent()
 
         assertEquals(newLicensingType, licensingTypeUpdate)
     }
 
     @Test
-    fun `getLicenceNumberIfPresent return null if the corresponding page is in not journeyData`() {
-        val testJourneyData = journeyDataBuilder.build()
+    fun `getLicenceNumberUpdateIfPresent returns null if the corresponding page is not in journeyData and there is a valid licence type`() {
+        val testJourneyData = journeyDataBuilder.withLicensingTypeUpdate(LicensingType.SELECTIVE_LICENCE).build()
 
-        val licenceNumberUpdate = testJourneyData.getLicenceNumberIfPresent("originalJourneyKey")
-
-        assertNull(licenceNumberUpdate)
-    }
-
-    @Test
-    fun `getLicenceNumberIfPresent return null if the licence type is NO_LICENSING in the journeyData`() {
-        val testJourneyData = journeyDataBuilder.withLicensingType(LicensingType.NO_LICENSING).build()
-
-        val licenceNumberUpdate = testJourneyData.getLicenceNumberIfPresent("originalJourneyKey")
+        val licenceNumberUpdate = testJourneyData.getLicenceNumberUpdateIfPresent("originalJourneyKey")
 
         assertNull(licenceNumberUpdate)
     }
 
     @Test
-    fun `getLicensingTypeIfPresent return a licence number if corresponding page is in journeyData`() {
+    fun `getLicenceNumberUpdateIfPresent returns null if the licence type is NO_LICENSING in the journeyData`() {
+        val testJourneyData = journeyDataBuilder.withLicensingTypeUpdate(LicensingType.NO_LICENSING).build()
+
+        val licenceNumberUpdate = testJourneyData.getLicenceNumberUpdateIfPresent("originalJourneyKey")
+
+        assertNull(licenceNumberUpdate)
+    }
+
+    @Test
+    fun `getLicenceNumberUpdateIfPresent returns a licence number if corresponding page is in journeyData`() {
         val newLicenceNumber = "LN123456"
-        val testJourneyData = journeyDataBuilder.withLicensingType(LicensingType.SELECTIVE_LICENCE, newLicenceNumber).build()
+        val testJourneyData = journeyDataBuilder.withLicenceUpdate(LicensingType.SELECTIVE_LICENCE, newLicenceNumber).build()
 
-        val licenceNumberUpdate = testJourneyData.getLicenceNumberIfPresent("originalJourneyKey")
+        val licenceNumberUpdate = testJourneyData.getLicenceNumberUpdateIfPresent("originalJourneyKey")
 
         assertEquals(newLicenceNumber, licenceNumberUpdate)
     }
 
     @Test
-    fun `getLicensingTypeIfPresent return a licence number if licence type is in the original journey data`() {
+    fun `getLicenceNumberUpdateIfPresent returns a licence number if licence type is in the original journey data`() {
         val originalJourneyKey = "originalJourneyKey"
+        val originalLicenseType = LicensingType.SELECTIVE_LICENCE
         val originalJourneyData =
             mapOf(
-                "licensing-type" to mapOf("licensingType" to LicensingType.SELECTIVE_LICENCE),
+                "licensing-type" to mapOf("licensingType" to originalLicenseType),
                 "selective-licence" to mapOf("licenceNumber" to "LN00000000"),
             )
 
         val newLicenceNumber = "LN123456"
         val testJourneyData =
             journeyDataBuilder
-                .withLicenceNumber(
-                    "selective-licence",
+                .withLicenceNumberUpdate(
                     newLicenceNumber,
+                    originalLicenseType,
                 ).withOriginalData(originalJourneyKey, originalJourneyData)
                 .build()
 
-        val licenceNumberUpdate = testJourneyData.getLicenceNumberIfPresent(originalJourneyKey)
+        val licenceNumberUpdate = testJourneyData.getLicenceNumberUpdateIfPresent(originalJourneyKey)
 
         assertEquals(newLicenceNumber, licenceNumberUpdate)
     }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/PropertyDetailsUpdateJourneyTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/PropertyDetailsUpdateJourneyTests.kt
@@ -250,9 +250,9 @@ class PropertyDetailsUpdateJourneyTests : IntegrationTest() {
             propertyDetailsUpdatePage.propertyDetailsSummaryList.licensingRow.clickActionLinkAndWait()
 
             // Update licence to selective
-            val updateLicenceTypePage = assertPageIs(page, LicensingTypeFormPagePropertyDetailsUpdate::class, urlArguments)
-            assertThat(updateLicenceTypePage.form.fieldsetHeading).containsText("Update the type of licensing you have for your property")
-            updateLicenceTypePage.submitLicensingType(newLicensingType)
+            val updateLicensingTypePage = assertPageIs(page, LicensingTypeFormPagePropertyDetailsUpdate::class, urlArguments)
+            assertThat(updateLicensingTypePage.form.fieldsetHeading).containsText("Update the type of licensing you have for your property")
+            updateLicensingTypePage.submitLicensingType(newLicensingType)
 
             // Update licence number
             val updateLicenceNumberPage = assertPageIs(page, SelectiveLicenceFormPagePropertyDetailsUpdate::class, urlArguments)
@@ -284,9 +284,9 @@ class PropertyDetailsUpdateJourneyTests : IntegrationTest() {
             propertyDetailsUpdatePage.propertyDetailsSummaryList.licensingRow.clickActionLinkAndWait()
 
             // Update licence to hmp mandatory
-            val updateLicenceTypePage = assertPageIs(page, LicensingTypeFormPagePropertyDetailsUpdate::class, urlArguments)
-            assertThat(updateLicenceTypePage.form.fieldsetHeading).containsText("Update the type of licensing you have for your property")
-            updateLicenceTypePage.submitLicensingType(newLicensingType)
+            val updateLicensingTypePage = assertPageIs(page, LicensingTypeFormPagePropertyDetailsUpdate::class, urlArguments)
+            assertThat(updateLicensingTypePage.form.fieldsetHeading).containsText("Update the type of licensing you have for your property")
+            updateLicensingTypePage.submitLicensingType(newLicensingType)
 
             val updateLicenceNumberPage = assertPageIs(page, HmoMandatoryLicenceFormPagePropertyDetailsUpdate::class, urlArguments)
             assertThat(updateLicenceNumberPage.form.fieldsetHeading).containsText("What is your HMO mandatory licence number?")
@@ -317,9 +317,9 @@ class PropertyDetailsUpdateJourneyTests : IntegrationTest() {
             propertyDetailsUpdatePage.propertyDetailsSummaryList.licensingRow.clickActionLinkAndWait()
 
             // Update licence to selective
-            val updateLicenceTypePage = assertPageIs(page, LicensingTypeFormPagePropertyDetailsUpdate::class, urlArguments)
-            assertThat(updateLicenceTypePage.form.fieldsetHeading).containsText("Update the type of licensing you have for your property")
-            updateLicenceTypePage.submitLicensingType(newLicensingType)
+            val updateLicensingTypePage = assertPageIs(page, LicensingTypeFormPagePropertyDetailsUpdate::class, urlArguments)
+            assertThat(updateLicensingTypePage.form.fieldsetHeading).containsText("Update the type of licensing you have for your property")
+            updateLicensingTypePage.submitLicensingType(newLicensingType)
 
             val updateLicenceNumberPage = assertPageIs(page, HmoAdditionalLicenceFormPagePropertyDetailsUpdate::class, urlArguments)
             assertThat(updateLicenceNumberPage.form.fieldsetHeading).containsText("What is your HMO additional licence number?")

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/basePages/LicensingTypeFormPage.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/basePages/LicensingTypeFormPage.kt
@@ -1,0 +1,27 @@
+package uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages
+
+import com.microsoft.playwright.Page
+import uk.gov.communities.prsdb.webapp.constants.enums.LicensingType
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.FormWithSectionHeader
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.Radios
+
+abstract class LicensingTypeFormPage(
+    page: Page,
+    urlSegment: String,
+) : BasePage(
+        page,
+        urlSegment,
+    ) {
+    val form = LicensingTypeForm(page)
+
+    fun submitLicensingType(licensingType: LicensingType) {
+        form.licensingTypeRadios.selectValue(licensingType)
+        form.submit()
+    }
+
+    class LicensingTypeForm(
+        page: Page,
+    ) : FormWithSectionHeader(page) {
+        val licensingTypeRadios = Radios(locator)
+    }
+}

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/basePages/PropertyDetailsBasePage.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/basePages/PropertyDetailsBasePage.kt
@@ -38,5 +38,6 @@ abstract class PropertyDetailsBasePage(
         val occupancyRow = getRow("Occupied by tenants")
         val numberOfHouseholdsRow = getRow("Number of households")
         val numberOfPeopleRow = getRow("Number of people")
+        val licensingRow = getRow("Licensing type")
     }
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/propertyDetailsUpdateJourneyPages/HmoAdditionalLicenceFormPagePropertyDetailsUpdate.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/propertyDetailsUpdateJourneyPages/HmoAdditionalLicenceFormPagePropertyDetailsUpdate.kt
@@ -1,0 +1,15 @@
+package uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyDetailsUpdateJourneyPages
+
+import com.microsoft.playwright.Page
+import uk.gov.communities.prsdb.webapp.controllers.PropertyDetailsController
+import uk.gov.communities.prsdb.webapp.forms.steps.UpdatePropertyDetailsStepId
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages.LicenceNumberFormPage
+
+class HmoAdditionalLicenceFormPagePropertyDetailsUpdate(
+    page: Page,
+    urlArguments: Map<String, String>,
+) : LicenceNumberFormPage(
+        page,
+        PropertyDetailsController.getUpdatePropertyDetailsPath(urlArguments["propertyOwnershipId"]!!.toLong()) +
+            "/${UpdatePropertyDetailsStepId.UpdateHmoAdditionalLicence.urlPathSegment}",
+    )

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/propertyDetailsUpdateJourneyPages/HmoMandatoryLicenceFormPagePropertyDetailsUpdate.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/propertyDetailsUpdateJourneyPages/HmoMandatoryLicenceFormPagePropertyDetailsUpdate.kt
@@ -1,0 +1,15 @@
+package uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyDetailsUpdateJourneyPages
+
+import com.microsoft.playwright.Page
+import uk.gov.communities.prsdb.webapp.controllers.PropertyDetailsController
+import uk.gov.communities.prsdb.webapp.forms.steps.UpdatePropertyDetailsStepId
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages.LicenceNumberFormPage
+
+class HmoMandatoryLicenceFormPagePropertyDetailsUpdate(
+    page: Page,
+    urlArguments: Map<String, String>,
+) : LicenceNumberFormPage(
+        page,
+        PropertyDetailsController.getUpdatePropertyDetailsPath(urlArguments["propertyOwnershipId"]!!.toLong()) +
+            "/${UpdatePropertyDetailsStepId.UpdateHmoMandatoryLicence.urlPathSegment}",
+    )

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/propertyDetailsUpdateJourneyPages/LicensingTypeFormPagePropertyDetailsUpdate.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/propertyDetailsUpdateJourneyPages/LicensingTypeFormPagePropertyDetailsUpdate.kt
@@ -1,0 +1,15 @@
+package uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyDetailsUpdateJourneyPages
+
+import com.microsoft.playwright.Page
+import uk.gov.communities.prsdb.webapp.controllers.PropertyDetailsController
+import uk.gov.communities.prsdb.webapp.forms.steps.UpdatePropertyDetailsStepId
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages.LicensingTypeFormPage
+
+class LicensingTypeFormPagePropertyDetailsUpdate(
+    page: Page,
+    urlArguments: Map<String, String>,
+) : LicensingTypeFormPage(
+        page,
+        PropertyDetailsController.getUpdatePropertyDetailsPath(urlArguments["propertyOwnershipId"]!!.toLong()) +
+            "/${UpdatePropertyDetailsStepId.UpdateLicensingType.urlPathSegment}",
+    )

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/propertyDetailsUpdateJourneyPages/SelectiveLicenceFormPagePropertyDetailsUpdate.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/propertyDetailsUpdateJourneyPages/SelectiveLicenceFormPagePropertyDetailsUpdate.kt
@@ -1,0 +1,15 @@
+package uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyDetailsUpdateJourneyPages
+
+import com.microsoft.playwright.Page
+import uk.gov.communities.prsdb.webapp.controllers.PropertyDetailsController
+import uk.gov.communities.prsdb.webapp.forms.steps.UpdatePropertyDetailsStepId
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages.LicenceNumberFormPage
+
+class SelectiveLicenceFormPagePropertyDetailsUpdate(
+    page: Page,
+    urlArguments: Map<String, String>,
+) : LicenceNumberFormPage(
+        page,
+        PropertyDetailsController.getUpdatePropertyDetailsPath(urlArguments["propertyOwnershipId"]!!.toLong()) +
+            "/${UpdatePropertyDetailsStepId.UpdateSelectiveLicence.urlPathSegment}",
+    )

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/propertyRegistrationJourneyPages/LicensingTypeFormPagePropertyRegistration.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/propertyRegistrationJourneyPages/LicensingTypeFormPagePropertyRegistration.kt
@@ -4,26 +4,11 @@ import com.microsoft.playwright.Page
 import uk.gov.communities.prsdb.webapp.constants.REGISTER_PROPERTY_JOURNEY_URL
 import uk.gov.communities.prsdb.webapp.constants.enums.LicensingType
 import uk.gov.communities.prsdb.webapp.forms.steps.RegisterPropertyStepId
-import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.FormWithSectionHeader
-import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.Radios
-import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages.BasePage
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages.LicensingTypeFormPage
 
 class LicensingTypeFormPagePropertyRegistration(
     page: Page,
-) : BasePage(
+) : LicensingTypeFormPage(
         page,
         "/$REGISTER_PROPERTY_JOURNEY_URL/${RegisterPropertyStepId.LicensingType.urlPathSegment}",
-    ) {
-    val form = LicensingTypeForm(page)
-
-    fun submitLicensingType(licensingType: LicensingType) {
-        form.licensingTypeRadios.selectValue(licensingType)
-        form.submit()
-    }
-
-    class LicensingTypeForm(
-        page: Page,
-    ) : FormWithSectionHeader(page) {
-        val licensingTypeRadios = Radios(locator)
-    }
-}
+    )

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/summaryModels/PropertyDetailsViewModelTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/summaryModels/PropertyDetailsViewModelTests.kt
@@ -248,7 +248,7 @@ class PropertyDetailsViewModelTests {
 
         val changeLinkCount = viewModel.propertyRecord.count { it.changeUrl != null }
 
-        assertEquals(4, changeLinkCount)
+        assertEquals(5, changeLinkCount)
     }
 
     @Test

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/LandlordServiceTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/LandlordServiceTests.kt
@@ -1,6 +1,7 @@
 package uk.gov.communities.prsdb.webapp.services
 
 import jakarta.persistence.EntityNotFoundException
+import jakarta.transaction.Transactional
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
@@ -36,6 +37,7 @@ import uk.gov.communities.prsdb.webapp.testHelpers.mockObjects.MockLandlordData
 import uk.gov.communities.prsdb.webapp.testHelpers.mockObjects.MockLandlordData.Companion.createAddress
 import uk.gov.communities.prsdb.webapp.testHelpers.mockObjects.MockLandlordData.Companion.createLandlord
 import java.time.LocalDate
+import kotlin.reflect.full.hasAnnotation
 import kotlin.test.assertNull
 
 @ExtendWith(MockitoExtension::class)
@@ -413,6 +415,11 @@ class LandlordServiceTests {
         assertEquals(updateModel.phoneNumber, landlordEntity.phoneNumber)
         assertEquals(newAddress, landlordEntity.address)
         assertEquals(updateModel.dateOfBirth, landlordEntity.dateOfBirth)
+    }
+
+    @Test
+    fun `updateLandlordForBaseUserId is annotated with @Transactional`() {
+        assertTrue(landlordService::updateLandlordForBaseUserId.hasAnnotation<Transactional>())
     }
 
     @Test

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/LicenseServiceTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/LicenseServiceTests.kt
@@ -1,6 +1,7 @@
 package uk.gov.communities.prsdb.webapp.services
 
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
@@ -49,14 +50,41 @@ class LicenseServiceTests {
     }
 
     @Test
-    fun `updateLicence calls update on the licenseRepository`() {
-        val newLicenceType = LicensingType.SELECTIVE_LICENCE
-        val newLicenceNumber = "SL123456"
+    fun `updateLicence returns an updated licence`() {
         val licence = License(LicensingType.HMO_MANDATORY_LICENCE, "LN123456")
+        val newLicence = License(LicensingType.SELECTIVE_LICENCE, "SL123456")
 
-        val updatedLicence = licenseService.updateLicence(licence, newLicenceType, newLicenceNumber)
+        val updatedLicence = licenseService.updateLicence(licence, newLicence.licenseType, newLicence.licenseNumber)
 
-        assertEquals(updatedLicence.licenseType, newLicenceType)
-        assertEquals(updatedLicence.licenseNumber, newLicenceNumber)
+        assertEquals(updatedLicence?.licenseType, newLicence.licenseType)
+        assertEquals(updatedLicence?.licenseNumber, newLicence.licenseNumber)
+    }
+
+    @Test
+    fun `updateLicence calls createLicence and returns the created licence`() {
+        val licenseType = LicensingType.SELECTIVE_LICENCE
+        val licenceNumber = "SL123456"
+        val expectedLicense = License(licenseType, licenceNumber)
+
+        whenever(mockLicenseRepository.save(any(License::class.java))).thenReturn(expectedLicense)
+
+        val updatedLicence = licenseService.updateLicence(null, licenseType, licenceNumber)
+
+        verify(mockLicenseRepository).save(any(License::class.java))
+
+        assertEquals(updatedLicence?.licenseType, expectedLicense.licenseType)
+        assertEquals(updatedLicence?.licenseNumber, expectedLicense.licenseNumber)
+    }
+
+    @Test
+    fun `updateLicence calls deleteLicence and returns null`() {
+        val licence = License(LicensingType.HMO_MANDATORY_LICENCE, "LN123456")
+        val newLicenceType = LicensingType.NO_LICENSING
+
+        val updatedLicence = licenseService.updateLicence(licence, newLicenceType, null)
+
+        verify(mockLicenseRepository).delete(licence)
+
+        assertNull(updatedLicence)
     }
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/LicenseServiceTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/LicenseServiceTests.kt
@@ -1,5 +1,6 @@
 package uk.gov.communities.prsdb.webapp.services
 
+import jakarta.transaction.Transactional
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
@@ -16,6 +17,7 @@ import org.mockito.kotlin.whenever
 import uk.gov.communities.prsdb.webapp.constants.enums.LicensingType
 import uk.gov.communities.prsdb.webapp.database.entity.License
 import uk.gov.communities.prsdb.webapp.database.repository.LicenseRepository
+import kotlin.reflect.full.hasAnnotation
 
 @ExtendWith(MockitoExtension::class)
 class LicenseServiceTests {
@@ -50,7 +52,7 @@ class LicenseServiceTests {
     }
 
     @Test
-    fun `updateLicence returns an updated licence`() {
+    fun `updateLicence returns an updated licence when there is an existing licence and a new licence`() {
         val licence = License(LicensingType.HMO_MANDATORY_LICENCE, "LN123456")
         val newLicence = License(LicensingType.SELECTIVE_LICENCE, "SL123456")
 
@@ -61,7 +63,7 @@ class LicenseServiceTests {
     }
 
     @Test
-    fun `updateLicence calls createLicence and returns the created licence`() {
+    fun `updateLicence calls createLicence and returns the created licence when there is no existing licence and there is a new licence`() {
         val licenseType = LicensingType.SELECTIVE_LICENCE
         val licenceNumber = "SL123456"
         val expectedLicense = License(licenseType, licenceNumber)
@@ -77,7 +79,7 @@ class LicenseServiceTests {
     }
 
     @Test
-    fun `updateLicence calls deleteLicence and returns null`() {
+    fun `updateLicence calls deleteLicence and returns null when there is an existing licence and the new licenceType is NO_LICENSING`() {
         val licence = License(LicensingType.HMO_MANDATORY_LICENCE, "LN123456")
         val newLicenceType = LicensingType.NO_LICENSING
 
@@ -86,5 +88,10 @@ class LicenseServiceTests {
         verify(mockLicenseRepository).delete(licence)
 
         assertNull(updatedLicence)
+    }
+
+    @Test
+    fun `updateLicence is annotated with @Transactional`() {
+        assertTrue(licenseService::updateLicence.hasAnnotation<Transactional>())
     }
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/LicenseServiceTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/LicenseServiceTests.kt
@@ -1,5 +1,6 @@
 package uk.gov.communities.prsdb.webapp.services
 
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
@@ -36,5 +37,26 @@ class LicenseServiceTests {
         val licenseCaptor = captor<License>()
         verify(mockLicenseRepository).save(licenseCaptor.capture())
         assertTrue(ReflectionEquals(expectedLicense).matches(licenseCaptor.value))
+    }
+
+    @Test
+    fun `deleteLicence calls delete on the licenseRepository`() {
+        val licence = License(LicensingType.HMO_MANDATORY_LICENCE, "LN123456")
+
+        licenseService.deleteLicence(licence)
+
+        verify(mockLicenseRepository).delete(licence)
+    }
+
+    @Test
+    fun `updateLicence calls update on the licenseRepository`() {
+        val newLicenceType = LicensingType.SELECTIVE_LICENCE
+        val newLicenceNumber = "SL123456"
+        val licence = License(LicensingType.HMO_MANDATORY_LICENCE, "LN123456")
+
+        val updatedLicence = licenseService.updateLicence(licence, newLicenceType, newLicenceNumber)
+
+        assertEquals(updatedLicence.licenseType, newLicenceType)
+        assertEquals(updatedLicence.licenseNumber, newLicenceNumber)
     }
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/PropertyOwnershipServiceTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/PropertyOwnershipServiceTests.kt
@@ -600,7 +600,7 @@ class PropertyOwnershipServiceTests {
                 ownershipType = OwnershipType.LEASEHOLD,
                 numberOfHouseholds = 1,
                 numberOfPeople = 2,
-                licenceType = updateLicence.licenseType,
+                licensingType = updateLicence.licenseType,
                 licenceNumber = updateLicence.licenseNumber,
             )
 
@@ -608,7 +608,7 @@ class PropertyOwnershipServiceTests {
             propertyOwnership,
         )
         whenever(
-            mockLicenseService.updateLicence(propertyOwnership.license!!, updateModel.licenceType, updateModel.licenceNumber),
+            mockLicenseService.updateLicence(propertyOwnership.license!!, updateModel.licensingType, updateModel.licenceNumber),
         ).thenReturn(updateLicence)
 
         // Act
@@ -618,7 +618,7 @@ class PropertyOwnershipServiceTests {
         assertEquals(updateModel.ownershipType, propertyOwnership.ownershipType)
         assertEquals(updateModel.numberOfHouseholds, propertyOwnership.currentNumHouseholds)
         assertEquals(updateModel.numberOfPeople, propertyOwnership.currentNumTenants)
-        assertEquals(updateModel.licenceType, propertyOwnership.license?.licenseType)
+        assertEquals(updateModel.licensingType, propertyOwnership.license?.licenseType)
         assertEquals(updateModel.licenceNumber, propertyOwnership.license?.licenseNumber)
     }
 
@@ -635,7 +635,7 @@ class PropertyOwnershipServiceTests {
                 ownershipType = OwnershipType.LEASEHOLD,
                 numberOfHouseholds = 1,
                 numberOfPeople = 2,
-                licenceType = LicensingType.NO_LICENSING,
+                licensingType = LicensingType.NO_LICENSING,
                 licenceNumber = null,
             )
 

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/PropertyOwnershipServiceTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/PropertyOwnershipServiceTests.kt
@@ -580,6 +580,7 @@ class PropertyOwnershipServiceTests {
         assertEquals(originalNumberOfHouseholds, propertyOwnership.currentNumHouseholds)
         assertEquals(originalNumberOfPeople, propertyOwnership.currentNumTenants)
         assertEquals(originalLicence, propertyOwnership.license)
+        verify(mockLicenseService, never()).updateLicence(any(), any(), any())
     }
 
     @Test
@@ -608,7 +609,7 @@ class PropertyOwnershipServiceTests {
             propertyOwnership,
         )
         whenever(
-            mockLicenseService.updateLicence(propertyOwnership.license!!, updateModel.licensingType, updateModel.licenceNumber),
+            mockLicenseService.updateLicence(propertyOwnership.license, updateModel.licensingType, updateModel.licenceNumber),
         ).thenReturn(updateLicence)
 
         // Act
@@ -642,6 +643,9 @@ class PropertyOwnershipServiceTests {
         whenever(mockPropertyOwnershipRepository.findByIdAndIsActiveTrue(propertyOwnership.id)).thenReturn(
             propertyOwnership,
         )
+        whenever(
+            mockLicenseService.updateLicence(propertyOwnership.license, updateModel.licensingType, updateModel.licenceNumber),
+        ).thenReturn(null)
 
         // Act
         propertyOwnershipService.updatePropertyOwnership(propertyOwnership.id, updateModel)

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/PropertyOwnershipServiceTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/PropertyOwnershipServiceTests.kt
@@ -607,6 +607,9 @@ class PropertyOwnershipServiceTests {
         whenever(mockPropertyOwnershipRepository.findByIdAndIsActiveTrue(propertyOwnership.id)).thenReturn(
             propertyOwnership,
         )
+        whenever(
+            mockLicenseService.updateLicence(propertyOwnership.license!!, updateModel.licenceType, updateModel.licenceNumber),
+        ).thenReturn(updateLicence)
 
         // Act
         propertyOwnershipService.updatePropertyOwnership(propertyOwnership.id, updateModel)
@@ -639,13 +642,6 @@ class PropertyOwnershipServiceTests {
         whenever(mockPropertyOwnershipRepository.findByIdAndIsActiveTrue(propertyOwnership.id)).thenReturn(
             propertyOwnership,
         )
-        whenever(
-            mockLicenseService.getUpdatedLicenceForPropertyOwnershipOrNull(
-                propertyOwnership.license,
-                updateModel.licenceType,
-                updateModel.licenceNumber,
-            ),
-        ).thenReturn(null)
 
         // Act
         propertyOwnershipService.updatePropertyOwnership(propertyOwnership.id, updateModel)

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/PropertyOwnershipServiceTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/PropertyOwnershipServiceTests.kt
@@ -2,6 +2,7 @@ package uk.gov.communities.prsdb.webapp.services
 
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
@@ -21,6 +22,7 @@ import org.springframework.data.domain.PageImpl
 import org.springframework.data.domain.PageRequest
 import org.springframework.http.HttpStatus
 import org.springframework.web.server.ResponseStatusException
+import uk.gov.communities.prsdb.webapp.constants.enums.LicensingType
 import uk.gov.communities.prsdb.webapp.constants.enums.OccupancyType
 import uk.gov.communities.prsdb.webapp.constants.enums.OwnershipType
 import uk.gov.communities.prsdb.webapp.constants.enums.RegistrationNumberType
@@ -51,6 +53,9 @@ class PropertyOwnershipServiceTests {
 
     @Mock
     private lateinit var mockLocalAuthorityDataService: LocalAuthorityDataService
+
+    @Mock
+    private lateinit var mockLicenseService: LicenseService
 
     @InjectMocks
     private lateinit var propertyOwnershipService: PropertyOwnershipService
@@ -554,12 +559,14 @@ class PropertyOwnershipServiceTests {
                 ownershipType = OwnershipType.FREEHOLD,
                 currentNumHouseholds = 2,
                 currentNumTenants = 4,
+                license = License(LicensingType.SELECTIVE_LICENCE, "licenceNumber"),
             )
         val originalOwnershipType = propertyOwnership.ownershipType
         val originalNumberOfHouseholds = propertyOwnership.currentNumHouseholds
         val originalNumberOfPeople = propertyOwnership.currentNumTenants
+        val originalLicence = propertyOwnership.license!!
         val updateModel =
-            PropertyOwnershipUpdateModel(ownershipType = null, numberOfHouseholds = null, numberOfPeople = null)
+            PropertyOwnershipUpdateModel(null, null, null, null, null)
 
         whenever(mockPropertyOwnershipRepository.findByIdAndIsActiveTrue(propertyOwnership.id)).thenReturn(
             propertyOwnership,
@@ -572,6 +579,7 @@ class PropertyOwnershipServiceTests {
         assertEquals(originalOwnershipType, propertyOwnership.ownershipType)
         assertEquals(originalNumberOfHouseholds, propertyOwnership.currentNumHouseholds)
         assertEquals(originalNumberOfPeople, propertyOwnership.currentNumTenants)
+        assertEquals(originalLicence, propertyOwnership.license)
     }
 
     @Test
@@ -583,12 +591,17 @@ class PropertyOwnershipServiceTests {
                 ownershipType = OwnershipType.FREEHOLD,
                 currentNumHouseholds = 2,
                 currentNumTenants = 6,
+                license = License(LicensingType.SELECTIVE_LICENCE, "licenceNumberSelective"),
             )
+
+        val updateLicence = License(LicensingType.HMO_MANDATORY_LICENCE, "licenceNumberMandatory")
         val updateModel =
             PropertyOwnershipUpdateModel(
                 ownershipType = OwnershipType.LEASEHOLD,
                 numberOfHouseholds = 1,
                 numberOfPeople = 2,
+                licenceType = updateLicence.licenseType,
+                licenceNumber = updateLicence.licenseNumber,
             )
 
         whenever(mockPropertyOwnershipRepository.findByIdAndIsActiveTrue(propertyOwnership.id)).thenReturn(
@@ -602,6 +615,43 @@ class PropertyOwnershipServiceTests {
         assertEquals(updateModel.ownershipType, propertyOwnership.ownershipType)
         assertEquals(updateModel.numberOfHouseholds, propertyOwnership.currentNumHouseholds)
         assertEquals(updateModel.numberOfPeople, propertyOwnership.currentNumTenants)
+        assertEquals(updateModel.licenceType, propertyOwnership.license?.licenseType)
+        assertEquals(updateModel.licenceNumber, propertyOwnership.license?.licenseNumber)
+    }
+
+    @Test
+    fun `updatePropertyOwnership removes the licence when the licence service returns no licence`() {
+        // Arrange
+        val propertyOwnership =
+            MockLandlordData.createPropertyOwnership(
+                license = License(LicensingType.SELECTIVE_LICENCE, "licenceNumberSelective"),
+            )
+
+        val updateModel =
+            PropertyOwnershipUpdateModel(
+                ownershipType = OwnershipType.LEASEHOLD,
+                numberOfHouseholds = 1,
+                numberOfPeople = 2,
+                licenceType = LicensingType.NO_LICENSING,
+                licenceNumber = null,
+            )
+
+        whenever(mockPropertyOwnershipRepository.findByIdAndIsActiveTrue(propertyOwnership.id)).thenReturn(
+            propertyOwnership,
+        )
+        whenever(
+            mockLicenseService.getUpdatedLicenceForPropertyOwnershipOrNull(
+                propertyOwnership.license,
+                updateModel.licenceType,
+                updateModel.licenceNumber,
+            ),
+        ).thenReturn(null)
+
+        // Act
+        propertyOwnershipService.updatePropertyOwnership(propertyOwnership.id, updateModel)
+
+        // Assert
+        assertNull(propertyOwnership.license)
     }
 
     @Test

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/testHelpers/builders/JourneyDataBuilder.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/testHelpers/builders/JourneyDataBuilder.kt
@@ -199,20 +199,19 @@ class JourneyDataBuilder(
     ): JourneyDataBuilder {
         journeyData["licensing-type"] = mapOf("licensingType" to licensingType.name)
         when (licensingType) {
-            LicensingType.SELECTIVE_LICENCE ->
-                journeyData["selective-licence"] =
-                    mapOf("licenceNumber" to licenseNumber)
-
-            LicensingType.HMO_MANDATORY_LICENCE ->
-                journeyData["hmo-mandatory-licence"] =
-                    mapOf("licenceNumber" to licenseNumber)
-
-            LicensingType.HMO_ADDITIONAL_LICENCE ->
-                journeyData["hmo-additional-licence"] =
-                    mapOf("licenceNumber" to licenseNumber)
-
+            LicensingType.SELECTIVE_LICENCE -> withLicenceNumber("selective-licence", licenseNumber)
+            LicensingType.HMO_MANDATORY_LICENCE -> withLicenceNumber("hmo-mandatory-licence", licenseNumber)
+            LicensingType.HMO_ADDITIONAL_LICENCE -> withLicenceNumber("hmo-additional-licence", licenseNumber)
             LicensingType.NO_LICENSING -> {}
         }
+        return this
+    }
+
+    fun withLicenceNumber(
+        urlPathSegment: String,
+        licenceNumber: String?,
+    ): JourneyDataBuilder {
+        journeyData[urlPathSegment] = mapOf("licenceNumber" to licenceNumber)
         return this
     }
 
@@ -353,6 +352,14 @@ class JourneyDataBuilder(
     fun withNumberOfPeopleUpdate(numberOfPeople: Int): JourneyDataBuilder {
         journeyData[UpdatePropertyDetailsStepId.UpdateNumberOfPeople.urlPathSegment] =
             mutableMapOf("numberOfPeople" to numberOfPeople)
+        return this
+    }
+
+    fun withOriginalData(
+        originalDataKey: String,
+        originalData: JourneyData,
+    ): JourneyDataBuilder {
+        journeyData[originalDataKey] = originalData
         return this
     }
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/testHelpers/builders/JourneyDataBuilder.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/testHelpers/builders/JourneyDataBuilder.kt
@@ -355,6 +355,34 @@ class JourneyDataBuilder(
         return this
     }
 
+    fun withLicensingTypeUpdate(licensingType: LicensingType): JourneyDataBuilder {
+        journeyData[UpdatePropertyDetailsStepId.UpdateLicensingType.urlPathSegment] = mutableMapOf("licensingType" to licensingType.name)
+        return this
+    }
+
+    fun withLicenceNumberUpdate(
+        licenceNumber: String,
+        licensingType: LicensingType,
+    ): JourneyDataBuilder {
+        val licenseNumberUpdateStepIdUrlPathSegment =
+            when (licensingType) {
+                LicensingType.SELECTIVE_LICENCE -> UpdatePropertyDetailsStepId.UpdateSelectiveLicence.urlPathSegment
+                LicensingType.HMO_MANDATORY_LICENCE -> UpdatePropertyDetailsStepId.UpdateHmoMandatoryLicence.urlPathSegment
+                LicensingType.HMO_ADDITIONAL_LICENCE -> UpdatePropertyDetailsStepId.UpdateHmoAdditionalLicence.urlPathSegment
+                LicensingType.NO_LICENSING -> ""
+            }
+        journeyData[licenseNumberUpdateStepIdUrlPathSegment] = mapOf("licenceNumber" to licenceNumber)
+        return this
+    }
+
+    fun withLicenceUpdate(
+        licensingType: LicensingType,
+        licenceNumber: String,
+    ): JourneyDataBuilder =
+        this
+            .withLicensingTypeUpdate(licensingType)
+            .withLicenceNumberUpdate(licenceNumber, licensingType)
+
     fun withOriginalData(
         originalDataKey: String,
         originalData: JourneyData,


### PR DESCRIPTION
Added Licensing Type and Licence Number to the Update Property Details Journey.
Added tests for new methods and updated existing tests where necessary

change link on update details page:
<img width="508" alt="{71EA22B0-0673-4511-B1CE-120913E3F428}" src="https://github.com/user-attachments/assets/90874be1-d151-4c5f-8cf1-f8856ac124b8" />

update licence type page: (note: there are no visual changes to the licence number pages)
<img width="513" alt="{3C6B64CD-A705-4708-B599-CD9300AC2D21}" src="https://github.com/user-attachments/assets/6b725c7e-bc6e-4c5c-a731-c953debc9185" />

updated licence type on update details page:
<img width="517" alt="{CD5D3E58-9FC2-44A0-96FE-C206268E877E}" src="https://github.com/user-attachments/assets/32081f96-3e11-45e6-8bec-8553d4531be6" />



