### PR TITLE
Feat/prsd 1002 add stream size capping

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/examples/ExampleFileUploadController.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/examples/ExampleFileUploadController.kt
@@ -14,6 +14,7 @@ import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.server.ResponseStatusException
+import uk.gov.communities.prsdb.webapp.examples.MaximumLengthInputStream.Companion.withMaxLength
 import java.security.Principal
 
 @Controller
@@ -53,7 +54,9 @@ class ExampleFileUploadController(
         // this will need to be a useful name for LA users to download (and we should not trust the uploaded file name)
         val key = "${principal.name}/$freeSegment/${file.name}"
 
-        val uploadOutcome = fileUploader.uploadFile(key, file.inputStream)
+        val exampleMaxFileSizeInBytes = 5L * 1024L * 1024L
+
+        val uploadOutcome = fileUploader.uploadFile(key, file.inputStream.withMaxLength(exampleMaxFileSizeInBytes))
         model.addAttribute(
             "fileUploadResponse",
             mapOf(

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/examples/MaximumLengthInputStream.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/examples/MaximumLengthInputStream.kt
@@ -1,0 +1,69 @@
+package uk.gov.communities.prsdb.webapp.examples
+
+import uk.gov.communities.prsdb.webapp.exceptions.PrsdbWebException
+import java.io.InputStream
+import java.io.OutputStream
+
+class MaximumLengthInputStream(
+    private val innerInputStream: InputStream,
+    private val maxLength: Long,
+) : InputStream() {
+    private var sizeSoFar: Long = 0
+
+    override fun read(): Int {
+        val byteRead = innerInputStream.read()
+        if (byteRead >= 0) {
+            recordReadBytes(1)
+        }
+        return byteRead
+    }
+
+    override fun read(buffer: ByteArray): Int = read(buffer, 0, buffer.size)
+
+    override fun read(
+        buffer: ByteArray,
+        offset: Int,
+        length: Int,
+    ): Int {
+        val i = innerInputStream.read(buffer, offset, length)
+        if (i >= 0) recordReadBytes(i)
+        return i
+    }
+
+    private fun recordReadBytes(numberOfBytesRead: Int) {
+        sizeSoFar += numberOfBytesRead
+        if (sizeSoFar > maxLength) {
+            throw PrsdbWebException("Stream too long: $sizeSoFar read so far; max size: $maxLength")
+        }
+    }
+
+    override fun readNBytes(
+        b: ByteArray,
+        off: Int,
+        len: Int,
+    ): Int = innerInputStream.readNBytes(b, off, len)
+
+    override fun readNBytes(len: Int): ByteArray = innerInputStream.readNBytes(len)
+
+    override fun readAllBytes(): ByteArray = innerInputStream.readAllBytes()
+
+    override fun skip(n: Long): Long = innerInputStream.skip(n)
+
+    override fun skipNBytes(n: Long) = innerInputStream.skipNBytes(n)
+
+    override fun mark(readlimit: Int) = innerInputStream.mark(readlimit)
+
+    override fun reset() = innerInputStream.reset()
+
+    override fun transferTo(out: OutputStream): Long = innerInputStream.transferTo(out)
+
+    override fun markSupported() = innerInputStream.markSupported()
+
+    override fun available() = innerInputStream.available()
+
+    override fun close() = innerInputStream.close()
+
+    companion object {
+        fun InputStream.withMaxLength(maxLength: Long): InputStream = MaximumLengthInputStream(this, maxLength)
+    }
+}

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/examples/MaximumLengthInputStream.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/examples/MaximumLengthInputStream.kt
@@ -64,6 +64,6 @@ class MaximumLengthInputStream(
     override fun close() = innerInputStream.close()
 
     companion object {
-        fun InputStream.withMaxLength(maxLength: Long): InputStream = MaximumLengthInputStream(this, maxLength)
+        fun InputStream.withMaxLength(maxLength: Long): MaximumLengthInputStream = MaximumLengthInputStream(this, maxLength)
     }
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/examples/MaximumLengthInputStreamTest.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/examples/MaximumLengthInputStreamTest.kt
@@ -1,0 +1,200 @@
+package uk.gov.communities.prsdb.webapp.examples
+
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.verify
+import org.mockito.kotlin.any
+import org.mockito.kotlin.whenever
+import uk.gov.communities.prsdb.webapp.examples.MaximumLengthInputStream.Companion.withMaxLength
+import uk.gov.communities.prsdb.webapp.exceptions.PrsdbWebException
+import java.io.InputStream
+import java.io.OutputStream
+import kotlin.test.assertEquals
+
+class MaximumLengthInputStreamTest {
+    @Nested
+    inner class MaxSizeTests {
+        @Test
+        fun `reading from a max size stream that is large enough allows the full stream to be read`() {
+            // Arrange
+            val testInput = "the quick brown fox jumps over the lazy dog"
+            val maxLengthStream = testInput.byteInputStream().withMaxLength(10000)
+
+            // Act
+            val testOutput = maxLengthStream.reader().use { it.readText() }
+
+            // Assert
+            assertEquals(testInput, testOutput)
+        }
+
+        @Test
+        fun `reading from a max size stream that is too small throws an exception once too much is read`() {
+            // Arrange
+            val testInput = "the quick brown fox jumps over the lazy dog"
+            val maxLengthStream = testInput.byteInputStream().withMaxLength(10)
+
+            // Act & assert
+            assertThrows<PrsdbWebException> { val testOutput = maxLengthStream.reader().use { it.readText() } }
+        }
+
+        @Test
+        fun `reading from a max size stream that is too small allows bytes before the limit to be read`() {
+            // Arrange
+            val testInput = "the quick brown fox jumps over the lazy dog"
+            val maxLengthStream = testInput.byteInputStream().withMaxLength(20)
+
+            // Act
+            val outputArray = ByteArray(20)
+            maxLengthStream.read(outputArray, 0, outputArray.size)
+
+            assertEquals(testInput.substring(0, 20), outputArray.toString(Charsets.UTF_8))
+        }
+    }
+
+    @Nested
+    inner class DelegationTests {
+        private lateinit var testStream: InputStream
+        private lateinit var sizeLimitedStream: MaximumLengthInputStream
+
+        @BeforeEach
+        fun setUp() {
+            testStream = mock()
+            sizeLimitedStream = testStream.withMaxLength(100)
+        }
+
+        @Test
+        fun `readNBytes calls delegated method`() {
+            // Arrange
+            whenever(testStream.readNBytes(any())).thenReturn(byteArrayOf())
+            val bytesToBeRead = 177
+
+            // Act
+            sizeLimitedStream.readNBytes(bytesToBeRead)
+
+            // Assert
+            verify(testStream).readNBytes(bytesToBeRead)
+        }
+
+        @Test
+        fun `readNBytes with byte array, offset, and length calls delegated method`() {
+            // Arrange
+            val byteArray = ByteArray(10)
+            val offset = 2
+            val length = 5
+            whenever(testStream.readNBytes(any(), any(), any())).thenReturn(5)
+
+            // Act
+            sizeLimitedStream.readNBytes(byteArray, offset, length)
+
+            // Assert
+            verify(testStream).readNBytes(byteArray, offset, length)
+        }
+
+        @Test
+        fun `readAllBytes calls delegated method`() {
+            // Arrange
+            whenever(testStream.readAllBytes()).thenReturn(byteArrayOf())
+
+            // Act
+            sizeLimitedStream.readAllBytes()
+
+            // Assert
+            verify(testStream).readAllBytes()
+        }
+
+        @Test
+        fun `skip calls delegated method`() {
+            // Arrange
+            val bytesToSkip = 50L
+            whenever(testStream.skip(any())).thenReturn(50L)
+
+            // Act
+            sizeLimitedStream.skip(bytesToSkip)
+
+            // Assert
+            verify(testStream).skip(bytesToSkip)
+        }
+
+        @Test
+        fun `skipNBytes calls delegated method`() {
+            // Arrange
+            val bytesToSkip = 50L
+
+            // Act
+            sizeLimitedStream.skipNBytes(bytesToSkip)
+
+            // Assert
+            verify(testStream).skipNBytes(bytesToSkip)
+        }
+
+        @Test
+        fun `available calls delegated method`() {
+            // Arrange
+            whenever(testStream.available()).thenReturn(10)
+
+            // Act
+            sizeLimitedStream.available()
+
+            // Assert
+            verify(testStream).available()
+        }
+
+        @Test
+        fun `close calls delegated method`() {
+            // Act
+            sizeLimitedStream.close()
+
+            // Assert
+            verify(testStream).close()
+        }
+
+        @Test
+        fun `mark calls delegated method`() {
+            // Arrange
+            val readLimit = 20
+
+            // Act
+            sizeLimitedStream.mark(readLimit)
+
+            // Assert
+            verify(testStream).mark(readLimit)
+        }
+
+        @Test
+        fun `reset calls delegated method`() {
+            // Act
+            sizeLimitedStream.reset()
+
+            // Assert
+            verify(testStream).reset()
+        }
+
+        @Test
+        fun `markSupported calls delegated method`() {
+            // Arrange
+            whenever(testStream.markSupported()).thenReturn(true)
+
+            // Act
+            sizeLimitedStream.markSupported()
+
+            // Assert
+            verify(testStream).markSupported()
+        }
+
+        @Test
+        fun `transferTo calls delegated method`() {
+            // Arrange
+            val outputStream: OutputStream = mock()
+            whenever(testStream.transferTo(any())).thenReturn(100L)
+
+            // Act
+            sizeLimitedStream.transferTo(outputStream)
+
+            // Assert
+            verify(testStream).transferTo(outputStream)
+        }
+    }
+}


### PR DESCRIPTION
Allows for a maximum size of an input stream, after which it throws an exception. The tests are split into two sections - mostly boilerplate that checks the delegating methods continue to delegate and the three interesting ones that check that reading the stream works how we like.
