### PR TITLE
PRSD-1098: Property Compliance - Gas Safety Upload Confirmation Page

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/PropertyComplianceJourney.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/PropertyComplianceJourney.kt
@@ -98,11 +98,7 @@ class PropertyComplianceJourney(
                     gasSafetyIssueDateStep,
                     gasSafetyEngineerNumStep,
                     gasSafetyUploadStep,
-                    // TODO PRSD-1098: Implement gas safety cert upload confirmation step
-                    placeholderStep(
-                        PropertyComplianceStepId.GasSafetyUploadConfirmation,
-                        "TODO PRSD-1098: Implement gas safety cert upload confirmation step",
-                    ),
+                    gasSafetyUploadConfirmationStep,
                     gasSafetyOutdatedStep,
                     gasSafetyExemptionStep,
                     gasSafetyExemptionReasonStep,
@@ -207,6 +203,23 @@ class PropertyComplianceJourney(
                             ),
                     ) { mapOf("fieldSetSubheading" to getPropertyAddress()) },
                 nextAction = { _, _ -> Pair(PropertyComplianceStepId.GasSafetyUploadConfirmation, null) },
+            )
+
+    private val gasSafetyUploadConfirmationStep
+        get() =
+            Step(
+                id = PropertyComplianceStepId.GasSafetyUploadConfirmation,
+                page =
+                    Page(
+                        formModel = NoInputFormModel::class,
+                        templateName = "forms/uploadCertificateConfirmationForm",
+                        content =
+                            mapOf(
+                                "title" to "propertyCompliance.title",
+                            ),
+                    ),
+                handleSubmitAndRedirect = { _, _ -> taskListUrlSegment },
+                nextAction = { _, _ -> Pair(eicrTask.startingStepId, null) },
             )
 
     private val gasSafetyOutdatedStep

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -827,6 +827,11 @@ forms.uploadCertificate.error.wrongType=The selected file must be a PDF, PNG or 
 forms.uploadCertificate.error.tooBig=The selected file must be smaller than 15MB
 forms.uploadCertificate.error.unsuccessfulUpload=The selected file could not be uploaded - try again
 
+forms.uploadCertificateConfirmation.heading=Your file is being scanned
+forms.uploadCertificateConfirmation.paragraph.one=Your file will be scanned for viruses. It will upload automatically if there are no issues found.
+forms.uploadCertificateConfirmation.paragraph.two=<strong>What if the file fails to upload?</strong>
+forms.uploadCertificateConfirmation.paragraph.three=If there are any issues with the virus scan, you will get an email letting you know what to do next.
+
 pagination.previousText=Previous
 pagination.pageText=page
 pagination.nextText=Next

--- a/src/main/resources/templates/forms/uploadCertificateConfirmationForm.html
+++ b/src/main/resources/templates/forms/uploadCertificateConfirmationForm.html
@@ -1,0 +1,16 @@
+<!--/*@thymesVar id="title" type="java.lang.String"*/-->
+<!--/*@thymesVar id="formModel" type="java.lang.Object"*/-->
+<!--/*@thymesVar id="backUrl" type="java.lang.String"*/-->
+<!--/*@thymesVar id="sectionHeaderInfo" type="uk.gov.communities.prsdb.webapp.models.viewModels.SectionHeaderViewModel"*/-->
+<!DOCTYPE html>
+<html id="form-content" th:replace="~{fragments/forms/questionPage :: questionPage(#{${title}}, ${formModel}, ~{::#form-content/content()}, ${backUrl}, ${sectionHeaderInfo})}">
+    <header>
+        <h1 class="govuk-heading-l" th:text="#{forms.uploadCertificateConfirmation.heading}">forms.uploadCertificateConfirmation.heading</h1>
+    </header>
+    <section>
+        <p class="govuk-body" th:text="#{forms.uploadCertificateConfirmation.paragraph.one}">forms.uploadCertificateConfirmation.paragraph.one</p>
+        <p class="govuk-body" th:utext="#{forms.uploadCertificateConfirmation.paragraph.two}">forms.uploadCertificateConfirmation.paragraph.two</p>
+        <p class="govuk-body" th:text="#{forms.uploadCertificateConfirmation.paragraph.three}">forms.uploadCertificateConfirmation.paragraph.three</p>
+    </section>
+    <button th:replace="~{fragments/buttons/primaryButton :: primaryButton(#{forms.buttons.saveAndContinue})}"></button>
+</html>

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/PropertyComplianceJourneyTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/PropertyComplianceJourneyTests.kt
@@ -32,6 +32,7 @@ import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyCom
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyComplianceJourneyPages.GasSafetyIssueDatePagePropertyCompliance
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyComplianceJourneyPages.GasSafetyOutdatedPagePropertyCompliance
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyComplianceJourneyPages.GasSafetyPagePropertyCompliance
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyComplianceJourneyPages.GasSafetyUploadConfirmationPagePropertyCompliance
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyComplianceJourneyPages.GasSafetyUploadPagePropertyCompliance
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyComplianceJourneyPages.TaskListPagePropertyCompliance
 import uk.gov.communities.prsdb.webapp.services.FileUploader
