### PR TITLE
Feat/prsd 1078 add complete by date coherence

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/RegisterPropertyController.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/RegisterPropertyController.kt
@@ -17,7 +17,6 @@ import uk.gov.communities.prsdb.webapp.constants.REGISTER_PROPERTY_JOURNEY_URL
 import uk.gov.communities.prsdb.webapp.constants.RESUME_PAGE_PATH_SEGMENT
 import uk.gov.communities.prsdb.webapp.constants.START_PAGE_PATH_SEGMENT
 import uk.gov.communities.prsdb.webapp.constants.TASK_LIST_PATH_SEGMENT
-import uk.gov.communities.prsdb.webapp.constants.enums.JourneyType
 import uk.gov.communities.prsdb.webapp.controllers.LandlordController.Companion.LANDLORD_DASHBOARD_URL
 import uk.gov.communities.prsdb.webapp.forms.PageData
 import uk.gov.communities.prsdb.webapp.forms.journeys.factories.PropertyRegistrationJourneyFactory
@@ -58,10 +57,11 @@ class RegisterPropertyController(
         principal: Principal,
         @RequestParam(value = "contextId", required = true) contextId: String,
     ): String {
+        val formContext = propertyRegistrationService.getIncompletePropertyForLandlord(contextId.toLong(), principal.name)
         journeyDataServiceFactory
             .create(
                 REGISTER_PROPERTY_JOURNEY_URL,
-            ).loadJourneyDataIntoSession(contextId.toLong(), principal.name, JourneyType.PROPERTY_REGISTRATION)
+            ).loadJourneyDataIntoSession(formContext)
         return "redirect:$TASK_LIST_PATH_SEGMENT"
     }
 

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/JourneyDataService.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/JourneyDataService.kt
@@ -2,8 +2,6 @@ package uk.gov.communities.prsdb.webapp.services
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import jakarta.servlet.http.HttpSession
-import org.springframework.http.HttpStatus
-import org.springframework.web.server.ResponseStatusException
 import uk.gov.communities.prsdb.webapp.constants.CONTEXT_ID
 import uk.gov.communities.prsdb.webapp.constants.enums.JourneyType
 import uk.gov.communities.prsdb.webapp.database.entity.FormContext
@@ -80,19 +78,6 @@ class JourneyDataService(
             formContextRepository
                 .findById(contextId)
                 .orElseThrow { IllegalStateException("FormContext with ID $contextId not found") }!!
-        loadJourneyDataIntoSession(formContext)
-    }
-
-    fun loadJourneyDataIntoSession(
-        contextId: Long,
-        baseUserId: String,
-        journeyType: JourneyType,
-    ) {
-        val formContext =
-            formContextRepository.findByIdAndUser_IdAndJourneyType(contextId, baseUserId, journeyType) ?: throw ResponseStatusException(
-                HttpStatus.NOT_FOUND,
-                "Form context with ID: $contextId and journey type: ${journeyType.name} not found for base user: $baseUserId",
-            )
         loadJourneyDataIntoSession(formContext)
     }
 

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/PropertyRegistrationService.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/PropertyRegistrationService.kt
@@ -6,7 +6,9 @@ import jakarta.servlet.http.HttpSession
 import jakarta.transaction.Transactional
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.toKotlinInstant
+import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Service
+import org.springframework.web.server.ResponseStatusException
 import uk.gov.communities.prsdb.webapp.constants.PROPERTY_REGISTRATION_NUMBER
 import uk.gov.communities.prsdb.webapp.constants.enums.JourneyType
 import uk.gov.communities.prsdb.webapp.constants.enums.LicensingType
