### PR TITLE
PRSD-1108: Fix Grouped Update Journey CYA Links

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/PropertyDetailsController.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/PropertyDetailsController.kt
@@ -76,7 +76,7 @@ class PropertyDetailsController(
     ): ModelAndView =
         if (propertyOwnershipService.getIsAuthorizedToEditRecord(propertyOwnershipId, principal.name)) {
             propertyDetailsUpdateJourneyFactory
-                .create(propertyOwnershipId, stepName)
+                .create(propertyOwnershipId, stepName, isChangingAnswer = changingAnswerForStep != null)
                 .getModelAndViewForStep(changingAnswersForStep = changingAnswerForStep)
         } else {
             throw ResponseStatusException(
@@ -97,7 +97,7 @@ class PropertyDetailsController(
     ): ModelAndView =
         if (propertyOwnershipService.getIsAuthorizedToEditRecord(propertyOwnershipId, principal.name)) {
             propertyDetailsUpdateJourneyFactory
-                .create(propertyOwnershipId, stepName)
+                .create(propertyOwnershipId, stepName, isChangingAnswer = changingAnswerForStep != null)
                 .completeStep(formData, principal, changingAnswerForStep)
         } else {
             throw ResponseStatusException(

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/GroupedUpdateJourney.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/GroupedUpdateJourney.kt
@@ -17,7 +17,7 @@ abstract class GroupedUpdateJourney<T : GroupedUpdateStepId<*>>(
     stepName: String,
     protected val isChangingAnswer: Boolean,
 ) : UpdateJourney<T>(journeyType, initialStepId, validator, journeyDataService, stepName) {
-    abstract override val stepRouter: GroupedStepRouter<T>
+    abstract override val stepRouter: GroupedUpdateStepRouter<T>
 
     override val checkYourAnswersStepId: T?
         get() {

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/GroupedUpdateJourney.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/GroupedUpdateJourney.kt
@@ -2,6 +2,7 @@ package uk.gov.communities.prsdb.webapp.forms.journeys
 
 import org.springframework.validation.Validator
 import org.springframework.web.servlet.ModelAndView
+import uk.gov.communities.prsdb.webapp.constants.BACK_URL_ATTR_NAME
 import uk.gov.communities.prsdb.webapp.constants.enums.JourneyType
 import uk.gov.communities.prsdb.webapp.forms.PageData
 import uk.gov.communities.prsdb.webapp.forms.steps.GroupedUpdateStepId
@@ -14,6 +15,7 @@ abstract class GroupedUpdateJourney<T : GroupedUpdateStepId<*>>(
     validator: Validator,
     journeyDataService: JourneyDataService,
     stepName: String,
+    protected val isChangingAnswer: Boolean,
 ) : UpdateJourney<T>(journeyType, initialStepId, validator, journeyDataService, stepName) {
     abstract override val stepRouter: GroupedStepRouter<T>
 
@@ -33,4 +35,11 @@ abstract class GroupedUpdateJourney<T : GroupedUpdateStepId<*>>(
         principal: Principal,
         changingAnswersForStep: String? = null,
     ): ModelAndView = completeStep(stepName, formData, null, principal, changingAnswersForStep)
+
+    protected fun Map<String, Any>.withBackUrlIfNotChangingAnswer(backUrl: String) =
+        if (isChangingAnswer) {
+            this
+        } else {
+            this + (BACK_URL_ATTR_NAME to backUrl)
+        }
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/Journey.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/Journey.kt
@@ -116,11 +116,6 @@ abstract class Journey<T : StepId>(
         return ModelAndView("redirect:$redirectUrl")
     }
 
-    private fun isDestinationAllowedWhenChangingAnswerTo(
-        destinationStep: T?,
-        stepBeingChanged: T?,
-    ): Boolean = stepRouter.isDestinationAllowedWhenChangingAnswerTo(destinationStep, stepBeingChanged)
-
     private fun buildPreviousStepUrl(
         prevStepDetails: StepDetails<T>?,
         changingAnswersFor: T?,
@@ -141,17 +136,16 @@ abstract class Journey<T : StepId>(
     ): String {
         val (newStepId: T?, newSubPageNumber: Int?) = currentStep.nextAction(newJourneyData, subPageNumber)
 
-        return if (changingAnswersFor == null || isDestinationAllowedWhenChangingAnswerTo(newStepId, changingAnswersFor)) {
+        return if (changingAnswersFor == null || stepRouter.isDestinationAllowedWhenChangingAnswerTo(newStepId, changingAnswersFor)) {
             if (newStepId == null) {
                 throw IllegalStateException("Cannot compute next step from step ${currentStep.id.urlPathSegment}")
             }
             Step.generateUrl(newStepId, newSubPageNumber, changingAnswersFor)
         } else {
             // Assigning to localCheckYourAnswersStep allows the null check here to smart cast from T? to T
-            val localCheckYourAnswersStep = checkYourAnswersStepId
-            if (localCheckYourAnswersStep == null) {
-                throw IllegalStateException("No check your answers step defined for journey ${journeyType.name}")
-            }
+            val localCheckYourAnswersStep =
+                checkYourAnswersStepId
+                    ?: throw IllegalStateException("No check your answers step defined for journey ${journeyType.name}")
             Step.generateUrl(localCheckYourAnswersStep, null, null)
         }
     }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/LandlordDetailsUpdateJourney.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/LandlordDetailsUpdateJourney.kt
@@ -44,7 +44,7 @@ class LandlordDetailsUpdateJourney(
     private val landlordService: LandlordService,
     private val landlordBaseUserId: String,
     stepName: String,
-) : GroupedUpdateJourney<LandlordDetailsUpdateStepId>(
+) : UpdateJourney<LandlordDetailsUpdateStepId>(
         journeyType = JourneyType.LANDLORD_DETAILS_UPDATE,
         initialStepId = LandlordDetailsUpdateStepId.UpdateEmail,
         validator = validator,
@@ -54,8 +54,6 @@ class LandlordDetailsUpdateJourney(
     init {
         initializeJourneyDataIfNotInitialized()
     }
-
-    override val stepRouter = GroupedStepRouter(this)
 
     override val unreachableStepRedirect = LandlordDetailsController.LANDLORD_DETAILS_ROUTE
 

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/PropertyDetailsUpdateJourney.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/PropertyDetailsUpdateJourney.kt
@@ -47,18 +47,20 @@ class PropertyDetailsUpdateJourney(
     private val propertyOwnershipService: PropertyOwnershipService,
     private val propertyOwnershipId: Long,
     stepName: String,
+    isChangingAnswer: Boolean,
 ) : GroupedUpdateJourney<UpdatePropertyDetailsStepId>(
         journeyType = JourneyType.PROPERTY_DETAILS_UPDATE,
         initialStepId = UpdatePropertyDetailsStepId.UpdateOwnershipType,
         validator = validator,
         journeyDataService = journeyDataService,
         stepName = stepName,
+        isChangingAnswer = isChangingAnswer,
     ) {
     init {
         initializeJourneyDataIfNotInitialized()
     }
 
-    override val stepRouter = GroupedStepRouter(this)
+    override val stepRouter = GroupedUpdateStepRouter(this)
 
     override val unreachableStepRedirect = PropertyDetailsController.getPropertyDetailsPath(propertyOwnershipId)
 
@@ -157,8 +159,7 @@ class PropertyDetailsUpdateJourney(
                                         labelMsgKey = "forms.licensingType.radios.option.noLicensing.label",
                                     ),
                                 ),
-                            BACK_URL_ATTR_NAME to RELATIVE_PROPERTY_DETAILS_PATH,
-                        ),
+                        ).withBackUrlIfNotChangingAnswer(RELATIVE_PROPERTY_DETAILS_PATH),
                 ),
             nextAction = { journeyData, _ -> licensingTypeNextAction(journeyData) },
             saveAfterSubmit = false,
@@ -178,7 +179,6 @@ class PropertyDetailsUpdateJourney(
                             "label" to "forms.selectiveLicence.label",
                             "detailSummary" to "forms.selectiveLicence.detail.summary",
                             "detailMainText" to "forms.selectiveLicence.detail.text",
-                            BACK_URL_ATTR_NAME to UpdatePropertyDetailsStepId.UpdateLicensingType.urlPathSegment,
                         ),
                 ),
             nextAction = { _, _ -> Pair(UpdatePropertyDetailsStepId.CheckYourLicensingAnswers, null) },
@@ -205,7 +205,6 @@ class PropertyDetailsUpdateJourney(
                                     "bulletTwo" to "forms.hmoMandatoryLicence.detail.bullet.two",
                                     "text" to "forms.hmoMandatoryLicence.detail.paragraph.two",
                                 ),
-                            BACK_URL_ATTR_NAME to UpdatePropertyDetailsStepId.UpdateLicensingType.urlPathSegment,
                         ),
                 ),
             nextAction = { _, _ -> Pair(UpdatePropertyDetailsStepId.CheckYourLicensingAnswers, null) },
@@ -226,7 +225,6 @@ class PropertyDetailsUpdateJourney(
                             "label" to "forms.hmoAdditionalLicence.label",
                             "detailSummary" to "forms.hmoAdditionalLicence.detail.summary",
                             "detailMainText" to "forms.hmoAdditionalLicence.detail.text",
-                            BACK_URL_ATTR_NAME to UpdatePropertyDetailsStepId.UpdateLicensingType.urlPathSegment,
                         ),
                 ),
             nextAction = { _, _ -> Pair(UpdatePropertyDetailsStepId.CheckYourLicensingAnswers, null) },
@@ -267,8 +265,7 @@ class PropertyDetailsUpdateJourney(
                                         hintMsgKey = "forms.occupancy.radios.option.no.hint",
                                     ),
                                 ),
-                            BACK_URL_ATTR_NAME to RELATIVE_PROPERTY_DETAILS_PATH,
-                        ),
+                        ).withBackUrlIfNotChangingAnswer(RELATIVE_PROPERTY_DETAILS_PATH),
                 ),
             nextAction = { journeyData, _ -> occupancyNextAction(journeyData) },
             saveAfterSubmit = false,
