### PR TITLE
PRSD-1102: Landlord No Session Update - DOB

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/LandlordDetailsUpdateJourney.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/LandlordDetailsUpdateJourney.kt
@@ -150,7 +150,7 @@ class LandlordDetailsUpdateJourney(
                             "fieldSetHeading" to "forms.update.dateOfBirth.fieldSetHeading",
                             "fieldSetHint" to "forms.dateOfBirth.fieldSetHint",
                             "showWarning" to true,
-                            "submitButtonText" to "forms.buttons.continue",
+                            "submitButtonText" to "forms.buttons.confirmAndSubmitUpdate",
                             BACK_URL_ATTR_NAME to LandlordDetailsController.LANDLORD_DETAILS_ROUTE,
                         ),
                 ),

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/LandlordDetailsUpdateJourney.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/LandlordDetailsUpdateJourney.kt
@@ -149,6 +149,7 @@ class LandlordDetailsUpdateJourney(
                             "title" to "forms.update.title",
                             "fieldSetHeading" to "forms.update.dateOfBirth.fieldSetHeading",
                             "fieldSetHint" to "forms.dateOfBirth.fieldSetHint",
+                            "showWarning" to true,
                             "submitButtonText" to "forms.buttons.continue",
                             BACK_URL_ATTR_NAME to LandlordDetailsController.LANDLORD_DETAILS_ROUTE,
                         ),

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/LandlordDetailsUpdateJourney.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/LandlordDetailsUpdateJourney.kt
@@ -146,7 +146,7 @@ class LandlordDetailsUpdateJourney(
                     templateName = "forms/dateForm",
                     content =
                         mapOf(
-                            "title" to "forms.update.title",
+                            "title" to "landlordDetails.update.title",
                             "fieldSetHeading" to "forms.update.dateOfBirth.fieldSetHeading",
                             "fieldSetHint" to "forms.dateOfBirth.fieldSetHint",
                             "showWarning" to true,

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/summaryModels/LandlordViewModel.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/summaryModels/LandlordViewModel.kt
@@ -60,8 +60,7 @@ class LandlordViewModel(
                     "landlordDetails.personalDetails.dateOfBirth",
                     landlord.dateOfBirth,
                     if (!landlord.isVerified) "$UPDATE_ROUTE/${LandlordDetailsUpdateStepId.UpdateDateOfBirth.urlPathSegment}" else null,
-                    // TODO PRSD-1102: Set to withChangeLinks
-                    withChangeLinks = false,
+                    withChangeLinks,
                 )
                 addRow(
                     "landlordDetails.personalDetails.oneLoginVerified",

--- a/src/main/resources/templates/forms/dateForm.html
+++ b/src/main/resources/templates/forms/dateForm.html
@@ -1,16 +1,16 @@
 <!--/*@thymesVar id="title" type="java.lang.String"*/-->
 <!--/*@thymesVar id="formModel" type="java.lang.Object"*/-->
+<!--/*@thymesVar id="backUrl" type="java.lang.String"*/-->
+<!--/*@thymesVar id="sectionHeaderInfo" type="java.lang.Object"*/-->
 <!--/*@thymesVar id="fieldSetHeading" type="java.lang.String"*/-->
 <!--/*@thymesVar id="fieldSetHint" type="java.lang.String"*/-->
+<!--/*@thymesVar id="showWarning" type="java.lang.Boolean"*/-->
 <!--/*@thymesVar id="submitButtonText" type="java.lang.String"*/-->
-<!--/*@thymesVar id="backUrl" type="java.lang.String"*/-->
 <!DOCTYPE html>
-
-<html th:replace="~{fragments/forms/questionPage :: questionPage(#{${title}}, ${formModel}, ~{::#form-content}, ${backUrl}, ${sectionHeaderInfo})}">
-<th:block id="form-content">
-    <th:block id="fieldset-content"
-              th:replace="~{fragments/forms/dateInput :: dateInput('date', 'day', 'month', 'year', #{${fieldSetHeading}}, #{${fieldSetHint}})}">
+<html id="form-content" th:replace="~{fragments/forms/questionPage :: questionPage(#{${title}}, ${formModel}, ~{::#form-content/content()}, ${backUrl}, ${sectionHeaderInfo})}">
+    <th:block id="fieldset-content" th:replace="~{fragments/forms/dateInput :: dateInput('date', 'day', 'month', 'year', #{${fieldSetHeading}}, #{${fieldSetHint}})}"></th:block>
+    <th:block th:if="${showWarning}">
+        <div th:replace="~{fragments/warningText :: warningText(#{forms.update.warning})}">forms.update.warning</div>
     </th:block>
     <button th:replace="~{fragments/buttons/primaryButton :: primaryButton(#{${submitButtonText}})}"></button>
-</th:block>
 </html>

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/LandlordDetailsUpdateJourneyTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/LandlordDetailsUpdateJourneyTests.kt
@@ -81,8 +81,6 @@ class LandlordDetailsUpdateJourneyTests : IntegrationTest() {
         }
     }
 
-    // TODO PRSD-1102: Re-enable and update to match flow
-    @Disabled
     @Nested
     inner class DateOfBirthUpdates {
         @Sql("/data-unverified-landlord.sql")

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/summaryModels/LandlordViewModelTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/summaryModels/LandlordViewModelTests.kt
@@ -338,8 +338,7 @@ class LandlordViewModelTests {
         val changeableByUnverifiedLandlordsPersonalDetailKeys =
             listOf(
                 "landlordDetails.personalDetails.name",
-                // TODO PRSD-1102: uncomment
-                // "landlordDetails.personalDetails.dateOfBirth",
+                "landlordDetails.personalDetails.dateOfBirth",
             )
 
         // Act


### PR DESCRIPTION
## Ticket number

PRSD-1102

## Goal of change

Implements updating landlord DOB without an edit session

## Description of main change(s)

- Adds conditionally shown warning text to DOB form template
- Updates DOB step in landlord update journey to match design
- Stops hiding name change link on landlord record

## Anything you'd like to highlight to the reviewer?

N/A

## Checklist

Delete any that are not applicable, and add explanation below for any that are applicable but haven't been done

- [X] Screenshots of any UI changes have been added
- [X] Unit tests for new logic (e.g. new service methods) have been added
- [X] New journey steps have been added to the appropriate journey integration test(s)
- [X] Test suite has been run in full locally and is passing
- [X] Branch has been rebased onto main and run locally, with everything working as expected (both for your new feature
  and any related functionality)

![image](https://github.com/user-attachments/assets/0af54572-43c4-43e6-b8d6-e400bee40719)
![image](https://github.com/user-attachments/assets/b1ae32f2-ce96-4193-8682-809a24af4310)