@@ -76,13 +77,14 @@ class PropertyComplianceJourneyTests : IntegrationTest() {
                 ),
             ).thenReturn(true)
             gasSafetyUploadPage.uploadCertificate("validFile.png")
+            val gasSafetyUploadConfirmationPage = assertPageIs(page, GasSafetyUploadConfirmationPagePropertyCompliance::class, urlArguments)
 
-            // TODO PRSD-1098: Continue journey tests
-            assertContains(
-                page.url(),
-                PropertyComplianceController.getPropertyCompliancePath(PROPERTY_OWNERSHIP_ID) +
-                    "/${PropertyComplianceStepId.GasSafetyUploadConfirmation.urlPathSegment}",
-            )
+            // Gas Safety Cert. Upload Confirmation page
+            assertThat(gasSafetyUploadConfirmationPage.heading).containsText("Your file is being scanned")
+            gasSafetyUploadConfirmationPage.saveAndContinueButton.clickAndWait()
+            assertPageIs(page, TaskListPagePropertyCompliance::class, urlArguments)
+
+            // TODO PRSD-954: Continue journey test
         }
 
         @Test

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/basePages/UploadConfirmationFormPage.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/basePages/UploadConfirmationFormPage.kt
@@ -1,0 +1,13 @@
+package uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages
+
+import com.microsoft.playwright.Locator
+import com.microsoft.playwright.Page
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.Button
+
+abstract class UploadConfirmationFormPage(
+    page: Page,
+    urlSegment: String,
+) : BasePage(page, urlSegment) {
+    val heading: Locator = page.locator(".govuk-heading-l")
+    val saveAndContinueButton = Button.byText(page, "Save and continue")
+}

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/propertyComplianceJourneyPages/GasSafetyUploadConfirmationPagePropertyCompliance.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/propertyComplianceJourneyPages/GasSafetyUploadConfirmationPagePropertyCompliance.kt
@@ -1,0 +1,15 @@
+package uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyComplianceJourneyPages
+
+import com.microsoft.playwright.Page
+import uk.gov.communities.prsdb.webapp.controllers.PropertyComplianceController
+import uk.gov.communities.prsdb.webapp.forms.steps.PropertyComplianceStepId
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages.UploadConfirmationFormPage
+
+class GasSafetyUploadConfirmationPagePropertyCompliance(
+    page: Page,
+    urlArguments: Map<String, String>,
+) : UploadConfirmationFormPage(
+        page,
+        PropertyComplianceController.getPropertyCompliancePath(urlArguments["propertyOwnershipId"]!!.toLong()) +
+            "/${PropertyComplianceStepId.GasSafetyUploadConfirmation.urlPathSegment}",
+    )


### PR DESCRIPTION
## Ticket number

PRSD-1098

## Goal of change

Adds gas safety upload confirmation step to property compliance journey

## Description of main change(s)

- Creates template for gas safety upload confirmation page
- Adds gas safety upload confirmation step to property compliance journey

## Anything you'd like to highlight to the reviewer?

N/A

## Checklist

Delete any that are not applicable, and add explanation below for any that are applicable but haven't been done

- [X] Screenshots of any UI changes have been added
- [X] New journey steps have been added to the appropriate journey integration test(s)
- [X] Test suite has been run in full locally and is passing
- [X] Branch has been rebased onto main and run locally, with everything working as expected (both for your new feature
  and any related functionality)

![image](https://github.com/user-attachments/assets/6e4b74b4-b5af-43d2-98b7-93a3954a464b)