### PR TITLE
PRSD-1001: Put file-upload into constants

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/constants/InfrastructureValues.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/constants/InfrastructureValues.kt
@@ -1,0 +1,10 @@
+package uk.gov.communities.prsdb.webapp.constants
+
+/* Incoming requests are limited to 8kb by default by the WAF, but that rule isn't applied to requests where the url
+ * contains this substring. The details of which requests are allowed through the WAF if they're larger than 8kb
+ * is specified in this module https://github.com/communitiesuk/prsdb-infra/blob/main/terraform/modules/frontdoor/waf.tf
+ *
+ * The scope_down_statements of "aws-managed-rules-common-rule-set-for-file-uploads" AND
+ * "aws-managed-rules-common-rule-set" must be updated to ensure the remainder of the AWS managed rules are applied.
+ */
+const val FILE_UPLOAD_URL_SUBSTRING = "file-upload"

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/examples/ExampleFileUploadController.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/examples/ExampleFileUploadController.kt
@@ -15,12 +15,13 @@ import org.springframework.web.bind.annotation.RequestAttribute
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.server.ResponseStatusException
 import uk.gov.communities.prsdb.webapp.config.filters.MultipartFormDataFilter
+import uk.gov.communities.prsdb.webapp.constants.FILE_UPLOAD_URL_SUBSTRING
 import uk.gov.communities.prsdb.webapp.examples.MaximumLengthInputStream.Companion.withMaxLength
 import java.security.Principal
 
 @Controller
 // This free segment allows the example controller to simulate multiple journeys in parallel
-@RequestMapping("example/file-upload/{freeSegment}")
+@RequestMapping("example/$FILE_UPLOAD_URL_SUBSTRING/{freeSegment}")
 class ExampleFileUploadController(
     private val fileUploader: FileUploader,
     private val tokenService: FileUploadTokenService,
@@ -79,7 +80,7 @@ class ExampleFileUploadController(
         // that the token is being used correctly by storing some additional information with the token in the session.
         val tokenCookie = Cookie(COOKIE_NAME, token)
         tokenCookie.isHttpOnly = true
-        tokenCookie.path = "/example/file-upload/$segment"
+        tokenCookie.path = "/example/$FILE_UPLOAD_URL_SUBSTRING/$segment"
         tokenCookie.secure = true
 
         return tokenCookie


### PR DESCRIPTION
## Ticket number

PRSD-1001

## Goal of change

Ensure that the urls for file uploads come from a source with a comment explaining how they interact with the WAF.

## Description of main change(s)

Created a constants file for InfrastructureConstants, which is then used to construct the example file upload URLs in the hope that future file upload endpoints will copy it.

## Checklist

Delete any that are not applicable, and add explanation below for any that are applicable but haven't been done

- [X] Test suite has been run in full locally and is passing
