### PR TITLE
PRSD-NONE: Adds powershell and bash scripts to start portforwarding

### DIFF
--- a/scripts/ssm_db_connect.ps1
+++ b/scripts/ssm_db_connect.ps1
@@ -1,0 +1,19 @@
+# Check if the argument for Environment name is provided
+if ($args.Length -eq 0) {
+    echo "Error: ENVIRONMENT_NAME argument is required."
+    exit 1
+}
+
+$ENVIRONMENT_NAME = $args[0]
+
+# Get the Bastion ID
+$BASTION_ID = (aws ec2 describe-instances --output text --filters "Name=tag:Name,Values=${ENVIRONMENT_NAME}-bastion-1" "Name=instance-state-name,Values=running" --query "Reservations[*].Instances[].InstanceId | [0]")
+
+# Get the DB URL from SSM
+$DB_URL = (aws ssm get-parameter --output text --name "${ENVIRONMENT_NAME}-prsdb-database-url" --query "Parameter.Value")
+
+# Extract the DB endpoint from the DB URL
+$DB_ENDPOINT = $DB_URL.Split(':')[0]
+
+# Start the port forwarding session and redirect output to file
+aws ssm start-session --region eu-west-2 --target $BASTION_ID --document-name AWS-StartPortForwardingSessionToRemoteHost --parameters host=$DB_ENDPOINT,portNumber="5432",localPortNumber="5432"

--- a/scripts/ssm_db_connect.sh
+++ b/scripts/ssm_db_connect.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# Check if the argument for Environment name is provided
+if [ $# -eq 0 ]; then
+    echo "Error: ENVIRONMENT_NAME argument is required."
+    exit 1
+fi
+
+ENVIRONMENT_NAME=$1
+
+# Get the Bastion ID
+BASTION_ID=$(aws ec2 describe-instances --output text --filters "Name=tag:Name,Values=${ENVIRONMENT_NAME}-bastion-1" "Name=instance-state-name,Values=running" --query "Reservations[*].Instances[].InstanceId | [0]")
+
+# Get the DB URL from SSM
+DB_URL=$(aws ssm get-parameter --output text --name "${ENVIRONMENT_NAME}-prsdb-database-url" --query "Parameter.Value")
+
+# Extract the DB endpoint from the DB URL
+DB_ENDPOINT=${DB_URL%%:*}
+
+# Start the port forwarding session
+aws ssm start-session --region eu-west-2 --target $BASTION_ID --document-name AWS-StartPortForwardingSessionToRemoteHost --parameters host=$DB_ENDPOINT,portNumber="5432",localPortNumber="5432"


### PR DESCRIPTION
## Ticket number

None

## Goal of change

Make it easier to start a port forwarding session

## Description of main change(s)

Creates 2 scripts (one bash, one powershell) that setup a port-forwarding session to the database via the bastion host.

## Anything you'd like to highlight to the reviewer?

I have not tested the bash script, if a reviewer with bash set up and AWS access could test it I'd be grateful :) 

## Checklist

Delete any that are not applicable, and add explanation below for any that are applicable but haven't been done

- [ ] ~~Screenshots of any UI changes have been added~~
- [ ] ~~Unit tests for new logic (e.g. new service methods) have been added~~
- [ ] ~~Controller tests for any new endpoints, including testing the relevant permissions~~
- [ ] ~~Single page integration tests have been added for any unhappy-flow UI features, e.g. validation errors~~
- [ ] ~~New journey steps have been added to the appropriate journey integration test(s)~~
- [ ] ~~A new journey integration test has been added for any new journeys~~
- [ ] ~~New email templates have been added to `/src/main/kotlin/resources/emails/emailTemplates.json`~~
- [ ] ~~Test suite has been run in full locally and is passing~~
- [x] Branch has been rebased onto main and run locally, with everything working as expected (both for your new feature
  and any related functionality)
  - For powershell only
- [ ] ~~Seed data has been updated as needed for your feature to be tested without having to e.g. register a new property~~
