### PR TITLE
Feat/prsd 1019 uploaded file metadata

### DIFF
--- a/src/main/resources/templates/example/fileUpload.html
+++ b/src/main/resources/templates/example/fileUpload.html
@@ -1,8 +1,14 @@
-<th:block id="main-content" th:replace="~{fragments/layout :: layout('Example Form Page', ~{::#main-content/content()}, null)}">
-    <form th:action="@{''}" novalidate method="post" enctype="multipart/form-data">
-        <input type="file" name="uploaded-file">
-        <input type="submit" value="Upload">
-    </form>
+<th:block id="main-content" th:replace="~{fragments/layout :: layout('Example Form Page', ~{::#main-content/content()},  ${#fields.hasErrors('${formModel.*}')})}">
+    <main class="govuk-main-wrapper">
+        <div id="page-content"
+             th:replace="~{fragments/layouts/twoThirdsLayout :: twoThirdsLayout(~{::#page-content/content()})}">
+            <form th:action="@{''}" novalidate method="post" enctype="multipart/form-data" th:object="${formModel}">
+                <div th:replace="~{fragments/forms/errorSummary :: errorSummary()}">Error Summary</div>
+                <input type="file" name="uploaded-file">
+                <input type="submit" value="Upload">
+            </form>
+        </div>
+    </main>
     <div th:unless="${fileUploadResponse} == null">
         <div th:text="${fileUploadResponse}"></div>
     </div>


### PR DESCRIPTION
## Ticket number

PRSD-1019 & PRSD-1003

## Goal of change
Add a sketch of extracting and validating metadata about the request and file.

## Description of main change(s)
Validates the request headers and file metadata on the file upload. On validation failure, redirects to the `GET` endpoint and shows the validation errors (in the summary box only).

## Anything you'd like to highlight to the reviewer?
I've deliberately not thought overly much about the errors themselves and have not added them to the message file. If added they are displayed correctly, but I didn't want to add clean up to be done in the message file! I've also only shown them in the summary box as I didn't want to get bogged down making a display component without designs. From there, adding them to a display component should fairly standard.

## Checklist

- [X] Screenshots of any UI changes have been added
- [x] Test suite has been run in full locally and is passing
- [X] Branch has been rebased onto main and run locally, with everything working as expected (both for your new feature
  and any related functionality)

![{6E1D53C7-E516-4A13-9FD0-73FF6EFCBEC7}](https://github.com/user-attachments/assets/bf092035-2a4a-415b-b1eb-eec871a97260)
