### PR TITLE
Feat/prsd 805 apply customback links between property and landlord pages

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/LandlordDetailsController.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/LandlordDetailsController.kt
@@ -114,6 +114,6 @@ class LandlordDetailsController(
         const val LANDLORD_DETAILS_ROUTE = "/$LANDLORD_DETAILS_PATH_SEGMENT"
         const val UPDATE_ROUTE = "$LANDLORD_DETAILS_ROUTE/$UPDATE_PATH_SEGMENT"
 
-        fun getLandlordDetailsPath(landlordId: Long?): String = LANDLORD_DETAILS_ROUTE + (landlordId?.let { "/$it" } ?: "")
+        fun getLandlordDetailsPath(landlordId: Long? = null): String = LANDLORD_DETAILS_ROUTE + (landlordId?.let { "/$it" } ?: "")
     }
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/PropertyDetailsController.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/PropertyDetailsController.kt
@@ -13,6 +13,7 @@ import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.server.ResponseStatusException
 import org.springframework.web.servlet.ModelAndView
 import org.springframework.web.util.UriTemplate
+import uk.gov.communities.prsdb.webapp.config.interceptors.BackLinkInterceptor.Companion.overrideBackLinkForUrl
 import uk.gov.communities.prsdb.webapp.constants.CHANGE_ANSWER_FOR_PARAMETER_NAME
 import uk.gov.communities.prsdb.webapp.constants.LOCAL_AUTHORITY_PATH_SEGMENT
 import uk.gov.communities.prsdb.webapp.constants.PROPERTY_DETAILS_SEGMENT
@@ -24,6 +25,7 @@ import uk.gov.communities.prsdb.webapp.forms.journeys.factories.PropertyDetailsU
 import uk.gov.communities.prsdb.webapp.helpers.DateTimeHelper
 import uk.gov.communities.prsdb.webapp.models.viewModels.summaryModels.PropertyDetailsLandlordViewModel
 import uk.gov.communities.prsdb.webapp.models.viewModels.summaryModels.PropertyDetailsViewModel
+import uk.gov.communities.prsdb.webapp.services.BackUrlStorageService
 import uk.gov.communities.prsdb.webapp.services.PropertyOwnershipService
 import java.security.Principal
 