@@ -286,8 +283,7 @@ class PropertyDetailsUpdateJourney(
                             "title" to "propertyDetails.update.title",
                             "fieldSetHeading" to getNumberOfHouseholdsStepFieldSetHeading(),
                             "label" to "forms.numberOfHouseholds.label",
-                            BACK_URL_ATTR_NAME to getNumberOfHouseholdsStepBackUrl(),
-                        ),
+                        ).withBackUrlIfNotChangingAnswer(getNumberOfHouseholdsStepBackUrl()),
                 ),
             nextAction = { _, _ -> Pair(UpdatePropertyDetailsStepId.UpdateNumberOfPeople, null) },
             saveAfterSubmit = false,
@@ -306,8 +302,7 @@ class PropertyDetailsUpdateJourney(
                             "fieldSetHeading" to getNumberOfPeopleStepFieldSetHeading(),
                             "fieldSetHint" to "forms.numberOfPeople.fieldSetHint",
                             "label" to "forms.numberOfPeople.label",
-                            BACK_URL_ATTR_NAME to getNumberOfPeopleStepBackUrl(),
-                        ),
+                        ).withBackUrlIfNotChangingAnswer(getNumberOfPeopleStepBackUrl()),
                     latestNumberOfHouseholds =
                         journeyDataService.getJourneyDataFromSession().getLatestNumberOfHouseholds(originalDataKey),
                 ),

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/StepRouter.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/StepRouter.kt
@@ -1,6 +1,7 @@
 package uk.gov.communities.prsdb.webapp.forms.journeys
 
 import uk.gov.communities.prsdb.webapp.forms.steps.GroupedStepId
