### PR TITLE
PRSD-956: Removes redundant certificate file name helper

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/helpers/extensions/journeyExtensions/PropertyComplianceJourneyDataExtensions.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/helpers/extensions/journeyExtensions/PropertyComplianceJourneyDataExtensions.kt
@@ -1,7 +1,6 @@
 package uk.gov.communities.prsdb.webapp.helpers.extensions.journeyExtensions
 
 import kotlinx.datetime.yearsUntil
-import org.apache.commons.io.FilenameUtils
 import uk.gov.communities.prsdb.webapp.constants.enums.EicrExemptionReason
 import uk.gov.communities.prsdb.webapp.constants.enums.GasSafetyExemptionReason
 import uk.gov.communities.prsdb.webapp.forms.JourneyData
@@ -76,19 +75,5 @@ class PropertyComplianceJourneyDataExtensions : JourneyDataExtensions() {
                     PropertyComplianceStepId.EicrExemptionReason.urlPathSegment,
                     EicrExemptionReasonFormModel::exemptionReason.name,
                 )?.let { it == EicrExemptionReason.OTHER }
-
-        fun getCertFilename(
-            propertyOwnershipId: Long,
-            stepName: String,
-            originalFileName: String,
-        ): String {
-            val certificateType =
-                when (stepName) {
-                    PropertyComplianceStepId.GasSafetyUpload.urlPathSegment -> "gas_safety_certificate"
-                    PropertyComplianceStepId.EicrUpload.urlPathSegment -> "eicr"
-                    else -> throw IllegalStateException("Invalid file upload step name: $stepName")
-                }
-            return "property_${propertyOwnershipId}_$certificateType.${FilenameUtils.getExtension(originalFileName)}"
-        }
     }
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/helpers/PropertyComplianceJourneyHelperTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/helpers/PropertyComplianceJourneyHelperTests.kt
@@ -7,7 +7,6 @@ import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
 import uk.gov.communities.prsdb.webapp.forms.steps.PropertyComplianceStepId
-import uk.gov.communities.prsdb.webapp.helpers.extensions.journeyExtensions.PropertyComplianceJourneyDataExtensions
 import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.EicrUploadCertificateFormModel
 import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.GasSafetyUploadCertificateFormModel
 import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.UploadCertificateFormModel
@@ -46,7 +45,7 @@ class PropertyComplianceJourneyHelperTests {
 
         assertEquals(
             expectedFileName,
-            PropertyComplianceJourneyDataExtensions.getCertFilename(PROPERTY_OWNERSHIP_ID, stepName, originalFileName),
+            PropertyComplianceJourneyHelper.getCertFilename(PROPERTY_OWNERSHIP_ID, stepName, originalFileName),
         )
     }
 
@@ -56,7 +55,7 @@ class PropertyComplianceJourneyHelperTests {
         val originalFileName = "any-name.$ORIGINAL_FILE_EXT"
 
         assertThrows<IllegalStateException> {
-            PropertyComplianceJourneyDataExtensions.getCertFilename(PROPERTY_OWNERSHIP_ID, invalidStepName, originalFileName)
+            PropertyComplianceJourneyHelper.getCertFilename(PROPERTY_OWNERSHIP_ID, invalidStepName, originalFileName)
         }
     }
 


### PR DESCRIPTION
## Ticket number

PRSD-956

## Goal of change

Removes redundant certificate file name helper method

## Description of main change(s)

- Removes redundant certificate file name helper method from property compliance journey extensions as the same method exists in property compliance journey helpers

## Anything you'd like to highlight to the reviewer?

N/A

## Checklist

Delete any that are not applicable, and add explanation below for any that are applicable but haven't been done

- [X] Test suite has been run in full locally and is passing
- [X] Branch has been rebased onto main and run locally, with everything working as expected (both for your new feature
  and any related functionality)