### PR TITLE
PRSD-1003: Initial file-too-large page

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/CustomErrorController.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/CustomErrorController.kt
@@ -6,10 +6,14 @@ import org.springframework.boot.web.servlet.error.ErrorController
 import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Controller
 import org.springframework.ui.Model
+import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestMapping
 
 @Controller
 class CustomErrorController : ErrorController {
+    @GetMapping("/file-too-large")
+    fun fileTooLargeErrorPage() = "error/fileTooLarge"
+
     @RequestMapping("/error")
     fun handleError(
         request: HttpServletRequest,

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/CustomErrorController.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/CustomErrorController.kt
@@ -10,11 +10,12 @@ import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestMapping
 
 @Controller
+@RequestMapping("error")
 class CustomErrorController : ErrorController {
-    @GetMapping("/file-too-large")
+    @GetMapping("file-too-large")
     fun fileTooLargeErrorPage() = "error/fileTooLarge"
 
-    @RequestMapping("/error")
+    @RequestMapping
     fun handleError(
         request: HttpServletRequest,
         model: Model,

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -16,6 +16,12 @@ error.notFound.header=Page not found
 error.notFound.body.one=If you typed the web address, check it is correct.
 error.notFound.body.two=If you pasted the web address, check you copied the entire address.
 
+error.fileTooLarge.title=File too large - {0,,serviceName} - GOV.UK
+error.fileTooLarge.header=The file you selected was too large
+error.fileTooLarge.body.one=The action you were taking has been cancelled because the file you've uploaded was too large.
+error.fileTooLarge.body.two=You can try another file by returning to the action you just tried.
+error.fileTooLarge.cta=Return to your dashboard
+
 error.forbidden.title=Access denied - {0,,serviceName} - GOV.UK
 error.forbidden.header=You do not have permission to access this page
 error.forbidden.body.one=If you typed the web address, check it is correct.

--- a/src/main/resources/templates/error/fileTooLarge.html
+++ b/src/main/resources/templates/error/fileTooLarge.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html th:replace="~{fragments/layout :: layout(#{error.fileTooLarge.title(#{serviceName})}, ~{::main}, false)}">
+<main class="govuk-main-wrapper govuk-main-wrapper--l" id="main-content" role="main">
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <h1 class="govuk-heading-l" th:text="#{error.fileTooLarge.header}">error.notFound.header</h1>
+            <p class="govuk-body" th:text="#{error.fileTooLarge.body.one}">error.notFound.body.one</p>
+            <p class="govuk-body" th:text="#{error.fileTooLarge.body.two}">error.notFound.body.two</p>
+            <button th:replace="~{fragments/buttons/primaryButtonLink :: primaryButtonLink('/', #{error.fileTooLarge.cta})}">error.notFound.cta</button>
+        </div>
+    </div>
+</main>
+</html>

--- a/src/main/resources/templates/error/fileTooLarge.html
+++ b/src/main/resources/templates/error/fileTooLarge.html
@@ -3,10 +3,10 @@
 <main class="govuk-main-wrapper govuk-main-wrapper--l" id="main-content" role="main">
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
-            <h1 class="govuk-heading-l" th:text="#{error.fileTooLarge.header}">error.notFound.header</h1>
-            <p class="govuk-body" th:text="#{error.fileTooLarge.body.one}">error.notFound.body.one</p>
-            <p class="govuk-body" th:text="#{error.fileTooLarge.body.two}">error.notFound.body.two</p>
-            <button th:replace="~{fragments/buttons/primaryButtonLink :: primaryButtonLink('/', #{error.fileTooLarge.cta})}">error.notFound.cta</button>
+            <h1 class="govuk-heading-l" th:text="#{error.fileTooLarge.header}">error.fileTooLarge.header</h1>
+            <p class="govuk-body" th:text="#{error.fileTooLarge.body.one}">error.fileTooLarge.body.one</p>
+            <p class="govuk-body" th:text="#{error.fileTooLarge.body.two}">error.fileTooLarge.body.two</p>
+            <button th:replace="~{fragments/buttons/primaryButtonLink :: primaryButtonLink('/', #{error.fileTooLarge.cta})}">error.fileTooLarge.cta</button>
         </div>
     </div>
 </main>

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/ErrorPageTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/ErrorPageTests.kt
@@ -13,4 +13,10 @@ class ErrorPageTests : IntegrationTest() {
         page.navigate("http://localhost:$port/error")
         assertThat(page.getByRole(AriaRole.HEADING)).containsText("Sorry, there is a problem with the service")
     }
+
+    @Test
+    fun `file too large page renders when file too large controller path called`(page: Page) {
+        page.navigate("http://localhost:$port/file-too-large")
+        assertThat(page.getByRole(AriaRole.HEADING)).containsText("The file you selected was too large")
+    }
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/ErrorPageTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/ErrorPageTests.kt
@@ -19,7 +19,7 @@ class ErrorPageTests : IntegrationTest() {
 
     @Test
     fun `file too large page renders when file too large controller path called`(page: Page) {
-        navigator.navigate("/file-too-large")
+        navigator.navigate("/error/file-too-large")
         val errorPage = createValidPage(page, ErrorPage::class)
         BaseComponent.assertThat(errorPage.heading).containsText("The file you selected was too large")
     }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/ErrorPageTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/ErrorPageTests.kt
@@ -2,21 +2,25 @@ package uk.gov.communities.prsdb.webapp.integration
 
 import com.microsoft.playwright.Page
 import com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat
-import com.microsoft.playwright.options.AriaRole
 import org.junit.jupiter.api.Test
 import org.springframework.test.context.jdbc.Sql
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.BaseComponent
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.ErrorPage
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages.BasePage.Companion.createValidPage
 
 @Sql("/data-local.sql")
 class ErrorPageTests : IntegrationTest() {
     @Test
     fun `500 page renders when error controller path called`(page: Page) {
-        page.navigate("http://localhost:$port/error")
-        assertThat(page.getByRole(AriaRole.HEADING)).containsText("Sorry, there is a problem with the service")
+        navigator.navigate("/error")
+        val errorPage = createValidPage(page, ErrorPage::class)
+        BaseComponent.assertThat(errorPage.heading).containsText("Sorry, there is a problem with the service")
     }
 
     @Test
     fun `file too large page renders when file too large controller path called`(page: Page) {
-        page.navigate("http://localhost:$port/file-too-large")
-        assertThat(page.getByRole(AriaRole.HEADING)).containsText("The file you selected was too large")
+        navigator.navigate("/file-too-large")
+        val errorPage = createValidPage(page, ErrorPage::class)
+        BaseComponent.assertThat(errorPage.heading).containsText("The file you selected was too large")
     }
 }


### PR DESCRIPTION
## Ticket number

PRSD-1003

## Goal of change
Adds a 'file-too-large' error page we can redirect to from the WAF for very large requests.

## Description of main change(s)
Adds a 'file-too-large' error page we can redirect to from the WAF for very large requests.

## Anything you'd like to highlight to the reviewer?
Non final design - asked for copy from the designers, but updating the template should be easy.

## Checklist
- [X] Screenshots of any UI changes have been added
- [X] Controller tests for any new endpoints, including testing the relevant permissions
- [x] Test suite has been run in full locally and is passing
- [X] Branch has been rebased onto main and run locally, with everything working as expected (both for your new feature
  and any related functionality)

![image](https://github.com/user-attachments/assets/cd9e0831-e7f9-4869-bde2-8042b9ec8f98)
