### PR TITLE
PRSD-954: Turns gasSafetyForm into Generic certificateForm

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/PropertyComplianceJourney.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/PropertyComplianceJourney.kt
@@ -128,7 +128,7 @@ class PropertyComplianceJourney(
                 page =
                     PageWithContentProvider(
                         formModel = GasSafetyFormModel::class,
-                        templateName = "forms/gasSafetyForm",
+                        templateName = "forms/certificateForm",
                         content =
                             mapOf(
                                 "title" to "propertyCompliance.title",

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/helpers/extensions/journeyExtensions/PropertyComplianceJourneyDataExtensions.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/helpers/extensions/journeyExtensions/PropertyComplianceJourneyDataExtensions.kt
@@ -16,7 +16,7 @@ class PropertyComplianceJourneyDataExtensions : JourneyDataExtensions() {
             JourneyDataHelper.getFieldBooleanValue(
                 this,
                 PropertyComplianceStepId.GasSafety.urlPathSegment,
-                GasSafetyFormModel::hasGasSafetyCert.name,
+                GasSafetyFormModel::hasCert.name,
             )
 
         fun JourneyData.getIsGasSafetyCertOutdated(): Boolean? {

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/requestModels/formModels/GasSafetyFormModel.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/requestModels/formModels/GasSafetyFormModel.kt
@@ -15,5 +15,5 @@ class GasSafetyFormModel : FormModel {
             ),
         ],
     )
-    var hasGasSafetyCert: Boolean? = null
+    var hasCert: Boolean? = null
 }

--- a/src/main/resources/templates/forms/certificateForm.html
+++ b/src/main/resources/templates/forms/certificateForm.html
@@ -8,8 +8,8 @@
 <!--/*@thymesVar id="radioOptions" type="uk.gov.communities.prsdb.webapp.models.viewModels.formModels.RadiosViewModel"*/-->
 <!DOCTYPE html>
 <html id="form-content" th:replace="~{fragments/forms/questionPage :: questionPage(#{${title}}, ${formModel}, ~{::#form-content/content()}, ${backUrl}, ${sectionHeaderInfo})}">
-    <th:block id="fieldset-content" th:replace="~{fragments/forms/fieldSet :: fieldSet(~{::#fieldset-content/content()}, 'hasGasSafetyCert', #{${fieldSetHeading}(${address})}, #{${fieldSetHint}})}">
-        <th:block th:replace="~{fragments/forms/radios :: radios(null,'hasGasSafetyCert',null, ${radioOptions})}"></th:block>
+    <th:block id="fieldset-content" th:replace="~{fragments/forms/fieldSet :: fieldSet(~{::#fieldset-content/content()}, 'hasCert', #{${fieldSetHeading}(${address})}, #{${fieldSetHint}})}">
+        <th:block th:replace="~{fragments/forms/radios :: radios(null, 'hasCert', null, ${radioOptions})}"></th:block>
     </th:block>
     <button th:replace="~{fragments/buttons/primaryButton :: primaryButton(#{forms.buttons.saveAndContinue})}"></button>
 </html>

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/testHelpers/builders/JourneyDataBuilder.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/testHelpers/builders/JourneyDataBuilder.kt
@@ -411,7 +411,7 @@ class JourneyDataBuilder(
 
     fun withGasSafetyCertStatus(hasGasSafetyCert: Boolean): JourneyDataBuilder {
         journeyData[PropertyComplianceStepId.GasSafety.urlPathSegment] =
-            mapOf(GasSafetyFormModel::hasGasSafetyCert.name to hasGasSafetyCert)
+            mapOf(GasSafetyFormModel::hasCert.name to hasGasSafetyCert)
         return this
     }
 


### PR DESCRIPTION
## Ticket number

PRSD-954

## Goal of change

Turns `gasSafetyForm` into a generic form that can be used for other certificate types

## Description of main change(s)

- Renames `gasSafetyForm` to `certificateForm` and corresponding form property `hasGasSafetyCert` to `hasCert`

## Anything you'd like to highlight to the reviewer?

N/A

## Checklist

Delete any that are not applicable, and add explanation below for any that are applicable but haven't been done

- [X] Test suite has been run in full locally and is passing
- [X] Branch has been rebased onto main and run locally, with everything working as expected (both for your new feature
  and any related functionality)
