### PR TITLE
PRSD-1100: Refactors TODOs in LandlordViewModelTests

### DIFF
--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/summaryModels/LandlordViewModelTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/summaryModels/LandlordViewModelTests.kt
@@ -7,6 +7,7 @@ import kotlinx.datetime.toJavaLocalDate
 import kotlinx.datetime.toLocalDateTime
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertIterableEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
@@ -327,25 +328,29 @@ class LandlordViewModelTests {
         // Arrange
         val testLandlord = MockLandlordData.createLandlord(isVerified = isVerified)
         val changeableByAllLandlordsPersonalDetailKeys =
-            listOf(
-                "landlordDetails.personalDetails.emailAddress",
-                "landlordDetails.personalDetails.telephoneNumber",
-                "landlordDetails.personalDetails.contactAddress",
+            listOf<String>(
+                // TODO PRSD-1103: uncomment
+                // "landlordDetails.personalDetails.emailAddress",
+                // TODO PRSD-1105: uncomment
+                // "landlordDetails.personalDetails.telephoneNumber",
+                // TODO PRSD-355 (address update): uncomment
+                // "landlordDetails.personalDetails.contactAddress",
             )
         val changeableByUnverifiedLandlordsPersonalDetailKeys =
-            listOf(
-                "landlordDetails.personalDetails.name",
-                "landlordDetails.personalDetails.dateOfBirth",
+            listOf<String>(
+                // TODO PRSD-1101: uncomment
+                // "landlordDetails.personalDetails.name",
+                // TODO PRSD-1102: uncomment
+                // "landlordDetails.personalDetails.dateOfBirth",
             )
 
         // Act
         val viewModel = LandlordViewModel(testLandlord)
 
         // Assert
-//         TODO: Uncomment this when PRSD-1103, PRSD-1105 and PRSD-355 (address update) are implemented
-//         for (i in viewModel.personalDetails.filter { detail -> detail.fieldHeading in changeableByAllLandlordsPersonalDetailKeys }) {
-//            assertNotNull(i.changeUrl)
-//         }
+        for (i in viewModel.personalDetails.filter { detail -> detail.fieldHeading in changeableByAllLandlordsPersonalDetailKeys }) {
+            assertNotNull(i.changeUrl)
+        }
 
         if (isVerified) {
             for (i in viewModel.personalDetails.filter { detail ->
@@ -354,15 +359,13 @@ class LandlordViewModelTests {
                 assertNull(i.changeUrl)
             }
         } else {
-//            TODO: Uncomment this when PRSD-1101 and PRSD-1102 are implemented
-//            for (i in viewModel.personalDetails.filter { detail ->
-//                detail.fieldHeading in changeableByUnverifiedLandlordsPersonalDetailKeys
-//            }) {
-//                assertNotNull(i.changeUrl)
-//            }
             for (i in viewModel.personalDetails.filter { detail ->
-                detail.fieldHeading !in
-                    changeableByAllLandlordsPersonalDetailKeys + changeableByUnverifiedLandlordsPersonalDetailKeys
+                detail.fieldHeading in changeableByUnverifiedLandlordsPersonalDetailKeys
+            }) {
+                assertNotNull(i.changeUrl)
+            }
+            for (i in viewModel.personalDetails.filter { detail ->
+                detail.fieldHeading !in changeableByAllLandlordsPersonalDetailKeys + changeableByUnverifiedLandlordsPersonalDetailKeys
             }) {
                 assertNull(i.changeUrl)
             }


### PR DESCRIPTION
## Ticket number

PRSD-1100

## Goal of change

Refactors TODOs in `LandlordViewModelTests` to not rely on multiple tickets

## Description of main change(s)

- Makes each TODO in `LandlordViewModelTests` rely on one ticket, rather than a set of them

## Anything you'd like to highlight to the reviewer?

N/A

## Checklist

Delete any that are not applicable, and add explanation below for any that are applicable but haven't been done

- [X] Test suite has been run in full locally and is passing
- [X] Branch has been rebased onto main and run locally, with everything working as expected (both for your new feature
  and any related functionality)
