### PR TITLE
Feat/prsd 1061 redirect registered landlords from registration flow to dashboard

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/constants/UserRoleConstants.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/constants/UserRoleConstants.kt
@@ -1,0 +1,7 @@
+package uk.gov.communities.prsdb.webapp.constants
+
+const val ROLE_LANDLORD = "ROLE_LANDLORD"
+
+const val ROLE_LA_ADMIN = "ROLE_LA_ADMIN"
+
+const val ROLE_LA_USER = "ROLE_LA_USER"

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/RegisterLandlordController.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/RegisterLandlordController.kt
@@ -19,6 +19,7 @@ import uk.gov.communities.prsdb.webapp.forms.journeys.factories.LandlordRegistra
 import uk.gov.communities.prsdb.webapp.models.dataModels.RegistrationNumberDataModel
 import uk.gov.communities.prsdb.webapp.services.LandlordService
 import uk.gov.communities.prsdb.webapp.services.OneLoginIdentityService
+import uk.gov.communities.prsdb.webapp.services.UserRolesService
 import java.security.Principal
 
 @Controller
@@ -27,6 +28,7 @@ class RegisterLandlordController(
     private val landlordRegistrationJourneyFactory: LandlordRegistrationJourneyFactory,
     private val identityService: OneLoginIdentityService,
     private val landlordService: LandlordService,
+    private val userRolesService: UserRolesService,
 ) {
     @GetMapping
     fun index(model: Model): CharSequence {
@@ -46,6 +48,10 @@ class RegisterLandlordController(
         principal: Principal,
         @AuthenticationPrincipal oidcUser: OidcUser,
     ): ModelAndView {
+        if (userRolesService.getHasLandlordUserRole(principal.name)) {
+            return ModelAndView("redirect:${LANDLORD_DASHBOARD_URL}")
+        }
+
         val identity = identityService.getVerifiedIdentityData(oidcUser) ?: mapOf()
 
         return landlordRegistrationJourneyFactory

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/UserRolesService.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/UserRolesService.kt
@@ -1,6 +1,9 @@
 package uk.gov.communities.prsdb.webapp.services
 
 import org.springframework.stereotype.Service
+import uk.gov.communities.prsdb.webapp.constants.ROLE_LANDLORD
+import uk.gov.communities.prsdb.webapp.constants.ROLE_LA_ADMIN
+import uk.gov.communities.prsdb.webapp.constants.ROLE_LA_USER
 import uk.gov.communities.prsdb.webapp.database.repository.LandlordRepository
 import uk.gov.communities.prsdb.webapp.database.repository.LocalAuthorityUserRepository
 
@@ -14,17 +17,22 @@ class UserRolesService(
 
         val matchingLandlordUser = landlordRepository.findByBaseUser_Id(subjectId)
         if (matchingLandlordUser != null) {
-            roles.add("ROLE_LANDLORD")
+            roles.add(ROLE_LANDLORD)
         }
 
         val matchingLocalAuthorityUser = localAuthorityUserRepository.findByBaseUser_Id(subjectId)
         if (matchingLocalAuthorityUser != null) {
             if (matchingLocalAuthorityUser.isManager) {
-                roles.add("ROLE_LA_ADMIN")
+                roles.add(ROLE_LA_ADMIN)
             }
-            roles.add("ROLE_LA_USER")
+            roles.add(ROLE_LA_USER)
         }
 
         return roles
+    }
+
+    fun getHasLandlordUserRole(subjectId: String): Boolean {
+        val roles = getRolesForSubjectId(subjectId)
+        return roles.contains(ROLE_LANDLORD)
     }
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/controllers/RegisterLandlordControllerTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/controllers/RegisterLandlordControllerTests.kt
@@ -1,9 +1,13 @@
 package uk.gov.communities.prsdb.webapp.controllers
 
 import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.whenever
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
-import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.security.test.context.support.WithMockUser
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.oidcLogin
+import org.springframework.test.context.bean.override.mockito.MockitoBean
 import org.springframework.test.web.servlet.get
 import org.springframework.web.context.WebApplicationContext
 import uk.gov.communities.prsdb.webapp.forms.journeys.factories.LandlordRegistrationJourneyFactory
@@ -14,13 +18,13 @@ import uk.gov.communities.prsdb.webapp.services.OneLoginIdentityService
 class RegisterLandlordControllerTests(
     @Autowired val webContext: WebApplicationContext,
 ) : ControllerTest(webContext) {
-    @MockBean
+    @MockitoBean
     lateinit var landlordRegistrationJourneyFactory: LandlordRegistrationJourneyFactory
 
-    @MockBean
+    @MockitoBean
     lateinit var identityService: OneLoginIdentityService
 
-    @MockBean
+    @MockitoBean
     lateinit var landlordService: LandlordService
 
     @Test
@@ -35,5 +39,17 @@ class RegisterLandlordControllerTests(
         mvc.get("/register-as-a-landlord/").andExpect {
             status { isPermanentRedirect() }
         }
+    }
+
+    @Test
+    @WithMockUser(roles = ["LANDLORD"])
+    fun `getVerifyIdentity returns 302 for authenticated user with Landlord role`() {
+        whenever(userRolesService.getHasLandlordUserRole(any())).thenReturn(true)
+        mvc
+            .get("/register-as-a-landlord/verify-identity") {
+                with(oidcLogin())
+            }.andExpect {
+                status { is3xxRedirection() }
+            }
     }
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/controllers/RegisterLandlordControllerTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/controllers/RegisterLandlordControllerTests.kt
@@ -48,8 +48,9 @@ class RegisterLandlordControllerTests(
         mvc
             .get("/register-as-a-landlord/verify-identity") {
                 with(oidcLogin())
-            }.andExpect {
+            }.andExpectAll {
                 status { is3xxRedirection() }
+                redirectedUrl("/landlord/dashboard")
             }
     }
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/IntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/IntegrationTest.kt
@@ -9,13 +9,13 @@ import org.junit.jupiter.api.BeforeEach
 import org.mockito.kotlin.whenever
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
-import org.springframework.boot.test.mock.mockito.MockBean
-import org.springframework.boot.test.mock.mockito.SpyBean
 import org.springframework.boot.test.web.server.LocalServerPort
 import org.springframework.context.annotation.Import
 import org.springframework.security.oauth2.client.registration.ClientRegistration
 import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository
 import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.bean.override.mockito.MockitoBean
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean
 import software.amazon.awssdk.transfer.s3.S3TransferManager
 import uk.gov.communities.prsdb.webapp.TestcontainersConfiguration
 import uk.gov.communities.prsdb.webapp.clients.OSPlacesClient
@@ -24,6 +24,7 @@ import uk.gov.communities.prsdb.webapp.config.OSPlacesConfig
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.Navigator
 import uk.gov.communities.prsdb.webapp.services.AbsoluteUrlProvider
 import uk.gov.communities.prsdb.webapp.services.OneLoginIdentityService
+import uk.gov.communities.prsdb.webapp.services.UserRolesService
 import uk.gov.service.notify.NotificationClient
 
 @Import(TestcontainersConfiguration::class)
@@ -37,29 +38,32 @@ abstract class IntegrationTest {
     @LocalServerPort
     val port: Int = 0
 
-    @MockBean
+    @MockitoBean
     lateinit var notifyConfig: NotifyConfig
 
-    @MockBean
+    @MockitoBean
     lateinit var notificationClient: NotificationClient
 
-    @MockBean
+    @MockitoBean
     lateinit var osPlacesConfig: OSPlacesConfig
 
-    @MockBean
+    @MockitoBean
     lateinit var osPlacesClient: OSPlacesClient
 
-    @MockBean
+    @MockitoBean
     lateinit var identityService: OneLoginIdentityService
 
-    @MockBean
+    @MockitoBean
     lateinit var absoluteUrlProvider: AbsoluteUrlProvider
 
-    @SpyBean
+    @MockitoSpyBean
     lateinit var clientRegistrationRepository: ClientRegistrationRepository
 
-    @MockBean
+    @MockitoBean
     lateinit var s3: S3TransferManager
+
+    @MockitoBean
+    lateinit var userRolesService: UserRolesService
 
     /**
      * The mock One Login URLs are hard-coded with port 8080 in the local-no-auth profile config. However, our tests
@@ -100,7 +104,7 @@ abstract class IntegrationTest {
 
     @BeforeEach
     fun setUp(page: Page) {
-        navigator = Navigator(page, port, identityService)
+        navigator = Navigator(page, port, identityService, userRolesService)
     }
 
     @AfterEach

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/IntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/IntegrationTest.kt
@@ -9,13 +9,13 @@ import org.junit.jupiter.api.BeforeEach
 import org.mockito.kotlin.whenever
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.boot.test.mock.mockito.SpyBean
 import org.springframework.boot.test.web.server.LocalServerPort
 import org.springframework.context.annotation.Import
 import org.springframework.security.oauth2.client.registration.ClientRegistration
 import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository
 import org.springframework.test.context.ActiveProfiles
-import org.springframework.test.context.bean.override.mockito.MockitoBean
-import org.springframework.test.context.bean.override.mockito.MockitoSpyBean
 import software.amazon.awssdk.transfer.s3.S3TransferManager
 import uk.gov.communities.prsdb.webapp.TestcontainersConfiguration
 import uk.gov.communities.prsdb.webapp.clients.OSPlacesClient
@@ -24,7 +24,6 @@ import uk.gov.communities.prsdb.webapp.config.OSPlacesConfig
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.Navigator
 import uk.gov.communities.prsdb.webapp.services.AbsoluteUrlProvider
 import uk.gov.communities.prsdb.webapp.services.OneLoginIdentityService
-import uk.gov.communities.prsdb.webapp.services.UserRolesService
 import uk.gov.service.notify.NotificationClient
 
 @Import(TestcontainersConfiguration::class)
@@ -38,32 +37,29 @@ abstract class IntegrationTest {
     @LocalServerPort
     val port: Int = 0
 
-    @MockitoBean
+    @MockBean
     lateinit var notifyConfig: NotifyConfig
 
-    @MockitoBean
+    @MockBean
     lateinit var notificationClient: NotificationClient
 
-    @MockitoBean
+    @MockBean
     lateinit var osPlacesConfig: OSPlacesConfig
 
-    @MockitoBean
+    @MockBean
     lateinit var osPlacesClient: OSPlacesClient
 
-    @MockitoBean
+    @MockBean
     lateinit var identityService: OneLoginIdentityService
 
-    @MockitoBean
+    @MockBean
     lateinit var absoluteUrlProvider: AbsoluteUrlProvider
 
-    @MockitoSpyBean
+    @SpyBean
     lateinit var clientRegistrationRepository: ClientRegistrationRepository
 
-    @MockitoBean
+    @MockBean
     lateinit var s3: S3TransferManager
-
-    @MockitoBean
-    lateinit var userRolesService: UserRolesService
 
     /**
      * The mock One Login URLs are hard-coded with port 8080 in the local-no-auth profile config. However, our tests
@@ -104,7 +100,7 @@ abstract class IntegrationTest {
 
     @BeforeEach
     fun setUp(page: Page) {
-        navigator = Navigator(page, port, identityService, userRolesService)
+        navigator = Navigator(page, port, identityService)
     }
 
     @AfterEach

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/LandlordRegistrationJourneyTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/LandlordRegistrationJourneyTests.kt
@@ -280,11 +280,12 @@ class LandlordRegistrationJourneyTests : IntegrationTest() {
     }
 
     @Nested
+    @Sql("/data-local.sql")
     inner class LandlordRegistrationStepVerifyIdentity {
         @Test
         fun `Navigating here as a registered landlord redirects to the landlord dashboard page`() {
-            val dashboardPage = navigator.redirectToLandlordDashboardPage()
-            assertThat(dashboardPage.bannerSubHeading).containsText("Arthur Dent")
+            val dashboardPage = navigator.redirectFromLandlordRegistrationVerifyIdentityToLandlordDashboardPage()
+            assertThat(dashboardPage.bannerHeading).containsText("Alexander Smith")
         }
     }
 

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/LandlordRegistrationJourneyTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/LandlordRegistrationJourneyTests.kt
@@ -284,7 +284,7 @@ class LandlordRegistrationJourneyTests : IntegrationTest() {
     inner class LandlordRegistrationStepVerifyIdentity {
         @Test
         fun `Navigating here as a registered landlord redirects to the landlord dashboard page`() {
-            val dashboardPage = navigator.redirectFromLandlordRegistrationVerifyIdentityToLandlordDashboardPage()
+            val dashboardPage = navigator.goToLandlordRegistrationVerifyIdentityAsRegisteredLandlord()
             assertThat(dashboardPage.bannerHeading).containsText("Alexander Smith")
         }
     }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/LandlordRegistrationJourneyTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/LandlordRegistrationJourneyTests.kt
@@ -280,6 +280,15 @@ class LandlordRegistrationJourneyTests : IntegrationTest() {
     }
 
     @Nested
+    inner class LandlordRegistrationStepVerifyIdentity {
+        @Test
+        fun `Navigating here as a registered landlord redirects to the landlord dashboard page`() {
+            val dashboardPage = navigator.redirectToLandlordDashboardPage()
+            assertThat(dashboardPage.bannerSubHeading).containsText("Arthur Dent")
+        }
+    }
+
+    @Nested
     inner class LandlordRegistrationStepName {
         @Test
         fun `Submitting an empty name returns an error`() {

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/RegisterLandlordPageTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/RegisterLandlordPageTests.kt
@@ -12,7 +12,7 @@ import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.VerifiedI
 import java.net.URI
 import java.time.LocalDate
 
-@Sql("/data-local.sql")
+@Sql("/data-mockuser-not-landlord.sql")
 class RegisterLandlordPageTests : IntegrationTest() {
     @Test
     fun `registerAsALandlord page renders`(page: Page) {
@@ -41,5 +41,20 @@ class RegisterLandlordPageTests : IntegrationTest() {
         page.navigate("http://localhost:$port/register-as-a-landlord")
         page.getByRole(AriaRole.BUTTON, Page.GetByRoleOptions().setName("Start Now")).click()
         assertEquals("/register-as-a-landlord/confirm-identity", URI(page.url()).path)
+    }
+
+    @Test
+    @Sql("/data-local.sql")
+    fun `the 'Start Now' button directs a registered landlord to the landlord dashboard page page`(page: Page) {
+        val verifiedIdentityMap =
+            mutableMapOf<String, Any?>(
+                VerifiedIdentityModel.NAME_KEY to "name",
+                VerifiedIdentityModel.BIRTH_DATE_KEY to LocalDate.now(),
+            )
+        whenever(identityService.getVerifiedIdentityData(any())).thenReturn(verifiedIdentityMap)
+
+        page.navigate("http://localhost:$port/register-as-a-landlord")
+        page.getByRole(AriaRole.BUTTON, Page.GetByRoleOptions().setName("Start Now")).click()
+        assertEquals("/landlord/dashboard", URI(page.url()).path)
     }
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/RegisterLandlordPageTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/RegisterLandlordPageTests.kt
@@ -8,6 +8,9 @@ import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.whenever
 import org.springframework.test.context.jdbc.Sql
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.BaseComponent
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.LandlordDashboardPage
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages.BasePage.Companion.assertPageIs
 import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.VerifiedIdentityModel
 import java.net.URI
 import java.time.LocalDate
@@ -45,16 +48,10 @@ class RegisterLandlordPageTests : IntegrationTest() {
 
     @Test
     @Sql("/data-local.sql")
-    fun `the 'Start Now' button directs a registered landlord to the landlord dashboard page page`(page: Page) {
-        val verifiedIdentityMap =
-            mutableMapOf<String, Any?>(
-                VerifiedIdentityModel.NAME_KEY to "name",
-                VerifiedIdentityModel.BIRTH_DATE_KEY to LocalDate.now(),
-            )
-        whenever(identityService.getVerifiedIdentityData(any())).thenReturn(verifiedIdentityMap)
-
-        page.navigate("http://localhost:$port/register-as-a-landlord")
-        page.getByRole(AriaRole.BUTTON, Page.GetByRoleOptions().setName("Start Now")).click()
-        assertEquals("/landlord/dashboard", URI(page.url()).path)
+    fun `the 'Start Now' button directs a registered landlord to the landlord dashboard page`(page: Page) {
+        val startPage = navigator.goToLandlordRegistrationStartPage()
+        startPage.startButton.clickAndWait()
+        val dashboardPage = assertPageIs(page, LandlordDashboardPage::class)
+        BaseComponent.assertThat(dashboardPage.bannerHeading).containsText("Alexander Smith")
     }
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/Navigator.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/Navigator.kt
@@ -90,12 +90,14 @@ import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyReg
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyRegistrationJourneyPages.TaskListPagePropertyRegistration
 import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.VerifiedIdentityModel
 import uk.gov.communities.prsdb.webapp.services.OneLoginIdentityService
+import uk.gov.communities.prsdb.webapp.services.UserRolesService
 import java.time.LocalDate
 
 class Navigator(
     private val page: Page,
     private val port: Int,
     private val identityService: OneLoginIdentityService,
+    private val userRolesService: UserRolesService,
 ) {
     fun goToManageLaUsers(authorityId: Int): ManageLaUsersPage {
         navigate("/local-authority/$authorityId/manage-users")
@@ -123,10 +125,18 @@ class Navigator(
                 VerifiedIdentityModel.NAME_KEY to "Arthur Dent",
                 VerifiedIdentityModel.BIRTH_DATE_KEY to LocalDate.of(2000, 6, 8),
             )
+        whenever(userRolesService.getHasLandlordUserRole(any())).thenReturn(false)
         whenever(identityService.getVerifiedIdentityData(any())).thenReturn(verifiedIdentityMap)
 
         navigate("/$REGISTER_LANDLORD_JOURNEY_URL/${LandlordRegistrationStepId.VerifyIdentity.urlPathSegment}")
         return createValidPage(page, ConfirmIdentityFormPageLandlordRegistration::class)
+    }
+
+    fun redirectToLandlordDashboardPage(): LandlordDashboardPage {
+        whenever(userRolesService.getHasLandlordUserRole(any())).thenReturn(true)
+
+        navigate("/$REGISTER_LANDLORD_JOURNEY_URL/${LandlordRegistrationStepId.VerifyIdentity.urlPathSegment}")
+        return createValidPage(page, LandlordDashboardPage::class)
     }
 
     fun goToLandlordRegistrationNameFormPage(): NameFormPageLandlordRegistration {

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/Navigator.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/Navigator.kt
@@ -90,14 +90,12 @@ import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyReg
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyRegistrationJourneyPages.TaskListPagePropertyRegistration
 import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.VerifiedIdentityModel
 import uk.gov.communities.prsdb.webapp.services.OneLoginIdentityService
-import uk.gov.communities.prsdb.webapp.services.UserRolesService
 import java.time.LocalDate
 
 class Navigator(
     private val page: Page,
     private val port: Int,
     private val identityService: OneLoginIdentityService,
-    private val userRolesService: UserRolesService,
 ) {
     fun goToManageLaUsers(authorityId: Int): ManageLaUsersPage {
         navigate("/local-authority/$authorityId/manage-users")
@@ -125,16 +123,13 @@ class Navigator(
                 VerifiedIdentityModel.NAME_KEY to "Arthur Dent",
                 VerifiedIdentityModel.BIRTH_DATE_KEY to LocalDate.of(2000, 6, 8),
             )
-        whenever(userRolesService.getHasLandlordUserRole(any())).thenReturn(false)
         whenever(identityService.getVerifiedIdentityData(any())).thenReturn(verifiedIdentityMap)
 
         navigate("/$REGISTER_LANDLORD_JOURNEY_URL/${LandlordRegistrationStepId.VerifyIdentity.urlPathSegment}")
         return createValidPage(page, ConfirmIdentityFormPageLandlordRegistration::class)
     }
 
-    fun redirectToLandlordDashboardPage(): LandlordDashboardPage {
-        whenever(userRolesService.getHasLandlordUserRole(any())).thenReturn(true)
-
+    fun redirectFromLandlordRegistrationVerifyIdentityToLandlordDashboardPage(): LandlordDashboardPage {
         navigate("/$REGISTER_LANDLORD_JOURNEY_URL/${LandlordRegistrationStepId.VerifyIdentity.urlPathSegment}")
         return createValidPage(page, LandlordDashboardPage::class)
     }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/Navigator.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/Navigator.kt
@@ -61,6 +61,7 @@ import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.landlordReg
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.landlordRegistrationJourneyPages.PhoneNumberFormPageLandlordRegistration
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.landlordRegistrationJourneyPages.SelectAddressFormPageLandlordRegistration
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.landlordRegistrationJourneyPages.SelectContactAddressFormPageLandlordRegistration
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.landlordRegistrationJourneyPages.StartPageLandlordRegistration
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyComplianceJourneyPages.GasSafeEngineerNumPagePropertyCompliance
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyComplianceJourneyPages.GasSafetyExemptionOtherReasonPagePropertyCompliance
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyComplianceJourneyPages.GasSafetyExemptionPagePropertyCompliance
@@ -117,6 +118,11 @@ class Navigator(
         return createValidPage(page, SearchPropertyRegisterPage::class)
     }
 
+    fun goToLandlordRegistrationStartPage(): StartPageLandlordRegistration {
+        navigate("/register-as-a-landlord")
+        return createValidPage(page, StartPageLandlordRegistration::class)
+    }
+
     fun goToLandlordRegistrationConfirmIdentityFormPage(): ConfirmIdentityFormPageLandlordRegistration {
         val verifiedIdentityMap =
             mutableMapOf<String, Any?>(
@@ -129,7 +135,7 @@ class Navigator(
         return createValidPage(page, ConfirmIdentityFormPageLandlordRegistration::class)
     }
 
-    fun redirectFromLandlordRegistrationVerifyIdentityToLandlordDashboardPage(): LandlordDashboardPage {
+    fun goToLandlordRegistrationVerifyIdentityAsRegisteredLandlord(): LandlordDashboardPage {
         navigate("/$REGISTER_LANDLORD_JOURNEY_URL/${LandlordRegistrationStepId.VerifyIdentity.urlPathSegment}")
         return createValidPage(page, LandlordDashboardPage::class)
     }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/landlordRegistrationJourneyPages/StartPageLandlordRegistration.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/landlordRegistrationJourneyPages/StartPageLandlordRegistration.kt
@@ -1,0 +1,14 @@
+package uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.landlordRegistrationJourneyPages
+
+import com.microsoft.playwright.Page
+import uk.gov.communities.prsdb.webapp.constants.REGISTER_LANDLORD_JOURNEY_URL
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.Button
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.Heading
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages.BasePage
+
+class StartPageLandlordRegistration(
+    page: Page,
+) : BasePage(page, "/$REGISTER_LANDLORD_JOURNEY_URL") {
+    val heading: Heading = Heading(page.locator("main h1"))
+    val startButton = Button.byText(page, "Start now")
+}

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/UserRolesServiceTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/UserRolesServiceTests.kt
@@ -5,6 +5,9 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.mockito.Mockito
 import org.mockito.kotlin.whenever
+import uk.gov.communities.prsdb.webapp.constants.ROLE_LANDLORD
+import uk.gov.communities.prsdb.webapp.constants.ROLE_LA_ADMIN
+import uk.gov.communities.prsdb.webapp.constants.ROLE_LA_USER
 import uk.gov.communities.prsdb.webapp.database.repository.LandlordRepository
 import uk.gov.communities.prsdb.webapp.database.repository.LocalAuthorityUserRepository
 import uk.gov.communities.prsdb.webapp.testHelpers.mockObjects.MockLandlordData
@@ -36,7 +39,7 @@ class UserRolesServiceTests {
 
         // Assert
         Assertions.assertEquals(1, roles.size)
-        Assertions.assertEquals("ROLE_LANDLORD", roles[0])
+        Assertions.assertEquals(ROLE_LANDLORD, roles[0])
     }
 
     @Test
@@ -53,8 +56,8 @@ class UserRolesServiceTests {
 
         // Assert
         Assertions.assertEquals(2, roles.size)
-        Assertions.assertEquals("ROLE_LA_ADMIN", roles[0])
-        Assertions.assertEquals("ROLE_LA_USER", roles[1])
+        Assertions.assertEquals(ROLE_LA_ADMIN, roles[0])
+        Assertions.assertEquals(ROLE_LA_USER, roles[1])
     }
 
     @Test
@@ -71,6 +74,65 @@ class UserRolesServiceTests {
 
         // Assert
         Assertions.assertEquals(1, roles.size)
-        Assertions.assertEquals("ROLE_LA_USER", roles[0])
+        Assertions.assertEquals(ROLE_LA_USER, roles[0])
+    }
+
+    @Test
+    fun `getHasLandlordUserRole returns true for a landlord user`() {
+        // Arrange
+        val baseUser = MockOneLoginUserData.createOneLoginUser()
+        val user = MockLandlordData.createLandlord(baseUser)
+        whenever(landlordRepository.findByBaseUser_Id(baseUser.id))
+            .thenReturn(user)
+
+        // Act
+        val hasLandlordUserRole = userRolesService.getHasLandlordUserRole(baseUser.id)
+
+        // Assert
+        Assertions.assertTrue(hasLandlordUserRole)
+    }
+
+    @Test
+    fun `getHasLandlordUserRole returns false for a local authority manager`() {
+        // Arrange
+        val baseUser = MockOneLoginUserData.createOneLoginUser()
+        val user = MockLocalAuthorityData.createLocalAuthorityUser(baseUser, isManager = true)
+
+        whenever(localAuthorityUserRepository.findByBaseUser_Id(baseUser.id))
+            .thenReturn(user)
+
+        // Act
+        val hasLandlordUserRole = userRolesService.getHasLandlordUserRole(baseUser.id)
+
+        // Assert
+        Assertions.assertFalse(hasLandlordUserRole)
+    }
+
+    @Test
+    fun `getHasLandlordUserRole returns false for a standard local authority user`() {
+        // Arrange
+        val baseUser = MockOneLoginUserData.createOneLoginUser()
+        val user = MockLocalAuthorityData.createLocalAuthorityUser(baseUser, isManager = false)
+
+        whenever(localAuthorityUserRepository.findByBaseUser_Id(baseUser.id))
+            .thenReturn(user)
+
+        // Act
+        val hasLandlordUserRole = userRolesService.getHasLandlordUserRole(baseUser.id)
+
+        // Assert
+        Assertions.assertFalse(hasLandlordUserRole)
+    }
+
+    @Test
+    fun `getHasLandlordUserRole returns false for a user without roles`() {
+        // Arrange
+        val baseUser = MockOneLoginUserData.createOneLoginUser()
+
+        // Act
+        val hasLandlordUserRole = userRolesService.getHasLandlordUserRole(baseUser.id)
+
+        // Assert
+        Assertions.assertFalse(hasLandlordUserRole)
     }
 }


### PR DESCRIPTION
## Ticket number

PRSD-1061

## Goal of change

Redirect registered landlords from the registration flow to the landlord dashboard

## Description of main change(s)

- Added a check to the `verify-identity` step in the landlord registration controller that redirects the user to the landlord dashboard if they are already registered
- Added a method to the UserRolesService to check if the user is a landlord and return a Boolean
- Added unit and integration tests

## Anything you'd like to highlight to the reviewer?

N/A

## Checklist

- [X] Unit tests for new logic (e.g. new service methods) have been added
- [X] Controller tests for any new endpoints, including testing the relevant permissions
- [X] Single page integration tests have been added for any unhappy-flow UI features, e.g. validation errors
- [X] Test suite has been run in full locally and is passing
- [X] Branch has been rebased onto main and run locally, with everything working as expected (both for your new feature
  and any related functionality)
