### PR TITLE
PRSD-1108: Use new CYA Flow in Update Journey

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/GroupedUpdateJourney.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/GroupedUpdateJourney.kt
@@ -1,0 +1,36 @@
+package uk.gov.communities.prsdb.webapp.forms.journeys
+
+import org.springframework.validation.Validator
+import org.springframework.web.servlet.ModelAndView
+import uk.gov.communities.prsdb.webapp.constants.enums.JourneyType
+import uk.gov.communities.prsdb.webapp.forms.PageData
+import uk.gov.communities.prsdb.webapp.forms.steps.GroupedUpdateStepId
+import uk.gov.communities.prsdb.webapp.services.JourneyDataService
+import java.security.Principal
+
+abstract class GroupedUpdateJourney<T : GroupedUpdateStepId<*>>(
+    journeyType: JourneyType,
+    initialStepId: T,
+    validator: Validator,
+    journeyDataService: JourneyDataService,
+    stepName: String,
+) : UpdateJourney<T>(journeyType, initialStepId, validator, journeyDataService, stepName) {
+    abstract override val stepRouter: GroupedStepRouter<T>
+
+    override val checkYourAnswersStepId: T?
+        get() {
+            val currentStepId = steps.singleOrNull { it.id.urlPathSegment == stepName }?.id ?: return null
+            return steps.singleOrNull { it.id.isCheckYourAnswersStepId && it.id.groupIdentifier == currentStepId.groupIdentifier }?.id
+        }
+
+    fun getModelAndViewForStep(
+        submittedPageData: PageData? = null,
+        changingAnswersForStep: String? = null,
+    ): ModelAndView = getModelAndViewForStep(stepName, null, submittedPageData, changingAnswersForStep)
+
+    fun completeStep(
+        formData: PageData,
+        principal: Principal,
+        changingAnswersForStep: String? = null,
+    ): ModelAndView = completeStep(stepName, formData, null, principal, changingAnswersForStep)
+}

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/LandlordDetailsUpdateJourney.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/LandlordDetailsUpdateJourney.kt
@@ -57,6 +57,8 @@ class LandlordDetailsUpdateJourney(
 
     override val stepRouter = GroupedStepRouter(this)
 
+    override val unreachableStepRedirect = LandlordDetailsController.LANDLORD_DETAILS_ROUTE
+
     override fun createOriginalJourneyData(): JourneyData {
         val landlord = landlordService.retrieveLandlordByBaseUserId(landlordBaseUserId)!!
 

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/LandlordDetailsUpdateJourney.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/LandlordDetailsUpdateJourney.kt
@@ -44,7 +44,7 @@ class LandlordDetailsUpdateJourney(
     private val landlordService: LandlordService,
     private val landlordBaseUserId: String,
     stepName: String,
-) : UpdateJourney<LandlordDetailsUpdateStepId>(
+) : GroupedUpdateJourney<LandlordDetailsUpdateStepId>(
         journeyType = JourneyType.LANDLORD_DETAILS_UPDATE,
         initialStepId = LandlordDetailsUpdateStepId.UpdateEmail,
         validator = validator,

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/LandlordDetailsUpdateJourney.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/LandlordDetailsUpdateJourney.kt
@@ -55,6 +55,8 @@ class LandlordDetailsUpdateJourney(
         initializeJourneyDataIfNotInitialized()
     }
 
+    override val stepRouter = GroupedStepRouter(this)
+
     override fun createOriginalJourneyData(): JourneyData {
         val landlord = landlordService.retrieveLandlordByBaseUserId(landlordBaseUserId)!!
 

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/PropertyDetailsUpdateJourney.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/PropertyDetailsUpdateJourney.kt
@@ -47,7 +47,7 @@ class PropertyDetailsUpdateJourney(
     private val propertyOwnershipService: PropertyOwnershipService,
     private val propertyOwnershipId: Long,
     stepName: String,
-) : UpdateJourney<UpdatePropertyDetailsStepId>(
+) : GroupedUpdateJourney<UpdatePropertyDetailsStepId>(
         journeyType = JourneyType.PROPERTY_DETAILS_UPDATE,
         initialStepId = UpdatePropertyDetailsStepId.UpdateOwnershipType,
         validator = validator,

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/PropertyDetailsUpdateJourney.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/PropertyDetailsUpdateJourney.kt
@@ -57,6 +57,8 @@ class PropertyDetailsUpdateJourney(
         initializeJourneyDataIfNotInitialized()
     }
 
+    override val stepRouter = GroupedStepRouter(this)
+
     override fun createOriginalJourneyData(): JourneyData {
         val propertyOwnership = propertyOwnershipService.getPropertyOwnership(propertyOwnershipId)
 

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/PropertyDetailsUpdateJourney.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/PropertyDetailsUpdateJourney.kt
@@ -5,6 +5,7 @@ import uk.gov.communities.prsdb.webapp.constants.BACK_URL_ATTR_NAME
 import uk.gov.communities.prsdb.webapp.constants.enums.JourneyType
 import uk.gov.communities.prsdb.webapp.constants.enums.LicensingType
 import uk.gov.communities.prsdb.webapp.constants.enums.OwnershipType
+import uk.gov.communities.prsdb.webapp.controllers.PropertyDetailsController
 import uk.gov.communities.prsdb.webapp.forms.JourneyData
 import uk.gov.communities.prsdb.webapp.forms.PageData
 import uk.gov.communities.prsdb.webapp.forms.pages.CheckLicensingPage
@@ -58,6 +59,8 @@ class PropertyDetailsUpdateJourney(
     }
 
     override val stepRouter = GroupedStepRouter(this)
+
+    override val unreachableStepRedirect = PropertyDetailsController.getPropertyDetailsPath(propertyOwnershipId)
 
     override fun createOriginalJourneyData(): JourneyData {
         val propertyOwnership = propertyOwnershipService.getPropertyOwnership(propertyOwnershipId)

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/UpdateJourney.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/UpdateJourney.kt
@@ -27,7 +27,7 @@ abstract class UpdateJourney<T : UpdateStepId<*>>(
 
     abstract override val stepRouter: GroupedStepRouter<T>
 
-    override val unreachableStepRedirect get() = last().step.id.urlPathSegment
+    abstract override val unreachableStepRedirect: String
 
     override val checkYourAnswersStepId: T?
         get() {

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/UpdateJourney.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/UpdateJourney.kt
@@ -7,17 +7,17 @@ import uk.gov.communities.prsdb.webapp.forms.JourneyData
 import uk.gov.communities.prsdb.webapp.forms.PageData
 import uk.gov.communities.prsdb.webapp.forms.ReachableStepDetailsIterator
 import uk.gov.communities.prsdb.webapp.forms.steps.StepDetails
-import uk.gov.communities.prsdb.webapp.forms.steps.UpdateStepId
+import uk.gov.communities.prsdb.webapp.forms.steps.StepId
 import uk.gov.communities.prsdb.webapp.helpers.JourneyDataHelper
 import uk.gov.communities.prsdb.webapp.services.JourneyDataService
 import java.security.Principal
 
-abstract class UpdateJourney<T : UpdateStepId<*>>(
+abstract class UpdateJourney<T : StepId>(
     journeyType: JourneyType,
     initialStepId: T,
     validator: Validator,
     journeyDataService: JourneyDataService,
-    private val stepName: String,
+    protected val stepName: String,
 ) : Journey<T>(journeyType, initialStepId, validator, journeyDataService) {
     companion object {
         fun getOriginalJourneyDataKey(journeyDataService: JourneyDataService) = "ORIGINAL_${journeyDataService.journeyDataKey}"
@@ -25,15 +25,7 @@ abstract class UpdateJourney<T : UpdateStepId<*>>(
 
     protected val originalDataKey = getOriginalJourneyDataKey(journeyDataService)
 
-    abstract override val stepRouter: GroupedStepRouter<T>
-
     abstract override val unreachableStepRedirect: String
-
-    override val checkYourAnswersStepId: T?
-        get() {
-            val currentStepId = steps.singleOrNull { it.id.urlPathSegment == stepName }?.id ?: return null
-            return steps.singleOrNull { it.id.isCheckYourAnswersStepId && it.id.groupIdentifier == currentStepId.groupIdentifier }?.id
-        }
 
     protected abstract fun createOriginalJourneyData(): JourneyData
 
@@ -45,14 +37,13 @@ abstract class UpdateJourney<T : UpdateStepId<*>>(
         }
     }
 
-    fun getModelAndViewForStep(changingAnswersForStep: String? = null): ModelAndView =
-        getModelAndViewForStep(stepName, null, null, changingAnswersForStep)
+    fun getModelAndViewForStep(submittedPageData: PageData? = null): ModelAndView =
+        getModelAndViewForStep(stepName, null, submittedPageData, null)
 
     fun completeStep(
         formData: PageData,
         principal: Principal,
-        changingAnswersForStep: String? = null,
-    ): ModelAndView = completeStep(stepName, formData, null, principal, changingAnswersForStep)
+    ): ModelAndView = completeStep(stepName, formData, null, principal, null)
 
     override fun iterator(): Iterator<StepDetails<T>> {
         val journeyData = journeyDataService.getJourneyDataFromSession()

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/factories/PropertyDetailsUpdateJourneyFactory.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/factories/PropertyDetailsUpdateJourneyFactory.kt
@@ -32,7 +32,7 @@ class PropertyDetailsUpdateJourneyFactory(
         stepName: String,
     ): String {
         val step = UpdatePropertyDetailsStepId.fromPathSegment(stepName) ?: throwInvalidStepNameException(stepName)
-        return PropertyDetailsController.getUpdatePropertyDetailsPath(propertyOwnershipId) + step.groupIdentifier.identifierString
+        return PropertyDetailsController.getUpdatePropertyDetailsPath(propertyOwnershipId) + step.groupIdentifier
     }
 
     private fun throwInvalidStepNameException(stepName: String): Nothing =

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/steps/LandlordDetailsUpdateStepId.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/steps/LandlordDetailsUpdateStepId.kt
@@ -3,7 +3,8 @@ package uk.gov.communities.prsdb.webapp.forms.steps
 enum class LandlordDetailsUpdateStepId(
     override val urlPathSegment: String,
     override val groupIdentifier: UpdateLandlordDetailsStepGroupIdentifier,
-) : GroupedStepId<UpdateLandlordDetailsStepGroupIdentifier> {
+    override val isCheckYourAnswersStepId: Boolean = false,
+) : UpdateStepId<UpdateLandlordDetailsStepGroupIdentifier> {
     UpdateEmail("email", UpdateLandlordDetailsStepGroupIdentifier.Email),
     UpdateName("name", UpdateLandlordDetailsStepGroupIdentifier.Name),
     UpdateDateOfBirth("date-of-birth", UpdateLandlordDetailsStepGroupIdentifier.DateOfBirth),

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/steps/LandlordDetailsUpdateStepId.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/steps/LandlordDetailsUpdateStepId.kt
@@ -4,7 +4,7 @@ enum class LandlordDetailsUpdateStepId(
     override val urlPathSegment: String,
     override val groupIdentifier: UpdateLandlordDetailsStepGroupIdentifier,
     override val isCheckYourAnswersStepId: Boolean = false,
-) : UpdateStepId<UpdateLandlordDetailsStepGroupIdentifier> {
+) : GroupedUpdateStepId<UpdateLandlordDetailsStepGroupIdentifier> {
     UpdateEmail("email", UpdateLandlordDetailsStepGroupIdentifier.Email),
     UpdateName("name", UpdateLandlordDetailsStepGroupIdentifier.Name),
     UpdateDateOfBirth("date-of-birth", UpdateLandlordDetailsStepGroupIdentifier.DateOfBirth),

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/steps/StepId.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/steps/StepId.kt
@@ -7,3 +7,7 @@ interface StepId {
 interface GroupedStepId<T : Enum<T>> : StepId {
     val groupIdentifier: T
 }
+
+interface UpdateStepId<T : Enum<T>> : GroupedStepId<T> {
+    val isCheckYourAnswersStepId: Boolean
+}

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/steps/StepId.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/steps/StepId.kt
@@ -8,6 +8,6 @@ interface GroupedStepId<T : Enum<T>> : StepId {
     val groupIdentifier: T
 }
 
-interface UpdateStepId<T : Enum<T>> : GroupedStepId<T> {
+interface GroupedUpdateStepId<T : Enum<T>> : GroupedStepId<T> {
     val isCheckYourAnswersStepId: Boolean
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/steps/UpdatePropertyDetailsStepId.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/steps/UpdatePropertyDetailsStepId.kt
@@ -4,7 +4,7 @@ enum class UpdatePropertyDetailsStepId(
     override val urlPathSegment: String,
     override val groupIdentifier: UpdatePropertyDetailsGroupIdentifier,
     override val isCheckYourAnswersStepId: Boolean = false,
-) : UpdateStepId<UpdatePropertyDetailsGroupIdentifier> {
+) : GroupedUpdateStepId<UpdatePropertyDetailsGroupIdentifier> {
     UpdateOwnershipType("ownership-type", UpdatePropertyDetailsGroupIdentifier.Ownership),
     UpdateOccupancy("occupancy", UpdatePropertyDetailsGroupIdentifier.Occupancy),
     UpdateNumberOfHouseholds("number-of-households", UpdatePropertyDetailsGroupIdentifier.Occupancy),

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/steps/UpdatePropertyDetailsStepId.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/steps/UpdatePropertyDetailsStepId.kt
@@ -2,29 +2,28 @@ package uk.gov.communities.prsdb.webapp.forms.steps
 
 enum class UpdatePropertyDetailsStepId(
     override val urlPathSegment: String,
-    override val groupIdentifier: UpdateGroupIdentifier,
-) : GroupedStepId<UpdateGroupIdentifier> {
-    UpdateOwnershipType("ownership-type", UpdateGroupIdentifier.Ownership),
-    UpdateOccupancy("occupancy", UpdateGroupIdentifier.Occupancy),
-    UpdateNumberOfHouseholds("number-of-households", UpdateGroupIdentifier.Occupancy),
-    UpdateNumberOfPeople("number-of-people", UpdateGroupIdentifier.Occupancy),
-    CheckYourOccupancyAnswers("check-occupancy-answers", UpdateGroupIdentifier.Occupancy),
-    UpdateLicensingType("licensing-type", UpdateGroupIdentifier.Licensing),
-    UpdateSelectiveLicence("selective-licence", UpdateGroupIdentifier.Licensing),
-    UpdateHmoMandatoryLicence("hmo-mandatory-licence", UpdateGroupIdentifier.Licensing),
-    UpdateHmoAdditionalLicence("hmo-additional-licence", UpdateGroupIdentifier.Licensing),
-    CheckYourLicensingAnswers("check-licensing-answers", UpdateGroupIdentifier.Licensing),
+    override val groupIdentifier: UpdatePropertyDetailsGroupIdentifier,
+    override val isCheckYourAnswersStepId: Boolean = false,
+) : UpdateStepId<UpdatePropertyDetailsGroupIdentifier> {
+    UpdateOwnershipType("ownership-type", UpdatePropertyDetailsGroupIdentifier.Ownership),
+    UpdateOccupancy("occupancy", UpdatePropertyDetailsGroupIdentifier.Occupancy),
+    UpdateNumberOfHouseholds("number-of-households", UpdatePropertyDetailsGroupIdentifier.Occupancy),
+    UpdateNumberOfPeople("number-of-people", UpdatePropertyDetailsGroupIdentifier.Occupancy),
+    CheckYourOccupancyAnswers("check-occupancy-answers", UpdatePropertyDetailsGroupIdentifier.Occupancy, true),
+    UpdateLicensingType("licensing-type", UpdatePropertyDetailsGroupIdentifier.Licensing),
+    UpdateSelectiveLicence("selective-licence", UpdatePropertyDetailsGroupIdentifier.Licensing),
+    UpdateHmoMandatoryLicence("hmo-mandatory-licence", UpdatePropertyDetailsGroupIdentifier.Licensing),
+    UpdateHmoAdditionalLicence("hmo-additional-licence", UpdatePropertyDetailsGroupIdentifier.Licensing),
+    CheckYourLicensingAnswers("check-licensing-answers", UpdatePropertyDetailsGroupIdentifier.Licensing, true),
     ;
 
     companion object {
-        fun fromPathSegment(segment: String): UpdatePropertyDetailsStepId? = entries.find { it.urlPathSegment == segment }
+        fun fromPathSegment(segment: String) = entries.find { it.urlPathSegment == segment }
     }
 }
 
-enum class UpdateGroupIdentifier(
-    val identifierString: String,
-) {
-    Ownership("-OWNERSHIP"),
-    Occupancy("-OCCUPANCY"),
-    Licensing("-LICENSING"),
+enum class UpdatePropertyDetailsGroupIdentifier {
+    Ownership,
+    Occupancy,
+    Licensing,
 }


### PR DESCRIPTION
## Ticket number

PRSD-1108

## Goal of change

Modifies update journeys to support new CYA flow.

## Description of main change(s)

- Creates new step ID interface for update journeys
- Modifies update journeys to support new CYA flow
- Changes update journey `unreachableStepRedirect`s to their corresponding details pages

## Anything you'd like to highlight to the reviewer?

This PR covers functionality common to all update journeys. The next PR for this ticket will focus on using the new CYA flow when updating property licensing.

## Checklist

Delete any that are not applicable, and add explanation below for any that are applicable but haven't been done

- [X] Test suite has been run in full locally and is passing
- [X] Branch has been rebased onto main and run locally, with everything working as expected (both for your new feature
  and any related functionality)
