### PR TITLE
feat/PRSD-1150 fire safety declaration page update submit button text

### DIFF
--- a/src/main/resources/templates/forms/fireSafetyDeclarationForm.html
+++ b/src/main/resources/templates/forms/fireSafetyDeclarationForm.html
@@ -38,5 +38,5 @@
         </p>
        <th:block th:replace="~{fragments/forms/radios :: radios(null,'hasDeclared',null, ${radioOptions})}"></th:block>
     </th:block>
-    <button th:replace="~{fragments/buttons/primaryButton :: primaryButton(#{forms.buttons.continue})}"></button>
+    <button th:replace="~{fragments/buttons/primaryButton :: primaryButton(#{forms.buttons.saveAndContinue})}"></button>
 </html>


### PR DESCRIPTION
## Ticket number

PRSD-1150

## Goal of change

On the Fire Safety Declaration page in the Property Compliance Journey change the submit button test from "Continue" to "Save and continue"

## Description of main change(s)

As above

## Screenshots

**Before change:**
![image](https://github.com/user-attachments/assets/883f1239-fa7c-4c24-b34d-bc1e603c1774)

**After change:**
![image](https://github.com/user-attachments/assets/b286eb06-edbf-4622-b852-c4c41c579614)

## Checklist

- [X] Screenshots of any UI changes have been added
- [X] Test suite has been run in full locally and is passing
- [X] Branch has been rebased onto main and run locally, with everything working as expected (both for your new feature
  and any related functionality)
