### PR TITLE
Feat/PRSD-1078 fix incomplete properties view

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/LandlordController.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/LandlordController.kt
@@ -78,6 +78,8 @@ class LandlordController(
         model.addAttribute("registerPropertyUrl", "/$REGISTER_PROPERTY_JOURNEY_URL")
         model.addAttribute("viewRegisteredPropertiesUrl", "/$LANDLORD_DETAILS_PATH_SEGMENT#$REGISTERED_PROPERTIES_PATH_SEGMENT")
 
+        model.addAttribute("backUrl", LANDLORD_DASHBOARD_URL)
+
         return "incompletePropertiesView"
     }
 

--- a/src/main/resources/templates/fragments/summaryCard.html
+++ b/src/main/resources/templates/fragments/summaryCard.html
@@ -3,8 +3,8 @@
         <h2 class="govuk-summary-card__title" th:text="${cardNumber != null} ? #{${title}} + ' ' + ${cardNumber} : #{${title}}">
             Title of the summary card
         </h2>
-        <ul th:unless="${actions == null or #lists.isEmpty(actions)}" class="govuk-summary-card__actions" th:each="action: ${actions}">
-            <li class="govuk-summary-card__action">
+        <ul th:unless="${actions == null or #lists.isEmpty(actions)}" class="govuk-summary-card__actions">
+            <li class="govuk-summary-card__action"  th:each="action: ${actions}">
                 <a class="govuk-link" th:href="@{${action.url}}" th:text="#{${action.text}}">Link text</a>
             </li>
         </ul>

--- a/src/main/resources/templates/incompletePropertiesView.html
+++ b/src/main/resources/templates/incompletePropertiesView.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
-<html th:replace="~{fragments/layout :: layout(#{landlord.incompleteProperties.title}, ~{::main}, false)}">
+<html id="main-content" th:replace="~{fragments/layout :: layout(#{landlord.incompleteProperties.title},~{::#main-content/content()}, false)}">
+<a href="#" th:replace="~{fragments/forms/backLink :: backLink(${backUrl})}">Back link</a>
 <main class="govuk-main-wrapper">
     <div id="page-content">
         <h1 class="govuk-heading-l" th:text="#{landlord.incompleteProperties.heading}">landlord.incompleteProperties.heading</h1>


### PR DESCRIPTION
## Ticket number

PRSD-1078

## Goal of change

Fixed some mistakes in the incomplete properties page view

## Description of main change(s)

Added a back link that redirects to the landlord's dashboard
Changed the display of actions on the summary cards to be right aligned, next to each other and to have the divider visible

## Screenshots

After this change:
![image](https://github.com/user-attachments/assets/2eb4fa40-1c5f-4586-bd20-5553ad3bed54)

Before this change:
![image](https://github.com/user-attachments/assets/ec42cea8-15a5-478d-b32b-a3ab00e5e2eb)


## Anything you'd like to highlight to the reviewer?


## Checklist

- [X] Screenshots of any UI changes have been added
