### PR TITLE
feat/PRSD-1077 changed notification banner wording for single incompl…

### DIFF
--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -472,6 +472,7 @@ landlord.dashboard.action.keepingPropertyCompliant.descriptionText=Make sure you
 landlord.dashboard.notification.banner.title=Important
 landlord.dashboard.notification.banner.subheadingBeforeNumber=You have
 landlord.dashboard.notification.banner.subheadingAfterNumber=incomplete properties:
+landlord.dashboard.notification.banner.subheadingAfterNumberIsOne=incomplete property:
 landlord.dashboard.notification.banner.linkText=View incomplete properties
 
 forms.errorSummary.heading=There is a problem

--- a/src/main/resources/templates/landlordDashboard.html
+++ b/src/main/resources/templates/landlordDashboard.html
@@ -4,7 +4,7 @@
     <div id="page-content">
         <div id="notification-banner"
              th:replace="${incompleteProperties != null} ? ~{fragments/banners/notificationBanner :: notificationBanner(#{landlord.dashboard.notification.banner.title},
-             #{landlord.dashboard.notification.banner.subheadingBeforeNumber} + ' ' + ${incompleteProperties} + ' ' + #{landlord.dashboard.notification.banner.subheadingAfterNumber} + ' ',
+             #{landlord.dashboard.notification.banner.subheadingBeforeNumber} + ' ' + ${incompleteProperties} + ' ' + (${incompleteProperties != 1} ? #{landlord.dashboard.notification.banner.subheadingAfterNumber} : #{landlord.dashboard.notification.banner.subheadingAfterNumberIsOne}) + ' ',
              ${viewIncompletePropertiesUrl}, #{landlord.dashboard.notification.banner.linkText})} : ~{}">
             Incomplete properties notification banner
         </div>

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/LandlordDashboardTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/LandlordDashboardTests.kt
@@ -59,7 +59,7 @@ class LandlordDashboardTests : IntegrationTest() {
 
     @Test
     @Sql("/data-mockuser-landlord-with-one-incomplete-property.sql")
-    fun `the dashboard loads with a notification banner  and correct message when the landlord has one incomplete property`(page: Page) {
+    fun `the dashboard loads with a notification banner and correct message when the landlord has one incomplete property`(page: Page) {
         val dashboard = navigator.goToLandlordDashboard()
         assertThat(dashboard.notificationBanner.title).containsText("Important")
         assertThat(dashboard.notificationBanner.subheading).containsText("You have 1 incomplete property: View incomplete properties")

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/LandlordDashboardTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/LandlordDashboardTests.kt
@@ -58,11 +58,19 @@ class LandlordDashboardTests : IntegrationTest() {
     }
 
     @Test
+    @Sql("/data-mockuser-landlord-with-one-incomplete-property.sql")
+    fun `the dashboard loads with a notification banner  and correct message when the landlord has one incomplete property`(page: Page) {
+        val dashboard = navigator.goToLandlordDashboard()
+        assertThat(dashboard.notificationBanner.title).containsText("Important")
+        assertThat(dashboard.notificationBanner.subheading).containsText("You have 1 incomplete property: View incomplete properties")
+    }
+
+    @Test
     @Sql("/data-mockuser-landlord-with-incomplete-properties.sql")
     fun `the dashboard loads with a notification banner when the landlord has incomplete properties`(page: Page) {
         val dashboard = navigator.goToLandlordDashboard()
         assertThat(dashboard.notificationBanner.title).containsText("Important")
-        assertThat(dashboard.notificationBanner.subheading).containsText("You have 1 incomplete properties: View incomplete properties")
+        assertThat(dashboard.notificationBanner.subheading).containsText("You have 2 incomplete properties: View incomplete properties")
     }
 
     @Test

--- a/src/test/resources/data-mockuser-landlord-with-one-incomplete-property.sql
+++ b/src/test/resources/data-mockuser-landlord-with-one-incomplete-property.sql
@@ -14,5 +14,4 @@ VALUES (1, '09/13/24', '09/13/24', 1, 1, '09/13/2000', true, 07111111111, 'urn:f
 SELECT setval(pg_get_serial_sequence('landlord', 'id'), (SELECT MAX(id) FROM landlord));
 
 INSERT INTO form_context (id, created_date, last_modified_date, journey_type, context, subject_identifier)
-VALUES (1, '09/13/24', '09/13/24',3, '{"lookup-address":{"houseNameOrNumber":"6","postcode":"NW5"}','urn:fdc:gov.uk:2022:UVWXY'),
-       (2, '09/13/24', '09/13/24',3, '{"lookup-address":{"houseNameOrNumber":"8","postcode":"NW5"}','urn:fdc:gov.uk:2022:UVWXY');
+VALUES (1, '09/13/24', '09/13/24',3, '{"lookup-address":{"houseNameOrNumber":"6","postcode":"NW5"}','urn:fdc:gov.uk:2022:UVWXY');


### PR DESCRIPTION
…ete property

## Ticket number

PRSD-1077

## Goal of change

Changed the wording on the landlord dashboard notification banner when there is a single incomplete property

## Description of main change(s)

Added a check to the dashboard view so the notification header reads "You have 1 incomplete property" instead of ""You have 1 incomplete properties" then there is only one incomplete property. 

## Screenshots

One incomplete property:
![image](https://github.com/user-attachments/assets/aa7fd763-d293-488e-ad79-268e42de23f9)

Multiple incomplete properties:
![image](https://github.com/user-attachments/assets/ceae3970-8b00-48d0-b21f-f6963ae4e93d)


## Anything you'd like to highlight to the reviewer?

N/A

## Checklist

Delete any that are not applicable, and add explanation below for any that are applicable but haven't been done

- [X] Screenshots of any UI changes have been added
- [X] Single page integration tests have been added ~for any unhappy-flow UI features, e.g. validation errors~
- [ ] New journey steps have been added to the appropriate journey integration test(s)
- [X] Test suite has been run in full locally and is passing
- [X] Branch has been rebased onto main and run locally, with everything working as expected (both for your new feature
  and any related functionality)
