### PR TITLE
PRSD-1107: Property No Session Update - Ownership Type

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/PropertyDetailsUpdateJourney.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/PropertyDetailsUpdateJourney.kt
@@ -107,6 +107,8 @@ class PropertyDetailsUpdateJourney(
                                         hintMsgKey = "forms.ownershipType.radios.option.leasehold.hint",
                                     ),
                                 ),
+                            "submitButtonText" to "forms.buttons.confirmAndSubmitUpdate",
+                            "showWarning" to true,
                             BACK_URL_ATTR_NAME to RELATIVE_PROPERTY_DETAILS_PATH,
                         ),
                 ),

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/PropertyRegistrationJourney.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/PropertyRegistrationJourney.kt
@@ -356,6 +356,7 @@ class PropertyRegistrationJourney(
                                         hintMsgKey = "forms.ownershipType.radios.option.leasehold.hint",
                                     ),
                                 ),
+                            "submitButtonText" to "forms.buttons.saveAndContinue",
                         ),
                     shouldDisplaySectionHeader = true,
                 ),

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/factories/PropertyDetailsUpdateJourneyFactory.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/factories/PropertyDetailsUpdateJourneyFactory.kt
@@ -1,9 +1,10 @@
 package uk.gov.communities.prsdb.webapp.forms.journeys.factories
 
+import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Component
 import org.springframework.validation.Validator
+import org.springframework.web.server.ResponseStatusException
 import uk.gov.communities.prsdb.webapp.controllers.PropertyDetailsController
-import uk.gov.communities.prsdb.webapp.exceptions.PrsdbWebException
 import uk.gov.communities.prsdb.webapp.forms.journeys.PropertyDetailsUpdateJourney
 import uk.gov.communities.prsdb.webapp.forms.steps.UpdatePropertyDetailsStepId
 import uk.gov.communities.prsdb.webapp.services.PropertyOwnershipService
@@ -35,5 +36,5 @@ class PropertyDetailsUpdateJourneyFactory(
     }
 
     private fun throwInvalidStepNameException(stepName: String): Nothing =
-        throw PrsdbWebException("Invalid PropertyDetailsUpdateJourney step name: $stepName")
+        throw ResponseStatusException(HttpStatus.NOT_FOUND, "Invalid PropertyDetailsUpdateJourney step name: $stepName")
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/summaryModels/PropertyDetailsViewModel.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/summaryModels/PropertyDetailsViewModel.kt
@@ -3,6 +3,7 @@ package uk.gov.communities.prsdb.webapp.models.viewModels.summaryModels
 import kotlinx.datetime.toKotlinInstant
 import uk.gov.communities.prsdb.webapp.constants.enums.LicensingType
 import uk.gov.communities.prsdb.webapp.controllers.LandlordDetailsController
+import uk.gov.communities.prsdb.webapp.controllers.PropertyDetailsController
 import uk.gov.communities.prsdb.webapp.database.entity.PropertyOwnership
 import uk.gov.communities.prsdb.webapp.forms.steps.UpdatePropertyDetailsStepId
 import uk.gov.communities.prsdb.webapp.helpers.DateTimeHelper