+import uk.gov.communities.prsdb.webapp.forms.steps.GroupedUpdateStepId
 import uk.gov.communities.prsdb.webapp.forms.steps.StepDetails
 import uk.gov.communities.prsdb.webapp.forms.steps.StepId
 
@@ -34,12 +35,23 @@ open class GroupedStepRouter<T : GroupedStepId<*>>(
         otherStep: T?,
     ): Boolean =
         destinationStep != null &&
-            steps.fold(null) { destinationIsAfterOtherStep, stepDetails ->
+            steps.fold(null as Boolean?) { destinationIsAfterOtherStep, stepDetails ->
                 destinationIsAfterOtherStep
                     ?: when (stepDetails.step.id) {
                         otherStep -> true
                         destinationStep -> false
-                        else -> destinationIsAfterOtherStep
+                        else -> null
                     }
             } ?: false
+}
+
+open class GroupedUpdateStepRouter<T : GroupedUpdateStepId<*>>(
+    steps: Iterable<StepDetails<T>>,
+) : GroupedStepRouter<T>(steps) {
+    override fun isDestinationAllowedWhenChangingAnswerTo(
+        destinationStep: T?,
+        stepBeingChanged: T?,
+    ): Boolean =
+        destinationStep?.isCheckYourAnswersStepId != true &&
+            super.isDestinationAllowedWhenChangingAnswerTo(destinationStep, stepBeingChanged)
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/factories/PropertyDetailsUpdateJourneyFactory.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/factories/PropertyDetailsUpdateJourneyFactory.kt
@@ -19,12 +19,14 @@ class PropertyDetailsUpdateJourneyFactory(
     fun create(
         propertyOwnershipId: Long,
         stepName: String,
+        isChangingAnswer: Boolean,
     ) = PropertyDetailsUpdateJourney(
         validator,
         journeyDataServiceFactory.create(getJourneyDataKey(propertyOwnershipId, stepName)),
         propertyOwnershipService,
         propertyOwnershipId,
         stepName,
+        isChangingAnswer,
     )
 
     private fun getJourneyDataKey(

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/steps/LandlordDetailsUpdateStepId.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/steps/LandlordDetailsUpdateStepId.kt
@@ -3,8 +3,7 @@ package uk.gov.communities.prsdb.webapp.forms.steps
 enum class LandlordDetailsUpdateStepId(
     override val urlPathSegment: String,
     override val groupIdentifier: UpdateLandlordDetailsStepGroupIdentifier,
-    override val isCheckYourAnswersStepId: Boolean = false,
-) : GroupedUpdateStepId<UpdateLandlordDetailsStepGroupIdentifier> {
+) : GroupedStepId<UpdateLandlordDetailsStepGroupIdentifier> {
     UpdateEmail("email", UpdateLandlordDetailsStepGroupIdentifier.Email),
     UpdateName("name", UpdateLandlordDetailsStepGroupIdentifier.Name),
     UpdateDateOfBirth("date-of-birth", UpdateLandlordDetailsStepGroupIdentifier.DateOfBirth),

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/controllers/PropertyDetailsControllerTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/controllers/PropertyDetailsControllerTests.kt
@@ -158,6 +158,7 @@ class PropertyDetailsControllerTests(
                 propertyDetailsUpdateJourneyFactory.create(
                     propertyOwnership.id,
                     UpdatePropertyDetailsStepId.UpdateOwnershipType.urlPathSegment,
+                    isChangingAnswer = false,
                 ),
             ).thenReturn(propertyDetailsUpdateJourney)
         }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/GroupedUpdateJourneyTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/GroupedUpdateJourneyTests.kt
@@ -1,0 +1,172 @@
+package uk.gov.communities.prsdb.webapp.forms.journeys
+
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.whenever
+import uk.gov.communities.prsdb.webapp.constants.BACK_URL_ATTR_NAME
+import uk.gov.communities.prsdb.webapp.constants.CHANGE_ANSWER_FOR_PARAMETER_NAME
+import uk.gov.communities.prsdb.webapp.constants.enums.JourneyType
+import uk.gov.communities.prsdb.webapp.forms.JourneyData
+import uk.gov.communities.prsdb.webapp.forms.pages.Page
+import uk.gov.communities.prsdb.webapp.forms.steps.GroupedUpdateStepId
+import uk.gov.communities.prsdb.webapp.forms.steps.Step
+import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.NoInputFormModel
+import uk.gov.communities.prsdb.webapp.services.JourneyDataService
+import uk.gov.communities.prsdb.webapp.testHelpers.mockObjects.AlwaysTrueValidator
+import kotlin.test.assertEquals
+
+@ExtendWith(MockitoExtension::class)
+class GroupedUpdateJourneyTests {
+    @Mock
+    private lateinit var mockJourneyDataService: JourneyDataService
+
+    enum class TestGroupedUpdateStepId(
+        override val urlPathSegment: String,
+        override val groupIdentifier: GroupIdentifier,
+        override val isCheckYourAnswersStepId: Boolean = false,
+    ) : GroupedUpdateStepId<GroupIdentifier> {
+        GroupOneStepOne("group1-step1", GroupIdentifier.GroupOne),
+        GroupOneStepTwo("group1-step2", GroupIdentifier.GroupOne),
+        GroupOneCyaStep("group1-cya", GroupIdentifier.GroupOne, true),
+        GroupTwoCyaStep("group2-cya", GroupIdentifier.GroupTwo, true),
+    }
+
+    enum class GroupIdentifier {
+        GroupOne,
+        GroupTwo,
+    }
+
+    class TestGroupedUpdateJourney(
+        journeyDataService: JourneyDataService,
+        currentStep: TestGroupedUpdateStepId,
+    ) : GroupedUpdateJourney<TestGroupedUpdateStepId>(
+            JourneyType.PROPERTY_DETAILS_UPDATE,
+            initialStepId = TestGroupedUpdateStepId.GroupOneStepOne,
+            AlwaysTrueValidator(),
+            journeyDataService,
+            currentStep.urlPathSegment,
+            isChangingAnswer = true,
+        ) {
+        override val sections =
+            createSingleSectionWithSingleTaskFromSteps(
+                currentStep,
+                setOf(
+                    Step(
+                        TestGroupedUpdateStepId.GroupOneStepOne,
+                        page = Page(NoInputFormModel::class, "templateName", emptyMap()),
+                        nextAction = { _, _ -> Pair(TestGroupedUpdateStepId.GroupOneStepTwo, null) },
+                    ),
+                    Step(
+                        TestGroupedUpdateStepId.GroupOneStepTwo,
+                        page = Page(NoInputFormModel::class, "templateName", emptyMap()),
+                        nextAction = { _, _ -> Pair(TestGroupedUpdateStepId.GroupOneCyaStep, null) },
+                    ),
+                    Step(
+                        TestGroupedUpdateStepId.GroupOneCyaStep,
+                        page = Page(NoInputFormModel::class, "templateName", emptyMap()),
+                        nextAction = { _, _ -> Pair(TestGroupedUpdateStepId.GroupTwoCyaStep, null) },
+                    ),
+                    Step(
+                        TestGroupedUpdateStepId.GroupTwoCyaStep,
+                        page = Page(NoInputFormModel::class, "templateName", emptyMap()),
+                    ),
+                ),
+            )
+
+        override val stepRouter = GroupedUpdateStepRouter(this)
+
+        override val unreachableStepRedirect: String = ""
+
+        override fun createOriginalJourneyData(): JourneyData = emptyMap()
+    }
+
+    @Nested
+    inner class ChangingAnswersTests {
+        @Test
+        fun `completeStep redirects to next step with same changingAnswerFor when not reaching end of group`() {
+            // Arrange
+            val groupedUpdateJourney = TestGroupedUpdateJourney(mockJourneyDataService, TestGroupedUpdateStepId.GroupOneStepOne)
+
+            // Act
+            val result =
+                groupedUpdateJourney
+                    .completeStep(
+                        formData = emptyMap(),
+                        principal = { "testPrincipalId" },
+                        changingAnswersForStep = TestGroupedUpdateStepId.GroupOneStepOne.urlPathSegment,
+                    )
+
+            // Assert
+            assertEquals(
+                "redirect:${TestGroupedUpdateStepId.GroupOneStepTwo.urlPathSegment}?" +
+                    "$CHANGE_ANSWER_FOR_PARAMETER_NAME=${TestGroupedUpdateStepId.GroupOneStepOne.urlPathSegment}",
+                result.viewName,
+            )
+        }
+
+        @Test
+        fun `completeStep redirects to the corresponding CYA step when reaching end of group`() {
+            // Arrange
+            val groupedUpdateJourney = TestGroupedUpdateJourney(mockJourneyDataService, TestGroupedUpdateStepId.GroupOneStepTwo)
+
+            // Act
+            val result =
+                groupedUpdateJourney
+                    .completeStep(
+                        formData = emptyMap(),
+                        principal = { "testPrincipalId" },
+                        changingAnswersForStep = TestGroupedUpdateStepId.GroupOneStepOne.urlPathSegment,
+                    )
+
+            // Assert
+            assertEquals(
+                "redirect:${TestGroupedUpdateStepId.GroupOneCyaStep.urlPathSegment}",
+                result.viewName,
+            )
+        }
+
+        @Test
+        fun `getModelAndViewForStep yields a back link to the previous step with same changingAnswerFor if not at start of group`() {
+            // Arrange
+            whenever(mockJourneyDataService.getJourneyDataFromSession())
+                .thenReturn(mapOf(TestGroupedUpdateStepId.GroupOneStepOne.urlPathSegment to emptyMap<String, Any>()))
+            val groupedUpdateJourney = TestGroupedUpdateJourney(mockJourneyDataService, TestGroupedUpdateStepId.GroupOneStepTwo)
+
+            // Act
+            val result =
+                groupedUpdateJourney.getModelAndViewForStep(
+                    submittedPageData = null,
+                    changingAnswersForStep = TestGroupedUpdateStepId.GroupOneStepOne.urlPathSegment,
+                )
+
+            // Assert
+            assertEquals(
+                "${TestGroupedUpdateStepId.GroupOneStepOne.urlPathSegment}?" +
+                    "$CHANGE_ANSWER_FOR_PARAMETER_NAME=${TestGroupedUpdateStepId.GroupOneStepOne.urlPathSegment}",
+                result.model[BACK_URL_ATTR_NAME],
+            )
+        }
+
+        @Test
+        fun `getModelAndViewForStep yields a back link to the corresponding CYA step if at start of group`() {
+            // Arrange
+            val groupedUpdateJourney = TestGroupedUpdateJourney(mockJourneyDataService, TestGroupedUpdateStepId.GroupOneStepOne)
+
+            // Act
+            val result =
+                groupedUpdateJourney.getModelAndViewForStep(
+                    submittedPageData = null,
+                    changingAnswersForStep = TestGroupedUpdateStepId.GroupOneStepOne.urlPathSegment,
+                )
+
+            // Assert
+            assertEquals(
+                TestGroupedUpdateStepId.GroupOneCyaStep.urlPathSegment,
+                result.model[BACK_URL_ATTR_NAME],
+            )
+        }
+    }
+}

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/GroupedUpdateJourneyTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/GroupedUpdateJourneyTests.kt
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.whenever
+import org.springframework.web.util.UriComponentsBuilder
 import uk.gov.communities.prsdb.webapp.constants.BACK_URL_ATTR_NAME
 import uk.gov.communities.prsdb.webapp.constants.CHANGE_ANSWER_FOR_PARAMETER_NAME
 import uk.gov.communities.prsdb.webapp.constants.enums.JourneyType
@@ -17,6 +18,7 @@ import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.NoInputFo
 import uk.gov.communities.prsdb.webapp.services.JourneyDataService
 import uk.gov.communities.prsdb.webapp.testHelpers.mockObjects.AlwaysTrueValidator
 import kotlin.test.assertEquals
+import kotlin.test.assertNull
 
 @ExtendWith(MockitoExtension::class)
 class GroupedUpdateJourneyTests {
@@ -97,14 +99,11 @@ class GroupedUpdateJourneyTests {
                         formData = emptyMap(),
                         principal = { "testPrincipalId" },
                         changingAnswersForStep = TestGroupedUpdateStepId.GroupOneStepOne.urlPathSegment,
-                    )
+                    ).viewName!!
 
             // Assert
-            assertEquals(
-                "redirect:${TestGroupedUpdateStepId.GroupOneStepTwo.urlPathSegment}?" +
-                    "$CHANGE_ANSWER_FOR_PARAMETER_NAME=${TestGroupedUpdateStepId.GroupOneStepOne.urlPathSegment}",
-                result.viewName,
-            )
+            assertEquals(TestGroupedUpdateStepId.GroupOneStepTwo.urlPathSegment, result.getPath())
+            assertEquals(TestGroupedUpdateStepId.GroupOneStepOne.urlPathSegment, result.getQueryParam(CHANGE_ANSWER_FOR_PARAMETER_NAME))
         }
 
         @Test
@@ -119,13 +118,11 @@ class GroupedUpdateJourneyTests {
                         formData = emptyMap(),
                         principal = { "testPrincipalId" },
                         changingAnswersForStep = TestGroupedUpdateStepId.GroupOneStepOne.urlPathSegment,
-                    )
+                    ).viewName!!
 
             // Assert
-            assertEquals(
-                "redirect:${TestGroupedUpdateStepId.GroupOneCyaStep.urlPathSegment}",
-                result.viewName,
-            )
+            assertEquals(TestGroupedUpdateStepId.GroupOneCyaStep.urlPathSegment, result.getPath())
+            assertNull(result.getQueryParam(CHANGE_ANSWER_FOR_PARAMETER_NAME))
         }
 
         @Test
