### PR TITLE
PRSD-1103: Landlord No Session Update - Email

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/LandlordDetailsUpdateJourney.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/LandlordDetailsUpdateJourney.kt
@@ -104,6 +104,7 @@ class LandlordDetailsUpdateJourney(
                             "fieldSetHeading" to "forms.update.email.fieldSetHeading",
                             "fieldSetHint" to "forms.email.fieldSetHint",
                             "label" to "forms.email.label",
+                            "showWarning" to true,
                             "submitButtonText" to "forms.buttons.continue",
                             BACK_URL_ATTR_NAME to LandlordDetailsController.LANDLORD_DETAILS_ROUTE,
                         ),

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/LandlordDetailsUpdateJourney.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/LandlordDetailsUpdateJourney.kt
@@ -105,7 +105,7 @@ class LandlordDetailsUpdateJourney(
                             "fieldSetHint" to "forms.email.fieldSetHint",
                             "label" to "forms.email.label",
                             "showWarning" to true,
-                            "submitButtonText" to "forms.buttons.continue",
+                            "submitButtonText" to "forms.buttons.confirmAndSubmitUpdate",
                             BACK_URL_ATTR_NAME to LandlordDetailsController.LANDLORD_DETAILS_ROUTE,
                         ),
                 ),

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/summaryModels/LandlordViewModel.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/summaryModels/LandlordViewModel.kt
@@ -74,8 +74,7 @@ class LandlordViewModel(
                     "landlordDetails.personalDetails.emailAddress",
                     landlord.email,
                     "$UPDATE_ROUTE/${LandlordDetailsUpdateStepId.UpdateEmail.urlPathSegment}",
-                    // TODO PRSD-1103: Set to withChangeLinks
-                    withChangeLinks = false,
+                    withChangeLinks,
                 )
                 addRow(
                     "landlordDetails.personalDetails.telephoneNumber",

--- a/src/main/resources/templates/forms/emailForm.html
+++ b/src/main/resources/templates/forms/emailForm.html
@@ -3,6 +3,7 @@
 <!--/*@thymesVar id="fieldSetHeading" type="java.lang.String"*/-->
 <!--/*@thymesVar id="fieldSetHint" type="java.lang.String"*/-->
 <!--/*@thymesVar id="label" type="java.lang.String"*/-->
+<!--/*@thymesVar id="showWarning" type="java.lang.Boolean"*/-->
 <!--/*@thymesVar id="submitButtonText" type="java.lang.String"*/-->
 <!--/*@thymesVar id="backUrl" type="java.lang.String"*/-->
 <!DOCTYPE html>
@@ -12,6 +13,9 @@
               th:replace="~{fragments/forms/fieldSet :: fieldSet(~{::#fieldset-content/content()}, 'emailAddress', #{${fieldSetHeading}}, #{${fieldSetHint}})}">
         <div th:replace="~{fragments/forms/emailInput :: emailInput(#{${label}}, 'emailAddress', null)}">
         </div>
+    </th:block>
+    <th:block th:if="${showWarning}">
+        <div th:replace="~{fragments/warningText :: warningText(#{forms.update.warning})}">forms.update.warning</div>
     </th:block>
     <button th:replace="~{fragments/buttons/primaryButton :: primaryButton(#{${submitButtonText}})}"></button>
 </th:block>

--- a/src/main/resources/templates/forms/emailForm.html
+++ b/src/main/resources/templates/forms/emailForm.html
@@ -1,22 +1,19 @@
 <!--/*@thymesVar id="title" type="java.lang.String"*/-->
 <!--/*@thymesVar id="formModel" type="java.lang.Object"*/-->
+<!--/*@thymesVar id="backUrl" type="java.lang.String"*/-->
+<!--/*@thymesVar id="sectionHeaderInfo" type="java.lang.Object"*/-->
 <!--/*@thymesVar id="fieldSetHeading" type="java.lang.String"*/-->
 <!--/*@thymesVar id="fieldSetHint" type="java.lang.String"*/-->
 <!--/*@thymesVar id="label" type="java.lang.String"*/-->
 <!--/*@thymesVar id="showWarning" type="java.lang.Boolean"*/-->
 <!--/*@thymesVar id="submitButtonText" type="java.lang.String"*/-->
-<!--/*@thymesVar id="backUrl" type="java.lang.String"*/-->
 <!DOCTYPE html>
-<html th:replace="~{fragments/forms/questionPage :: questionPage(#{${title}}, ${formModel}, ~{::#form-content}, ${backUrl}, ${sectionHeaderInfo})}">
-<th:block id="form-content">
-    <th:block id="fieldset-content"
-              th:replace="~{fragments/forms/fieldSet :: fieldSet(~{::#fieldset-content/content()}, 'emailAddress', #{${fieldSetHeading}}, #{${fieldSetHint}})}">
-        <div th:replace="~{fragments/forms/emailInput :: emailInput(#{${label}}, 'emailAddress', null)}">
-        </div>
+<html id="form-content" th:replace="~{fragments/forms/questionPage :: questionPage(#{${title}}, ${formModel}, ~{::#form-content/content()}, ${backUrl}, ${sectionHeaderInfo})}">
+    <th:block id="fieldset-content" th:replace="~{fragments/forms/fieldSet :: fieldSet(~{::#fieldset-content/content()}, 'emailAddress', #{${fieldSetHeading}}, #{${fieldSetHint}})}">
+        <div th:replace="~{fragments/forms/emailInput :: emailInput(#{${label}}, 'emailAddress', null)}"></div>
     </th:block>
     <th:block th:if="${showWarning}">
         <div th:replace="~{fragments/warningText :: warningText(#{forms.update.warning})}">forms.update.warning</div>
     </th:block>
     <button th:replace="~{fragments/buttons/primaryButton :: primaryButton(#{${submitButtonText}})}"></button>
-</th:block>
 </html>

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/LandlordDetailsUpdateJourneyTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/LandlordDetailsUpdateJourneyTests.kt
@@ -118,8 +118,6 @@ class LandlordDetailsUpdateJourneyTests : IntegrationTest() {
         }
     }
 
