### PR TITLE
PRSD-953: Makes EICR task reachable from Gas Safety Outdated step

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/PropertyComplianceJourney.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/PropertyComplianceJourney.kt
@@ -177,7 +177,7 @@ class PropertyComplianceJourney(
                                 "gasSafeRegisterURL" to GAS_SAFE_REGISTER,
                             ),
                     ),
-                nextAction = { _, _ -> (PropertyComplianceStepId.GasSafetyUpload to null) },
+                nextAction = { _, _ -> Pair(PropertyComplianceStepId.GasSafetyUpload, null) },
             )
 
     private val gasSafetyOutdatedStep
@@ -194,7 +194,7 @@ class PropertyComplianceJourney(
                             ),
                     ),
                 handleSubmitAndRedirect = { _, _ -> taskListUrlSegment },
-                nextAction = { _, _ -> (eicrTask.startingStepId to null) },
+                nextAction = { _, _ -> Pair(eicrTask.startingStepId, null) },
             )
 
     private fun placeholderStep(

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/PropertyComplianceJourney.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/PropertyComplianceJourney.kt
@@ -55,11 +55,7 @@ class PropertyComplianceJourney(
         get() =
             listOf(
                 gasSafetyTask,
-                // TODO PRSD-954: Implement EICR upload task
-                JourneyTask.withOneStep(
-                    placeholderStep(PropertyComplianceStepId.EICR, "TODO PRSD-954: Implement EICR upload task"),
-                    "propertyCompliance.taskList.upload.eicr",
-                ),
+                eicrTask,
                 // TODO PRSD-395: Implement EPC upload task
                 JourneyTask.withOneStep(
                     placeholderStep(PropertyComplianceStepId.EPC, "TODO PRSD-395: Implement EPC task"),
@@ -104,6 +100,14 @@ class PropertyComplianceJourney(
                     ),
                 ),
                 "propertyCompliance.taskList.upload.gasSafety",
+            )
+
+    // TODO PRSD-954: Implement EICR upload task
+    private val eicrTask
+        get() =
+            JourneyTask.withOneStep(
+                placeholderStep(PropertyComplianceStepId.EICR, "TODO PRSD-954: Implement EICR upload task"),
+                "propertyCompliance.taskList.upload.eicr",
             )
 
     private val gasSafetyStep
@@ -187,9 +191,10 @@ class PropertyComplianceJourney(
                         content =
                             mapOf(
                                 "title" to "propertyCompliance.title",
-                                "taskListUrl" to taskListUrlSegment,
                             ),
                     ),
+                handleSubmitAndRedirect = { _, _ -> taskListUrlSegment },
+                nextAction = { _, _ -> (eicrTask.startingStepId to null) },
             )
 
     private fun placeholderStep(

--- a/src/main/resources/templates/forms/gasSafetyOutdatedForm.html
+++ b/src/main/resources/templates/forms/gasSafetyOutdatedForm.html
@@ -1,26 +1,22 @@
 <!--/*@thymesVar id="title" type="java.lang.String"*/-->
+<!--/*@thymesVar id="formModel" type="java.lang.Object"*/-->
 <!--/*@thymesVar id="backUrl" type="java.lang.String"*/-->
-<!--/*@thymesVar id="taskListUrl" type="java.lang.String"*/-->
+<!--/*@thymesVar id="sectionHeaderInfo" type="uk.gov.communities.prsdb.webapp.models.viewModels.SectionHeaderViewModel"*/-->
 <!DOCTYPE html>
-<html id="main-content" th:replace="~{fragments/layout :: layout(#{${title}}, ~{::#main-content/content()}, false)}">
-    <a th:replace="~{fragments/forms/backLink :: backLink(${backUrl})}">Back link</a>
-    <main class="govuk-main-wrapper">
-        <div id="page-content" th:replace="~{fragments/layouts/twoThirdsLayout :: twoThirdsLayout(~{::#page-content/content()})}">
-            <header>
-                <h1 class="govuk-heading-l" th:text="#{forms.gasSafetyOutdated.heading}">forms.gasSafetyOutdated.heading</h1>
-            </header>
-            <section>
-                <p class="govuk-body" th:text="#{forms.gasSafetyOutdated.paragraph.one}">forms.gasSafetyOutdated.paragraph.one</p>
-                <p class="govuk-body" th:text="#{forms.gasSafetyOutdated.bullet.heading}">forms.gasSafetyOutdated.bullet.heading</p>
-                <ul class="govuk-list govuk-list--bullet">
-                    <li th:text="#{forms.gasSafetyOutdated.bullet.one}">forms.gasSafetyOutdated.bullet.one</li>
-                    <li th:text="#{forms.gasSafetyOutdated.bullet.two}">forms.gasSafetyOutdated.bullet.two</li>
-                    <li th:text="#{forms.gasSafetyOutdated.bullet.three}">forms.gasSafetyOutdated.bullet.three</li>
-                </ul>
-                <p class="govuk-body" th:text="#{forms.gasSafetyOutdated.paragraph.two}">forms.gasSafetyOutdated.paragraph.two</p>
-                <p class="govuk-body" th:text="#{forms.gasSafetyOutdated.paragraph.three}">forms.gasSafetyOutdated.paragraph.three</p>
-            </section>
-            <button th:replace="~{fragments/buttons/primaryButtonLink :: primaryButtonLink(${taskListUrl}, #{forms.buttons.saveAndReturnToTaskList})}"></button>
-        </div>
-    </main>
+<html id="form-content" th:replace="~{fragments/forms/questionPage :: questionPage(#{${title}}, ${formModel}, ~{::#form-content/content()}, ${backUrl}, ${sectionHeaderInfo})}">
+    <header>
+        <h1 class="govuk-heading-l" th:text="#{forms.gasSafetyOutdated.heading}">forms.gasSafetyOutdated.heading</h1>
+    </header>
+    <section>
+        <p class="govuk-body" th:text="#{forms.gasSafetyOutdated.paragraph.one}">forms.gasSafetyOutdated.paragraph.one</p>
+        <p class="govuk-body" th:text="#{forms.gasSafetyOutdated.bullet.heading}">forms.gasSafetyOutdated.bullet.heading</p>
+        <ul class="govuk-list govuk-list--bullet">
+            <li th:text="#{forms.gasSafetyOutdated.bullet.one}">forms.gasSafetyOutdated.bullet.one</li>
+            <li th:text="#{forms.gasSafetyOutdated.bullet.two}">forms.gasSafetyOutdated.bullet.two</li>
+            <li th:text="#{forms.gasSafetyOutdated.bullet.three}">forms.gasSafetyOutdated.bullet.three</li>
+        </ul>
+        <p class="govuk-body" th:text="#{forms.gasSafetyOutdated.paragraph.two}">forms.gasSafetyOutdated.paragraph.two</p>
+        <p class="govuk-body" th:text="#{forms.gasSafetyOutdated.paragraph.three}">forms.gasSafetyOutdated.paragraph.three</p>
+    </section>
+    <button th:replace="~{fragments/buttons/primaryButton :: primaryButton(#{forms.buttons.saveAndReturnToTaskList})}"></button>
 </html>


### PR DESCRIPTION
## Ticket number

PRSD-953

## Goal of change

Makes EICR task reachable from Gas Safety Outdated step

## Description of main change(s)

- Updates gas safety outdated template button to send a POST request
- Updates gas safety outdated step to redirect to task list and make first step of EICR task reachable upon completion

## Anything you'd like to highlight to the reviewer?

N/A

## Checklist

Delete any that are not applicable, and add explanation below for any that are applicable but haven't been done

- [X] Screenshots of any UI changes have been added
- [ ] New journey steps have been added to the appropriate journey integration test(s)
  - This feature will be tested when the EICR task's first step is implemented (PRSD-954)
- [X] Test suite has been run in full locally and is passing
- [X] Branch has been rebased onto main and run locally, with everything working as expected (both for your new feature
  and any related functionality)

![image](https://github.com/user-attachments/assets/fda8e879-73c7-4cda-a1de-6a129b94fe39)