### PR TITLE
PRSD-1040: Use db-specific roles for migrations

### DIFF
--- a/.github/workflows/build-and-deploy-integration.yml
+++ b/.github/workflows/build-and-deploy-integration.yml
@@ -10,6 +10,7 @@ jobs:
     with:
       environment: "integration"
       build-and-deploy-role: "arn:aws:iam::794038239680:role/integration-push-image"
+      migrations-role: "arn:aws:iam::794038239680:role/integration-rds-access"
       update-ecs-role: "arn:aws:iam::794038239680:role/github-actions-terraform-admin"
       ecr-repository: "integration-webapp"
       account-id: "794038239680"

--- a/.github/workflows/build-and-deploy-test.yml
+++ b/.github/workflows/build-and-deploy-test.yml
@@ -10,6 +10,7 @@ jobs:
     with:
       environment: "test"
       build-and-deploy-role: "arn:aws:iam::869935096717:role/test-push-image"
+      migrations-role: "arn:aws:iam::869935096717:role/test-rds-access"
       update-ecs-role: "arn:aws:iam::869935096717:role/github-actions-terraform-admin"
       ecr-repository: "test-webapp"
       account-id: "869935096717"

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -14,6 +14,10 @@ on:
         description: "Developer role used to update the ecs task definition"
         required: true
         type: string
+      migrations-role:
+        description: "Developer role used to run the database migration"
+        required: true
+        type: string
       ecr-repository:
         description: "Name of the ecr repository for the build image"
         required: true
@@ -125,7 +129,6 @@ jobs:
       contents: read
     env:
       AWS_REGION: eu-west-2
-      IAM_ROLE: arn:aws:iam::${{ inputs.account-id }}:role/github-actions-terraform-admin
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -133,7 +136,7 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume: ${{ env.IAM_ROLE }}
+          role-to-assume: ${{ inputs.migrations-role }}
           aws-region: ${{ env.AWS_REGION }}
 
       - name: Start SSM port-forwarding Session
@@ -188,7 +191,7 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          role-to-assume:  ${{ inputs.update-ecs-role }}
+          role-to-assume: ${{ inputs.update-ecs-role }}
           aws-region: ${{ env.AWS_REGION }}
 
       - name: Redeploy ECS service

--- a/.github/workflows/reset-database.yml
+++ b/.github/workflows/reset-database.yml
@@ -18,7 +18,7 @@ permissions:
 
 env:
   AWS_REGION: eu-west-2
-  IAM_ROLE: arn:aws:iam::${{ inputs.aws-account-id }}:role/github-actions-terraform-admin
+  IAM_ROLE: arn:aws:iam::${{ inputs.aws-account-id }}:role/${{ inputs.environment }}-rds-access
 
 jobs:
   validate-target-environment:


### PR DESCRIPTION
## Ticket number

PRSD-1040

## Goal of change

Use the new rds access role for jobs that run migrations

## Description of main change(s)

Updates our github actions to use our new role which has more restricted permissions to run the migrations - following the principle of least privilege. 