-    // TODO PRSD-1103: Re-enable and update to match flow
-    @Disabled
     @Nested
     inner class EmailUpdates {
         @Test
@@ -131,7 +129,7 @@ class LandlordDetailsUpdateJourneyTests : IntegrationTest() {
             val updateEmailPage = assertPageIs(page, EmailFormPageUpdateLandlordDetails::class)
 
             // Update Email page
-            val newEmail = "new landlord name"
+            val newEmail = "newEmail@test.com"
             updateEmailPage.submitEmail(newEmail)
             landlordDetailsPage = assertPageIs(page, LandlordDetailsPage::class)
 

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/summaryModels/LandlordViewModelTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/summaryModels/LandlordViewModelTests.kt
@@ -328,9 +328,8 @@ class LandlordViewModelTests {
         // Arrange
         val testLandlord = MockLandlordData.createLandlord(isVerified = isVerified)
         val changeableByAllLandlordsPersonalDetailKeys =
-            listOf<String>(
-                // TODO PRSD-1103: uncomment
-                // "landlordDetails.personalDetails.emailAddress",
+            listOf(
+                "landlordDetails.personalDetails.emailAddress",
                 // TODO PRSD-1105: uncomment
                 // "landlordDetails.personalDetails.telephoneNumber",
                 // TODO PRSD-355 (address update): uncomment


### PR DESCRIPTION
## Ticket number

PRSD-1103

## Goal of change

Implements updating landlord email without an edit session

## Description of main change(s)

- Adds conditionally shown warning text to email form template
- Updates email step in landlord update journey to match design
- Stops hiding email change link on landlord record

## Anything you'd like to highlight to the reviewer?

N/A

## Checklist

Delete any that are not applicable, and add explanation below for any that are applicable but haven't been done

- [X] Screenshots of any UI changes have been added
- [X] Unit tests for new logic (e.g. new service methods) have been added
- [X] New journey steps have been added to the appropriate journey integration test(s)
- [X] Test suite has been run in full locally and is passing
- [X] Branch has been rebased onto main and run locally, with everything working as expected (both for your new feature
  and any related functionality)

![image](https://github.com/user-attachments/assets/4a3fd604-3f00-4c12-a1a3-cfca95e54679)
![image](https://github.com/user-attachments/assets/064d49d7-a3bd-4925-bc48-9302da6e2275)