### PR TITLE
Chore/prsd none send user to next compliance task

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/PropertyComplianceJourney.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/PropertyComplianceJourney.kt
@@ -252,9 +252,9 @@ class PropertyComplianceJourney(
                         content =
                             mapOf(
                                 "title" to "propertyCompliance.title",
+                                "submitButtonText" to "forms.buttons.saveAndContinueToEICR",
                             ),
                     ),
-                handleSubmitAndRedirect = { _, _, _ -> taskListUrlSegment },
                 nextAction = { _, _ -> Pair(eicrTask.startingStepId, null) },
             )
 
@@ -271,7 +271,6 @@ class PropertyComplianceJourney(
                                 "title" to "propertyCompliance.title",
                             ),
                     ),
-                handleSubmitAndRedirect = { _, _, _ -> taskListUrlSegment },
                 nextAction = { _, _ -> Pair(eicrTask.startingStepId, null) },
             )
 
@@ -371,7 +370,6 @@ class PropertyComplianceJourney(
                                 "title" to "propertyCompliance.title",
                             ),
                     ),
-                handleSubmitAndRedirect = { _, _, _ -> taskListUrlSegment },
                 nextAction = { _, _ -> Pair(eicrTask.startingStepId, null) },
             )
 
@@ -388,7 +386,6 @@ class PropertyComplianceJourney(
                                 "title" to "propertyCompliance.title",
                             ),
                     ),
-                handleSubmitAndRedirect = { _, _, _ -> taskListUrlSegment },
                 nextAction = { _, _ -> Pair(eicrTask.startingStepId, null) },
             )
 
@@ -472,9 +469,9 @@ class PropertyComplianceJourney(
                         content =
                             mapOf(
                                 "title" to "propertyCompliance.title",
+                                "submitButtonText" to "forms.buttons.saveAndContinueToEPC",
                             ),
                     ),
-                handleSubmitAndRedirect = { _, _, _ -> taskListUrlSegment },
                 nextAction = { _, _ -> Pair(epcTask.startingStepId, null) },
             )
 
@@ -493,7 +490,6 @@ class PropertyComplianceJourney(
                                 "rcpElectricalRegisterUrl" to RCP_ELECTRICAL_REGISTER_URL,
                             ),
                     ),
-                handleSubmitAndRedirect = { _, _, _ -> taskListUrlSegment },
                 nextAction = { _, _ -> Pair(epcTask.startingStepId, null) },
             )
 
@@ -597,7 +593,6 @@ class PropertyComplianceJourney(
                                 "title" to "propertyCompliance.title",
                             ),
                     ),
-                handleSubmitAndRedirect = { _, _, _ -> taskListUrlSegment },
                 nextAction = { _, _ -> Pair(epcTask.startingStepId, null) },
             )
 
@@ -616,7 +611,6 @@ class PropertyComplianceJourney(
                                 "rcpElectricalRegisterUrl" to RCP_ELECTRICAL_REGISTER_URL,
                             ),
                     ),
-                handleSubmitAndRedirect = { _, _, _ -> taskListUrlSegment },
                 nextAction = { _, _ -> Pair(epcTask.startingStepId, null) },
             )
 

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -510,6 +510,8 @@ forms.buttons.saveAndReturnToTaskList=Save and return to task list
 forms.buttons.returnToTaskList=Return to task list
 forms.buttons.submit=Submit
 forms.buttons.confirmAndSubmitUpdate=Confirm and submit update
+forms.buttons.saveAndContinueToEICR=Save and continue to EICR
+forms.buttons.saveAndContinueToEPC=Save and continue to EPC
 
 forms.links.change=Change
 

--- a/src/main/resources/templates/forms/eicrExemptionConfirmationForm.html
+++ b/src/main/resources/templates/forms/eicrExemptionConfirmationForm.html
@@ -12,5 +12,5 @@
     <p class="govuk-body" th:text="#{forms.eicrExemptionConfirmation.paragraph.two}">forms.eicrExemptionConfirmation.paragraph.two</p>
     <p class="govuk-body" th:text="#{forms.eicrExemptionConfirmation.paragraph.three}">forms.eicrExemptionConfirmation.paragraph.three</p>
   </section>
-  <button th:replace="~{fragments/buttons/primaryButton :: primaryButton(#{forms.buttons.saveAndReturnToTaskList})}"></button>
+  <button th:replace="~{fragments/buttons/primaryButton :: primaryButton(#{forms.buttons.saveAndContinueToEPC})}"></button>
 </html>