@@ -137,17 +134,16 @@ class GroupedUpdateJourneyTests {
 
             // Act
             val result =
-                groupedUpdateJourney.getModelAndViewForStep(
-                    submittedPageData = null,
-                    changingAnswersForStep = TestGroupedUpdateStepId.GroupOneStepOne.urlPathSegment,
-                )
+                groupedUpdateJourney
+                    .getModelAndViewForStep(
+                        submittedPageData = null,
+                        changingAnswersForStep = TestGroupedUpdateStepId.GroupOneStepOne.urlPathSegment,
+                    ).model[BACK_URL_ATTR_NAME]
+                    .toString()
 
             // Assert
-            assertEquals(
-                "${TestGroupedUpdateStepId.GroupOneStepOne.urlPathSegment}?" +
-                    "$CHANGE_ANSWER_FOR_PARAMETER_NAME=${TestGroupedUpdateStepId.GroupOneStepOne.urlPathSegment}",
-                result.model[BACK_URL_ATTR_NAME],
-            )
+            assertEquals(TestGroupedUpdateStepId.GroupOneStepOne.urlPathSegment, result.getPath())
+            assertEquals(TestGroupedUpdateStepId.GroupOneStepOne.urlPathSegment, result.getQueryParam(CHANGE_ANSWER_FOR_PARAMETER_NAME))
         }
 
         @Test
