### PR TITLE
Feat/prsd 805 apply custom back links to resume journey

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/config/interceptors/BackLinkInterceptor.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/config/interceptors/BackLinkInterceptor.kt
@@ -19,6 +19,12 @@ class BackLinkInterceptor(
         modelAndView: ModelAndView?,
     ) {
         val backDestination = getBackUrlParameter(request)
+
+        if (modelAndView?.viewName?.let { it.startsWith("redirect:") || it.startsWith("forward:") } == true) {
+            modelAndView.modelMap.addAttribute(WITH_BACK_URL_PARAMETER_NAME, backDestination)
+            return
+        }
+
         if (backDestination != null) {
             val backUrl = backProvider.getBackUrl(backDestination)
             if (backUrl != null) {

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/LandlordController.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/LandlordController.kt
@@ -27,6 +27,7 @@ import uk.gov.communities.prsdb.webapp.models.dataModels.RegistrationNumberDataM
 import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.DeleteIncompletePropertyRegistrationAreYouSureFormModel
 import uk.gov.communities.prsdb.webapp.models.viewModels.formModels.RadiosButtonViewModel
 import uk.gov.communities.prsdb.webapp.models.viewModels.summaryModels.IncompletePropertiesViewModel
+import uk.gov.communities.prsdb.webapp.services.BackUrlStorageService
 import uk.gov.communities.prsdb.webapp.services.LandlordService
 import uk.gov.communities.prsdb.webapp.services.PropertyRegistrationService
 import java.security.Principal
@@ -37,6 +38,7 @@ import java.security.Principal
 class LandlordController(
     private val landlordService: LandlordService,
     private val propertyRegistrationService: PropertyRegistrationService,
+    private val backUrlStorageService: BackUrlStorageService,
 ) {
     @GetMapping
     fun index(): CharSequence = "redirect:$LANDLORD_DASHBOARD_URL"
@@ -83,7 +85,7 @@ class LandlordController(
         val incompleteProperties =
             propertyRegistrationService.getIncompletePropertiesForLandlord(principal.name)
 
-        val incompletePropertiesViewModel = IncompletePropertiesViewModel(incompleteProperties)
+        val incompletePropertiesViewModel = IncompletePropertiesViewModel(incompleteProperties, backUrlStorageService.rememberCurrentUrl())
 
         model.addAttribute("incompleteProperties", incompletePropertiesViewModel.incompleteProperties)
         model.addAttribute("registerPropertyUrl", "/$REGISTER_PROPERTY_JOURNEY_URL")

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/PropertyRegistrationJourney.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/PropertyRegistrationJourney.kt
@@ -80,6 +80,7 @@ class PropertyRegistrationJourney(
             "registerProperty.title",
             "registerProperty.taskList.heading",
             listOf("registerProperty.taskList.subtitle"),
+            backUrl = "/$REGISTER_PROPERTY_JOURNEY_URL",
         )
 
     private fun registerPropertyTasks(): List<JourneyTask<RegisterPropertyStepId>> =

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/summaryModels/IncompletePropertiesViewModel.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/summaryModels/IncompletePropertiesViewModel.kt
@@ -1,6 +1,7 @@
 package uk.gov.communities.prsdb.webapp.models.viewModels.summaryModels
 
 import kotlinx.datetime.LocalDate
+import uk.gov.communities.prsdb.webapp.config.interceptors.BackLinkInterceptor.Companion.overrideBackLinkForUrl
 import uk.gov.communities.prsdb.webapp.controllers.LandlordController
 import uk.gov.communities.prsdb.webapp.controllers.RegisterPropertyController
 import uk.gov.communities.prsdb.webapp.helpers.extensions.addAction
@@ -8,7 +9,8 @@ import uk.gov.communities.prsdb.webapp.helpers.extensions.addRow
 import uk.gov.communities.prsdb.webapp.models.dataModels.IncompletePropertiesDataModel
 
 class IncompletePropertiesViewModel(
-    private val incompletePropertiesData: List<IncompletePropertiesDataModel>,
+    incompletePropertiesData: List<IncompletePropertiesDataModel>,
+    currentUrlKey: Int? = null,
 ) {
     val incompleteProperties: List<SummaryCardViewModel> =
         incompletePropertiesData.mapIndexed { index, property ->
@@ -17,7 +19,7 @@ class IncompletePropertiesViewModel(
                 cardNumber = (index + 1).toString(),
                 title = "landlord.incompleteProperties.summaryCardTitlePrefix",
                 summaryList = getSummaryList(property.singleLineAddress, property.localAuthorityName, property.completeByDate),
-                actions = getActions(property.contextId),
+                actions = getActions(property.contextId, currentUrlKey),
             )
         }
 
@@ -42,12 +44,15 @@ class IncompletePropertiesViewModel(
                 )
             }.toList()
 
-    private fun getActions(contextId: Long): List<SummaryCardActionViewModel> =
+    private fun getActions(
+        contextId: Long,
+        currentUrlKey: Int?,
+    ): List<SummaryCardActionViewModel> =
         mutableListOf<SummaryCardActionViewModel>()
             .apply {
                 addAction(
                     "landlord.incompleteProperties.action.continue",
-                    RegisterPropertyController.getResumePropertyRegistrationPath(contextId),
+                    RegisterPropertyController.getResumePropertyRegistrationPath(contextId).overrideBackLinkForUrl(currentUrlKey),
                 )
                 addAction(
                     "landlord.incompleteProperties.action.delete",

--- a/src/main/resources/templates/taskList.html
+++ b/src/main/resources/templates/taskList.html
@@ -2,7 +2,7 @@
 <!DOCTYPE html>
 <html>
     <body th:replace="~{fragments/layout :: layout(#{${taskListViewModel.title}}, ~{::body/content()}, false)}">
-        <a th:replace="~{fragments/forms/backLink :: backLink(${taskListViewModel.backUrl})}"></a>
+        <a th:replace="~{fragments/forms/backLink :: backLink(${backUrl ?: taskListViewModel.backUrl})}"></a>
         <main class="govuk-main-wrapper" id="main-content">
             <th:block id="page-contents" th:replace="~{fragments/layouts/twoThirdsLayout :: twoThirdsLayout(~{::#page-contents/content()})}">
                 <header id="header">

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/LandlordIncompletePropertiesPageTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/LandlordIncompletePropertiesPageTests.kt
@@ -10,6 +10,7 @@ import uk.gov.communities.prsdb.webapp.integration.SinglePageTestWithSeedData.Ne
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.BaseComponent.Companion.assertThat
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.DeleteIncompletePropertyRegistrationAreYouSurePage
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.LandlordDetailsPage
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.LandlordIncompletePropertiesPage
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages.BasePage.Companion.assertPageIs
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyRegistrationJourneyPages.RegisterPropertyStartPage
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyRegistrationJourneyPages.TaskListPagePropertyRegistration
@@ -61,7 +62,10 @@ class LandlordIncompletePropertiesPageTests : IntegrationTest() {
         fun `Clicking on a summary card Continue link redirects to the task list page`(page: Page) {
             val incompletePropertiesPage = navigator.goToLandlordIncompleteProperties()
             incompletePropertiesPage.firstSummaryCard.continueLink.clickAndWait()
-            assertPageIs(page, TaskListPagePropertyRegistration::class)
+            val taskListPage = assertPageIs(page, TaskListPagePropertyRegistration::class)
+
+            taskListPage.backLink.clickAndWait()
+            assertPageIs(page, LandlordIncompletePropertiesPage::class)
         }
 
         @Test

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/propertyRegistrationJourneyPages/TaskListPagePropertyRegistration.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/propertyRegistrationJourneyPages/TaskListPagePropertyRegistration.kt
@@ -3,6 +3,7 @@ package uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyRe
 import com.microsoft.playwright.Page
 import uk.gov.communities.prsdb.webapp.constants.REGISTER_PROPERTY_JOURNEY_URL
 import uk.gov.communities.prsdb.webapp.constants.TASK_LIST_PATH_SEGMENT
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.BackLink
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.TaskList
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages.BasePage
 
@@ -14,6 +15,7 @@ class TaskListPagePropertyRegistration(
     ) {
     private val registerTasks = TaskList.byIndex(page, 0)
     private val checkAndSubmitTasks = TaskList.byIndex(page, 1)
+    val backLink = BackLink.default(page)
 
     fun clickRegisterTaskWithName(name: String) = registerTasks.getTask(name).clickAndWait()
 


### PR DESCRIPTION
## Ticket number
PRSD-805

## Goal of change
Add a custom back link to the task list page on the property registration journey if reached from the incomplete properties page.

## Anything you'd like to highlight to the reviewer?
My previous implementation meant that redirects where a back link override was set would have the actual url added as an attribute to the redirect model, which gets added as a urlParameter to the redirect. I've updated it to instead add the original urlParameter for redirects and forwards.

This also adds a default back link from the task list page to the journey start page.

## Checklist

Delete any that are not applicable, and add explanation below for any that are applicable but haven't been done

- [X] Single page integration tests have been added for any unhappy-flow UI features, e.g. validation errors
- [X] Test suite has been run in full locally and is passing
- [ ] Branch has been rebased onto main and run locally, with everything working as expected (both for your new feature
  and any related functionality)
- [X] Seed data has been updated as needed for your feature to be tested without having to e.g. register a new property