@@ -32,6 +34,7 @@ import java.security.Principal
 class PropertyDetailsController(
     private val propertyOwnershipService: PropertyOwnershipService,
     private val propertyDetailsUpdateJourneyFactory: PropertyDetailsUpdateJourneyFactory,
+    private val backLinkStorageService: BackUrlStorageService,
 ) {
     @PreAuthorize("hasRole('LANDLORD')")
     @GetMapping(PROPERTY_DETAILS_ROUTE)
@@ -43,18 +46,23 @@ class PropertyDetailsController(
         val propertyOwnership =
             propertyOwnershipService.getPropertyOwnershipIfAuthorizedUser(propertyOwnershipId, principal.name)
 
+        val landlordDetailsUrl =
+            LandlordDetailsController
+                .getLandlordDetailsPath()
+                .overrideBackLinkForUrl(backLinkStorageService.storeCurrentUrlReturningKey())
+
         val propertyDetails =
             PropertyDetailsViewModel(
                 propertyOwnership = propertyOwnership,
                 withChangeLinks = true,
                 hideNullUprn = true,
-                landlordDetailsUrl = LandlordDetailsController.LANDLORD_DETAILS_ROUTE,
+                landlordDetailsUrl = landlordDetailsUrl,
             )
 
         val landlordViewModel =
             PropertyDetailsLandlordViewModel(
                 landlord = propertyOwnership.primaryLandlord,
-                landlordDetailsUrl = LandlordDetailsController.LANDLORD_DETAILS_ROUTE,
+                landlordDetailsUrl = landlordDetailsUrl,
             )
 
         model.addAttribute("propertyDetails", propertyDetails)
@@ -118,19 +126,23 @@ class PropertyDetailsController(
 
         val lastModifiedDate = DateTimeHelper.getDateInUK(propertyOwnership.getMostRecentlyUpdated().toKotlinInstant())
         val lastModifiedBy = propertyOwnership.primaryLandlord.name
+        val primaryLandlordDetailsUrl =
+            LandlordDetailsController
+                .getLandlordDetailsPath(propertyOwnership.primaryLandlord.id)
+                .overrideBackLinkForUrl(backLinkStorageService.storeCurrentUrlReturningKey())
 
         val propertyDetails =
             PropertyDetailsViewModel(
                 propertyOwnership = propertyOwnership,
                 withChangeLinks = false,
                 hideNullUprn = false,
-                landlordDetailsUrl = "${LandlordDetailsController.LANDLORD_DETAILS_ROUTE}/${propertyOwnership.primaryLandlord.id}",
+                landlordDetailsUrl = primaryLandlordDetailsUrl,
             )
 
         val landlordViewModel =
             PropertyDetailsLandlordViewModel(
                 propertyOwnership.primaryLandlord,
-                "${LandlordDetailsController.LANDLORD_DETAILS_ROUTE}/${propertyOwnership.primaryLandlord.id}",
+                primaryLandlordDetailsUrl,
             )
 
         model.addAttribute("propertyDetails", propertyDetails)

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/summaryModels/PropertyDetailsLandlordViewModel.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/summaryModels/PropertyDetailsLandlordViewModel.kt
@@ -7,7 +7,7 @@ import uk.gov.communities.prsdb.webapp.helpers.extensions.addRow
 
 class PropertyDetailsLandlordViewModel(
     private val landlord: Landlord,
-    private val landlordDetailsUrl: String = LandlordDetailsController.LANDLORD_DETAILS_ROUTE,
+    landlordDetailsUrl: String = LandlordDetailsController.LANDLORD_DETAILS_ROUTE,
 ) {
     private val isEnglandOrWalesResident = landlord.isEnglandOrWalesResident()
 

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/summaryModels/RegisteredPropertyViewModel.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/summaryModels/RegisteredPropertyViewModel.kt
@@ -1,5 +1,6 @@
 package uk.gov.communities.prsdb.webapp.models.viewModels.summaryModels
 
+import uk.gov.communities.prsdb.webapp.config.interceptors.BackLinkInterceptor.Companion.overrideBackLinkForUrl
 import uk.gov.communities.prsdb.webapp.constants.enums.LicensingType
 import uk.gov.communities.prsdb.webapp.controllers.PropertyDetailsController
 import uk.gov.communities.prsdb.webapp.database.entity.PropertyOwnership
@@ -18,6 +19,7 @@ data class RegisteredPropertyViewModel(
         fun fromPropertyOwnership(
             propertyOwnership: PropertyOwnership,
             isLaView: Boolean = false,
+            currentUrlKey: Int? = null,
         ): RegisteredPropertyViewModel =
             RegisteredPropertyViewModel(
                 address = propertyOwnership.property.address.singleLineAddress,
@@ -34,7 +36,10 @@ data class RegisteredPropertyViewModel(
                         propertyOwnership.license?.licenseType ?: LicensingType.NO_LICENSING,
                     ),
                 isTenantedMessageKey = MessageKeyConverter.convert(propertyOwnership.isOccupied),
-                recordLink = PropertyDetailsController.getPropertyDetailsPath(propertyOwnership.id, isLaView),
+                recordLink =
+                    PropertyDetailsController
+                        .getPropertyDetailsPath(propertyOwnership.id, isLaView)
+                        .overrideBackLinkForUrl(currentUrlKey),
             )
     }
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/PropertyOwnershipService.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/PropertyOwnershipService.kt
@@ -111,12 +111,19 @@ class PropertyOwnershipService(
 
     fun getRegisteredPropertiesForLandlordUser(baseUserId: String): List<RegisteredPropertyViewModel> =
         retrieveAllActiveRegisteredPropertiesForLandlord(baseUserId).map { propertyOwnership ->
-            RegisteredPropertyViewModel.fromPropertyOwnership(propertyOwnership)
+            RegisteredPropertyViewModel.fromPropertyOwnership(
+                propertyOwnership,
+                currentUrlKey = backLinkService.storeCurrentUrlReturningKey(),
+            )
         }
 
     fun getRegisteredPropertiesForLandlord(landlordId: Long): List<RegisteredPropertyViewModel> =
         retrieveAllActiveRegisteredPropertiesForLandlord(landlordId).map { propertyOwnership ->
-            RegisteredPropertyViewModel.fromPropertyOwnership(propertyOwnership, isLaView = true)
+            RegisteredPropertyViewModel.fromPropertyOwnership(
+                propertyOwnership,
+                isLaView = true,
+                currentUrlKey = backLinkService.storeCurrentUrlReturningKey(),
+            )
         }
 
     fun retrievePropertyOwnership(registrationNumber: Long): PropertyOwnership? =

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/LandlordDetailTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/LandlordDetailTests.kt
@@ -2,15 +2,14 @@ package uk.gov.communities.prsdb.webapp.integration
 
 import com.microsoft.playwright.Page
 import com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat
-import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
-import uk.gov.communities.prsdb.webapp.controllers.PropertyDetailsController
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.BaseComponent.Companion.assertThat
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.LandlordDetailsPage
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.LocalAuthorityViewLandlordDetailsPage
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.PropertyDetailsPageLandlordView
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.PropertyDetailsPageLocalAuthorityView
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages.BasePage.Companion.assertPageIs
-import java.net.URI
 import kotlin.test.assertEquals
 
 class LandlordDetailTests : SinglePageTestWithSeedData("data-local.sql") {
@@ -44,11 +43,15 @@ class LandlordDetailTests : SinglePageTestWithSeedData("data-local.sql") {
 
             detailsPage.getPropertyAddressLink("1, Example Road, EG").clickAndWait()
 
-            assertPageIs(page, PropertyDetailsPageLandlordView::class, mapOf("propertyOwnershipId" to propertyOwnershipId.toString()))
-            Assertions.assertEquals(
-                PropertyDetailsController.getPropertyDetailsPath(propertyOwnershipId.toLong(), isLaView = false),
-                URI(page.url()).path,
-            )
+            val propertyDetailsView =
+                assertPageIs(
+                    page,
+                    PropertyDetailsPageLandlordView::class,
+                    mapOf("propertyOwnershipId" to propertyOwnershipId.toString()),
+                )
+
+            propertyDetailsView.backLink.clickAndWait()
+            assertPageIs(page, LandlordDetailsPage::class)
         }
     }
 
@@ -90,15 +93,15 @@ class LandlordDetailTests : SinglePageTestWithSeedData("data-local.sql") {
 
             detailsPage.getPropertyAddressLink("1, Example Road, EG").clickAndWait()
 
-            assertPageIs(
-                page,
-                PropertyDetailsPageLocalAuthorityView::class,
-                mapOf("propertyOwnershipId" to propertyOwnershipId.toString()),
-            )
-            Assertions.assertEquals(
-                PropertyDetailsController.getPropertyDetailsPath(1, isLaView = true),
-                URI(page.url()).path,
-            )
+            val propertyDetailsView =
+                assertPageIs(
+                    page,
+                    PropertyDetailsPageLocalAuthorityView::class,
+                    mapOf("propertyOwnershipId" to propertyOwnershipId.toString()),
+                )
+
+            propertyDetailsView.backLink.clickAndWait()
+            assertPageIs(page, LocalAuthorityViewLandlordDetailsPage::class)
         }
     }
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/PropertyDetailsTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/PropertyDetailsTests.kt
@@ -10,6 +10,8 @@ import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.LandlordDas
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.LandlordDetailsPage
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.LocalAuthorityDashboardPage
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.LocalAuthorityViewLandlordDetailsPage
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.PropertyDetailsPageLandlordView
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.PropertyDetailsPageLocalAuthorityView
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages.BasePage.Companion.assertPageIs
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyDeregistrationJourneyPages.AreYouSureFormPagePropertyDeregistration
 import java.net.URI
@@ -59,8 +61,10 @@ class PropertyDetailsTests : SinglePageTestWithSeedData("data-local.sql") {
 
             detailsPage.getLandlordLinkFromLandlordDetails("Alexander Smith").clickAndWait()
 
-            assertPageIs(page, LandlordDetailsPage::class)
-            Assertions.assertEquals(LandlordDetailsController.LANDLORD_DETAILS_ROUTE, URI(page.url()).path)
+            val landlordDetailsPage = assertPageIs(page, LandlordDetailsPage::class)
+
+            landlordDetailsPage.backLink.clickAndWait()
+            assertPageIs(page, PropertyDetailsPageLandlordView::class, mapOf("propertyOwnershipId" to "1"))
         }
 
         @Test
@@ -126,8 +130,14 @@ class PropertyDetailsTests : SinglePageTestWithSeedData("data-local.sql") {
 
             detailsPage.getLandlordLinkFromLandlordDetails("Alexander Smith").clickAndWait()
 
-            assertPageIs(page, LocalAuthorityViewLandlordDetailsPage::class)
-            Assertions.assertEquals("${LandlordDetailsController.LANDLORD_DETAILS_ROUTE}/1", URI(page.url()).path)
+            val landlordDetailsPage = assertPageIs(page, LocalAuthorityViewLandlordDetailsPage::class)
+
+            landlordDetailsPage.backLink.clickAndWait()
+            assertPageIs(
+                page,
+                PropertyDetailsPageLocalAuthorityView::class,
+                mapOf("propertyOwnershipId" to "1"),
+            )
         }
 
         @Test

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/LocalAuthorityViewLandlordDetailsPage.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/LocalAuthorityViewLandlordDetailsPage.kt
@@ -2,7 +2,6 @@ package uk.gov.communities.prsdb.webapp.integration.pageObjects.pages
 
 import com.microsoft.playwright.Page
 import uk.gov.communities.prsdb.webapp.controllers.LandlordDetailsController
-import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.BackLink
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.InsetText
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages.LandlordDetailsBasePage
 
@@ -10,5 +9,4 @@ class LocalAuthorityViewLandlordDetailsPage(
     page: Page,
 ) : LandlordDetailsBasePage(page, LandlordDetailsController.LANDLORD_DETAILS_ROUTE) {
     val insetText = InsetText(page)
-    val backLink = BackLink.default(page)
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/basePages/LandlordDetailsBasePage.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/basePages/LandlordDetailsBasePage.kt
@@ -1,6 +1,7 @@
 package uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages
 
 import com.microsoft.playwright.Page
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.BackLink
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.Link
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.SummaryList
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.Table
@@ -11,6 +12,7 @@ abstract class LandlordDetailsBasePage(
     urlSegment: String,
 ) : BasePage(page, urlSegment) {
     val tabs = LandlordDetailsTabs(page)
+    val backLink = BackLink.default(page)
     val personalDetailsSummaryList = LandlordPersonalDetailsSummaryList(page)
     val registeredPropertiesTable = Table(page)
 

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/PropertyOwnershipServiceTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/PropertyOwnershipServiceTests.kt
@@ -28,6 +28,7 @@ import org.springframework.data.domain.PageImpl
 import org.springframework.data.domain.PageRequest
 import org.springframework.http.HttpStatus
 import org.springframework.web.server.ResponseStatusException
+import uk.gov.communities.prsdb.webapp.config.interceptors.BackLinkInterceptor.Companion.overrideBackLinkForUrl
 import uk.gov.communities.prsdb.webapp.constants.enums.JourneyType
 import uk.gov.communities.prsdb.webapp.constants.enums.LicensingType
 import uk.gov.communities.prsdb.webapp.constants.enums.OccupancyType
@@ -175,6 +176,7 @@ class PropertyOwnershipServiceTests {
         private val localAuthority = LocalAuthority(11, "DERBYSHIRE DALES DISTRICT COUNCIL", "1045")
         private val expectedPropertyLicence = "forms.checkPropertyAnswers.propertyDetails.noLicensing"
         private val expectedIsTenantedMessageKey = "commonText.no"
+        private val expectedCurrentUrlKey = 101
 
         private val propertyOwnership1 =
             MockLandlordData.createPropertyOwnership(
@@ -211,6 +213,8 @@ class PropertyOwnershipServiceTests {
                 ),
             ).thenReturn(landlordsProperties)
 
+            whenever(mockBackUrlStorageService.storeCurrentUrlReturningKey()).thenReturn(expectedCurrentUrlKey)
+
             val expectedResults: List<RegisteredPropertyViewModel> =
                 listOf(
                     RegisteredPropertyViewModel(
@@ -222,7 +226,10 @@ class PropertyOwnershipServiceTests {
                         localAuthorityName = localAuthority.name,
                         licenseTypeMessageKey = expectedPropertyLicence,
                         isTenantedMessageKey = expectedIsTenantedMessageKey,
-                        recordLink = PropertyDetailsController.getPropertyDetailsPath(propertyOwnership1.id),
+                        recordLink =
+                            PropertyDetailsController
+                                .getPropertyDetailsPath(propertyOwnership1.id)
+                                .overrideBackLinkForUrl(expectedCurrentUrlKey),
                     ),
                     RegisteredPropertyViewModel(
                         address = propertyOwnership2.property.address.singleLineAddress,
@@ -233,7 +240,10 @@ class PropertyOwnershipServiceTests {
                         localAuthorityName = localAuthority.name,
                         licenseTypeMessageKey = expectedPropertyLicence,
                         isTenantedMessageKey = expectedIsTenantedMessageKey,
-                        recordLink = PropertyDetailsController.getPropertyDetailsPath(propertyOwnership2.id),
+                        recordLink =
+                            PropertyDetailsController
+                                .getPropertyDetailsPath(propertyOwnership2.id)
+                                .overrideBackLinkForUrl(expectedCurrentUrlKey),
                     ),
                 )
 
@@ -252,6 +262,8 @@ class PropertyOwnershipServiceTests {
                 ),
             ).thenReturn(landlordsProperties)
 
+            whenever(mockBackUrlStorageService.storeCurrentUrlReturningKey()).thenReturn(expectedCurrentUrlKey)
+
             val expectedResults: List<RegisteredPropertyViewModel> =
                 listOf(
                     RegisteredPropertyViewModel(
@@ -264,10 +276,9 @@ class PropertyOwnershipServiceTests {
                         licenseTypeMessageKey = expectedPropertyLicence,
                         isTenantedMessageKey = expectedIsTenantedMessageKey,
                         recordLink =
-                            PropertyDetailsController.getPropertyDetailsPath(
-                                propertyOwnership1.id,
-                                isLaView = true,
-                            ),
+                            PropertyDetailsController
+                                .getPropertyDetailsPath(propertyOwnership1.id, isLaView = true)
+                                .overrideBackLinkForUrl(expectedCurrentUrlKey),
                     ),
                     RegisteredPropertyViewModel(
                         address = propertyOwnership2.property.address.singleLineAddress,
@@ -279,10 +290,9 @@ class PropertyOwnershipServiceTests {
                         licenseTypeMessageKey = expectedPropertyLicence,
                         isTenantedMessageKey = expectedIsTenantedMessageKey,
                         recordLink =
-                            PropertyDetailsController.getPropertyDetailsPath(
-                                propertyOwnership2.id,
-                                isLaView = true,
-                            ),
+                            PropertyDetailsController
+                                .getPropertyDetailsPath(propertyOwnership2.id, isLaView = true)
+                                .overrideBackLinkForUrl(expectedCurrentUrlKey),
                     ),
                 )
 


### PR DESCRIPTION
## Ticket number
PRSD-805

## Goal of change

Add custom back links when navigating between property details page and landlord details page both for landlords and LA users.

## Checklist

Delete any that are not applicable, and add explanation below for any that are applicable but haven't been done

- [X] Single page integration tests have been added for any unhappy-flow UI features, e.g. validation errors
- [X] Test suite has been run in full locally and is passing
- [x] Branch has been rebased onto main and run locally, with everything working as expected (both for your new feature
  and any related functionality)
