### PR TITLE
PRSD-623: Create Journey Data Controller

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/factories/LandlordRegistrationJourneyFactory.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/factories/LandlordRegistrationJourneyFactory.kt
@@ -25,11 +25,15 @@ class LandlordRegistrationJourneyFactory(
     fun create() =
         LandlordRegistrationJourney(
             validator,
-            journeyDataServiceFactory.create(REGISTER_LANDLORD_JOURNEY_URL),
+            journeyDataServiceFactory.create(JOURNEY_DATA_KEY),
             addressLookupService,
             landlordService,
             absoluteUrlProvider,
             emailNotificationService,
             securityContextService,
         )
+
+    companion object {
+        const val JOURNEY_DATA_KEY = REGISTER_LANDLORD_JOURNEY_URL
+    }
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/Navigator.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/Navigator.kt
@@ -2,6 +2,7 @@ package uk.gov.communities.prsdb.webapp.integration.pageObjects
 
 import com.microsoft.playwright.Page
 import com.microsoft.playwright.Response
+import com.microsoft.playwright.options.RequestOptions
 import org.mockito.kotlin.any
 import org.mockito.kotlin.whenever
 import uk.gov.communities.prsdb.webapp.constants.CONFIRMATION_PATH_SEGMENT
@@ -24,6 +25,7 @@ import uk.gov.communities.prsdb.webapp.controllers.LandlordDetailsController
 import uk.gov.communities.prsdb.webapp.controllers.LocalAuthorityDashboardController.Companion.LOCAL_AUTHORITY_DASHBOARD_URL
 import uk.gov.communities.prsdb.webapp.controllers.PropertyComplianceController
 import uk.gov.communities.prsdb.webapp.controllers.PropertyDetailsController
+import uk.gov.communities.prsdb.webapp.forms.JourneyData
 import uk.gov.communities.prsdb.webapp.forms.steps.DeregisterLandlordStepId
 import uk.gov.communities.prsdb.webapp.forms.steps.DeregisterPropertyStepId
 import uk.gov.communities.prsdb.webapp.forms.steps.LandlordDetailsUpdateStepId
@@ -104,7 +106,10 @@ import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyReg
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyRegistrationJourneyPages.TaskListPagePropertyRegistration
 import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.VerifiedIdentityModel
 import uk.gov.communities.prsdb.webapp.services.OneLoginIdentityService
+import uk.gov.communities.prsdb.webapp.testHelpers.api.controllers.JourneyDataController
+import uk.gov.communities.prsdb.webapp.testHelpers.api.requestModels.SetJourneyDataRequestModel
 import java.time.LocalDate
+import kotlin.test.assertTrue
 
 class Navigator(
     private val page: Page,
@@ -659,4 +664,17 @@ class Navigator(
     }
 
     fun navigate(path: String): Response? = page.navigate("http://localhost:$port$path")
+
+    fun setJourneyDataInSession(
+        journeyDataKey: String,
+        journeyData: JourneyData,
+    ) {
+        val response =
+            page.request().post(
+                "http://localhost:$port${JourneyDataController.SET_JOURNEY_DATA_ROUTE}",
+                RequestOptions.create().setData(SetJourneyDataRequestModel(journeyDataKey, journeyData)),
+            )
+        assertTrue(response.ok(), "Failed to set journey data. Received status code: ${response.status()}")
+        response.dispose()
+    }
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/Navigator.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/Navigator.kt
@@ -671,7 +671,7 @@ class Navigator(
     ) {
         val response =
             page.request().post(
-                "http://localhost:$port${JourneyDataController.SET_JOURNEY_DATA_ROUTE}",
+                "http://localhost:$port/${JourneyDataController.SET_JOURNEY_DATA_ROUTE}",
                 RequestOptions.create().setData(SetJourneyDataRequestModel(journeyDataKey, journeyData)),
             )
         assertTrue(response.ok(), "Failed to set journey data. Received status code: ${response.status()}")

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/testHelpers/api/controllers/JourneyDataController.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/testHelpers/api/controllers/JourneyDataController.kt
@@ -10,7 +10,7 @@ import uk.gov.communities.prsdb.webapp.testHelpers.api.requestModels.SetJourneyD
 
 @Profile("local")
 @RestController
-@RequestMapping(JourneyDataController.SET_JOURNEY_DATA_ROUTE)
+@RequestMapping("/${JourneyDataController.SET_JOURNEY_DATA_ROUTE}")
 class JourneyDataController(
     private val session: HttpSession,
 ) {
@@ -22,6 +22,6 @@ class JourneyDataController(
     }
 
     companion object {
-        const val SET_JOURNEY_DATA_ROUTE = "/local/set-journey-data"
+        const val SET_JOURNEY_DATA_ROUTE = "local/set-journey-data"
     }
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/testHelpers/api/controllers/JourneyDataController.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/testHelpers/api/controllers/JourneyDataController.kt
@@ -1,0 +1,27 @@
+package uk.gov.communities.prsdb.webapp.testHelpers.api.controllers
+
+import jakarta.servlet.http.HttpSession
+import org.springframework.context.annotation.Profile
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import uk.gov.communities.prsdb.webapp.testHelpers.api.requestModels.SetJourneyDataRequestModel
+
+@Profile("local")
+@RestController
+@RequestMapping(JourneyDataController.SET_JOURNEY_DATA_ROUTE)
+class JourneyDataController(
+    private val session: HttpSession,
+) {
+    @PostMapping(consumes = ["application/json"])
+    fun index(
+        @RequestBody requestBody: SetJourneyDataRequestModel,
+    ) {
+        session.setAttribute(requestBody.journeyDataKey, requestBody.journeyData)
+    }
+
+    companion object {
+        const val SET_JOURNEY_DATA_ROUTE = "/local/set-journey-data"
+    }
+}

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/testHelpers/api/requestModels/SetJourneyDataRequestModel.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/testHelpers/api/requestModels/SetJourneyDataRequestModel.kt
@@ -1,0 +1,8 @@
+package uk.gov.communities.prsdb.webapp.testHelpers.api.requestModels
+
+import uk.gov.communities.prsdb.webapp.forms.JourneyData
+
+data class SetJourneyDataRequestModel(
+    val journeyDataKey: String,
+    val journeyData: JourneyData,
+)

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/testHelpers/builders/JourneyDataBuilder.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/testHelpers/builders/JourneyDataBuilder.kt
@@ -304,6 +304,7 @@ class JourneyDataBuilder(
         name: String,
         dob: LocalDate,
     ): JourneyDataBuilder {
+        journeyData[LandlordRegistrationStepId.VerifyIdentity.urlPathSegment] = emptyMap<String, Any?>()
         journeyData[LandlordRegistrationStepId.Name.urlPathSegment] = mapOf("name" to name)
         journeyData[LandlordRegistrationStepId.DateOfBirth.urlPathSegment] =
             mapOf("day" to dob.dayOfMonth, "month" to dob.monthValue, "year" to dob.year)


### PR DESCRIPTION
## Ticket number

PRSD-623

## Goal of change

Creates controller for setting journey data in tests

## Description of main change(s)

- Creates controller (in test module) with endpoint for setting journey data
- Refactors a single page journey test to use created endpoint as PoC

## Anything you'd like to highlight to the reviewer?

- The next PR for this ticket will refactor be an integration test refactor that makes use of the journey data setting endpoint

## Checklist

Delete any that are not applicable, and add explanation below for any that are applicable but haven't been done

- [X] Controller tests for any new endpoints, including testing the relevant permissions
- [X] Test suite has been run in full locally and is passing
- [X] Branch has been rebased onto main and run locally, with everything working as expected (both for your new feature
  and any related functionality)
