### PR TITLE
PRSD-891: Update reason page heading

### DIFF
--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -738,7 +738,7 @@ forms.areYouSure.landlordDeregistration.noProperties.radios.error.missing=Select
 forms.areYouSure.landlordDeregistration.withProperties.radios.error.missing=Select whether you want to delete your landlord record and properties
 
 forms.reason.propertyDeregistration.fieldSetHeading=Why are you deleting this property? (optional)
-forms.reason.landlordDeregistration.fieldSetHeading=Why are you deleting this account? (optional)
+forms.reason.landlordDeregistration.fieldSetHeading=Why are you deleting your account? (optional)
 forms.reason.propertyDeregistration.fieldSetHint=This will help us understand why landlords might want to remove a property from the database
 forms.reason.propertyDeregistration.error.tooLong=Your reason for deleting this property must be 200 characters or fewer.
 forms.reason.landlordDeregistration.error.tooLong=Your reason for deleting your account must be 200 characters or fewer.

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/LandlordDeregistrationJourneyTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/LandlordDeregistrationJourneyTests.kt
@@ -24,6 +24,8 @@ class LandlordDeregistrationJourneyTests : IntegrationTest() {
             areYouSurePage.submitWantsToProceed()
 
             val reasonPage = assertPageIs(page, ReasonFormPageLandlordDeregistration::class)
+            assertThat(reasonPage.form.fieldsetHeading)
+                .containsText("Why are you deleting your account? (optional)")
             reasonPage.form.submit()
 
             val confirmationPage = assertPageIs(page, ConfirmationPageLandlordDeregistration::class)


### PR DESCRIPTION
Update the heading on the reason page of landlord deregistration

![image](https://github.com/user-attachments/assets/317805a4-cc88-4a83-8085-b92e520dc314)