@@ -17,6 +18,8 @@ class PropertyDetailsViewModel(
     landlordDetailsUrl: String = LandlordDetailsController.LANDLORD_DETAILS_ROUTE,
 ) {
     val address: String = propertyOwnership.property.address.singleLineAddress
+
+    private val baseChangeLink = PropertyDetailsController.getUpdatePropertyDetailsPath(propertyOwnership.id)
 
     val isTenantedKey: String = MessageKeyConverter.convert(propertyOwnership.isOccupied)
 
@@ -67,9 +70,8 @@ class PropertyDetailsViewModel(
                 addRow(
                     "propertyDetails.propertyRecord.ownershipType",
                     MessageKeyConverter.convert(propertyOwnership.ownershipType),
-                    UpdatePropertyDetailsStepId.UpdateOwnershipType.urlPathSegment,
-                    // TODO PRSD-1107: Set to withChangeLinks when ticket has been implemented
-                    withChangeLinks = false,
+                    "$baseChangeLink/${UpdatePropertyDetailsStepId.UpdateOwnershipType.urlPathSegment}",
+                    withChangeLinks,
                 )
                 addRow(
                     "propertyDetails.propertyRecord.licensingType",
@@ -80,14 +82,14 @@ class PropertyDetailsViewModel(
                             listOf(MessageKeyConverter.convert(it.licenseType), it.licenseNumber)
                         }
                     } ?: MessageKeyConverter.convert(LicensingType.NO_LICENSING),
-                    UpdatePropertyDetailsStepId.UpdateLicensingType.urlPathSegment,
+                    "$baseChangeLink/${UpdatePropertyDetailsStepId.UpdateLicensingType.urlPathSegment}",
                     // TODO PRSD-1108: Set to withChangeLinks when ticket has been implemented
                     withChangeLinks = false,
                 )
                 addRow(
                     "propertyDetails.propertyRecord.occupied",
                     isTenantedKey,
-                    UpdatePropertyDetailsStepId.UpdateOccupancy.urlPathSegment,
+                    "$baseChangeLink/${UpdatePropertyDetailsStepId.UpdateOccupancy.urlPathSegment}",
                     // TODO PRSD-1109: Set to withChangeLinks when ticket has been implemented
                     withChangeLinks = false,
                 )
@@ -95,14 +97,14 @@ class PropertyDetailsViewModel(
                     addRow(
                         "propertyDetails.propertyRecord.numberOfHouseholds",
                         propertyOwnership.currentNumHouseholds,
-                        UpdatePropertyDetailsStepId.UpdateNumberOfHouseholds.urlPathSegment,
+                        "$baseChangeLink/${UpdatePropertyDetailsStepId.UpdateNumberOfHouseholds.urlPathSegment}",
                         // TODO PRSD-1109: Set to withChangeLinks when ticket has been implemented
                         withChangeLinks = false,
                     )
                     addRow(
                         "propertyDetails.propertyRecord.numberOfPeople",
                         propertyOwnership.currentNumTenants,
-                        UpdatePropertyDetailsStepId.UpdateNumberOfPeople.urlPathSegment,
+                        "$baseChangeLink/${UpdatePropertyDetailsStepId.UpdateNumberOfPeople.urlPathSegment}",
                         // TODO PRSD-1109: Set to withChangeLinks when ticket has been implemented
                         withChangeLinks = false,
                     )

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -504,6 +504,7 @@ forms.buttons.useThisAddress=Use this address
 forms.buttons.saveAndReturnToTaskList=Save and return to task list
 forms.buttons.returnToTaskList=Return to task list
 forms.buttons.submit=Submit
+forms.buttons.confirmAndSubmitUpdate=Confirm and submit update
 
 forms.links.change=Change
 

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -769,6 +769,7 @@ forms.update.occupancy.occupied.fieldSetHeading=Is your property still occupied 
 forms.update.numberOfHouseholds.fieldSetHeading=Update the number of households in the property
 forms.update.numberOfPeople.fieldSetHeading=Update how many people live in your property
 forms.update.licensingType.fieldSetHeading=Update the type of licensing you have for your property
+forms.update.warning=You must not provide any false or misleading information on the database. By submitting this information, you agree it\u2019s accurate to the best of your knowledge at the time of updating.
 
 forms.areYouSure.propertyDeregistration.fieldSetHeading=Are you sure you want to delete {0,,address} from the database?
 forms.areYouSure.landlordDeregistration.noProperties.fieldSetHeading=Are you sure you want to delete your account from the database?

--- a/src/main/resources/templates/forms/ownershipTypeForm.html
+++ b/src/main/resources/templates/forms/ownershipTypeForm.html
@@ -1,18 +1,20 @@
 <!--/*@thymesVar id="title" type="java.lang.String"*/-->
 <!--/*@thymesVar id="formModel" type="java.lang.Object"*/-->
-<!--/*@thymesVar id="fieldSetHeading" type="java.lang.String"*/-->
 <!--/*@thymesVar id="backUrl" type="java.lang.String"*/-->
+<!--/*@thymesVar id="sectionHeaderInfo" type="uk.gov.communities.prsdb.webapp.models.viewModels.SectionHeaderViewModel"*/-->
+<!--/*@thymesVar id="fieldSetHeading" type="java.lang.String"*/-->
 <!--/*@thymesVar id="radioOptions" type="java.lang.Object"*/-->
+<!--/*@thymesVar id="showWarning" type="java.lang.Boolean"*/-->
 <!DOCTYPE html>
-<html th:replace="~{fragments/forms/questionPage :: questionPage(#{${title}}, ${formModel}, ~{::#form-content}, ${backUrl}, ${sectionHeaderInfo})}">
-<th:block id="form-content">
-    <th:block id="fieldset-content"
-              th:replace="~{fragments/forms/fieldSet :: fieldSet(~{::#fieldset-content/content()}, 'ownershipType', #{${fieldSetHeading}}, null)}">
+<html id="form-content" th:replace="~{fragments/forms/questionPage :: questionPage(#{${title}}, ${formModel}, ~{::#form-content/content()}, ${backUrl}, ${sectionHeaderInfo})}">
+    <th:block id="fieldset-content" th:replace="~{fragments/forms/fieldSet :: fieldSet(~{::#fieldset-content/content()}, 'ownershipType', #{${fieldSetHeading}}, null)}">
         <th:block th:replace="~{fragments/forms/radios :: radios(null,'ownershipType',null, ${radioOptions})}"></th:block>
     </th:block>
-    <details id="details-content" th:replace="~{fragments/details :: details(#{'forms.ownershipType.details.summary.text'},~{::#details-content/content()})}">
-        <div class="govuk-details__text" th:text="#{'forms.ownershipType.details.text'}">detailsText</div>
+    <details id="details-content" th:replace="~{fragments/details :: details(#{forms.ownershipType.details.summary.text},~{::#details-content/content()})}">
+        <div class="govuk-details__text" th:text="#{forms.ownershipType.details.text}">detailsText</div>
     </details>
+    <th:block th:if="${showWarning}">
+        <div th:replace="~{fragments/warningText :: warningText(#{forms.update.warning})}">forms.update.warning</div>
+    </th:block>
     <button th:replace="~{fragments/buttons/primaryButton :: primaryButton(#{forms.buttons.saveAndContinue})}"></button>
-</th:block>
 </html>

--- a/src/main/resources/templates/forms/ownershipTypeForm.html
+++ b/src/main/resources/templates/forms/ownershipTypeForm.html
@@ -5,6 +5,7 @@
 <!--/*@thymesVar id="fieldSetHeading" type="java.lang.String"*/-->
 <!--/*@thymesVar id="radioOptions" type="java.lang.Object"*/-->
 <!--/*@thymesVar id="showWarning" type="java.lang.Boolean"*/-->
+<!--/*@thymesVar id="submitButtonText" type="java.lang.String"*/-->
 <!DOCTYPE html>
 <html id="form-content" th:replace="~{fragments/forms/questionPage :: questionPage(#{${title}}, ${formModel}, ~{::#form-content/content()}, ${backUrl}, ${sectionHeaderInfo})}">
     <th:block id="fieldset-content" th:replace="~{fragments/forms/fieldSet :: fieldSet(~{::#fieldset-content/content()}, 'ownershipType', #{${fieldSetHeading}}, null)}">
@@ -16,5 +17,5 @@
     <th:block th:if="${showWarning}">
         <div th:replace="~{fragments/warningText :: warningText(#{forms.update.warning})}">forms.update.warning</div>
     </th:block>
-    <button th:replace="~{fragments/buttons/primaryButton :: primaryButton(#{forms.buttons.saveAndContinue})}"></button>
+    <button th:replace="~{fragments/buttons/primaryButton :: primaryButton(#{${submitButtonText}})}"></button>
 </html>

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/PropertyDetailsUpdateJourneyTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/PropertyDetailsUpdateJourneyTests.kt
@@ -25,17 +25,18 @@ class PropertyDetailsUpdateJourneyTests : IntegrationTest() {
     private val propertyOwnershipId = 1L
     private val urlArguments = mapOf("propertyOwnershipId" to propertyOwnershipId.toString())
 
-    // TODO PRSD-1107 - re-enable tests and update them to match new flow
-    @Disabled
     @Nested
     inner class OwnershipTypeUpdates {
         @Test
         fun `A property can have its ownership type updated`(page: Page) {
             // Details page
             var propertyDetailsPage = navigator.goToPropertyDetailsLandlordView(propertyOwnershipId)
+            propertyDetailsPage.propertyDetailsSummaryList.ownershipTypeRow.clickActionLinkAndWait()
+            val updateOwnershipTypePage = assertPageIs(page, OwnershipTypeFormPagePropertyDetailsUpdate::class, urlArguments)
 
-            val newOwnershipType = OwnershipType.LEASEHOLD
-            propertyDetailsPage = updateOwnershipTypeAndReturn(propertyDetailsPage, newOwnershipType)
+            // Update Ownership Type page
+            updateOwnershipTypePage.submitOwnershipType(OwnershipType.LEASEHOLD)
+            propertyDetailsPage = assertPageIs(page, PropertyDetailsPageLandlordView::class, urlArguments)
 
             // Check changes have occurred
             assertThat(propertyDetailsPage.propertyDetailsSummaryList.ownershipTypeRow.value).containsText("Leasehold")
@@ -248,19 +249,6 @@ class PropertyDetailsUpdateJourneyTests : IntegrationTest() {
         }
 
         // TODO PRSD-1109 - add test for updating just number of people
-    }
-
-    private fun updateOwnershipTypeAndReturn(
-        detailsPage: PropertyDetailsPageLandlordView,
-        newOwnershipType: OwnershipType,
-    ): PropertyDetailsPageLandlordView {
-        val page = detailsPage.page
-        detailsPage.propertyDetailsSummaryList.ownershipTypeRow.clickActionLinkAndWait()
-
-        val updateOwnershipTypePage = assertPageIs(page, OwnershipTypeFormPagePropertyDetailsUpdate::class, urlArguments)
-        updateOwnershipTypePage.submitOwnershipType(newOwnershipType)
-
-        return assertPageIs(page, PropertyDetailsPageLandlordView::class, urlArguments)
     }
 
     private fun updateLicensingTypeToNoneAndReturn(detailsPage: PropertyDetailsPageLandlordView): PropertyDetailsPageLandlordView {

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/summaryModels/PropertyDetailsViewModelTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/summaryModels/PropertyDetailsViewModelTests.kt
@@ -248,8 +248,8 @@ class PropertyDetailsViewModelTests {
 
         val changeLinkCount = viewModel.propertyRecord.count { it.changeUrl != null }
 
-        // TODO PRSD-1107, PRSD-1108, PRSD-1109: Update expected count when tickets implemented
-        assertEquals(0, changeLinkCount)
+        // TODO PRSD-1108, PRSD-1109: Update expected count when tickets implemented
+        assertEquals(1, changeLinkCount)
     }
 
     @Test


### PR DESCRIPTION
## Ticket number

PRSD-1107

## Goal of change

Implements updating property ownership type without an edit session

## Description of main change(s)

- Adds conditionally shown warning text and variable submit button text to ownership type form template
- Updates ownership type step in property registration and update journey to match their designs
- Stops hiding ownership type change link on property record

## Anything you'd like to highlight to the reviewer?

N/A

## Checklist

Delete any that are not applicable, and add explanation below for any that are applicable but haven't been done

- [X] Screenshots of any UI changes have been added
- [X] New journey steps have been added to the appropriate journey integration test(s)
- [X] Test suite has been run in full locally and is passing
- [X] Branch has been rebased onto main and run locally, with everything working as expected (both for your new feature
  and any related functionality)

![image](https://github.com/user-attachments/assets/60b2dbda-9616-4886-b301-ec5a54593fd8)
![image](https://github.com/user-attachments/assets/91c3e537-8a95-4faa-ab40-69f9cff687f6)