--- a/src/main/resources/templates/forms/eicrExemptionMissingForm.html
+++ b/src/main/resources/templates/forms/eicrExemptionMissingForm.html
@@ -34,5 +34,5 @@
         <p class="govuk-body" th:text="#{forms.eicrExemptionMissing.subsection.paragraph.one}">forms.eicrExemptionMissing.subsection.paragraph.one</p>
         <p class="govuk-body" th:text="#{forms.eicrExemptionMissing.subsection.paragraph.two}">forms.eicrExemptionMissing.subsection.paragraph.two</p>
     </section>
-    <button th:replace="~{fragments/buttons/primaryButton :: primaryButton(#{forms.buttons.returnToTaskList})}"></button>
+    <button th:replace="~{fragments/buttons/primaryButton :: primaryButton(#{forms.buttons.saveAndContinueToEPC})}"></button>
 </html>

--- a/src/main/resources/templates/forms/eicrOutdatedForm.html
+++ b/src/main/resources/templates/forms/eicrOutdatedForm.html
@@ -30,5 +30,5 @@
         <p class="govuk-body" th:text="#{forms.eicrOutdated.paragraph.four}">forms.eicrOutdated.paragraph.four</p>
         <p class="govuk-body" th:text="#{forms.eicrOutdated.paragraph.five}">forms.eicrOutdated.paragraph.five</p>
     </section>
-    <button th:replace="~{fragments/buttons/primaryButton :: primaryButton(#{forms.buttons.returnToTaskList})}"></button>
+    <button th:replace="~{fragments/buttons/primaryButton :: primaryButton(#{forms.buttons.saveAndContinueToEPC})}"></button>
 </html>

--- a/src/main/resources/templates/forms/gasSafetyExemptionConfirmationForm.html
+++ b/src/main/resources/templates/forms/gasSafetyExemptionConfirmationForm.html
@@ -12,5 +12,5 @@
     <p class="govuk-body" th:text="#{forms.gasSafetyExemptionConfirmation.paragraph.two}">forms.gasSafetyExemptionConfirmation.paragraph.two</p>
     <p class="govuk-body" th:text="#{forms.gasSafetyExemptionConfirmation.paragraph.three}">forms.gasSafetyExemptionConfirmation.paragraph.three</p>
   </section>
-  <button th:replace="~{fragments/buttons/primaryButton :: primaryButton(#{forms.buttons.saveAndReturnToTaskList})}"></button>
+  <button th:replace="~{fragments/buttons/primaryButton :: primaryButton(#{forms.buttons.saveAndContinueToEICR})}"></button>
 </html>

--- a/src/main/resources/templates/forms/gasSafetyExemptionMissingForm.html
+++ b/src/main/resources/templates/forms/gasSafetyExemptionMissingForm.html
@@ -19,5 +19,5 @@
   <p class="govuk-body" th:text="#{forms.gasSafetyExemptionMissing.paragraph.two}">forms.gasSafetyExemptionMissing.paragraph.two</p>
   <p class="govuk-body" th:text="#{forms.gasSafetyExemptionMissing.paragraph.three}">forms.gasSafetyExemptionMissing.paragraph.three</p>
 </section>
-<button th:replace="~{fragments/buttons/primaryButton :: primaryButton(#{forms.buttons.saveAndReturnToTaskList})}"></button>
+<button th:replace="~{fragments/buttons/primaryButton :: primaryButton(#{forms.buttons.saveAndContinueToEICR})}"></button>
 </html>

--- a/src/main/resources/templates/forms/gasSafetyOutdatedForm.html
+++ b/src/main/resources/templates/forms/gasSafetyOutdatedForm.html
@@ -18,5 +18,5 @@
         <p class="govuk-body" th:text="#{forms.gasSafetyOutdated.paragraph.two}">forms.gasSafetyOutdated.paragraph.two</p>
         <p class="govuk-body" th:text="#{forms.gasSafetyOutdated.paragraph.three}">forms.gasSafetyOutdated.paragraph.three</p>
     </section>
-    <button th:replace="~{fragments/buttons/primaryButton :: primaryButton(#{forms.buttons.saveAndReturnToTaskList})}"></button>
+    <button th:replace="~{fragments/buttons/primaryButton :: primaryButton(#{forms.buttons.saveAndContinueToEICR})}"></button>
 </html>

--- a/src/main/resources/templates/forms/uploadCertificateConfirmationForm.html
+++ b/src/main/resources/templates/forms/uploadCertificateConfirmationForm.html
@@ -2,6 +2,7 @@
 <!--/*@thymesVar id="formModel" type="java.lang.Object"*/-->
 <!--/*@thymesVar id="backUrl" type="java.lang.String"*/-->
 <!--/*@thymesVar id="sectionHeaderInfo" type="uk.gov.communities.prsdb.webapp.models.viewModels.SectionHeaderViewModel"*/-->
