### PR TITLE
PRSD-1018: Avoid hardcoded journey data property names

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/database/entity/Address.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/database/entity/Address.kt
@@ -8,6 +8,7 @@ import jakarta.persistence.GenerationType
 import jakarta.persistence.Id
 import jakarta.persistence.JoinColumn
 import jakarta.persistence.ManyToOne
+import uk.gov.communities.prsdb.webapp.constants.MANUAL_ADDRESS_CHOSEN
 import uk.gov.communities.prsdb.webapp.models.dataModels.AddressDataModel
 
 @Entity
@@ -68,4 +69,12 @@ class Address() : ModifiableAuditableEntity() {
         this.postcode = addressDataModel.postcode
         this.localAuthority = localAuthority
     }
+
+    fun getPostcodeSearchTerm(): String = postcode ?: singleLineAddress
+
+    fun getHouseNameOrNumber(): String = buildingName ?: buildingNumber ?: singleLineAddress
+
+    fun getSelectedAddress(): String = if (uprn == null) MANUAL_ADDRESS_CHOSEN else singleLineAddress
+
+    fun getTownOrCity(): String = townName ?: singleLineAddress
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/database/entity/Address.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/database/entity/Address.kt
@@ -70,11 +70,5 @@ class Address() : ModifiableAuditableEntity() {
         this.localAuthority = localAuthority
     }
 
-    fun getPostcodeSearchTerm(): String = postcode ?: singleLineAddress
-
-    fun getHouseNameOrNumber(): String = buildingName ?: buildingNumber ?: singleLineAddress
-
     fun getSelectedAddress(): String = if (uprn == null) MANUAL_ADDRESS_CHOSEN else singleLineAddress
-
-    fun getTownOrCity(): String = townName ?: singleLineAddress
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/ExcludeFromPageData.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/ExcludeFromPageData.kt
@@ -1,0 +1,4 @@
+package uk.gov.communities.prsdb.webapp.forms
+
+@Target(AnnotationTarget.PROPERTY)
+annotation class ExcludeFromPageData

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/ReachableStepDetailsIterator.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/ReachableStepDetailsIterator.kt
@@ -87,6 +87,7 @@ class ReachableStepDetailsIterator<T : StepId>(
                 step.step.name,
                 step.subPageNumber,
             )
-        return subPageData != null && step.step.isSatisfied(validator, subPageData)
+        val bindingResult = step.step.page.bindDataToFormModel(validator, subPageData)
+        return subPageData != null && step.step.isSatisfied(bindingResult, subPageData)
     }
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/ReachableStepDetailsIterator.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/ReachableStepDetailsIterator.kt
@@ -88,6 +88,6 @@ class ReachableStepDetailsIterator<T : StepId>(
                 step.subPageNumber,
             )
         val bindingResult = step.step.page.bindDataToFormModel(validator, subPageData)