@@ -157,16 +153,24 @@ class GroupedUpdateJourneyTests {
 
             // Act
             val result =
-                groupedUpdateJourney.getModelAndViewForStep(
-                    submittedPageData = null,
-                    changingAnswersForStep = TestGroupedUpdateStepId.GroupOneStepOne.urlPathSegment,
-                )
+                groupedUpdateJourney
+                    .getModelAndViewForStep(
+                        submittedPageData = null,
+                        changingAnswersForStep = TestGroupedUpdateStepId.GroupOneStepOne.urlPathSegment,
+                    ).model[BACK_URL_ATTR_NAME]
+                    .toString()
 
             // Assert
-            assertEquals(
-                TestGroupedUpdateStepId.GroupOneCyaStep.urlPathSegment,
-                result.model[BACK_URL_ATTR_NAME],
-            )
+            assertEquals(TestGroupedUpdateStepId.GroupOneCyaStep.urlPathSegment, result.getPath())
+            assertNull(result.getQueryParam(CHANGE_ANSWER_FOR_PARAMETER_NAME))
         }
+    }
+
+    companion object {
+        private fun String.getUriComponents() = UriComponentsBuilder.fromUriString(this.removePrefix("redirect:")).build()
+
+        private fun String.getPath() = this.getUriComponents().path
+
+        private fun String.getQueryParam(name: String) = this.getUriComponents().queryParams.getFirst(name)
     }
 }


### PR DESCRIPTION
## Ticket number

PRSD-1108

## Goal of change

Fixes grouped update journey CYA links

## Description of main change(s)

- Makes `LandlordDetailsUpdateJourney` a non-grouped update journey as it currently doesn't have grouped updates
- Prevents property update journey back URLs from being overridden when changing answers
- Creates grouped update step router so CYA steps are seen as separate from the other steps in their groups

## Anything you'd like to highlight to the reviewer?

N/A

## Checklist

Delete any that are not applicable, and add explanation below for any that are applicable but haven't been done

- [X] Unit tests for new logic (e.g. new service methods) have been added
- [X] Test suite has been run in full locally and is passing
- [X] Branch has been rebased onto main and run locally, with everything working as expected (both for your new feature
  and any related functionality)