### PR TITLE
PRSD-603: Adds new filter to handle trailing forward slashes

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/config/filters/TrailingSlashFilter.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/config/filters/TrailingSlashFilter.kt
@@ -1,0 +1,27 @@
+package uk.gov.communities.prsdb.webapp.config.filters
+
+import jakarta.servlet.FilterChain
+import jakarta.servlet.ServletException
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.core.Ordered
+import org.springframework.core.annotation.Order
+import org.springframework.stereotype.Component
+import org.springframework.web.filter.OncePerRequestFilter
+import org.springframework.web.filter.UrlHandlerFilter
+import java.io.IOException
+
+@Component
+@Order(Ordered.HIGHEST_PRECEDENCE)
+class TrailingSlashFilter : OncePerRequestFilter() {
+    @Throws(ServletException::class, IOException::class)
+    override fun doFilterInternal(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        filterChain: FilterChain
+    ) {
+        // Wraps any request with a url that ends in a '/' in a new request without that trailing slash
+        val filter: UrlHandlerFilter = UrlHandlerFilter.trailingSlashHandler("/**").wrapRequest().build()
+        filter.doFilter(request, response, filterChain)
+    }
+}

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/controllers/ControllerTest.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/controllers/ControllerTest.kt
@@ -1,6 +1,7 @@
 package uk.gov.communities.prsdb.webapp.controllers
 
 import org.junit.jupiter.api.BeforeEach
+import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.mock.mockito.MockBean
 import org.springframework.context.annotation.Import
 import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository
@@ -11,19 +12,24 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders
 import org.springframework.web.context.WebApplicationContext
 import uk.gov.communities.prsdb.webapp.config.CustomErrorConfig
 import uk.gov.communities.prsdb.webapp.config.CustomSecurityConfig
+import uk.gov.communities.prsdb.webapp.config.filters.TrailingSlashFilter
 import uk.gov.communities.prsdb.webapp.services.UserRolesService
 
-@Import(CustomSecurityConfig::class, CustomErrorConfig::class)
+@Import(CustomSecurityConfig::class, CustomErrorConfig::class, TrailingSlashFilter::class)
 abstract class ControllerTest(
     private val context: WebApplicationContext,
 ) {
     protected lateinit var mvc: MockMvc
+
+    @Autowired
+    private lateinit var trailingSlashFilter: TrailingSlashFilter
 
     @BeforeEach
     fun setup() {
         mvc =
             MockMvcBuilders
                 .webAppContextSetup(context)
+                .addFilters<DefaultMockMvcBuilder>(trailingSlashFilter)
                 .apply<DefaultMockMvcBuilder>(springSecurity())
                 .build()
     }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/controllers/HealthCheckControllerTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/controllers/HealthCheckControllerTests.kt
@@ -2,6 +2,7 @@ package uk.gov.communities.prsdb.webapp.controllers
 
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.get
 import org.springframework.web.context.WebApplicationContext
 import kotlin.test.Test
@@ -10,10 +11,22 @@ import kotlin.test.Test
 class HealthCheckControllerTests(
     @Autowired val webContext: WebApplicationContext,
 ) : ControllerTest(webContext) {
+    @Autowired
+    private lateinit var mockMvc: MockMvc
+
     @Test
     fun `HealthCheckController returns 200 unauthenticated user`() {
         mvc
             .get("/healthcheck")
+            .andExpect {
+                status { isOk() }
+            }
+    }
+
+    @Test
+    fun `HealthCheckController returns 200 when trailing slash is included`() {
+        mvc
+            .get("/healthcheck/")
             .andExpect {
                 status { isOk() }
             }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/controllers/RegisterLandlordControllerTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/controllers/RegisterLandlordControllerTests.kt
@@ -14,6 +14,7 @@ import uk.gov.communities.prsdb.webapp.services.OneLoginIdentityService
 class RegisterLandlordControllerTests(
     @Autowired val webContext: WebApplicationContext,
 ) : ControllerTest(webContext) {
+
     @MockBean
     lateinit var landlordRegistrationJourneyFactory: LandlordRegistrationJourneyFactory
 
@@ -26,6 +27,13 @@ class RegisterLandlordControllerTests(
     @Test
     fun `RegisterLandlordController returns 200 for unauthenticated user`() {
         mvc.get("/register-as-a-landlord").andExpect {
+            status { isOk() }
+        }
+    }
+
+    @Test
+    fun `RegisterLandlordController returns 200 for authenticated user with trailing slash`() {
+        mvc.get("/register-as-a-landlord/").andExpect {
             status { isOk() }
         }
     }


### PR DESCRIPTION
- Creates new OncePerRequestFilter subclass that intercepts any request with a url - excluding query strings - that ends in a '/', wraps it in a new request without the trailing slash, and delegates handling that new request to the rest of the filter chain
  - this leverages the new `UrlHandlerFilter` added in Spring boot 3.4
 - Adds this as the highest precedence filter to ensure that the rest of the filter chain operates on the correct url
 - Adds two tests to ensure this all works - one for a public endpoint and one for one behind auth