-        return subPageData != null && step.step.isSatisfied(bindingResult, subPageData)
+        return subPageData != null && step.step.isSatisfied(bindingResult)
     }
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/Journey.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/Journey.kt
@@ -84,7 +84,7 @@ abstract class Journey<T : StepId>(
 
         val bindingResult = currentStep.page.bindDataToFormModel(validator, formData)
 
-        if (!currentStep.isSatisfied(bindingResult, formData)) {
+        if (!currentStep.isSatisfied(bindingResult)) {
             return getModelAndViewForStep(
                 stepPathSegment,
                 subPageNumber,

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/Journey.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/Journey.kt
@@ -19,6 +19,7 @@ import uk.gov.communities.prsdb.webapp.models.viewModels.SectionHeaderViewModel
 import uk.gov.communities.prsdb.webapp.services.JourneyDataService
 import java.security.Principal
 import java.util.Optional
+import kotlin.reflect.cast
 
 abstract class Journey<T : StepId>(
     private val journeyType: JourneyType,
@@ -61,12 +62,12 @@ abstract class Journey<T : StepId>(
         val pageData =
             submittedPageData
                 ?: JourneyDataHelper.getPageData(journeyDataService.getJourneyDataFromSession(), requestedStep.name, subPageNumber)
+        val bindingResult = requestedStep.page.bindDataToFormModel(validator, pageData)
 
         val sectionHeaderInfo = getSectionHeaderInfo(requestedStep)
 
         return requestedStep.page.getModelAndView(
-            validator,
-            pageData,
+            bindingResult,
             prevStepUrl,
             prevStepDetails?.filteredJourneyData,
             sectionHeaderInfo,
@@ -75,20 +76,25 @@ abstract class Journey<T : StepId>(
 
     fun completeStep(
         stepPathSegment: String,
-        pageData: PageData,
+        formData: PageData,
         subPageNumber: Int?,
         principal: Principal,
     ): ModelAndView {
         val currentStep = getStep(stepPathSegment)
-        if (!currentStep.isSatisfied(validator, pageData)) {
+
+        val bindingResult = currentStep.page.bindDataToFormModel(validator, formData)
+
+        if (!currentStep.isSatisfied(bindingResult, formData)) {
             return getModelAndViewForStep(
                 stepPathSegment,
                 subPageNumber,
-                pageData,
+                formData,
             )
         }
 
-        val newJourneyData = currentStep.updatedJourneyData(journeyDataService.getJourneyDataFromSession(), pageData, subPageNumber)
+        val formModel = currentStep.page.formModel.cast(bindingResult.target)
+
+        val newJourneyData = currentStep.updatedJourneyData(journeyDataService.getJourneyDataFromSession(), formModel, subPageNumber)
         journeyDataService.setJourneyDataInSession(newJourneyData)
 
         if (currentStep.saveAfterSubmit) {

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/LaUserRegistrationJourney.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/LaUserRegistrationJourney.kt
@@ -36,8 +36,8 @@ class LaUserRegistrationJourney(
     init {
         val journeyData = journeyDataService.getJourneyDataFromSession()
         if (!isJourneyDataInitialized(journeyData)) {
-            val emailFormData = mapOf("emailAddress" to invitation.invitedEmail)
-            val newJourneyData = emailStep().updatedJourneyData(journeyData, emailFormData, subPageNumber = null)
+            val emailForm = EmailFormModel.fromLaInvitation(invitation)
+            val newJourneyData = emailStep().updatedJourneyData(journeyData, emailForm, subPageNumber = null)
             journeyDataService.setJourneyDataInSession(newJourneyData)
         }
     }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/PropertyDetailsUpdateJourney.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/PropertyDetailsUpdateJourney.kt
@@ -6,6 +6,7 @@ import uk.gov.communities.prsdb.webapp.constants.enums.JourneyType
 import uk.gov.communities.prsdb.webapp.constants.enums.LicensingType
 import uk.gov.communities.prsdb.webapp.constants.enums.OwnershipType
 import uk.gov.communities.prsdb.webapp.controllers.PropertyDetailsController
+import uk.gov.communities.prsdb.webapp.database.entity.PropertyOwnership
 import uk.gov.communities.prsdb.webapp.forms.JourneyData
 import uk.gov.communities.prsdb.webapp.forms.PageData
 import uk.gov.communities.prsdb.webapp.forms.pages.Page
@@ -71,14 +72,34 @@ class PropertyDetailsUpdateJourney(
                 UpdatePropertyDetailsStepId.UpdateLicensingType toPageData LicensingTypeFormModel::fromPropertyOwnership,
             )
 
-        val licenceStepIdAndFormModel = PropertyDetailsUpdateJourneyDataExtensions.getLicenceNumberStepIdAndFormModel(propertyOwnership)
-        if (licenceStepIdAndFormModel != null) {
-            val (licenceNumberUpdateStepId, licenceFormModel) = licenceStepIdAndFormModel
+        val licenceNumberStepIdAndFormModel = getLicenceNumberStepIdAndFormModel(propertyOwnership)
+        if (licenceNumberStepIdAndFormModel != null) {
+            val (licenceNumberUpdateStepId, licenceFormModel) = licenceNumberStepIdAndFormModel
             originalPropertyData[licenceNumberUpdateStepId.urlPathSegment] = licenceFormModel.toPageData()
         }
 
         return originalPropertyData
     }
+
+    private fun getLicenceNumberStepIdAndFormModel(propertyOwnership: PropertyOwnership): Pair<UpdatePropertyDetailsStepId, FormModel>? =
+        when (propertyOwnership.license?.licenseType) {
+            LicensingType.SELECTIVE_LICENCE ->
+                Pair(
+                    UpdatePropertyDetailsStepId.UpdateSelectiveLicence,
+                    SelectiveLicenceFormModel.fromPropertyOwnership(propertyOwnership),
+                )
+            LicensingType.HMO_MANDATORY_LICENCE ->
+                Pair(
+                    UpdatePropertyDetailsStepId.UpdateHmoMandatoryLicence,
+                    HmoMandatoryLicenceFormModel.fromPropertyOwnership(propertyOwnership),
+                )
+            LicensingType.HMO_ADDITIONAL_LICENCE ->
+                Pair(
+                    UpdatePropertyDetailsStepId.UpdateHmoAdditionalLicence,
+                    HmoAdditionalLicenceFormModel.fromPropertyOwnership(propertyOwnership),
+                )
+            else -> null
+        }
 
     private val updateDetailsStep =
         Step(

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/UpdateLandlordDetailsJourney.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/UpdateLandlordDetailsJourney.kt
@@ -6,14 +6,14 @@ import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.validation.Validator
 import uk.gov.communities.prsdb.webapp.constants.BACK_URL_ATTR_NAME
 import uk.gov.communities.prsdb.webapp.constants.LOOKED_UP_ADDRESSES_JOURNEY_DATA_KEY
-import uk.gov.communities.prsdb.webapp.constants.MANUAL_ADDRESS_CHOSEN
 import uk.gov.communities.prsdb.webapp.constants.enums.JourneyType
 import uk.gov.communities.prsdb.webapp.controllers.LandlordDetailsController
-import uk.gov.communities.prsdb.webapp.database.entity.Address
 import uk.gov.communities.prsdb.webapp.forms.JourneyData
+import uk.gov.communities.prsdb.webapp.forms.PageData
 import uk.gov.communities.prsdb.webapp.forms.pages.Page
 import uk.gov.communities.prsdb.webapp.forms.pages.SelectAddressPage
 import uk.gov.communities.prsdb.webapp.forms.steps.Step
+import uk.gov.communities.prsdb.webapp.forms.steps.StepId
 import uk.gov.communities.prsdb.webapp.forms.steps.UpdateLandlordDetailsStepId
 import uk.gov.communities.prsdb.webapp.helpers.JourneyDataHelper
 import uk.gov.communities.prsdb.webapp.helpers.LandlordRegistrationJourneyDataHelper
@@ -24,6 +24,7 @@ import uk.gov.communities.prsdb.webapp.models.dataModels.AddressDataModel
 import uk.gov.communities.prsdb.webapp.models.dataModels.updateModels.LandlordUpdateModel
 import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.DateOfBirthFormModel
 import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.EmailFormModel
+import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.FormModel
 import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.LookupAddressFormModel
 import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.ManualAddressFormModel
 import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.NameFormModel
@@ -33,6 +34,7 @@ import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.SelectAdd
 import uk.gov.communities.prsdb.webapp.services.AddressLookupService
 import uk.gov.communities.prsdb.webapp.services.JourneyDataService
 import uk.gov.communities.prsdb.webapp.services.LandlordService
+import kotlin.reflect.KFunction
 
 class UpdateLandlordDetailsJourney(
     validator: Validator,
@@ -55,35 +57,23 @@ class UpdateLandlordDetailsJourney(
     override fun createOriginalJourneyData(): JourneyData {
         val landlord = landlordService.retrieveLandlordByBaseUserId(landlordBaseUserId)!!
 
+        infix fun <T : FormModel> StepId.toPageData(fromLandlordFunc: KFunction<T>): Pair<String, PageData> =
+            this.urlPathSegment to fromLandlordFunc.call(landlord).toPageData()
+
         val originalLandlordData =
             mutableMapOf(
                 IS_IDENTITY_VERIFIED_KEY to landlord.isVerified,
                 LOOKED_UP_ADDRESSES_JOURNEY_DATA_KEY to Json.encodeToString(listOf(AddressDataModel.fromAddress(landlord.address))),
-                UpdateLandlordDetailsStepId.UpdateEmail.urlPathSegment to mapOf("emailAddress" to landlord.email),
-                UpdateLandlordDetailsStepId.UpdateName.urlPathSegment to mapOf("name" to landlord.name),
-                UpdateLandlordDetailsStepId.UpdatePhoneNumber.urlPathSegment to mapOf("phoneNumber" to landlord.phoneNumber),
-                UpdateLandlordDetailsStepId.LookupEnglandAndWalesAddress.urlPathSegment to
-                    mapOf(
-                        "postcode" to landlord.address.getPostcodeSearchTerm(),
-                        "houseNameOrNumber" to landlord.address.getHouseNameOrNumber(),
-                    ),
-                UpdateLandlordDetailsStepId.SelectEnglandAndWalesAddress.urlPathSegment to
-                    mapOf("address" to landlord.address.getSelectedAddress()),
-                UpdateLandlordDetailsStepId.UpdateDateOfBirth.urlPathSegment to
-                    mapOf(
-                        "day" to landlord.dateOfBirth?.dayOfMonth.toString(),
-                        "month" to landlord.dateOfBirth?.monthValue.toString(),
-                        "year" to landlord.dateOfBirth?.year.toString(),
-                    ),
+                UpdateLandlordDetailsStepId.UpdateEmail toPageData EmailFormModel::fromLandlord,
+                UpdateLandlordDetailsStepId.UpdateName toPageData NameFormModel::fromLandlord,
+                UpdateLandlordDetailsStepId.UpdatePhoneNumber toPageData PhoneNumberFormModel::fromLandlord,
+                UpdateLandlordDetailsStepId.LookupEnglandAndWalesAddress toPageData LookupAddressFormModel::fromLandlord,
+                UpdateLandlordDetailsStepId.SelectEnglandAndWalesAddress toPageData SelectAddressFormModel::fromLandlord,
+                UpdateLandlordDetailsStepId.UpdateDateOfBirth toPageData DateOfBirthFormModel::fromLandlord,
             )
 
         if (landlord.address.uprn == null) {
-            originalLandlordData[UpdateLandlordDetailsStepId.ManualEnglandAndWalesAddress.urlPathSegment] =
-                mapOf(
-                    "addressLineOne" to landlord.address.singleLineAddress,
-                    "townOrCity" to landlord.address.getTownOrCity(),
-                    "postcode" to landlord.address.getPostcodeSearchTerm(),
-                )
+            originalLandlordData += UpdateLandlordDetailsStepId.ManualEnglandAndWalesAddress toPageData ManualAddressFormModel::fromLandlord
         }
 
         return originalLandlordData
@@ -325,14 +315,6 @@ class UpdateLandlordDetailsJourney(
 
         return LandlordDetailsController.LANDLORD_DETAILS_ROUTE
     }
-
-    private fun Address.getHouseNameOrNumber(): String = buildingName ?: buildingNumber ?: singleLineAddress
-
-    private fun Address.getPostcodeSearchTerm(): String = postcode ?: singleLineAddress
-
-    private fun Address.getSelectedAddress(): String = if (uprn == null) MANUAL_ADDRESS_CHOSEN else singleLineAddress
-
-    private fun Address.getTownOrCity(): String = townName ?: singleLineAddress
 
     companion object {
         const val IS_IDENTITY_VERIFIED_KEY = "isIdentityVerified"

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/pages/AbstractPage.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/pages/AbstractPage.kt
@@ -61,10 +61,7 @@ abstract class AbstractPage(
         return modelAndView
     }
 
-    open fun isSatisfied(
-        bindingResult: BindingResult,
-        formData: PageData,
-    ): Boolean = !bindingResult.hasErrors()
+    open fun isSatisfied(bindingResult: BindingResult): Boolean = !bindingResult.hasErrors()
 
     protected open fun enrichFormData(formData: PageData?): PageData? = formData
 

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/pages/AlreadyRegisteredPage.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/pages/AlreadyRegisteredPage.kt
@@ -4,6 +4,7 @@ import org.springframework.web.servlet.ModelAndView
 import uk.gov.communities.prsdb.webapp.forms.JourneyData
 import uk.gov.communities.prsdb.webapp.helpers.JourneyDataHelper
 import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.FormModel
+import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.SelectAddressFormModel
 import kotlin.reflect.KClass
 
 class AlreadyRegisteredPage(
@@ -18,7 +19,11 @@ class AlreadyRegisteredPage(
     ) {
         modelAndView.addObject(
             "singleLineAddress",
-            JourneyDataHelper.getFieldStringValue(filteredJourneyData!!, selectedAddressPathSegment, "address"),
+            JourneyDataHelper.getFieldStringValue(
+                filteredJourneyData!!,
+                selectedAddressPathSegment,
+                SelectAddressFormModel::address.name,
+            ),
         )
     }
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/pages/LandlordDeregistrationAreYouSurePage.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/pages/LandlordDeregistrationAreYouSurePage.kt
@@ -1,8 +1,6 @@
 package uk.gov.communities.prsdb.webapp.forms.pages
 
 import org.springframework.http.HttpStatus
-import org.springframework.validation.BindingResult
-import org.springframework.validation.Validator
 import org.springframework.web.server.ResponseStatusException
 import org.springframework.web.servlet.ModelAndView
 import uk.gov.communities.prsdb.webapp.forms.JourneyData
@@ -41,17 +39,14 @@ class LandlordDeregistrationAreYouSurePage(
         }
     }
 
-    override fun bindDataToFormModel(
-        validator: Validator,
-        formData: PageData?,
-    ): BindingResult {
-        val newFormData = formData?.toMutableMap()
-        if (newFormData != null) {
-            val journeyData = journeyDataService.getJourneyDataFromSession()
-            val landlordHasRegisteredProperties = journeyData.getLandlordUserHasRegisteredProperties()
-            newFormData["userHasRegisteredProperties"] = landlordHasRegisteredProperties
+    override fun enrichFormData(formData: PageData?): PageData? {
+        if (formData == null) {
+            return null
         }
-
-        return super.bindDataToFormModel(validator, newFormData)
+        val newFormData = formData.toMutableMap()
+        val journeyData = journeyDataService.getJourneyDataFromSession()
+        val landlordHasRegisteredProperties = journeyData.getLandlordUserHasRegisteredProperties()
+        newFormData["userHasRegisteredProperties"] = landlordHasRegisteredProperties
+        return newFormData
     }
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/pages/LandlordDeregistrationAreYouSurePage.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/pages/LandlordDeregistrationAreYouSurePage.kt
@@ -46,7 +46,7 @@ class LandlordDeregistrationAreYouSurePage(
         val newFormData = formData.toMutableMap()
         val journeyData = journeyDataService.getJourneyDataFromSession()
         val landlordHasRegisteredProperties = journeyData.getLandlordUserHasRegisteredProperties()
-        newFormData["userHasRegisteredProperties"] = landlordHasRegisteredProperties
+        newFormData[LandlordDeregistrationAreYouSureFormModel::userHasRegisteredProperties.name] = landlordHasRegisteredProperties
         return newFormData
     }
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/pages/PropertyRegistrationNumberOfPeoplePage.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/pages/PropertyRegistrationNumberOfPeoplePage.kt
@@ -4,6 +4,8 @@ import org.springframework.web.servlet.ModelAndView
 import uk.gov.communities.prsdb.webapp.forms.JourneyData
 import uk.gov.communities.prsdb.webapp.forms.PageData
 import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.FormModel
+import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.NumberOfPeopleFormModel
+import uk.gov.communities.prsdb.webapp.services.JourneyDataService
 import kotlin.reflect.KClass
 
 class PropertyRegistrationNumberOfPeoplePage(
@@ -23,7 +25,7 @@ class PropertyRegistrationNumberOfPeoplePage(
             return null
         }
         val newFormData = formData.toMutableMap()
-        newFormData["numberOfHouseholds"] = latestNumberOfHouseholds.toString()
+        newFormData[NumberOfPeopleFormModel::numberOfHouseholds.name] = latestNumberOfHouseholds.toString()
         return newFormData
     }
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/pages/PropertyRegistrationNumberOfPeoplePage.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/pages/PropertyRegistrationNumberOfPeoplePage.kt
@@ -5,7 +5,6 @@ import uk.gov.communities.prsdb.webapp.forms.JourneyData
 import uk.gov.communities.prsdb.webapp.forms.PageData
 import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.FormModel
 import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.NumberOfPeopleFormModel
-import uk.gov.communities.prsdb.webapp.services.JourneyDataService
 import kotlin.reflect.KClass
 
 class PropertyRegistrationNumberOfPeoplePage(

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/pages/PropertyRegistrationNumberOfPeoplePage.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/pages/PropertyRegistrationNumberOfPeoplePage.kt
@@ -1,7 +1,5 @@
 package uk.gov.communities.prsdb.webapp.forms.pages
 
-import org.springframework.validation.BindingResult
-import org.springframework.validation.Validator
 import org.springframework.web.servlet.ModelAndView
 import uk.gov.communities.prsdb.webapp.forms.JourneyData
 import uk.gov.communities.prsdb.webapp.forms.PageData
@@ -20,14 +18,12 @@ class PropertyRegistrationNumberOfPeoplePage(
         filteredJourneyData: JourneyData?,
     ) {}
 
-    override fun bindDataToFormModel(
-        validator: Validator,
-        formData: PageData?,
-    ): BindingResult {
-        val newFormData = formData?.toMutableMap()
-        if (newFormData != null) {
-            newFormData["numberOfHouseholds"] = latestNumberOfHouseholds.toString()
+    override fun enrichFormData(formData: PageData?): PageData? {
+        if (formData == null) {
+            return null
         }
-        return super.bindDataToFormModel(validator, newFormData)
+        val newFormData = formData.toMutableMap()
+        newFormData["numberOfHouseholds"] = latestNumberOfHouseholds.toString()
+        return newFormData
     }
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/pages/SelectAddressPage.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/pages/SelectAddressPage.kt
@@ -9,6 +9,7 @@ import uk.gov.communities.prsdb.webapp.helpers.JourneyDataHelper
 import uk.gov.communities.prsdb.webapp.helpers.extensions.journeyDataExtensions.JourneyDataExtensions.Companion.getLookedUpAddress
 import uk.gov.communities.prsdb.webapp.helpers.extensions.journeyDataExtensions.JourneyDataExtensions.Companion.withUpdatedLookedUpAddresses
 import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.FormModel
+import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.SelectAddressFormModel
 import uk.gov.communities.prsdb.webapp.models.viewModels.formModels.RadiosButtonViewModel
 import uk.gov.communities.prsdb.webapp.models.viewModels.formModels.RadiosDividerViewModel
 import uk.gov.communities.prsdb.webapp.models.viewModels.formModels.RadiosViewModel
@@ -68,7 +69,7 @@ class SelectAddressPage(
         bindingResult: BindingResult,
         formData: PageData,
     ): Boolean {
-        val selectedAddress = formData["address"].toString()
+        val selectedAddress = formData[SelectAddressFormModel::address.name].toString()
         val journeyData = journeyDataService.getJourneyDataFromSession()
 
         return selectedAddress == MANUAL_ADDRESS_CHOSEN || journeyData.getLookedUpAddress(selectedAddress) != null

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/pages/SelectAddressPage.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/pages/SelectAddressPage.kt
@@ -4,7 +4,6 @@ import org.springframework.validation.BindingResult
 import org.springframework.web.servlet.ModelAndView
 import uk.gov.communities.prsdb.webapp.constants.MANUAL_ADDRESS_CHOSEN
 import uk.gov.communities.prsdb.webapp.forms.JourneyData
-import uk.gov.communities.prsdb.webapp.forms.PageData
 import uk.gov.communities.prsdb.webapp.helpers.JourneyDataHelper
 import uk.gov.communities.prsdb.webapp.helpers.extensions.journeyDataExtensions.JourneyDataExtensions.Companion.getLookedUpAddress
 import uk.gov.communities.prsdb.webapp.helpers.extensions.journeyDataExtensions.JourneyDataExtensions.Companion.withUpdatedLookedUpAddresses
@@ -65,13 +64,12 @@ class SelectAddressPage(
         modelAndView.addObject("options", addressRadiosViewModel)
     }
 
-    override fun isSatisfied(
-        bindingResult: BindingResult,
-        formData: PageData,
-    ): Boolean {
-        val selectedAddress = formData[SelectAddressFormModel::address.name].toString()
+    override fun isSatisfied(bindingResult: BindingResult): Boolean {
+        val selectAddressFormModel = bindingResult.target as SelectAddressFormModel
+        val selectedAddress = selectAddressFormModel.address
         val journeyData = journeyDataService.getJourneyDataFromSession()
 
-        return selectedAddress == MANUAL_ADDRESS_CHOSEN || journeyData.getLookedUpAddress(selectedAddress) != null
+        return selectedAddress == MANUAL_ADDRESS_CHOSEN ||
+            (selectedAddress != null && journeyData.getLookedUpAddress(selectedAddress) != null)
     }
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/pages/SelectAddressPage.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/pages/SelectAddressPage.kt
@@ -1,6 +1,6 @@
 package uk.gov.communities.prsdb.webapp.forms.pages
 
-import org.springframework.validation.Validator
+import org.springframework.validation.BindingResult
 import org.springframework.web.servlet.ModelAndView
 import uk.gov.communities.prsdb.webapp.constants.MANUAL_ADDRESS_CHOSEN
 import uk.gov.communities.prsdb.webapp.forms.JourneyData
@@ -65,7 +65,7 @@ class SelectAddressPage(
     }
 
     override fun isSatisfied(
-        validator: Validator,
+        bindingResult: BindingResult,
         formData: PageData,
     ): Boolean {
         val selectedAddress = formData["address"].toString()

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/steps/Step.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/steps/Step.kt
@@ -1,18 +1,19 @@
 package uk.gov.communities.prsdb.webapp.forms.steps
 
-import org.springframework.validation.Validator
+import org.springframework.validation.BindingResult
 import uk.gov.communities.prsdb.webapp.forms.JourneyData
 import uk.gov.communities.prsdb.webapp.forms.PageData
 import uk.gov.communities.prsdb.webapp.forms.objectToStringKeyedMap
 import uk.gov.communities.prsdb.webapp.forms.pages.AbstractPage
+import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.FormModel
 
 class Step<T : StepId>(
     val id: T,
     val page: AbstractPage,
     val handleSubmitAndRedirect: ((journeyData: JourneyData, subPageNumber: Int?) -> String)? = null,
-    val isSatisfied: (validator: Validator, pageData: PageData) -> Boolean = { validator, pageData ->
+    val isSatisfied: (bindingResult: BindingResult, formData: PageData) -> Boolean = { bindingResult, pageData ->
         page.isSatisfied(
-            validator,
+            bindingResult,
             pageData,
         )
     },
@@ -28,14 +29,14 @@ class Step<T : StepId>(
 
     fun updatedJourneyData(
         journeyData: JourneyData,
-        pageData: PageData,
+        formModel: FormModel,
         subPageNumber: Int?,
     ): JourneyData =
         if (subPageNumber != null) {
-            val newStepData = updatedStepData(journeyData, subPageNumber, pageData)
+            val newStepData = updatedStepData(journeyData, subPageNumber, formModel.toPageData())
             journeyData + (name to newStepData)
         } else {
-            journeyData + (name to pageData)
+            journeyData + (name to formModel.toPageData())
         }
 
     private fun updatedStepData(

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/steps/Step.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/steps/Step.kt
@@ -11,12 +11,7 @@ class Step<T : StepId>(
     val id: T,
     val page: AbstractPage,
     val handleSubmitAndRedirect: ((journeyData: JourneyData, subPageNumber: Int?) -> String)? = null,
-    val isSatisfied: (bindingResult: BindingResult, formData: PageData) -> Boolean = { bindingResult, pageData ->
-        page.isSatisfied(
-            bindingResult,
-            pageData,
-        )
-    },
+    val isSatisfied: (bindingResult: BindingResult) -> Boolean = { bindingResult -> page.isSatisfied(bindingResult) },
     val nextAction: (journeyData: JourneyData, subPageNumber: Int?) -> Pair<T?, Int?> = { _, _ ->
         Pair(
             null,

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/tasks/JourneyTask.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/tasks/JourneyTask.kt
@@ -59,7 +59,8 @@ class JourneyTask<T : StepId>(
         validator: Validator,
     ): Boolean {
         val pageData = JourneyDataHelper.getPageData(journeyData, step.name)
-        return pageData != null && step.isSatisfied(validator, pageData)
+        val bindingResult = step.page.bindDataToFormModel(validator, pageData)
+        return pageData != null && step.isSatisfied(bindingResult, pageData)
     }
 
     companion object {

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/tasks/JourneyTask.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/tasks/JourneyTask.kt
@@ -60,7 +60,7 @@ class JourneyTask<T : StepId>(
     ): Boolean {
         val pageData = JourneyDataHelper.getPageData(journeyData, step.name)
         val bindingResult = step.page.bindDataToFormModel(validator, pageData)
-        return pageData != null && step.isSatisfied(bindingResult, pageData)
+        return pageData != null && step.isSatisfied(bindingResult)
     }
 
     companion object {

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/helpers/JourneyDataHelper.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/helpers/JourneyDataHelper.kt
@@ -4,6 +4,9 @@ import uk.gov.communities.prsdb.webapp.forms.JourneyData
 import uk.gov.communities.prsdb.webapp.forms.PageData
 import uk.gov.communities.prsdb.webapp.forms.objectToStringKeyedMap
 import uk.gov.communities.prsdb.webapp.models.dataModels.AddressDataModel
+import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.LookupAddressFormModel
+import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.ManualAddressFormModel
+import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.SelectLocalAuthorityFormModel
 import java.time.LocalDate
 
 open class JourneyDataHelper {
@@ -13,11 +16,11 @@ open class JourneyDataHelper {
             lookupAddressPathSegment: String,
         ): Pair<String, String>? {
             val houseNameOrNumber =
-                getFieldStringValue(journeyData, lookupAddressPathSegment, "houseNameOrNumber")
+                getFieldStringValue(journeyData, lookupAddressPathSegment, LookupAddressFormModel::houseNameOrNumber.name)
                     ?: return null
 
             val postcode =
-                getFieldStringValue(journeyData, lookupAddressPathSegment, "postcode")
+                getFieldStringValue(journeyData, lookupAddressPathSegment, LookupAddressFormModel::postcode.name)
                     ?: return null
 
             return Pair(houseNameOrNumber, postcode)
@@ -32,35 +35,35 @@ open class JourneyDataHelper {
                 getFieldStringValue(
                     journeyData,
                     manualAddressPathSegment,
-                    "addressLineOne",
+                    ManualAddressFormModel::addressLineOne.name,
                 ) ?: return null
 
             val townOrCity =
                 getFieldStringValue(
                     journeyData,
                     manualAddressPathSegment,
-                    "townOrCity",
+                    ManualAddressFormModel::townOrCity.name,
                 ) ?: return null
 
             val postcode =
                 getFieldStringValue(
                     journeyData,
                     manualAddressPathSegment,
-                    "postcode",
+                    ManualAddressFormModel::postcode.name,
                 ) ?: return null
 
             val addressLineTwo =
                 getFieldStringValue(
                     journeyData,
                     manualAddressPathSegment,
-                    "addressLineTwo",
+                    ManualAddressFormModel::addressLineTwo.name,
                 )
 
             val county =
                 getFieldStringValue(
                     journeyData,
                     manualAddressPathSegment,
-                    "county",
+                    ManualAddressFormModel::county.name,
                 )
 
             val localAuthorityId =
@@ -68,7 +71,7 @@ open class JourneyDataHelper {
                     getFieldIntegerValue(
                         journeyData,
                         it,
-                        "localAuthorityId",
+                        SelectLocalAuthorityFormModel::localAuthorityId.name,
                     ) ?: return null
                 }
 

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/helpers/LaUserRegistrationJourneyDataHelper.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/helpers/LaUserRegistrationJourneyDataHelper.kt
@@ -2,6 +2,8 @@ package uk.gov.communities.prsdb.webapp.helpers
 
 import uk.gov.communities.prsdb.webapp.forms.JourneyData
 import uk.gov.communities.prsdb.webapp.forms.steps.RegisterLaUserStepId
+import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.EmailFormModel
+import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.NameFormModel
 
 class LaUserRegistrationJourneyDataHelper : JourneyDataHelper() {
     companion object {
@@ -9,14 +11,14 @@ class LaUserRegistrationJourneyDataHelper : JourneyDataHelper() {
             getFieldStringValue(
                 journeyData,
                 RegisterLaUserStepId.Name.urlPathSegment,
-                "name",
+                NameFormModel::name.name,
             )
 
         fun getEmail(journeyData: JourneyData) =
             getFieldStringValue(
                 journeyData,
                 RegisterLaUserStepId.Email.urlPathSegment,
-                "emailAddress",
+                EmailFormModel::emailAddress.name,
             )
     }
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/helpers/LandlordRegistrationJourneyDataHelper.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/helpers/LandlordRegistrationJourneyDataHelper.kt
@@ -5,6 +5,14 @@ import uk.gov.communities.prsdb.webapp.constants.MANUAL_ADDRESS_CHOSEN
 import uk.gov.communities.prsdb.webapp.forms.JourneyData
 import uk.gov.communities.prsdb.webapp.forms.steps.LandlordRegistrationStepId
 import uk.gov.communities.prsdb.webapp.models.dataModels.AddressDataModel
+import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.CountryOfResidenceFormModel
+import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.DateOfBirthFormModel
+import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.EmailFormModel
+import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.NameFormModel
+import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.NonEnglandOrWalesAddressFormModel
+import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.PhoneNumberFormModel
+import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.SelectAddressFormModel
+import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.VerifiedIdentityModel
 import java.time.LocalDate
 
 class LandlordRegistrationJourneyDataHelper : JourneyDataHelper() {
@@ -15,14 +23,14 @@ class LandlordRegistrationJourneyDataHelper : JourneyDataHelper() {
             getFieldStringValue(
                 journeyData,
                 LandlordRegistrationStepId.Name.urlPathSegment,
-                "name",
+                NameFormModel::name.name,
             )
 
         fun getVerifiedName(journeyData: JourneyData) =
             getFieldStringValue(
                 journeyData,
                 LandlordRegistrationStepId.VerifyIdentity.urlPathSegment,
-                "name",
+                VerifiedIdentityModel::name.name,
             )
 
         fun getDOB(journeyData: JourneyData) = getVerifiedDOB(journeyData) ?: getManualDOB(journeyData)
@@ -31,7 +39,7 @@ class LandlordRegistrationJourneyDataHelper : JourneyDataHelper() {
             getFieldLocalDateValue(
                 journeyData,
                 LandlordRegistrationStepId.VerifyIdentity.urlPathSegment,
-                "birthDate",
+                VerifiedIdentityModel::birthDate.name,
             )
 
         private fun getManualDOB(journeyData: JourneyData): LocalDate? {
@@ -39,21 +47,21 @@ class LandlordRegistrationJourneyDataHelper : JourneyDataHelper() {
                 getFieldIntegerValue(
                     journeyData,
                     LandlordRegistrationStepId.DateOfBirth.urlPathSegment,
-                    "day",
+                    DateOfBirthFormModel::day.name,
                 ) ?: return null
 
             val month =
                 getFieldIntegerValue(
                     journeyData,
                     LandlordRegistrationStepId.DateOfBirth.urlPathSegment,
-                    "month",
+                    DateOfBirthFormModel::month.name,
                 ) ?: return null
 
             val year =
                 getFieldIntegerValue(
                     journeyData,
                     LandlordRegistrationStepId.DateOfBirth.urlPathSegment,
-                    "year",
+                    DateOfBirthFormModel::year.name,
                 ) ?: return null
 
             return LocalDate.of(year, month, day)
@@ -63,21 +71,21 @@ class LandlordRegistrationJourneyDataHelper : JourneyDataHelper() {
             getFieldStringValue(
                 journeyData,
                 LandlordRegistrationStepId.Email.urlPathSegment,
-                "emailAddress",
+                EmailFormModel::emailAddress.name,
             )
 
         fun getPhoneNumber(journeyData: JourneyData) =
             getFieldStringValue(
                 journeyData,
                 LandlordRegistrationStepId.PhoneNumber.urlPathSegment,
-                "phoneNumber",
+                PhoneNumberFormModel::phoneNumber.name,
             )
 
         fun getLivesInEnglandOrWales(journeyData: JourneyData) =
             getFieldBooleanValue(
                 journeyData,
                 LandlordRegistrationStepId.CountryOfResidence.urlPathSegment,
-                "livesInEnglandOrWales",
+                CountryOfResidenceFormModel::livesInEnglandOrWales.name,
             )
 
         fun getNonEnglandOrWalesCountryOfResidence(journeyData: JourneyData) =
@@ -87,7 +95,7 @@ class LandlordRegistrationJourneyDataHelper : JourneyDataHelper() {
                 getFieldStringValue(
                     journeyData,
                     LandlordRegistrationStepId.CountryOfResidence.urlPathSegment,
-                    "countryOfResidence",
+                    CountryOfResidenceFormModel::countryOfResidence.name,
                 )
             }
 
@@ -119,7 +127,7 @@ class LandlordRegistrationJourneyDataHelper : JourneyDataHelper() {
             return getFieldStringValue(
                 journeyData,
                 selectAddressPathSegment,
-                "address",
+                SelectAddressFormModel::address.name,
             )
         }
 
@@ -141,7 +149,7 @@ class LandlordRegistrationJourneyDataHelper : JourneyDataHelper() {
             getFieldStringValue(
                 journeyData,
                 LandlordRegistrationStepId.NonEnglandOrWalesAddress.urlPathSegment,
-                "nonEnglandOrWalesAddress",
+                NonEnglandOrWalesAddressFormModel::nonEnglandOrWalesAddress.name,
             )
 
         fun isIdentityVerified(journeyData: JourneyData) =

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/helpers/PropertyRegistrationJourneyDataHelper.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/helpers/PropertyRegistrationJourneyDataHelper.kt
@@ -7,6 +7,16 @@ import uk.gov.communities.prsdb.webapp.constants.enums.PropertyType
 import uk.gov.communities.prsdb.webapp.forms.JourneyData
 import uk.gov.communities.prsdb.webapp.forms.steps.RegisterPropertyStepId
 import uk.gov.communities.prsdb.webapp.models.dataModels.AddressDataModel
+import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.HmoAdditionalLicenceFormModel
+import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.HmoMandatoryLicenceFormModel
+import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.LicensingTypeFormModel
+import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.NumberOfHouseholdsFormModel
+import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.NumberOfPeopleFormModel
+import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.OccupancyFormModel
+import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.OwnershipTypeFormModel
+import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.PropertyTypeFormModel
+import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.SelectAddressFormModel
+import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.SelectiveLicenceFormModel
 
 class PropertyRegistrationJourneyDataHelper : JourneyDataHelper() {
     companion object {
@@ -29,68 +39,71 @@ class PropertyRegistrationJourneyDataHelper : JourneyDataHelper() {
             getFieldEnumValue<PropertyType>(
                 journeyData,
                 RegisterPropertyStepId.PropertyType.urlPathSegment,
-                "propertyType",
+                PropertyTypeFormModel::propertyType.name,
             )
 
         fun getCustomPropertyType(journeyData: JourneyData): String? =
             getFieldStringValue(
                 journeyData,
                 RegisterPropertyStepId.PropertyType.urlPathSegment,
-                "customPropertyType",
+                PropertyTypeFormModel::customPropertyType.name,
             )
 
         fun getOwnershipType(journeyData: JourneyData): OwnershipType? =
             getFieldEnumValue<OwnershipType>(
                 journeyData,
                 RegisterPropertyStepId.OwnershipType.urlPathSegment,
-                "ownershipType",
+                OwnershipTypeFormModel::ownershipType.name,
             )
 
         fun getIsOccupied(journeyData: JourneyData): Boolean? =
             getFieldBooleanValue(
                 journeyData,
                 RegisterPropertyStepId.Occupancy.urlPathSegment,
-                "occupied",
+                OccupancyFormModel::occupied.name,
             )
 
         fun getNumberOfHouseholds(journeyData: JourneyData): Int =
             getFieldIntegerValue(
                 journeyData,
                 RegisterPropertyStepId.NumberOfHouseholds.urlPathSegment,
-                "numberOfHouseholds",
+                NumberOfHouseholdsFormModel::numberOfHouseholds.name,
             ) ?: 0
 
         fun getNumberOfTenants(journeyData: JourneyData): Int =
             getFieldIntegerValue(
                 journeyData,
                 RegisterPropertyStepId.NumberOfPeople.urlPathSegment,
-                "numberOfPeople",
+                NumberOfPeopleFormModel::numberOfPeople.name,
             ) ?: 0
 
         fun getLicensingType(journeyData: JourneyData): LicensingType? =
             getFieldEnumValue<LicensingType>(
                 journeyData,
                 RegisterPropertyStepId.LicensingType.urlPathSegment,
-                "licensingType",
+                LicensingTypeFormModel::licensingType.name,
             )
 
         fun getLicenseNumber(journeyData: JourneyData): String? {
-            val licenseNumberPathSegment =
+            val (stepId, fieldName) =
                 when (getLicensingType(journeyData)!!) {
-                    LicensingType.SELECTIVE_LICENCE -> RegisterPropertyStepId.SelectiveLicence.urlPathSegment
-                    LicensingType.HMO_MANDATORY_LICENCE -> RegisterPropertyStepId.HmoMandatoryLicence.urlPathSegment
-                    LicensingType.HMO_ADDITIONAL_LICENCE -> RegisterPropertyStepId.HmoAdditionalLicence.urlPathSegment
+                    LicensingType.SELECTIVE_LICENCE ->
+                        Pair(RegisterPropertyStepId.SelectiveLicence, SelectiveLicenceFormModel::licenceNumber.name)
+                    LicensingType.HMO_MANDATORY_LICENCE ->
+                        Pair(RegisterPropertyStepId.HmoMandatoryLicence, HmoMandatoryLicenceFormModel::licenceNumber.name)
+                    LicensingType.HMO_ADDITIONAL_LICENCE ->
+                        Pair(RegisterPropertyStepId.HmoAdditionalLicence, HmoAdditionalLicenceFormModel::licenceNumber.name)
                     LicensingType.NO_LICENSING -> return ""
                 }
 
-            return getFieldStringValue(journeyData, licenseNumberPathSegment, "licenceNumber")
+            return getFieldStringValue(journeyData, stepId.urlPathSegment, fieldName)
         }
 
         private fun getSelectedAddress(journeyData: JourneyData): String? =
             getFieldStringValue(
                 journeyData,
                 RegisterPropertyStepId.SelectAddress.urlPathSegment,
-                "address",
+                SelectAddressFormModel::address.name,
             )
 
         fun isManualAddressChosen(journeyData: JourneyData) = getSelectedAddress(journeyData) == MANUAL_ADDRESS_CHOSEN

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/helpers/UpdateLandlordDetailsJourneyDataHelper.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/helpers/UpdateLandlordDetailsJourneyDataHelper.kt
@@ -6,6 +6,11 @@ import uk.gov.communities.prsdb.webapp.forms.journeys.UpdateLandlordDetailsJourn
 import uk.gov.communities.prsdb.webapp.forms.steps.UpdateLandlordDetailsStepId
 import uk.gov.communities.prsdb.webapp.helpers.extensions.journeyDataExtensions.JourneyDataExtensions.Companion.getLookedUpAddress
 import uk.gov.communities.prsdb.webapp.models.dataModels.AddressDataModel
+import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.DateOfBirthFormModel
+import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.EmailFormModel
+import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.NameFormModel
+import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.PhoneNumberFormModel
+import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.SelectAddressFormModel
 import java.time.LocalDate
 
 class UpdateLandlordDetailsJourneyDataHelper : JourneyDataHelper() {
@@ -17,21 +22,21 @@ class UpdateLandlordDetailsJourneyDataHelper : JourneyDataHelper() {
             getFieldStringValue(
                 journeyData,
                 UpdateLandlordDetailsStepId.UpdateEmail.urlPathSegment,
-                "emailAddress",
+                EmailFormModel::emailAddress.name,
             )
 
         fun getNameUpdateIfPresent(journeyData: JourneyData) =
             getFieldStringValue(
                 journeyData,
                 UpdateLandlordDetailsStepId.UpdateName.urlPathSegment,
-                "name",
+                NameFormModel::name.name,
             )
 
         fun getPhoneNumberIfPresent(journeyData: JourneyData) =
             getFieldStringValue(
                 journeyData,
                 UpdateLandlordDetailsStepId.UpdatePhoneNumber.urlPathSegment,
-                "phoneNumber",
+                PhoneNumberFormModel::phoneNumber.name,
             )
 
         fun getAddressIfPresent(journeyData: JourneyData): AddressDataModel? {
@@ -39,7 +44,7 @@ class UpdateLandlordDetailsJourneyDataHelper : JourneyDataHelper() {
                 getFieldStringValue(
                     journeyData,
                     UpdateLandlordDetailsStepId.SelectEnglandAndWalesAddress.urlPathSegment,
-                    "address",
+                    SelectAddressFormModel::address.name,
                 )
 
             return if (selectedAddress == MANUAL_ADDRESS_CHOSEN) {
@@ -56,21 +61,21 @@ class UpdateLandlordDetailsJourneyDataHelper : JourneyDataHelper() {
                 getFieldIntegerValue(
                     journeyData,
                     UpdateLandlordDetailsStepId.UpdateDateOfBirth.urlPathSegment,
-                    "day",
+                    DateOfBirthFormModel::day.name,
                 ) ?: return null
 
             val month =
                 getFieldIntegerValue(
                     journeyData,
                     UpdateLandlordDetailsStepId.UpdateDateOfBirth.urlPathSegment,
-                    "month",
+                    DateOfBirthFormModel::month.name,
                 ) ?: return null
 
             val year =
                 getFieldIntegerValue(
                     journeyData,
                     UpdateLandlordDetailsStepId.UpdateDateOfBirth.urlPathSegment,
-                    "year",
+                    DateOfBirthFormModel::year.name,
                 ) ?: return null
 
             return LocalDate.of(year, month, day)

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/helpers/extensions/journeyDataExtensions/JourneyDataExtensions.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/helpers/extensions/journeyDataExtensions/JourneyDataExtensions.kt
@@ -6,6 +6,7 @@ import uk.gov.communities.prsdb.webapp.constants.LOOKED_UP_ADDRESSES_JOURNEY_DAT
 import uk.gov.communities.prsdb.webapp.forms.JourneyData
 import uk.gov.communities.prsdb.webapp.helpers.JourneyDataHelper
 import uk.gov.communities.prsdb.webapp.models.dataModels.AddressDataModel
+import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.PropertyDeregistrationAreYouSureFormModel
 
 open class JourneyDataExtensions {
     companion object {
@@ -33,7 +34,7 @@ open class JourneyDataExtensions {
             JourneyDataHelper.getFieldBooleanValue(
                 this,
                 urlPathSegment,
-                "wantsToProceed",
+                PropertyDeregistrationAreYouSureFormModel::wantsToProceed.name,
             )
     }
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/helpers/extensions/journeyDataExtensions/JourneyDataExtensions.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/helpers/extensions/journeyDataExtensions/JourneyDataExtensions.kt
@@ -6,7 +6,6 @@ import uk.gov.communities.prsdb.webapp.constants.LOOKED_UP_ADDRESSES_JOURNEY_DAT
 import uk.gov.communities.prsdb.webapp.forms.JourneyData
 import uk.gov.communities.prsdb.webapp.helpers.JourneyDataHelper
 import uk.gov.communities.prsdb.webapp.models.dataModels.AddressDataModel
-import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.PropertyDeregistrationAreYouSureFormModel
 
 open class JourneyDataExtensions {
     companion object {
@@ -28,13 +27,5 @@ open class JourneyDataExtensions {
 
         fun JourneyData.withUpdatedLookedUpAddresses(lookedUpAddresses: List<AddressDataModel>): JourneyData =
             this.withUpdatedLookedUpAddresses(Json.encodeToString(lookedUpAddresses))
-
-        @JvmStatic
-        protected fun JourneyData.getWantsToProceed(urlPathSegment: String): Boolean? =
-            JourneyDataHelper.getFieldBooleanValue(
-                this,
-                urlPathSegment,
-                PropertyDeregistrationAreYouSureFormModel::wantsToProceed.name,
-            )
     }
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/helpers/extensions/journeyDataExtensions/LandlordDeregistrationJourneyDataExtensions.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/helpers/extensions/journeyDataExtensions/LandlordDeregistrationJourneyDataExtensions.kt
@@ -3,11 +3,17 @@ package uk.gov.communities.prsdb.webapp.helpers.extensions.journeyDataExtensions
 import uk.gov.communities.prsdb.webapp.forms.JourneyData
 import uk.gov.communities.prsdb.webapp.forms.steps.DeregisterLandlordStepId
 import uk.gov.communities.prsdb.webapp.helpers.JourneyDataHelper
+import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.LandlordDeregistrationAreYouSureFormModel
 import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.LandlordDeregistrationCheckUserPropertiesFormModel.Companion.USER_HAS_REGISTERED_PROPERTIES_JOURNEY_DATA_KEY
 
 class LandlordDeregistrationJourneyDataExtensions : JourneyDataExtensions() {
     companion object {
-        fun JourneyData.getWantsToProceed() = this.getWantsToProceed(DeregisterLandlordStepId.AreYouSure.urlPathSegment)
+        fun JourneyData.getWantsToProceed() =
+            JourneyDataHelper.getFieldBooleanValue(
+                this,
+                DeregisterLandlordStepId.AreYouSure.urlPathSegment,
+                LandlordDeregistrationAreYouSureFormModel::wantsToProceed.name,
+            )
 
         fun JourneyData.getLandlordUserHasRegisteredProperties(): Boolean? =
             JourneyDataHelper.getFieldBooleanValue(

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/helpers/extensions/journeyDataExtensions/PropertyDeregistrationJourneyDataExtensions.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/helpers/extensions/journeyDataExtensions/PropertyDeregistrationJourneyDataExtensions.kt
@@ -2,9 +2,16 @@ package uk.gov.communities.prsdb.webapp.helpers.extensions.journeyDataExtensions
 
 import uk.gov.communities.prsdb.webapp.forms.JourneyData
 import uk.gov.communities.prsdb.webapp.forms.steps.DeregisterPropertyStepId
+import uk.gov.communities.prsdb.webapp.helpers.JourneyDataHelper
+import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.PropertyDeregistrationAreYouSureFormModel
 
 class PropertyDeregistrationJourneyDataExtensions : JourneyDataExtensions() {
     companion object {
-        fun JourneyData.getWantsToProceed() = this.getWantsToProceed(DeregisterPropertyStepId.AreYouSure.urlPathSegment)
+        fun JourneyData.getWantsToProceed() =
+            JourneyDataHelper.getFieldBooleanValue(
+                this,
+                DeregisterPropertyStepId.AreYouSure.urlPathSegment,
+                PropertyDeregistrationAreYouSureFormModel::wantsToProceed.name,
+            )
     }
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/helpers/extensions/journeyDataExtensions/PropertyDetailsUpdateJourneyDataExtensions.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/helpers/extensions/journeyDataExtensions/PropertyDetailsUpdateJourneyDataExtensions.kt
@@ -2,10 +2,15 @@ package uk.gov.communities.prsdb.webapp.helpers.extensions.journeyDataExtensions
 
 import uk.gov.communities.prsdb.webapp.constants.enums.LicensingType
 import uk.gov.communities.prsdb.webapp.constants.enums.OwnershipType
+import uk.gov.communities.prsdb.webapp.database.entity.PropertyOwnership
 import uk.gov.communities.prsdb.webapp.forms.JourneyData
 import uk.gov.communities.prsdb.webapp.forms.steps.UpdatePropertyDetailsStepId
 import uk.gov.communities.prsdb.webapp.helpers.JourneyDataHelper
 import uk.gov.communities.prsdb.webapp.helpers.extensions.journeyDataExtensions.UpdateJourneyDataExtensions.Companion.getOriginalJourneyDataIfPresent
+import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.FormModel
+import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.HmoAdditionalLicenceFormModel
+import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.HmoMandatoryLicenceFormModel
+import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.SelectiveLicenceFormModel
 
 class PropertyDetailsUpdateJourneyDataExtensions {
     companion object {
@@ -65,6 +70,26 @@ class PropertyDetailsUpdateJourneyDataExtensions {
                 LicensingType.SELECTIVE_LICENCE -> UpdatePropertyDetailsStepId.UpdateSelectiveLicence
                 LicensingType.HMO_MANDATORY_LICENCE -> UpdatePropertyDetailsStepId.UpdateHmoMandatoryLicence
                 LicensingType.HMO_ADDITIONAL_LICENCE -> UpdatePropertyDetailsStepId.UpdateHmoAdditionalLicence
+                else -> null
+            }
+
+        fun getLicenceNumberStepIdAndFormModel(propertyOwnership: PropertyOwnership): Pair<UpdatePropertyDetailsStepId, FormModel>? =
+            when (propertyOwnership.license?.licenseType) {
+                LicensingType.SELECTIVE_LICENCE ->
+                    Pair(
+                        UpdatePropertyDetailsStepId.UpdateSelectiveLicence,
+                        SelectiveLicenceFormModel.fromPropertyOwnership(propertyOwnership),
+                    )
+                LicensingType.HMO_MANDATORY_LICENCE ->
+                    Pair(
+                        UpdatePropertyDetailsStepId.UpdateHmoMandatoryLicence,
+                        HmoMandatoryLicenceFormModel.fromPropertyOwnership(propertyOwnership),
+                    )
+                LicensingType.HMO_ADDITIONAL_LICENCE ->
+                    Pair(
+                        UpdatePropertyDetailsStepId.UpdateHmoAdditionalLicence,
+                        HmoAdditionalLicenceFormModel.fromPropertyOwnership(propertyOwnership),
+                    )
                 else -> null
             }
 

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/helpers/extensions/journeyDataExtensions/PropertyDetailsUpdateJourneyDataExtensions.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/helpers/extensions/journeyDataExtensions/PropertyDetailsUpdateJourneyDataExtensions.kt
@@ -2,20 +2,15 @@ package uk.gov.communities.prsdb.webapp.helpers.extensions.journeyDataExtensions
 
 import uk.gov.communities.prsdb.webapp.constants.enums.LicensingType
 import uk.gov.communities.prsdb.webapp.constants.enums.OwnershipType
-import uk.gov.communities.prsdb.webapp.database.entity.PropertyOwnership
 import uk.gov.communities.prsdb.webapp.forms.JourneyData
 import uk.gov.communities.prsdb.webapp.forms.steps.UpdatePropertyDetailsStepId
 import uk.gov.communities.prsdb.webapp.helpers.JourneyDataHelper
 import uk.gov.communities.prsdb.webapp.helpers.extensions.journeyDataExtensions.UpdateJourneyDataExtensions.Companion.getOriginalJourneyDataIfPresent
-import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.FormModel
-import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.HmoAdditionalLicenceFormModel
-import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.HmoMandatoryLicenceFormModel
 import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.LicensingTypeFormModel
 import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.NumberOfHouseholdsFormModel
 import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.NumberOfPeopleFormModel
 import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.OccupancyFormModel
 import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.OwnershipTypeFormModel
-import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.SelectiveLicenceFormModel
 
 class PropertyDetailsUpdateJourneyDataExtensions {
     companion object {
@@ -75,26 +70,6 @@ class PropertyDetailsUpdateJourneyDataExtensions {
                 LicensingType.SELECTIVE_LICENCE -> UpdatePropertyDetailsStepId.UpdateSelectiveLicence
                 LicensingType.HMO_MANDATORY_LICENCE -> UpdatePropertyDetailsStepId.UpdateHmoMandatoryLicence
                 LicensingType.HMO_ADDITIONAL_LICENCE -> UpdatePropertyDetailsStepId.UpdateHmoAdditionalLicence
-                else -> null
-            }
-
-        fun getLicenceNumberStepIdAndFormModel(propertyOwnership: PropertyOwnership): Pair<UpdatePropertyDetailsStepId, FormModel>? =
-            when (propertyOwnership.license?.licenseType) {
-                LicensingType.SELECTIVE_LICENCE ->
-                    Pair(
-                        UpdatePropertyDetailsStepId.UpdateSelectiveLicence,
-                        SelectiveLicenceFormModel.fromPropertyOwnership(propertyOwnership),
-                    )
-                LicensingType.HMO_MANDATORY_LICENCE ->
-                    Pair(
-                        UpdatePropertyDetailsStepId.UpdateHmoMandatoryLicence,
-                        HmoMandatoryLicenceFormModel.fromPropertyOwnership(propertyOwnership),
-                    )
-                LicensingType.HMO_ADDITIONAL_LICENCE ->
-                    Pair(
-                        UpdatePropertyDetailsStepId.UpdateHmoAdditionalLicence,
-                        HmoAdditionalLicenceFormModel.fromPropertyOwnership(propertyOwnership),
-                    )
                 else -> null
             }
 

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/helpers/extensions/journeyDataExtensions/PropertyDetailsUpdateJourneyDataExtensions.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/helpers/extensions/journeyDataExtensions/PropertyDetailsUpdateJourneyDataExtensions.kt
@@ -10,6 +10,11 @@ import uk.gov.communities.prsdb.webapp.helpers.extensions.journeyDataExtensions.
 import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.FormModel
 import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.HmoAdditionalLicenceFormModel
 import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.HmoMandatoryLicenceFormModel
+import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.LicensingTypeFormModel
+import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.NumberOfHouseholdsFormModel
+import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.NumberOfPeopleFormModel
+import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.OccupancyFormModel
+import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.OwnershipTypeFormModel
 import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.SelectiveLicenceFormModel
 
 class PropertyDetailsUpdateJourneyDataExtensions {
@@ -18,7 +23,7 @@ class PropertyDetailsUpdateJourneyDataExtensions {
             JourneyDataHelper.getFieldEnumValue<OwnershipType>(
                 this,
                 UpdatePropertyDetailsStepId.UpdateOwnershipType.urlPathSegment,
-                "ownershipType",
+                OwnershipTypeFormModel::ownershipType.name,
             )
 
         fun JourneyData.getOriginalIsOccupied(originalJourneyKey: String) =
@@ -33,7 +38,7 @@ class PropertyDetailsUpdateJourneyDataExtensions {
                 JourneyDataHelper.getFieldIntegerValue(
                     this,
                     UpdatePropertyDetailsStepId.UpdateNumberOfHouseholds.urlPathSegment,
-                    "numberOfHouseholds",
+                    NumberOfHouseholdsFormModel::numberOfHouseholds.name,
                 )
             }
 
@@ -44,7 +49,7 @@ class PropertyDetailsUpdateJourneyDataExtensions {
                 JourneyDataHelper.getFieldIntegerValue(
                     this,
                     UpdatePropertyDetailsStepId.UpdateNumberOfPeople.urlPathSegment,
-                    "numberOfPeople",
+                    NumberOfPeopleFormModel::numberOfPeople.name,
                 )
             }
 
@@ -52,7 +57,7 @@ class PropertyDetailsUpdateJourneyDataExtensions {
             JourneyDataHelper.getFieldEnumValue<LicensingType>(
                 this,
                 UpdatePropertyDetailsStepId.UpdateLicensingType.urlPathSegment,
-                "licensingType",
+                LicensingTypeFormModel::licensingType.name,
             )
 
         fun JourneyData.getLicenceNumberUpdateIfPresent(originalJourneyKey: String): String? {
@@ -97,7 +102,7 @@ class PropertyDetailsUpdateJourneyDataExtensions {
             JourneyDataHelper.getFieldBooleanValue(
                 this,
                 UpdatePropertyDetailsStepId.UpdateOccupancy.urlPathSegment,
-                "occupied",
+                OccupancyFormModel::occupied.name,
             )
 
         fun JourneyData.getLatestNumberOfHouseholds(originalJourneyDataKey: String?): Int {

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/requestModels/formModels/DateOfBirthFormModel.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/requestModels/formModels/DateOfBirthFormModel.kt
@@ -1,5 +1,7 @@
 package uk.gov.communities.prsdb.webapp.models.requestModels.formModels
 
+import uk.gov.communities.prsdb.webapp.database.entity.Landlord
+import uk.gov.communities.prsdb.webapp.forms.ExcludeFromPageData
 import uk.gov.communities.prsdb.webapp.validation.ConstraintDescriptor
 import uk.gov.communities.prsdb.webapp.validation.DateValidator
 import uk.gov.communities.prsdb.webapp.validation.DelegatedPropertyConstraintValidator
@@ -177,6 +179,7 @@ class DateOfBirthFormModel(
     )
     var year: String = "",
 ) : FormModel {
+    @ExcludeFromPageData
     val dateValidator = DateValidator()
 
     fun notAllBlank(): Boolean = !(dateValidator.isAllBlank(day, month, year))
@@ -221,4 +224,13 @@ class DateOfBirthFormModel(
     }
 
     fun isValidDateOfBirth(): Boolean = isValidDate() && isValidDateForMinimumAge() && isValidDateForMaximumAge()
+
+    companion object {
+        fun fromLandlord(landlord: Landlord): DateOfBirthFormModel =
+            DateOfBirthFormModel().apply {
+                day = landlord.dateOfBirth?.dayOfMonth.toString()
+                month = landlord.dateOfBirth?.monthValue.toString()
+                year = landlord.dateOfBirth?.year.toString()
+            }
+    }
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/requestModels/formModels/EmailFormModel.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/requestModels/formModels/EmailFormModel.kt
@@ -1,5 +1,7 @@
 package uk.gov.communities.prsdb.webapp.models.requestModels.formModels
 
+import uk.gov.communities.prsdb.webapp.database.entity.Landlord
+import uk.gov.communities.prsdb.webapp.database.entity.LocalAuthorityInvitation
 import uk.gov.communities.prsdb.webapp.validation.ConstraintDescriptor
 import uk.gov.communities.prsdb.webapp.validation.EmailConstraintValidator
 import uk.gov.communities.prsdb.webapp.validation.IsValidPrioritised
@@ -21,4 +23,14 @@ class EmailFormModel : FormModel {
         ],
     )
     var emailAddress: String? = null
+
+    companion object {
+        fun fromLandlord(landlord: Landlord): EmailFormModel = EmailFormModel().apply { emailAddress = landlord.email }
+
+        fun fromLaInvitation(invitation: LocalAuthorityInvitation): EmailFormModel =
+            EmailFormModel().apply {
+                emailAddress =
+                    invitation.invitedEmail
+            }
+    }
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/requestModels/formModels/FormModel.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/requestModels/formModels/FormModel.kt
@@ -2,12 +2,12 @@ package uk.gov.communities.prsdb.webapp.models.requestModels.formModels
 
 import uk.gov.communities.prsdb.webapp.forms.ExcludeFromPageData
 import uk.gov.communities.prsdb.webapp.forms.PageData
-import kotlin.reflect.full.findAnnotation
+import kotlin.reflect.full.hasAnnotation
 import kotlin.reflect.full.memberProperties
 
 interface FormModel {
     open fun toPageData(): PageData =
         this.javaClass.kotlin.memberProperties
-            .filter { it.findAnnotation<ExcludeFromPageData>() == null }
+            .filter { !it.hasAnnotation<ExcludeFromPageData>() }
             .associate { it.name to it.get(this) }
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/requestModels/formModels/FormModel.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/requestModels/formModels/FormModel.kt
@@ -1,3 +1,13 @@
 package uk.gov.communities.prsdb.webapp.models.requestModels.formModels
 
-interface FormModel
+import uk.gov.communities.prsdb.webapp.forms.ExcludeFromPageData
+import uk.gov.communities.prsdb.webapp.forms.PageData
+import kotlin.reflect.full.findAnnotation
+import kotlin.reflect.full.memberProperties
+
+interface FormModel {
+    open fun toPageData(): PageData =
+        this.javaClass.kotlin.memberProperties
+            .filter { it.findAnnotation<ExcludeFromPageData>() == null }
+            .associate { it.name to it.get(this) }
+}

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/requestModels/formModels/HmoAdditionalLicenceFormModel.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/requestModels/formModels/HmoAdditionalLicenceFormModel.kt
@@ -1,5 +1,6 @@
 package uk.gov.communities.prsdb.webapp.models.requestModels.formModels
 
+import uk.gov.communities.prsdb.webapp.database.entity.PropertyOwnership
 import uk.gov.communities.prsdb.webapp.validation.ConstraintDescriptor
 import uk.gov.communities.prsdb.webapp.validation.IsValidPrioritised
 import uk.gov.communities.prsdb.webapp.validation.LengthConstraintValidator
@@ -22,4 +23,11 @@ class HmoAdditionalLicenceFormModel : FormModel {
         ],
     )
     var licenceNumber: String? = null
+
+    companion object {
+        fun fromPropertyOwnership(propertyOwnership: PropertyOwnership): HmoAdditionalLicenceFormModel =
+            HmoAdditionalLicenceFormModel().apply {
+                licenceNumber = propertyOwnership.license?.licenseNumber
+            }
+    }
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/requestModels/formModels/HmoMandatoryLicenceFormModel.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/requestModels/formModels/HmoMandatoryLicenceFormModel.kt
@@ -1,5 +1,6 @@
 package uk.gov.communities.prsdb.webapp.models.requestModels.formModels
 
+import uk.gov.communities.prsdb.webapp.database.entity.PropertyOwnership
 import uk.gov.communities.prsdb.webapp.validation.ConstraintDescriptor
 import uk.gov.communities.prsdb.webapp.validation.IsValidPrioritised
 import uk.gov.communities.prsdb.webapp.validation.LengthConstraintValidator
@@ -22,4 +23,11 @@ class HmoMandatoryLicenceFormModel : FormModel {
         ],
     )
     var licenceNumber: String? = null
+
+    companion object {
+        fun fromPropertyOwnership(propertyOwnership: PropertyOwnership): HmoMandatoryLicenceFormModel =
+            HmoMandatoryLicenceFormModel().apply {
+                licenceNumber = propertyOwnership.license?.licenseNumber
+            }
+    }
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/requestModels/formModels/LicensingTypeFormModel.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/requestModels/formModels/LicensingTypeFormModel.kt
@@ -1,6 +1,7 @@
 package uk.gov.communities.prsdb.webapp.models.requestModels.formModels
 
 import uk.gov.communities.prsdb.webapp.constants.enums.LicensingType
+import uk.gov.communities.prsdb.webapp.database.entity.PropertyOwnership
 import uk.gov.communities.prsdb.webapp.validation.ConstraintDescriptor
 import uk.gov.communities.prsdb.webapp.validation.IsValidPrioritised
 import uk.gov.communities.prsdb.webapp.validation.NotNullConstraintValidator
@@ -17,4 +18,11 @@ class LicensingTypeFormModel : FormModel {
         ],
     )
     var licensingType: LicensingType? = null
+
+    companion object {
+        fun fromPropertyOwnership(propertyOwnership: PropertyOwnership): LicensingTypeFormModel =
+            LicensingTypeFormModel().apply {
+                licensingType = propertyOwnership.license?.licenseType ?: LicensingType.NO_LICENSING
+            }
+    }
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/requestModels/formModels/LookupAddressFormModel.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/requestModels/formModels/LookupAddressFormModel.kt
@@ -1,5 +1,6 @@
 package uk.gov.communities.prsdb.webapp.models.requestModels.formModels
 
+import uk.gov.communities.prsdb.webapp.database.entity.Landlord
 import uk.gov.communities.prsdb.webapp.validation.ConstraintDescriptor
 import uk.gov.communities.prsdb.webapp.validation.IsValidPrioritised
 import uk.gov.communities.prsdb.webapp.validation.NotBlankConstraintValidator
@@ -26,4 +27,12 @@ class LookupAddressFormModel : FormModel {
         ],
     )
     var houseNameOrNumber: String? = null
+
+    companion object {
+        fun fromLandlord(landlord: Landlord): LookupAddressFormModel =
+            LookupAddressFormModel().apply {
+                postcode = landlord.address.getPostcodeSearchTerm()
+                houseNameOrNumber = landlord.address.getHouseNameOrNumber()
+            }
+    }
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/requestModels/formModels/LookupAddressFormModel.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/requestModels/formModels/LookupAddressFormModel.kt
@@ -31,8 +31,11 @@ class LookupAddressFormModel : FormModel {
     companion object {
         fun fromLandlord(landlord: Landlord): LookupAddressFormModel =
             LookupAddressFormModel().apply {
-                postcode = landlord.address.getPostcodeSearchTerm()
-                houseNameOrNumber = landlord.address.getHouseNameOrNumber()
+                // We default to singleLineAddress not because that's useful data, but because we want this form to
+                // be considered valid, and thus its journey Step to be satisfied, in the case that a manual address was
+                // provided rather than address lookup terms.
+                postcode = landlord.address.postcode ?: landlord.address.singleLineAddress
+                houseNameOrNumber = landlord.address.buildingName ?: landlord.address.buildingNumber ?: landlord.address.singleLineAddress
             }
     }
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/requestModels/formModels/ManualAddressFormModel.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/requestModels/formModels/ManualAddressFormModel.kt
@@ -1,5 +1,6 @@
 package uk.gov.communities.prsdb.webapp.models.requestModels.formModels
 
+import uk.gov.communities.prsdb.webapp.database.entity.Landlord
 import uk.gov.communities.prsdb.webapp.validation.ConstraintDescriptor
 import uk.gov.communities.prsdb.webapp.validation.IsValidPrioritised
 import uk.gov.communities.prsdb.webapp.validation.NotBlankConstraintValidator
@@ -40,4 +41,13 @@ class ManualAddressFormModel : FormModel {
         ],
     )
     var postcode: String? = null
+
+    companion object {
+        fun fromLandlord(landlord: Landlord): ManualAddressFormModel =
+            ManualAddressFormModel().apply {
+                addressLineOne = landlord.address.singleLineAddress
+                townOrCity = landlord.address.getTownOrCity()
+                postcode = landlord.address.getPostcodeSearchTerm()
+            }
+    }
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/requestModels/formModels/ManualAddressFormModel.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/requestModels/formModels/ManualAddressFormModel.kt
@@ -46,8 +46,8 @@ class ManualAddressFormModel : FormModel {
         fun fromLandlord(landlord: Landlord): ManualAddressFormModel =
             ManualAddressFormModel().apply {
                 addressLineOne = landlord.address.singleLineAddress
-                townOrCity = landlord.address.getTownOrCity()
-                postcode = landlord.address.getPostcodeSearchTerm()
+                townOrCity = landlord.address.townName
+                postcode = landlord.address.postcode
             }
     }
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/requestModels/formModels/NameFormModel.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/requestModels/formModels/NameFormModel.kt
@@ -1,5 +1,6 @@
 package uk.gov.communities.prsdb.webapp.models.requestModels.formModels
 
+import uk.gov.communities.prsdb.webapp.database.entity.Landlord
 import uk.gov.communities.prsdb.webapp.validation.ConstraintDescriptor
 import uk.gov.communities.prsdb.webapp.validation.IsValidPrioritised
 import uk.gov.communities.prsdb.webapp.validation.NotBlankConstraintValidator
@@ -16,4 +17,8 @@ class NameFormModel : FormModel {
         ],
     )
     var name: String? = null
+
+    companion object {
+        fun fromLandlord(landlord: Landlord): NameFormModel = NameFormModel().apply { name = landlord.name }
+    }
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/requestModels/formModels/NumberOfHouseholdsFormModel.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/requestModels/formModels/NumberOfHouseholdsFormModel.kt
@@ -1,5 +1,6 @@
 package uk.gov.communities.prsdb.webapp.models.requestModels.formModels
 
+import uk.gov.communities.prsdb.webapp.database.entity.PropertyOwnership
 import uk.gov.communities.prsdb.webapp.validation.ConstraintDescriptor
 import uk.gov.communities.prsdb.webapp.validation.IsValidPrioritised
 import uk.gov.communities.prsdb.webapp.validation.NotBlankConstraintValidator
@@ -21,4 +22,9 @@ class NumberOfHouseholdsFormModel : FormModel {
         ],
     )
     var numberOfHouseholds: String = ""
+
+    companion object {
+        fun fromPropertyOwnership(propertyOwnership: PropertyOwnership): NumberOfHouseholdsFormModel =
+            NumberOfHouseholdsFormModel().apply { numberOfHouseholds = propertyOwnership.currentNumHouseholds.toString() }
+    }
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/requestModels/formModels/NumberOfPeopleFormModel.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/requestModels/formModels/NumberOfPeopleFormModel.kt
@@ -1,5 +1,6 @@
 package uk.gov.communities.prsdb.webapp.models.requestModels.formModels
 
+import uk.gov.communities.prsdb.webapp.database.entity.PropertyOwnership
 import uk.gov.communities.prsdb.webapp.validation.ConstraintDescriptor
 import uk.gov.communities.prsdb.webapp.validation.DelegatedPropertyConstraintValidator
 import uk.gov.communities.prsdb.webapp.validation.IsValidPrioritised
@@ -30,4 +31,9 @@ class NumberOfPeopleFormModel(
     var numberOfHouseholds: String = "",
 ) : FormModel {
     fun isNotLessThanNumberOfHouseholds(): Boolean = numberOfPeople.toInt() >= numberOfHouseholds.toInt()
+
+    companion object {
+        fun fromPropertyOwnership(propertyOwnership: PropertyOwnership): NumberOfPeopleFormModel =
+            NumberOfPeopleFormModel().apply { numberOfPeople = propertyOwnership.currentNumTenants.toString() }
+    }
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/requestModels/formModels/NumberOfPeopleFormModel.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/requestModels/formModels/NumberOfPeopleFormModel.kt
@@ -34,6 +34,9 @@ class NumberOfPeopleFormModel(
 
     companion object {
         fun fromPropertyOwnership(propertyOwnership: PropertyOwnership): NumberOfPeopleFormModel =
-            NumberOfPeopleFormModel().apply { numberOfPeople = propertyOwnership.currentNumTenants.toString() }
+            NumberOfPeopleFormModel().apply {
+                numberOfPeople = propertyOwnership.currentNumTenants.toString()
+                numberOfHouseholds = propertyOwnership.currentNumHouseholds.toString()
+            }
     }
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/requestModels/formModels/OccupancyFormModel.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/requestModels/formModels/OccupancyFormModel.kt
@@ -1,5 +1,6 @@
 package uk.gov.communities.prsdb.webapp.models.requestModels.formModels
 
+import uk.gov.communities.prsdb.webapp.database.entity.PropertyOwnership
 import uk.gov.communities.prsdb.webapp.validation.ConstraintDescriptor
 import uk.gov.communities.prsdb.webapp.validation.IsValidPrioritised
 import uk.gov.communities.prsdb.webapp.validation.NotNullConstraintValidator
@@ -16,4 +17,9 @@ class OccupancyFormModel : FormModel {
         ],
     )
     var occupied: Boolean? = null
+
+    companion object {
+        fun fromPropertyOwnership(propertyOwnership: PropertyOwnership): OccupancyFormModel =
+            OccupancyFormModel().apply { occupied = propertyOwnership.isOccupied }
+    }
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/requestModels/formModels/OwnershipTypeFormModel.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/requestModels/formModels/OwnershipTypeFormModel.kt
@@ -1,6 +1,7 @@
 package uk.gov.communities.prsdb.webapp.models.requestModels.formModels
 
 import uk.gov.communities.prsdb.webapp.constants.enums.OwnershipType
+import uk.gov.communities.prsdb.webapp.database.entity.PropertyOwnership
 import uk.gov.communities.prsdb.webapp.validation.ConstraintDescriptor
 import uk.gov.communities.prsdb.webapp.validation.IsValidPrioritised
 import uk.gov.communities.prsdb.webapp.validation.NotNullConstraintValidator
@@ -17,4 +18,9 @@ class OwnershipTypeFormModel : FormModel {
         ],
     )
     var ownershipType: OwnershipType? = null
+
+    companion object {
+        fun fromPropertyOwnership(propertyOwnership: PropertyOwnership): OwnershipTypeFormModel =
+            OwnershipTypeFormModel().apply { ownershipType = propertyOwnership.ownershipType }
+    }
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/requestModels/formModels/PhoneNumberFormModel.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/requestModels/formModels/PhoneNumberFormModel.kt
@@ -1,5 +1,6 @@
 package uk.gov.communities.prsdb.webapp.models.requestModels.formModels
 
+import uk.gov.communities.prsdb.webapp.database.entity.Landlord
 import uk.gov.communities.prsdb.webapp.validation.ConstraintDescriptor
 import uk.gov.communities.prsdb.webapp.validation.IsValidPrioritised
 import uk.gov.communities.prsdb.webapp.validation.NotBlankConstraintValidator
@@ -21,4 +22,8 @@ class PhoneNumberFormModel : FormModel {
         ],
     )
     var phoneNumber: String? = null
+
+    companion object {
+        fun fromLandlord(landlord: Landlord): PhoneNumberFormModel = PhoneNumberFormModel().apply { phoneNumber = landlord.phoneNumber }
+    }
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/requestModels/formModels/SelectAddressFormModel.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/requestModels/formModels/SelectAddressFormModel.kt
@@ -1,5 +1,6 @@
 package uk.gov.communities.prsdb.webapp.models.requestModels.formModels
 
+import uk.gov.communities.prsdb.webapp.database.entity.Landlord
 import uk.gov.communities.prsdb.webapp.validation.ConstraintDescriptor
 import uk.gov.communities.prsdb.webapp.validation.IsValidPrioritised
 import uk.gov.communities.prsdb.webapp.validation.NotNullConstraintValidator
@@ -16,4 +17,9 @@ class SelectAddressFormModel : FormModel {
         ],
     )
     var address: String? = null
+
+    companion object {
+        fun fromLandlord(landlord: Landlord): SelectAddressFormModel =
+            SelectAddressFormModel().apply { address = landlord.address.getSelectedAddress() }
+    }
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/requestModels/formModels/SelectiveLicenceFormModel.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/requestModels/formModels/SelectiveLicenceFormModel.kt
@@ -1,5 +1,6 @@
 package uk.gov.communities.prsdb.webapp.models.requestModels.formModels
 
+import uk.gov.communities.prsdb.webapp.database.entity.PropertyOwnership
 import uk.gov.communities.prsdb.webapp.validation.ConstraintDescriptor
 import uk.gov.communities.prsdb.webapp.validation.IsValidPrioritised
 import uk.gov.communities.prsdb.webapp.validation.LengthConstraintValidator
@@ -22,4 +23,11 @@ class SelectiveLicenceFormModel : FormModel {
         ],
     )
     var licenceNumber: String? = null
+
+    companion object {
+        fun fromPropertyOwnership(propertyOwnership: PropertyOwnership): SelectiveLicenceFormModel =
+            SelectiveLicenceFormModel().apply {
+                licenceNumber = propertyOwnership.license?.licenseNumber
+            }
+    }
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/JourneyTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/JourneyTests.kt
@@ -17,6 +17,7 @@ import org.mockito.Mockito.mock
 import org.mockito.internal.matchers.apachecommons.ReflectionEquals
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.never
@@ -460,10 +461,10 @@ class JourneyTests {
                             ),
                         ),
                 )
-            val pageDataStepOne: PageData = mapOf("testProperty" to "testProperty")
-            val pageDataStepTwo: PageData = mapOf("testPropertyTwo" to "testProperty")
-            val pageDataStepThree: PageData = mapOf("testProperty" to "testProperty")
-            val pageDataStepFour: PageData = mapOf("testProperty" to "testProperty")
+            val pageDataStepOne: PageData = mapOf("testProperty" to "testProperty1")
+            val pageDataStepTwo: PageData = mapOf("testProperty" to "testProperty2")
+            val pageDataStepThree: PageData = mapOf("testProperty" to "testProperty3")
+            val pageDataStepFour: PageData = mapOf("testProperty" to "testProperty4")
             val journeyData: JourneyData =
                 mapOf(
                     TestStepId.StepOne.urlPathSegment to pageDataStepOne,
@@ -487,11 +488,10 @@ class JourneyTests {
 
             // Assert
             verify(spiedOnPage).getModelAndView(
-                validator,
-                pageDataStepFour,
-                TestStepId.StepThree.urlPathSegment,
-                filteredJourneyData,
-                null,
+                anyOrNull(),
+                eq(TestStepId.StepThree.urlPathSegment),
+                eq(filteredJourneyData),
+                eq(null),
             )
         }
     }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/LandlordRegistrationJourneyTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/LandlordRegistrationJourneyTests.kt
@@ -19,7 +19,6 @@ import uk.gov.communities.prsdb.webapp.services.EmailNotificationService
 import uk.gov.communities.prsdb.webapp.services.JourneyDataService
 import uk.gov.communities.prsdb.webapp.services.LandlordService
 import uk.gov.communities.prsdb.webapp.testHelpers.JourneyTestHelper
-import uk.gov.communities.prsdb.webapp.testHelpers.JourneyTestHelper.Companion.setMockUser
 import uk.gov.communities.prsdb.webapp.testHelpers.builders.JourneyDataBuilder
 import uk.gov.communities.prsdb.webapp.testHelpers.mockObjects.AlwaysTrueValidator
 import uk.gov.communities.prsdb.webapp.testHelpers.mockObjects.MockLandlordData
@@ -108,7 +107,7 @@ class LandlordRegistrationJourneyTests {
             // Act
             testJourney.completeStep(
                 stepPathSegment = LandlordRegistrationStepId.Declaration.urlPathSegment,
-                pageData = mapOf(),
+                formData = mapOf(),
                 subPageNumber = null,
                 principal = mock(),
             )

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/PropertyRegistrationJourneyTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/PropertyRegistrationJourneyTests.kt
@@ -24,7 +24,6 @@ import uk.gov.communities.prsdb.webapp.services.LandlordService
 import uk.gov.communities.prsdb.webapp.services.LocalAuthorityService
 import uk.gov.communities.prsdb.webapp.services.PropertyRegistrationService
 import uk.gov.communities.prsdb.webapp.testHelpers.JourneyTestHelper
-import uk.gov.communities.prsdb.webapp.testHelpers.JourneyTestHelper.Companion.setMockUser
 import uk.gov.communities.prsdb.webapp.testHelpers.builders.JourneyDataBuilder
 import uk.gov.communities.prsdb.webapp.testHelpers.mockObjects.AlwaysTrueValidator
 import uk.gov.communities.prsdb.webapp.testHelpers.mockObjects.MockLandlordData
@@ -224,7 +223,7 @@ class PropertyRegistrationJourneyTests {
         ) {
             testJourney.completeStep(
                 stepPathSegment = stepId.urlPathSegment,
-                pageData = pageData,
+                formData = pageData,
                 subPageNumber = null,
                 principal = mock(),
             )

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/forms/pages/LandlordDeregistrationAreYouSurePageTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/forms/pages/LandlordDeregistrationAreYouSurePageTests.kt
@@ -11,7 +11,6 @@ import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.whenever
 import org.springframework.boot.test.mock.mockito.MockBean
 import org.springframework.http.HttpStatus
-import org.springframework.validation.BindingResult
 import org.springframework.validation.Validator
 import org.springframework.web.server.ResponseStatusException
 import org.springframework.web.servlet.ModelAndView
@@ -96,24 +95,11 @@ class LandlordDeregistrationAreYouSurePageTests {
         whenever(mockValidator.supports(anyOrNull())).thenReturn(true)
 
         // Act
-        val modelAndView =
-            page.getModelAndView(
-                mockValidator,
-                formData,
-                DeregisterLandlordStepId.CheckForUserProperties.urlPathSegment,
-                journeyData,
-                null,
-            )
+        val bindingResult = page.bindDataToFormModel(mockValidator, formData)
 
         // Assert
-        val userHasRegisteredProperties =
-            (
-                (
-                    modelAndView
-                        .model[BindingResult.MODEL_KEY_PREFIX + "formModel"] as BindingResult
-                ).target as LandlordDeregistrationAreYouSureFormModel
-            ).userHasRegisteredProperties
-
+        val formModel = bindingResult.target as LandlordDeregistrationAreYouSureFormModel
+        val userHasRegisteredProperties = formModel.userHasRegisteredProperties
         assertNotNull(userHasRegisteredProperties)
         assertTrue(userHasRegisteredProperties)
     }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/forms/pages/LandlordRegistrationCheckAnswersPageTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/forms/pages/LandlordRegistrationCheckAnswersPageTests.kt
@@ -43,7 +43,8 @@ class LandlordRegistrationCheckAnswersPageTests {
     private fun getFormData(journeyData: JourneyData): List<SummaryListRowViewModel> {
         whenever(journeyDataService.getJourneyDataFromSession()).thenReturn(journeyData)
 
-        val result = page.getModelAndView(validator, pageData, prevStepUrl, journeyData, null)
+        val bindingResult = page.bindDataToFormModel(validator, pageData)
+        val result = page.getModelAndView(bindingResult, prevStepUrl, journeyData, null)
 
         val formData = result.model["formData"] as List<*>
         return formData.filterIsInstance<SummaryListRowViewModel>()

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/forms/pages/PageTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/forms/pages/PageTests.kt
@@ -54,7 +54,7 @@ class PageTests {
         val bindingResult = testPage.bindDataToFormModel(validator, formData)
 
         // Act
-        val result = testPage.isSatisfied(bindingResult, formData)
+        val result = testPage.isSatisfied(bindingResult)
 
         // Assert
         assertTrue(result)
@@ -67,7 +67,7 @@ class PageTests {
         val bindingResult = testPage.bindDataToFormModel(validator, formData)
 
         // Act
-        val result = testPage.isSatisfied(bindingResult, formData)
+        val result = testPage.isSatisfied(bindingResult)
 
         // Assert
         assertFalse(result)

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/forms/pages/PageTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/forms/pages/PageTests.kt
@@ -6,7 +6,6 @@ import jakarta.validation.constraints.NotNull
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.assertThrows
-import org.springframework.validation.BindingResult
 import org.springframework.validation.Validator
 import org.springframework.validation.beanvalidation.SpringValidatorAdapter
 import uk.gov.communities.prsdb.webapp.exceptions.PrsdbWebException
@@ -17,7 +16,6 @@ import kotlin.test.Test
 import kotlin.test.assertContains
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
-import kotlin.test.assertIs
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
@@ -53,9 +51,10 @@ class PageTests {
     fun `isSatisfied returns true when validation is satisfied`() {
         // Arrange
         val formData = mapOf("testProperty" to "testPropertyValue")
+        val bindingResult = testPage.bindDataToFormModel(validator, formData)
 
         // Act
-        val result = testPage.isSatisfied(validator, formData)
+        val result = testPage.isSatisfied(bindingResult, formData)
 
         // Assert
         assertTrue(result)
@@ -65,9 +64,10 @@ class PageTests {
     fun `isSatisfied returns false when validation is not satisfied`() {
         // Arrange
         val formData = mapOf("anotherProperty" to "testPropertyValue", "testProperty" to null)
+        val bindingResult = testPage.bindDataToFormModel(validator, formData)
 
         // Act
-        val result = testPage.isSatisfied(validator, formData)
+        val result = testPage.isSatisfied(bindingResult, formData)
 
         // Assert
         assertFalse(result)
@@ -81,11 +81,10 @@ class PageTests {
         val sectionHeader = SectionHeaderViewModel("testSectionHeader", 3, 5)
 
         // Act
-        val result = testPage.getModelAndView(validator, formData, previousUrl, null, sectionHeader)
+        val bindingResult = testPage.bindDataToFormModel(validator, formData)
+        val result = testPage.getModelAndView(bindingResult, previousUrl, null, sectionHeader)
 
         // Assert
-        assertIs<BindingResult>(result.model[BindingResult.MODEL_KEY_PREFIX + "formModel"])
-        val bindingResult: BindingResult = result.model[BindingResult.MODEL_KEY_PREFIX + "formModel"] as BindingResult
         assertContains(result.model, "testKey")
         assertEquals("testValue", result.model["testKey"])
         assertContains(result.model, "backUrl")
@@ -111,8 +110,10 @@ class PageTests {
                 mapOf("testKey" to "testValue"),
                 shouldDisplaySectionHeader = false,
             )
+
         // Act
-        val result = testPageWithoutSectionHeader.getModelAndView(validator, formData, previousUrl, null, sectionHeader)
+        val bindingResult = testPage.bindDataToFormModel(validator, formData)
+        val result = testPageWithoutSectionHeader.getModelAndView(bindingResult, previousUrl, null, sectionHeader)
 
         assertNull(result.model["sectionHeaderInfo"])
     }
@@ -126,8 +127,9 @@ class PageTests {
         val sectionHeaderInfo = null
 
         // Act, Assert
+        val bindingResult = testPage.bindDataToFormModel(validator, formData)
         assertThrows<PrsdbWebException> {
-            testPage.getModelAndView(validator, formData, previousUrl, filteredJourneyData, sectionHeaderInfo)
+            testPage.getModelAndView(bindingResult, previousUrl, filteredJourneyData, sectionHeaderInfo)
         }
     }
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/forms/pages/PropertyRegistrationCheckAnswersPageTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/forms/pages/PropertyRegistrationCheckAnswersPageTests.kt
@@ -45,7 +45,8 @@ class PropertyRegistrationCheckAnswersPageTests {
     private fun getPropertyDetails(journeyData: JourneyData): List<SummaryListRowViewModel> {
         whenever(journeyDataService.getJourneyDataFromSession()).thenReturn(journeyData)
 
-        val result = page.getModelAndView(validator, pageData, prevStepUrl, journeyData, null)
+        val bindingResult = page.bindDataToFormModel(validator, pageData)
+        val result = page.getModelAndView(bindingResult, prevStepUrl, journeyData, null)
 
         val propertyDetails = result.model["propertyDetails"] as List<*>
         return propertyDetails.filterIsInstance<SummaryListRowViewModel>()

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/forms/steps/StepTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/forms/steps/StepTests.kt
@@ -2,10 +2,12 @@ package uk.gov.communities.prsdb.webapp.forms.steps
 
 import org.mockito.Mock
 import org.mockito.Mockito.mock
+import org.mockito.kotlin.whenever
 import uk.gov.communities.prsdb.webapp.forms.JourneyData
 import uk.gov.communities.prsdb.webapp.forms.PageData
 import uk.gov.communities.prsdb.webapp.forms.objectToStringKeyedMap
 import uk.gov.communities.prsdb.webapp.forms.pages.Page
+import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.FormModel
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -25,11 +27,12 @@ class StepTests {
         val journeyData: JourneyData =
             mapOf("existingPage" to mapOf("existingProperty" to "existingValue"))
         val pageData: PageData = mapOf("newProperty" to "newValue")
+        val mockFormModel: FormModel = mock()
+        whenever(mockFormModel.toPageData()).thenReturn(pageData)
         val testStep = Step<TestStepId>(TestStepId.StepOne, mockPage)
 
         // Act
-
-        val newJourneyData = testStep.updatedJourneyData(journeyData, pageData, null)
+        val newJourneyData = testStep.updatedJourneyData(journeyData, mockFormModel, null)
         val existingPageData = objectToStringKeyedMap(newJourneyData["existingPage"])
         val newPageData = objectToStringKeyedMap(newJourneyData[testStep.name])
 
@@ -43,12 +46,14 @@ class StepTests {
         // Arrange
         val subPageNumber = 12
         val pageData: PageData = mapOf("newProperty" to "newValue")
+        val mockFormModel: FormModel = mock()
+        whenever(mockFormModel.toPageData()).thenReturn(pageData)
         val testStep = Step<TestStepId>(TestStepId.StepOne, mockPage)
         val journeyData: JourneyData =
             mapOf(testStep.name to mapOf(("existingProperty" to "existingValue")))
 
         // Act
-        val newJourneyData = testStep.updatedJourneyData(journeyData, pageData, subPageNumber)
+        val newJourneyData = testStep.updatedJourneyData(journeyData, mockFormModel, subPageNumber)
         val existingPageData = objectToStringKeyedMap(newJourneyData[testStep.name])
         val subPageData = objectToStringKeyedMap(existingPageData?.get(subPageNumber.toString()))
 
@@ -64,10 +69,12 @@ class StepTests {
         val journeyData: JourneyData =
             mapOf("existingPage" to mapOf(("existingProperty" to "existingValue")))
         val pageData: PageData = mapOf("newProperty" to "newValue")
+        val mockFormModel: FormModel = mock()
+        whenever(mockFormModel.toPageData()).thenReturn(pageData)
         val testStep = Step<TestStepId>(TestStepId.StepOne, mockPage)
 
         // Act
-        val newJourneyData = testStep.updatedJourneyData(journeyData, pageData, subPageNumber)
+        val newJourneyData = testStep.updatedJourneyData(journeyData, mockFormModel, subPageNumber)
         val existingPageData = objectToStringKeyedMap(newJourneyData["existingPage"])
         val newPageData = objectToStringKeyedMap(newJourneyData[TestStepId.StepOne.urlPathSegment])
         val subPageData = objectToStringKeyedMap(newPageData?.get(subPageNumber.toString()))

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/forms/tasks/TaskListTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/forms/tasks/TaskListTests.kt
@@ -6,11 +6,14 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.mockito.Mock
 import org.mockito.Mockito.mock
+import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.whenever
+import org.springframework.validation.BindingResult
 import org.springframework.validation.Validator
 import uk.gov.communities.prsdb.webapp.constants.enums.JourneyType
 import uk.gov.communities.prsdb.webapp.constants.enums.TaskStatus
 import uk.gov.communities.prsdb.webapp.forms.journeys.JourneyWithTaskList
+import uk.gov.communities.prsdb.webapp.forms.pages.Page
 import uk.gov.communities.prsdb.webapp.forms.steps.Step
 import uk.gov.communities.prsdb.webapp.forms.steps.StepId
 import uk.gov.communities.prsdb.webapp.models.viewModels.taskModels.TaskListViewModel
@@ -67,19 +70,26 @@ class TaskListTests {
         whenever(mockJourneyDataService.getJourneyDataFromSession()).thenReturn(journeyData.toMutableMap())
     }
 
+    fun getMockPage(): Page {
+        val mockPage = mock<Page>()
+        val mockBindingResult = mock<BindingResult>()
+        whenever(mockPage.bindDataToFormModel(anyOrNull(), anyOrNull())).thenReturn(mockBindingResult)
+        return mockPage
+    }
+
     fun getTwoStepTask(status: TaskStatus = TaskStatus.COMPLETED): JourneyTask<TestStepId> =
         JourneyTask(
             TestStepId.TwoStepTaskPartOne,
             setOf(
                 Step(
                     TestStepId.TwoStepTaskPartOne,
-                    mock(),
+                    getMockPage(),
                     isSatisfied = { _, _ -> status == TaskStatus.IN_PROGRESS || status == TaskStatus.COMPLETED },
                     nextAction = { _, _ -> Pair(TestStepId.TwoStepTaskPartTwo, null) },
                 ),
                 Step(
                     TestStepId.TwoStepTaskPartTwo,
-                    mock(),
+                    getMockPage(),
                     isSatisfied = { _, _ -> status == TaskStatus.COMPLETED },
                     nextAction = { _, _ -> Pair(TestStepId.SimpleTaskTwo, null) },
                 ),
@@ -93,7 +103,7 @@ class TaskListTests {
             setOf(
                 Step(
                     TestStepId.MultiPathTaskStart,
-                    mock(),
+                    getMockPage(),
                     isSatisfied = { _, _ -> true },
                     nextAction = { _, _ ->
                         Pair(
@@ -104,19 +114,19 @@ class TaskListTests {
                 ),
                 Step(
                     TestStepId.MultiPathTaskMainline,
-                    mock(),
+                    getMockPage(),
                     isSatisfied = { _, _ -> true },
                     nextAction = { _, _ -> Pair(TestStepId.TwoStepTaskPartOne, null) },
                 ),
                 Step(
                     TestStepId.MultiPathTaskAlternateRoutePartOne,
-                    mock(),
+                    getMockPage(),
                     isSatisfied = { _, _ -> false },
                     nextAction = { _, _ -> Pair(TestStepId.MultiPathTaskAlternateRoutePartTwo, null) },
                 ),
                 Step(
                     TestStepId.MultiPathTaskAlternateRoutePartTwo,
-                    mock(),
+                    getMockPage(),
                     isSatisfied = { _, _ -> false },
                     nextAction = { _, _ -> Pair(TestStepId.TwoStepTaskPartOne, null) },
                 ),
@@ -137,7 +147,7 @@ class TaskListTests {
                             JourneyTask.withOneStep(
                                 Step(
                                     TestStepId.SimpleTaskOne,
-                                    mock(),
+                                    getMockPage(),
                                     isSatisfied = { _, _ -> true },
                                     nextAction = { _, _ -> Pair(TestStepId.MultiPathTaskStart, null) },
                                 ),
@@ -148,7 +158,7 @@ class TaskListTests {
                             JourneyTask.withOneStep(
                                 Step(
                                     TestStepId.SimpleTaskTwo,
-                                    mock(),
+                                    getMockPage(),
                                     isSatisfied = { _, _ -> false },
                                 ),
                                 "task 4",
@@ -223,7 +233,7 @@ class TaskListTests {
                         JourneyTask.withOneStep(
                             Step(
                                 TestStepId.SimpleTaskOne,
-                                mock(),
+                                getMockPage(),
                                 isSatisfied = { _, _ -> simpleTaskOneCompleted },
                                 nextAction = { _, _ -> Pair(TestStepId.TwoStepTaskPartOne, null) },
                             ),
@@ -233,7 +243,7 @@ class TaskListTests {
                         JourneyTask.withOneStep(
                             Step(
                                 TestStepId.SimpleTaskTwo,
-                                mock(),
+                                getMockPage(),
                                 isSatisfied = { _, _ -> simpleTaskTwoCompleted },
                             ),
                             "task 3",
@@ -325,7 +335,7 @@ class TaskListTests {
                             JourneyTask.withOneStep(
                                 Step(
                                     TestStepId.SimpleTaskOne,
-                                    mock(),
+                                    getMockPage(),
                                     isSatisfied = { _, _ -> true },
                                     nextAction = { _, _ -> Pair(TestStepId.TwoStepTaskPartOne, null) },
                                 ),
@@ -339,7 +349,7 @@ class TaskListTests {
                             JourneyTask.withOneStep(
                                 Step(
                                     TestStepId.SimpleTaskTwo,
-                                    mock(),
+                                    getMockPage(),
                                     isSatisfied = { _, _ -> true },
                                 ),
                             ),

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/forms/tasks/TaskListTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/forms/tasks/TaskListTests.kt
@@ -84,13 +84,13 @@ class TaskListTests {
                 Step(
                     TestStepId.TwoStepTaskPartOne,
                     getMockPage(),
-                    isSatisfied = { _, _ -> status == TaskStatus.IN_PROGRESS || status == TaskStatus.COMPLETED },
+                    isSatisfied = { _ -> status == TaskStatus.IN_PROGRESS || status == TaskStatus.COMPLETED },
                     nextAction = { _, _ -> Pair(TestStepId.TwoStepTaskPartTwo, null) },
                 ),
                 Step(
                     TestStepId.TwoStepTaskPartTwo,
                     getMockPage(),
-                    isSatisfied = { _, _ -> status == TaskStatus.COMPLETED },
+                    isSatisfied = { _ -> status == TaskStatus.COMPLETED },
                     nextAction = { _, _ -> Pair(TestStepId.SimpleTaskTwo, null) },
                 ),
             ),
@@ -104,7 +104,7 @@ class TaskListTests {
                 Step(
                     TestStepId.MultiPathTaskStart,
                     getMockPage(),
-                    isSatisfied = { _, _ -> true },
+                    isSatisfied = { _ -> true },
                     nextAction = { _, _ ->
                         Pair(
                             if (useMainline) TestStepId.MultiPathTaskMainline else TestStepId.MultiPathTaskAlternateRoutePartOne,
@@ -115,19 +115,19 @@ class TaskListTests {
                 Step(
                     TestStepId.MultiPathTaskMainline,
                     getMockPage(),
-                    isSatisfied = { _, _ -> true },
+                    isSatisfied = { _ -> true },
                     nextAction = { _, _ -> Pair(TestStepId.TwoStepTaskPartOne, null) },
                 ),
                 Step(
                     TestStepId.MultiPathTaskAlternateRoutePartOne,
                     getMockPage(),
-                    isSatisfied = { _, _ -> false },
+                    isSatisfied = { _ -> false },
                     nextAction = { _, _ -> Pair(TestStepId.MultiPathTaskAlternateRoutePartTwo, null) },
                 ),
                 Step(
                     TestStepId.MultiPathTaskAlternateRoutePartTwo,
                     getMockPage(),
-                    isSatisfied = { _, _ -> false },
+                    isSatisfied = { _ -> false },
                     nextAction = { _, _ -> Pair(TestStepId.TwoStepTaskPartOne, null) },
                 ),
             ),
@@ -148,7 +148,7 @@ class TaskListTests {
                                 Step(
                                     TestStepId.SimpleTaskOne,
                                     getMockPage(),
-                                    isSatisfied = { _, _ -> true },
+                                    isSatisfied = { _ -> true },
                                     nextAction = { _, _ -> Pair(TestStepId.MultiPathTaskStart, null) },
                                 ),
                                 "task 1",
@@ -159,7 +159,7 @@ class TaskListTests {
                                 Step(
                                     TestStepId.SimpleTaskTwo,
                                     getMockPage(),
-                                    isSatisfied = { _, _ -> false },
+                                    isSatisfied = { _ -> false },
                                 ),
                                 "task 4",
                             ),
@@ -234,7 +234,7 @@ class TaskListTests {
                             Step(
                                 TestStepId.SimpleTaskOne,
                                 getMockPage(),
-                                isSatisfied = { _, _ -> simpleTaskOneCompleted },
+                                isSatisfied = { _ -> simpleTaskOneCompleted },
                                 nextAction = { _, _ -> Pair(TestStepId.TwoStepTaskPartOne, null) },
                             ),
                             "task 1",
@@ -244,7 +244,7 @@ class TaskListTests {
                             Step(
                                 TestStepId.SimpleTaskTwo,
                                 getMockPage(),
-                                isSatisfied = { _, _ -> simpleTaskTwoCompleted },
+                                isSatisfied = { _ -> simpleTaskTwoCompleted },
                             ),
                             "task 3",
                         ),
@@ -336,7 +336,7 @@ class TaskListTests {
                                 Step(
                                     TestStepId.SimpleTaskOne,
                                     getMockPage(),
-                                    isSatisfied = { _, _ -> true },
+                                    isSatisfied = { _ -> true },
                                     nextAction = { _, _ -> Pair(TestStepId.TwoStepTaskPartOne, null) },
                                 ),
                                 "task 1",
@@ -350,7 +350,7 @@ class TaskListTests {
                                 Step(
                                     TestStepId.SimpleTaskTwo,
                                     getMockPage(),
-                                    isSatisfied = { _, _ -> true },
+                                    isSatisfied = { _ -> true },
                                 ),
                             ),
                         ),

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/testHelpers/builders/TestIteratorBuilder.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/testHelpers/builders/TestIteratorBuilder.kt
@@ -1,10 +1,14 @@
 package uk.gov.communities.prsdb.webapp.testHelpers.builders
 
 import org.mockito.Mockito.mock
+import org.mockito.kotlin.anyOrNull
+import org.mockito.kotlin.whenever
+import org.springframework.validation.BindingResult
 import uk.gov.communities.prsdb.webapp.exceptions.PrsdbWebException
 import uk.gov.communities.prsdb.webapp.forms.JourneyData
 import uk.gov.communities.prsdb.webapp.forms.ReachableStepDetailsIterator
 import uk.gov.communities.prsdb.webapp.forms.TestStepId
+import uk.gov.communities.prsdb.webapp.forms.pages.AbstractPage
 import uk.gov.communities.prsdb.webapp.forms.steps.Step
 
 data class TestStepModel(
@@ -101,16 +105,21 @@ class TestIteratorBuilder {
         nextSegment: String? = null,
         isSatisfied: Boolean = true,
         customNextActionAddition: ((JourneyData) -> Unit)? = null,
-    ) = Step(
-        TestStepId(urlPathSegment),
-        mock(),
-        handleSubmitAndRedirect = null,
-        isSatisfied = { _, _ -> isSatisfied },
-        nextAction = { journeyData, _ ->
-            customNextActionAddition?.invoke(journeyData)
-            Pair(nextSegment?.let { TestStepId(it) }, null)
-        },
-    )
+    ): Step<TestStepId> {
+        val mockPage: AbstractPage = mock()
+        val mockBindingResult: BindingResult = mock()
+        whenever(mockPage.bindDataToFormModel(anyOrNull(), anyOrNull())).thenReturn(mockBindingResult)
+        return Step(
+            TestStepId(urlPathSegment),
+            mockPage,
+            handleSubmitAndRedirect = null,
+            isSatisfied = { bindingResult, formData -> isSatisfied },
+            nextAction = { journeyData, _ ->
+                customNextActionAddition?.invoke(journeyData)
+                Pair(nextSegment?.let { TestStepId(it) }, null)
+            },
+        )
+    }
 
     fun getDataForStep(urlPathSegment: String): Any? = journeyData[urlPathSegment]
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/testHelpers/builders/TestIteratorBuilder.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/testHelpers/builders/TestIteratorBuilder.kt
@@ -113,7 +113,7 @@ class TestIteratorBuilder {
             TestStepId(urlPathSegment),
             mockPage,
             handleSubmitAndRedirect = null,
-            isSatisfied = { bindingResult, formData -> isSatisfied },
+            isSatisfied = { _ -> isSatisfied },
             nextAction = { journeyData, _ ->
                 customNextActionAddition?.invoke(journeyData)
                 Pair(nextSegment?.let { TestStepId(it) }, null)


### PR DESCRIPTION
As an alternative implementation to #305 

I would have liked to get rid of the JourneyDataHelper-and-friends classes and methods, and do something more statically typed, but I think that's too large a change at this point.