### PR TITLE
feat/PRSD-1127 remove null checks from incomplete property address data

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/PropertyRegistrationService.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/PropertyRegistrationService.kt
@@ -143,14 +143,13 @@ class PropertyRegistrationService(
     ): IncompletePropertiesDataModel {
         val address = getAddressData(formContext)
 
-        // TODO PRSD-1127 remove the "Not yet completed" options as address and local authority should no longer be nullable
-        val localAuthorityName = address?.localAuthorityId?.let { localAuthorityService.retrieveLocalAuthorityById(it).name }
+        val localAuthorityName = localAuthorityService.retrieveLocalAuthorityById(address.localAuthorityId!!).name
 
         return IncompletePropertiesDataModel(
             contextId = formContext.id,
             completeByDate = completeByDate,
-            singleLineAddress = address?.singleLineAddress ?: "Not yet completed",
-            localAuthorityName = localAuthorityName ?: "Not yet completed",
+            singleLineAddress = address.singleLineAddress,
+            localAuthorityName = localAuthorityName,
         )
     }
 
@@ -159,11 +158,10 @@ class PropertyRegistrationService(
         return DateTimeHelper.get28DaysFromDate(createdDateInUk)
     }
 
-    private fun getAddressData(formContext: FormContext): AddressDataModel? {
+    private fun getAddressData(formContext: FormContext): AddressDataModel {
         val formContextJourneyData = formContext.toJourneyData()
         val lookedUpAddresses = formContextJourneyData.getLookedUpAddresses()
-        // TODO PRSD-1127 set this to return a not nullable AddressDataModel
-        return PropertyRegistrationJourneyDataHelper.getAddress(formContextJourneyData, lookedUpAddresses)
+        return PropertyRegistrationJourneyDataHelper.getAddress(formContextJourneyData, lookedUpAddresses)!!
     }
 
     fun getIncompletePropertyFormContextForLandlordIfNotExpired(


### PR DESCRIPTION
## Ticket number

PRSD-1127

## Goal of change

Remove null checking and stand in text from incomplete property address display

## Description of main change(s)

When populating `IncompletePropertiesDataModel`s:
- Removed null checks when we can expect data to always be present
- Removed "Not yet completed" default text that is no longer necessary 

## Anything you'd like to highlight to the reviewer?

This PR is changes what we expect the json stored in `context` on the `form_context` table to look like, there is a risk of the incomplete properties page breaking when these changes are promoted to integration and test environments.

For integration:
When this PR is is ready to be merged the Form Context database table should be reset

For test:
A requirement for resetting the database has been been added to the instructions for the next test release

## Checklist

- [X] Test suite has been run in full locally and is passing
- [X] Branch has been rebased onto main and run locally, with everything working as expected (both for your new feature
  and any related functionality)
- [X] Any special release instructions (e.g. the database will need resetting) have been added as checklist items to a draft PR (merging `main` into `test`) for the next release