+<!--/*@thymesVar id="submitButtonText" type="java.lang.String"*/-->
 <!DOCTYPE html>
 <html id="form-content" th:replace="~{fragments/forms/questionPage :: questionPage(#{${title}}, ${formModel}, ~{::#form-content/content()}, ${backUrl}, ${sectionHeaderInfo})}">
     <header>
@@ -14,5 +15,5 @@
         <h2 class="govuk-heading-s" th:text="#{forms.uploadCertificateConfirmation.subsection.heading}">forms.uploadCertificateConfirmation.subsection.heading</h2>
         <p class="govuk-body" th:text="#{forms.uploadCertificateConfirmation.subsection.paragraph}">forms.uploadCertificateConfirmation.subsection.paragraph</p>
     </section>
-    <button th:replace="~{fragments/buttons/primaryButton :: primaryButton(#{forms.buttons.saveAndContinue})}"></button>
+    <button th:replace="~{fragments/buttons/primaryButton :: primaryButton(#{${submitButtonText}})}"></button>
 </html>

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/PropertyComplianceJourneyTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/PropertyComplianceJourneyTests.kt
@@ -101,10 +101,7 @@ class PropertyComplianceJourneyTests : IntegrationTest() {
             // Gas Safety Cert. Upload Confirmation page
             assertThat(gasSafetyUploadConfirmationPage.heading).containsText("Your file is being scanned")
             gasSafetyUploadConfirmationPage.saveAndContinueButton.clickAndWait()
-            taskListPage = assertPageIs(page, TaskListPagePropertyCompliance::class, urlArguments)
 
-            // Task List page
-            taskListPage.clickUploadTaskWithName("Upload the Electrical Installation Condition Report (EICR)")
             val eicrPage = assertPageIs(page, EicrPagePropertyCompliance::class, urlArguments)
 
             // EICR page
@@ -134,10 +131,6 @@ class PropertyComplianceJourneyTests : IntegrationTest() {
             // EICR Upload Confirmation page
             assertThat(eicrUploadConfirmationPage.heading).containsText("Your file is being scanned")
             eicrUploadConfirmationPage.saveAndContinueButton.clickAndWait()
-            taskListPage = assertPageIs(page, TaskListPagePropertyCompliance::class, urlArguments)
-
-            // Task List page
-            taskListPage.clickUploadTaskWithName("Confirm the energy performance certificate (EPC)")
             val epcPage = assertPageIs(page, EpcPagePropertyCompliance::class, urlArguments)
 
             // EPC page
@@ -170,11 +163,7 @@ class PropertyComplianceJourneyTests : IntegrationTest() {
 
             // Gas Safety Outdated page
             assertThat(gasSafetyOutdatedPage.heading).containsText("Your gas safety certificate is out of date")
-            gasSafetyOutdatedPage.saveAndReturnToTaskListButton.clickAndWait()
-            taskListPage = assertPageIs(page, TaskListPagePropertyCompliance::class, urlArguments)
-
-            // Task List page
-            taskListPage.clickUploadTaskWithName("Upload the Electrical Installation Condition Report (EICR)")
+            gasSafetyOutdatedPage.saveAndContinueToEicrButton.clickAndWait()
             val eicrPage = assertPageIs(page, EicrPagePropertyCompliance::class, urlArguments)
 
             // EICR page
@@ -187,12 +176,7 @@ class PropertyComplianceJourneyTests : IntegrationTest() {
 
             // EICR Outdated page
             assertThat(eicrOutdatedPage.heading).containsText("This property’s EICR is out of date")
-            eicrOutdatedPage.returnToTaskListButton.clickAndWait()
-
-            taskListPage = assertPageIs(page, TaskListPagePropertyCompliance::class, urlArguments)
-
-            // Task List page
-            taskListPage.clickUploadTaskWithName("Confirm the energy performance certificate (EPC)")
+            eicrOutdatedPage.saveAndContinueToEpcButton.clickAndWait()
             val epcPage = assertPageIs(page, EpcPagePropertyCompliance::class, urlArguments)
 
             // EPC page
@@ -230,11 +214,7 @@ class PropertyComplianceJourneyTests : IntegrationTest() {
             // Gas Safety Exemption Confirmation page
             assertThat(gasSafetyExemptionConfirmationPage.heading)
                 .containsText("You’ve marked this property as not needing a gas safety certificate")
-            gasSafetyExemptionConfirmationPage.saveAndReturnToTaskListButton.clickAndWait()
-            taskListPage = assertPageIs(page, TaskListPagePropertyCompliance::class, urlArguments)
-
-            // Task List page
-            taskListPage.clickUploadTaskWithName("Upload the Electrical Installation Condition Report (EICR)")
+            gasSafetyExemptionConfirmationPage.saveAndContinueToEicrButton.clickAndWait()
             val eicrPage = assertPageIs(page, EicrPagePropertyCompliance::class, urlArguments)
 
             // EICR page
@@ -252,11 +232,7 @@ class PropertyComplianceJourneyTests : IntegrationTest() {
 
             // Gas Safety Exemption Confirmation page
             assertThat(eicrExemptionConfirmationPage.heading).containsText("You’ve marked this property as exempt from needing an EICR")
-            eicrExemptionConfirmationPage.saveAndReturnToTaskListButton.clickAndWait()
-            taskListPage = assertPageIs(page, TaskListPagePropertyCompliance::class, urlArguments)
-
-            // Task List page
-            taskListPage.clickUploadTaskWithName("Confirm the energy performance certificate (EPC)")
+            eicrExemptionConfirmationPage.saveAndContinueToEpcButton.clickAndWait()
             val epcPage = assertPageIs(page, EpcPagePropertyCompliance::class, urlArguments)
 
             // EPC page
@@ -288,11 +264,7 @@ class PropertyComplianceJourneyTests : IntegrationTest() {
 
             // Gas Safety Exemption Missing page
             assertThat(gasSafetyExemptionMissingPage.heading).containsText("You must get a valid gas safety certificate for this property")
-            gasSafetyExemptionMissingPage.saveAndReturnToTaskListButton.clickAndWait()
-            taskListPage = assertPageIs(page, TaskListPagePropertyCompliance::class, urlArguments)
-
-            // Task List page
-            taskListPage.clickUploadTaskWithName("Upload the Electrical Installation Condition Report (EICR)")
+            gasSafetyExemptionMissingPage.saveAndContinueToEicrButton.clickAndWait()
             val eicrPage = assertPageIs(page, EicrPagePropertyCompliance::class, urlArguments)
 
             // EICR page
@@ -305,12 +277,7 @@ class PropertyComplianceJourneyTests : IntegrationTest() {
 
             // EICR Exemption Missing page
             assertThat(eicrExemptionMissingPage.heading).containsText("You must get a valid EICR for this property")
-            eicrExemptionMissingPage.returnToTaskListButton.clickAndWait()
-
-            taskListPage = assertPageIs(page, TaskListPagePropertyCompliance::class, urlArguments)
-
-            // Task List page
-            taskListPage.clickUploadTaskWithName("Confirm the energy performance certificate (EPC)")
+            eicrExemptionMissingPage.saveAndContinueToEicrButton.clickAndWait()
             val epcPage = assertPageIs(page, EpcPagePropertyCompliance::class, urlArguments)
 
             // EPC page

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/Navigator.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/Navigator.kt
@@ -504,7 +504,7 @@ class Navigator(
                 GasSafetyExemptionMissingPagePropertyCompliance::class,
                 mapOf("propertyOwnershipId" to propertyOwnershipId.toString()),
             )
-        gasSafetyExemptionMissingPage.saveAndReturnToTaskListButton.clickAndWait()
+        gasSafetyExemptionMissingPage.saveAndContinueToEicrButton.clickAndWait()
         navigate(
             PropertyComplianceController.getPropertyCompliancePath(propertyOwnershipId) +
                 "/${PropertyComplianceStepId.EICR.urlPathSegment}",
@@ -572,7 +572,7 @@ class Navigator(
                 EicrExemptionMissingPagePropertyCompliance::class,
                 mapOf("propertyOwnershipId" to propertyOwnershipId.toString()),
             )
-        eicrExemptionMissingPage.returnToTaskListButton.clickAndWait()
+        eicrExemptionMissingPage.saveAndContinueToEicrButton.clickAndWait()
 
         navigate(
             PropertyComplianceController.getPropertyCompliancePath(propertyOwnershipId) +

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/propertyComplianceJourneyPages/EicrExemptionConfirmationPagePropertyCompliance.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/propertyComplianceJourneyPages/EicrExemptionConfirmationPagePropertyCompliance.kt
@@ -16,5 +16,5 @@ class EicrExemptionConfirmationPagePropertyCompliance(
             "/${PropertyComplianceStepId.EicrExemptionConfirmation.urlPathSegment}",
     ) {
     val heading: Locator = page.locator(".govuk-heading-l")
-    val saveAndReturnToTaskListButton = Button.byText(page, "Save and return to task list")
+    val saveAndContinueToEpcButton = Button.byText(page, "Save and continue to EPC")
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/propertyComplianceJourneyPages/EicrExemptionMissingPagePropertyCompliance.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/propertyComplianceJourneyPages/EicrExemptionMissingPagePropertyCompliance.kt
@@ -16,5 +16,5 @@ class EicrExemptionMissingPagePropertyCompliance(
             "/${PropertyComplianceStepId.EicrExemptionMissing.urlPathSegment}",
     ) {
     val heading: Locator = page.locator(".govuk-heading-l")
-    val returnToTaskListButton = Button.byText(page, "Return to task list")
+    val saveAndContinueToEicrButton = Button.byText(page, "Save and continue to EPC")
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/propertyComplianceJourneyPages/EicrOutdatedPagePropertyCompliance.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/propertyComplianceJourneyPages/EicrOutdatedPagePropertyCompliance.kt
@@ -16,5 +16,5 @@ class EicrOutdatedPagePropertyCompliance(
             "/${PropertyComplianceStepId.EicrOutdated.urlPathSegment}",
     ) {
     val heading: Locator = page.locator(".govuk-heading-l")
-    val returnToTaskListButton = Button.byText(page, "Return to task list")
+    val saveAndContinueToEpcButton = Button.byText(page, "Save and continue to EPC")
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/propertyComplianceJourneyPages/GasSafetyExemptionConfirmationPagePropertyCompliance.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/propertyComplianceJourneyPages/GasSafetyExemptionConfirmationPagePropertyCompliance.kt
@@ -16,5 +16,5 @@ class GasSafetyExemptionConfirmationPagePropertyCompliance(
             "/${PropertyComplianceStepId.GasSafetyExemptionConfirmation.urlPathSegment}",
     ) {
     val heading: Locator = page.locator(".govuk-heading-l")
-    val saveAndReturnToTaskListButton = Button.byText(page, "Save and return to task list")
+    val saveAndContinueToEicrButton = Button.byText(page, "Save and continue to EICR")
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/propertyComplianceJourneyPages/GasSafetyExemptionMissingPagePropertyCompliance.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/propertyComplianceJourneyPages/GasSafetyExemptionMissingPagePropertyCompliance.kt
@@ -16,5 +16,5 @@ class GasSafetyExemptionMissingPagePropertyCompliance(
             "/${PropertyComplianceStepId.GasSafetyExemptionMissing.urlPathSegment}",
     ) {
     val heading: Locator = page.locator(".govuk-heading-l")
-    val saveAndReturnToTaskListButton = Button.byText(page, "Save and return to task list")
+    val saveAndContinueToEicrButton = Button.byText(page, "Save and continue to EICR")
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/propertyComplianceJourneyPages/GasSafetyOutdatedPagePropertyCompliance.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/propertyComplianceJourneyPages/GasSafetyOutdatedPagePropertyCompliance.kt
@@ -16,5 +16,5 @@ class GasSafetyOutdatedPagePropertyCompliance(
             "/${PropertyComplianceStepId.GasSafetyOutdated.urlPathSegment}",
     ) {
     val heading: Locator = page.locator(".govuk-heading-l")
-    val saveAndReturnToTaskListButton = Button.byText(page, "Save and return to task list")
+    val saveAndContinueToEicrButton = Button.byText(page, "Save and continue to EICR")
 }


### PR DESCRIPTION
## Ticket number

PRSD-1199

## Goal of change

Update gas safety and eicr tasks so that when they are completed, the user is sent to the start of the next task.

## Description of main change(s)

For each affected page, remove the handleSubmitAndRedirect function so that nextAction is used and update the button text

This affects the following pages:
- Gas safety upload confirmation page
- Gas safety outdated step
- Gas safety exemption confirmation
- Gas safety exemption missing
- EICR upload confirmation
- EICR outdated
- EICR exemption confirmation
- EICR exemption missing

(Adding one screenshot of each task showing updated button text)

![image](https://github.com/user-attachments/assets/e66298e3-8abd-4818-b7c8-232e3a3d2008)
![image](https://github.com/user-attachments/assets/9ec2fc96-3ea9-445f-b510-006183c752e5)


## Anything you'd like to highlight to the reviewer?

N/A

## Checklist

Delete any that are not applicable, and add explanation below for any that are applicable but haven't been done

- [X] Screenshots of any UI changes have been added
- [X] New journey steps have been added to the appropriate journey integration test(s)
- [x] Test suite has been run in full locally and is passing
- [x] Branch has been rebased onto main and run locally, with everything working as expected (both for your new feature
  and any related functionality)