@@ -170,5 +172,27 @@ class PropertyRegistrationService(
         val lookedUpAddresses = formContextJourneyData.getLookedUpAddresses()
         // TODO PRSD-1127 set this to return a not nullable AddressDataModel
         return PropertyRegistrationJourneyDataHelper.getAddress(formContextJourneyData, lookedUpAddresses)
+    }
+
+    fun getIncompletePropertyForLandlord(
+        contextId: Long,
+        principalName: String,
+    ): FormContext {
+        val formContext =
+            formContextRepository.findByIdAndUser_IdAndJourneyType(contextId, principalName, JourneyType.PROPERTY_REGISTRATION)
+                ?: throw ResponseStatusException(
+                    HttpStatus.NOT_FOUND,
+                    "Form context with ID: $contextId and journey type: " +
+                        "${JourneyType.PROPERTY_REGISTRATION.name} not found for base user: $principalName",
+                )
+        val completeByDate = getCompleteByDate(formContext.createdDate)
+
+        if (DateTimeHelper.isDateInPast(completeByDate, DateTimeHelper().getCurrentDateInUK())) {
+            throw ResponseStatusException(
+                HttpStatus.BAD_REQUEST,
+                "Completed date for orm context with ID: $contextId is in the past",
+            )
+        }
+        return formContext
     }
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/PropertyRegistrationService.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/PropertyRegistrationService.kt
@@ -119,11 +119,9 @@ class PropertyRegistrationService(
     private fun filterIncompleteProperties(incompleteProperties: List<FormContext>): List<FormContext>? {
         val filteredIncompleteProperties = mutableListOf<FormContext>()
 
-        val currentDate = DateTimeHelper().getCurrentDateInUK()
-
         incompleteProperties.forEach { property ->
-            val completeByDate = getCompleteByDate(property.createdDate)
-            if (!DateTimeHelper.isDateInPast(completeByDate, currentDate)) {
+            val completeByDate = getIncompletePropertyCompleteByDate(property.createdDate)
+            if (!DateTimeHelper.isDateInPast(completeByDate)) {
                 filteredIncompleteProperties.add(property)
             }
         }
@@ -185,9 +183,9 @@ class PropertyRegistrationService(
                     "Form context with ID: $contextId and journey type: " +
                         "${JourneyType.PROPERTY_REGISTRATION.name} not found for base user: $principalName",
                 )
-        val completeByDate = getCompleteByDate(formContext.createdDate)
+        val completeByDate = getIncompletePropertyCompleteByDate(formContext.createdDate)
 
-        if (DateTimeHelper.isDateInPast(completeByDate, DateTimeHelper().getCurrentDateInUK())) {
+        if (DateTimeHelper.isDateInPast(completeByDate)) {
             throw ResponseStatusException(
                 HttpStatus.BAD_REQUEST,
                 "Completed date for orm context with ID: $contextId is in the past",

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/controllers/RegisterPropertyControllerTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/controllers/RegisterPropertyControllerTests.kt
@@ -20,7 +20,6 @@ import uk.gov.communities.prsdb.webapp.constants.REGISTER_PROPERTY_JOURNEY_URL
 import uk.gov.communities.prsdb.webapp.constants.RESUME_PAGE_PATH_SEGMENT
 import uk.gov.communities.prsdb.webapp.constants.START_PAGE_PATH_SEGMENT
 import uk.gov.communities.prsdb.webapp.constants.TASK_LIST_PATH_SEGMENT
-import uk.gov.communities.prsdb.webapp.constants.enums.JourneyType
 import uk.gov.communities.prsdb.webapp.constants.enums.RegistrationNumberType
 import uk.gov.communities.prsdb.webapp.database.entity.RegistrationNumber
 import uk.gov.communities.prsdb.webapp.forms.journeys.PropertyRegistrationJourney
@@ -30,6 +29,7 @@ import uk.gov.communities.prsdb.webapp.services.JourneyDataService
 import uk.gov.communities.prsdb.webapp.services.PropertyOwnershipService
 import uk.gov.communities.prsdb.webapp.services.PropertyRegistrationService
 import uk.gov.communities.prsdb.webapp.services.factories.JourneyDataServiceFactory
+import uk.gov.communities.prsdb.webapp.testHelpers.mockObjects.MockLandlordData.Companion.createFormContext
 import uk.gov.communities.prsdb.webapp.testHelpers.mockObjects.MockLandlordData.Companion.createPropertyOwnership
 
 @WebMvcTest(RegisterPropertyController::class)
@@ -167,12 +167,15 @@ class RegisterPropertyControllerTests(
     @WithMockUser(roles = ["LANDLORD"], value = "user")
     fun `getResume redirects to task-list after calling load journey data method from propertyRegistrationService`() {
         val contextId = "1"
+        val formContext = createFormContext()
+        whenever(propertyRegistrationService.getIncompletePropertyForLandlord(contextId.toLong(), "user")).thenReturn(formContext)
         mvc
             .get("/$REGISTER_PROPERTY_JOURNEY_URL/$RESUME_PAGE_PATH_SEGMENT?contextId=$contextId")
             .andExpect {
                 status { is3xxRedirection() }
                 redirectedUrl(TASK_LIST_PATH_SEGMENT)
             }
-        verify(journeyDataService).loadJourneyDataIntoSession(contextId.toLong(), "user", JourneyType.PROPERTY_REGISTRATION)
+        verify(propertyRegistrationService).getIncompletePropertyForLandlord(contextId.toLong(), "user")
+        verify(journeyDataService).loadJourneyDataIntoSession(formContext)
     }
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/JourneyDataServiceTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/JourneyDataServiceTests.kt
@@ -15,8 +15,6 @@ import org.mockito.kotlin.eq
 import org.mockito.kotlin.spy
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
-import org.springframework.http.HttpStatus
-import org.springframework.web.server.ResponseStatusException
 import uk.gov.communities.prsdb.webapp.constants.CONTEXT_ID
 import uk.gov.communities.prsdb.webapp.constants.enums.JourneyType
 import uk.gov.communities.prsdb.webapp.database.entity.FormContext
@@ -261,51 +259,6 @@ class JourneyDataServiceTests {
                 assertThrows<IllegalStateException> {
                     journeyDataService.loadJourneyDataIntoSession(formContextId)
                 }
-            }
-        }
-
-        @Nested
-        inner class WithContextIdAndUserIdAndJourneyTypeTests {
-            @Test
-            fun `calls loadJourneyDataIntoSession when form context exists`() {
-                // Arrange
-                whenever(
-                    mockFormContextRepository.findByIdAndUser_IdAndJourneyType(
-                        formContext.id,
-                        formContext.user.id,
-                        formContext.journeyType,
-                    ),
-                ).thenReturn(formContext)
-
-                // Act
-                journeyDataService.loadJourneyDataIntoSession(formContext.id, formContext.user.id, formContext.journeyType)
-                val formContextCaptor = captor<JourneyData>()
-                verify(mockHttpSession).setAttribute(eq(journeyDataKey), formContextCaptor.capture())
-                val contextIdCaptor = captor<Long>()
-                verify(mockHttpSession).setAttribute(eq(CONTEXT_ID), contextIdCaptor.capture())
-
-                // Assert
-                assertEquals(journeyData, formContextCaptor.value)
-                assertEquals(formContext.id, contextIdCaptor.value)
-            }
-
-            @Test
-            fun `throws a response status exception NOT_FOUND if form context is missing`() {
-                // Arrange
-                val formContextId: Long = 123
-                val baseUserId = "user"
-                val journeyType = JourneyType.PROPERTY_REGISTRATION
-
-                whenever(
-                    mockFormContextRepository.findByIdAndUser_IdAndJourneyType(formContextId, baseUserId, journeyType),
-                ).thenReturn(null)
-
-                // Act and Assert
-                val exception =
-                    assertThrows<ResponseStatusException> {
-                        journeyDataService.loadJourneyDataIntoSession(formContextId, baseUserId, journeyType)
-                    }
-                assertEquals(HttpStatus.NOT_FOUND, exception.statusCode)
             }
         }
     }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/PropertyRegistrationServiceTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/PropertyRegistrationServiceTests.kt
@@ -47,7 +47,6 @@ import uk.gov.communities.prsdb.webapp.database.repository.PropertyRepository
 import uk.gov.communities.prsdb.webapp.helpers.DateTimeHelper
 import uk.gov.communities.prsdb.webapp.models.dataModels.AddressDataModel
 import uk.gov.communities.prsdb.webapp.testHelpers.mockObjects.MockLandlordData.Companion.createFormContext
-import uk.gov.communities.prsdb.webapp.testHelpers.mockObjects.MockLandlordData.Companion.createOneLoginUser
 import uk.gov.communities.prsdb.webapp.testHelpers.mockObjects.MockLandlordData.Companion.createPropertyOwnership
 
 @ExtendWith(MockitoExtension::class)
@@ -377,25 +376,6 @@ class PropertyRegistrationServiceTests {
             val incompleteProperties = propertyRegistrationService.getNumberOfIncompletePropertyRegistrationsForLandlord(principalName)
 
             assertNull(incompleteProperties)
-        }
-
-        @Test
-        fun `getIncompletePropertiesForLandlord returns list of incomplete properties from FormContextRepo`() {
-            val principalName = "principalName"
-            val user = createOneLoginUser(principalName)
-            val expectedIncompletePropertyFormContexts =
-                mutableListOf(
-                    FormContext(JourneyType.PROPERTY_REGISTRATION, "", user),
-                    FormContext(JourneyType.PROPERTY_REGISTRATION, "", user),
-                )
-            whenever(
-                mockFormContextRepository.findAllByUser_IdAndJourneyType(principalName, JourneyType.PROPERTY_REGISTRATION),
-            ).thenReturn(expectedIncompletePropertyFormContexts)
-
-            val incompleteProperties = propertyRegistrationService.getIncompletePropertiesForLandlord(principalName)
-
-            verify(mockFormContextRepository).findAllByUser_IdAndJourneyType(principalName, JourneyType.PROPERTY_REGISTRATION)
-            assertEquals(expectedIncompletePropertyFormContexts, incompleteProperties)
         }
 
         @Test

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/testHelpers/mockObjects/MockLandlordData.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/testHelpers/mockObjects/MockLandlordData.kt
@@ -2,12 +2,14 @@ package uk.gov.communities.prsdb.webapp.testHelpers.mockObjects
 
 import org.springframework.test.util.ReflectionTestUtils
 import uk.gov.communities.prsdb.webapp.constants.ENGLAND_OR_WALES
+import uk.gov.communities.prsdb.webapp.constants.enums.JourneyType
 import uk.gov.communities.prsdb.webapp.constants.enums.OccupancyType
 import uk.gov.communities.prsdb.webapp.constants.enums.OwnershipType
 import uk.gov.communities.prsdb.webapp.constants.enums.PropertyType
 import uk.gov.communities.prsdb.webapp.constants.enums.RegistrationNumberType
 import uk.gov.communities.prsdb.webapp.constants.enums.RegistrationStatus
 import uk.gov.communities.prsdb.webapp.database.entity.Address
+import uk.gov.communities.prsdb.webapp.database.entity.FormContext
 import uk.gov.communities.prsdb.webapp.database.entity.Landlord
 import uk.gov.communities.prsdb.webapp.database.entity.LandlordWithListedPropertyCount
 import uk.gov.communities.prsdb.webapp.database.entity.License
@@ -112,6 +114,24 @@ class MockLandlordData {
             ReflectionTestUtils.setField(propertyOwnership, "createdDate", createdDate)
 
             return propertyOwnership
+        }
+
+        fun createFormContext(
+            journeyType: JourneyType = JourneyType.PROPERTY_REGISTRATION,
+            context: String =
+                "{\"lookup-address\":{\"houseNameOrNumber\":\"73\",\"postcode\":\"WC2R 1LA\"}," +
+                    "\"looked-up-addresses\":\"[{\\\"singleLineAddress\\\":\\\"2, Example Road, EG\\\"," +
+                    "\\\"localAuthorityId\\\":241,\\\"uprn\\\":2123456,\\\"buildingNumber\\\":\\\"2\\\"," +
+                    "\\\"postcode\\\":\\\"EG\\\"}]\",\"select-address\":{\"address\":\"2, Example Road, EG\"}}",
+            user: OneLoginUser = createOneLoginUser(),
+            createdDate: Instant = Instant.now(),
+            id: Long = 0,
+        ): FormContext {
+            val formContext = FormContext(journeyType, context, user)
+
+            ReflectionTestUtils.setField(formContext, "createdDate", createdDate)
+            ReflectionTestUtils.setField(formContext, "id", id)
+            return formContext
         }
     }
 }


### PR DESCRIPTION
## Ticket number

PRSD-1078

## Goal of change

Stop landlords from resuming incomplete properties that are more then 28 days old
On landlord dashboard only show number of incomplete properties from within  show number 

## Description of main change(s)

Added check when getting the number of incomplete properties for landlord to filter out properties older than 28 days
Added check when resuming an incomplete property  to ensure the property is not more than 28 days old

## Anything you'd like to highlight to the reviewer?

N/A

## Checklist

- [X] Unit tests for new logic (e.g. new service methods) have been added
- [X] Test suite has been run in full locally and is passing
- [ ] Branch has been rebased onto main and run locally, with everything working as expected (both for your new feature
  and any related functionality)
