### PR TITLE
feat/PRSD-1127 stop saving property registration journey data before …

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/PropertyRegistrationJourney.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/PropertyRegistrationJourney.kt
@@ -159,7 +159,7 @@ class PropertyRegistrationJourney(
                             "postcodeHint" to "forms.lookupAddress.postcode.hint",
                             "houseNameOrNumberLabel" to "forms.lookupAddress.houseNameOrNumber.label",
                             "houseNameOrNumberHint" to "forms.lookupAddress.houseNameOrNumber.hint",
-                            "submitButtonText" to "forms.buttons.saveAndContinue",
+                            "submitButtonText" to "forms.buttons.continue",
                         ),
                     shouldDisplaySectionHeader = true,
                 ),
@@ -167,6 +167,7 @@ class PropertyRegistrationJourney(
             nextStepIfNoAddressesFound = RegisterPropertyStepId.NoAddressFound,
             addressLookupService = addressLookupService,
             journeyDataService = journeyDataService,
+            saveAfterSubmit = false,
         )
 
     private fun selectAddressStep() =
@@ -195,6 +196,7 @@ class PropertyRegistrationJourney(
                     propertyRegistrationService,
                 )
             },
+            saveAfterSubmit = false,
         )
 
     private fun alreadyRegisteredStep() =
@@ -213,6 +215,7 @@ class PropertyRegistrationJourney(
                         ),
                     selectedAddressPathSegment = RegisterPropertyStepId.SelectAddress.urlPathSegment,
                 ),
+            saveAfterSubmit = false,
         )
 
     private fun noAddressFoundStep() =
@@ -234,6 +237,7 @@ class PropertyRegistrationJourney(
                     shouldDisplaySectionHeader = true,
                 ),
             nextAction = { _, _ -> Pair(RegisterPropertyStepId.ManualAddress, null) },
+            saveAfterSubmit = false,
         )
 
     private fun getHouseNameOrNumberAndPostcode() =
@@ -260,11 +264,12 @@ class PropertyRegistrationJourney(
                             "townOrCityLabel" to "forms.manualAddress.townOrCity.label",
                             "countyLabel" to "forms.manualAddress.county.label",
                             "postcodeLabel" to "forms.manualAddress.postcode.label",
-                            "submitButtonText" to "forms.buttons.saveAndContinue",
+                            "submitButtonText" to "forms.buttons.continue",
                         ),
                     shouldDisplaySectionHeader = true,
                 ),
             nextAction = { _, _ -> Pair(RegisterPropertyStepId.LocalAuthority, null) },
+            saveAfterSubmit = false,
         )
 
     private fun localAuthorityStep() =
@@ -284,6 +289,7 @@ class PropertyRegistrationJourney(
                     displaySectionHeader = true,
                 ),
             nextAction = { _, _ -> Pair(RegisterPropertyStepId.PropertyType, null) },
+            saveAfterSubmit = false,
         )
 
     private fun propertyTypeStep() =

--- a/src/main/resources/templates/forms/selectLocalAuthorityForm.html
+++ b/src/main/resources/templates/forms/selectLocalAuthorityForm.html
@@ -17,6 +17,6 @@
         </p>
         <select th:replace="~{fragments/forms/select :: select(#{${selectLabel}},'localAuthorityId',null, ${selectOptions})}"></select>
     </fieldset>
-    <button th:replace="~{fragments/buttons/primaryButton :: primaryButton(#{forms.buttons.saveAndContinue})}"></button>
+    <button th:replace="~{fragments/buttons/primaryButton :: primaryButton(#{forms.buttons.continue})}"></button>
 </th:block>
 </html>


### PR DESCRIPTION
…property type step

## Ticket number

PRSD-1127

## Goal of change

We should only start saving the property registration journey data to the database from the Property Type step.

## Description of main change(s)

Set `saveAfterSubmit` to `false` for steps before Property Type in the journey
Should change the wording on the submit buttons for those pages to “Continue“ rather than “Save and continue“

## Screenshots

After changes:

Look up address page:
![image](https://github.com/user-attachments/assets/5700437a-af11-46ee-bd03-978fee3dc276)

Manual address page:
![image](https://github.com/user-attachments/assets/bbc66142-bca9-4b04-818b-d46bc513a033)

Local authority page:
![image](https://github.com/user-attachments/assets/75a747d7-2466-46fe-b7af-3c8610f908d5)

Before changes:

Look up address page:
![image](https://github.com/user-attachments/assets/9553af59-29c1-4c59-a9dd-b19762a38510)

Manual address page:
![image](https://github.com/user-attachments/assets/c870743c-dbc7-4c85-b35e-08d6a6cc0fef)

Local authority page:
![image](https://github.com/user-attachments/assets/e2636e25-0492-4011-986e-0d60574bf27a)

## Anything you'd like to highlight to the reviewer?

N/A

## Checklist

Delete any that are not applicable, and add explanation below for any that are applicable but haven't been done

- [X] Screenshots of any UI changes have been added
- [X] Test suite has been run in full locally and is passing
- [X] Branch has been rebased onto main and run locally, with everything working as expected (both for your new feature
  and any related functionality)
