### PR TITLE
Feat/prsd 1002 read csrf from apache upload

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/config/filters/MultipartFormDataFilter.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/config/filters/MultipartFormDataFilter.kt
@@ -41,7 +41,7 @@ class MultipartFormDataFilter(
     ) {
         val upload = JakartaServletFileUpload()
         val multipartItemIterator = upload.getItemIterator(multipartRequest)
-        multipartRequest.setAttribute("multipartItemIterator", multipartItemIterator)
+        multipartRequest.setAttribute(ITERATOR_ATTRIBUTE, multipartItemIterator)
 
         val tokenDetails = getCsrfTokenDetails(multipartRequest, response, multipartItemIterator)
 
@@ -96,4 +96,8 @@ class MultipartFormDataFilter(
         val parameterName: String,
         val token: String,
     )
+
+    companion object {
+        const val ITERATOR_ATTRIBUTE = "multipartItemIterator"
+    }
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/config/filters/MultipartFormDataFilter.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/config/filters/MultipartFormDataFilter.kt
@@ -1,28 +1,18 @@
 package uk.gov.communities.prsdb.webapp.config.filters
 
-import jakarta.servlet.Filter
 import jakarta.servlet.FilterChain
-import jakarta.servlet.ServletRequest
-import jakarta.servlet.ServletResponse
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
 import org.apache.commons.fileupload2.core.FileItemInputIterator
 import org.apache.commons.fileupload2.jakarta.JakartaServletFileUpload
 import org.springframework.security.web.csrf.CsrfTokenRepository
+import org.springframework.web.filter.OncePerRequestFilter
 import uk.gov.communities.prsdb.webapp.exceptions.PrsdbWebException
 
 class MultipartFormDataFilter(
     private val tokenRepository: CsrfTokenRepository,
-) : Filter {
-    override fun doFilter(
-        request: ServletRequest?,
-        response: ServletResponse?,
-        chain: FilterChain,
-    ) {
-        doFilter(request as HttpServletRequest, response as HttpServletResponse, chain)
-    }
-
-    private fun doFilter(
+) : OncePerRequestFilter() {
+    override fun doFilterInternal(
         request: HttpServletRequest,
         response: HttpServletResponse,
         chain: FilterChain,

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/examples/ExampleFileUploadController.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/examples/ExampleFileUploadController.kt
@@ -14,6 +14,7 @@ import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestAttribute
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.server.ResponseStatusException
+import uk.gov.communities.prsdb.webapp.config.filters.MultipartFormDataFilter
 import java.security.Principal
 
 @Controller
@@ -36,7 +37,7 @@ class ExampleFileUploadController(
 
     @PostMapping
     fun uploadFile(
-        @RequestAttribute("multipartItemIterator") iterator: FileItemInputIterator,
+        @RequestAttribute(MultipartFormDataFilter.ITERATOR_ATTRIBUTE) iterator: FileItemInputIterator,
         @CookieValue(value = COOKIE_NAME) token: String,
         model: Model,
         @PathVariable("freeSegment") freeSegment: String,


### PR DESCRIPTION
## Ticket number

PRSD-1002

## Goal of change
Fix the HTTP 500 error being caused by re-applying my filter

## Description of main change(s)
Made it a `OncePerRequestFilter`. Also I missed pushing a change before merging on the previous request so I've added it here (making the attribute name a `const`)

## Anything you'd like to highlight to the reviewer?
As discussed on Slack with @Travis-Softwire 

## Checklist

Delete any that are not applicable, and add explanation below for any that are applicable but haven't been done

- [x] Test suite has been run in full locally and is passing
- [X] Branch has been rebased onto main and run locally, with everything working as expected (both for your new feature
  and any related functionality)
