### PR TITLE
PRSD-734: Change initial journey step back links

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/LandlordRegistrationJourney.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/LandlordRegistrationJourney.kt
@@ -210,6 +210,7 @@ class LandlordRegistrationJourney(
                             "fieldSetHeading" to "forms.confirmDetails.heading",
                             "fieldSetHint" to "forms.confirmDetails.summary",
                             "submitButtonText" to "forms.buttons.confirmAndContinue",
+                            "backUrl" to "/$REGISTER_LANDLORD_JOURNEY_URL",
                         ),
                     displaySectionHeader = true,
                 ),

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/LandlordRegistrationJourney.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/LandlordRegistrationJourney.kt
@@ -2,6 +2,7 @@ package uk.gov.communities.prsdb.webapp.forms.journeys
 
 import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.validation.Validator
+import uk.gov.communities.prsdb.webapp.constants.BACK_URL_ATTR_NAME
 import uk.gov.communities.prsdb.webapp.constants.CONFIRMATION_PATH_SEGMENT
 import uk.gov.communities.prsdb.webapp.constants.INTERNATIONAL_PLACE_NAMES
 import uk.gov.communities.prsdb.webapp.constants.NON_ENGLAND_OR_WALES_ADDRESS_MAX_LENGTH
@@ -169,7 +170,7 @@ class LandlordRegistrationJourney(
                             "fieldSetHint" to "forms.name.fieldSetHint",
                             "label" to "forms.name.label",
                             "submitButtonText" to "forms.buttons.continue",
-                            "backUrl" to "/$REGISTER_LANDLORD_JOURNEY_URL",
+                            BACK_URL_ATTR_NAME to "/$REGISTER_LANDLORD_JOURNEY_URL",
                         ),
                     shouldDisplaySectionHeader = true,
                 ),
@@ -210,7 +211,7 @@ class LandlordRegistrationJourney(
                             "fieldSetHeading" to "forms.confirmDetails.heading",
                             "fieldSetHint" to "forms.confirmDetails.summary",
                             "submitButtonText" to "forms.buttons.confirmAndContinue",
-                            "backUrl" to "/$REGISTER_LANDLORD_JOURNEY_URL",
+                            BACK_URL_ATTR_NAME to "/$REGISTER_LANDLORD_JOURNEY_URL",
                         ),
                     displaySectionHeader = true,
                 ),

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/PropertyRegistrationJourney.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/PropertyRegistrationJourney.kt
@@ -3,6 +3,7 @@ package uk.gov.communities.prsdb.webapp.forms.journeys
 import jakarta.persistence.EntityExistsException
 import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.validation.Validator
+import uk.gov.communities.prsdb.webapp.constants.BACK_URL_ATTR_NAME
 import uk.gov.communities.prsdb.webapp.constants.CONFIRMATION_PATH_SEGMENT
 import uk.gov.communities.prsdb.webapp.constants.FIND_LOCAL_AUTHORITY_URL
 import uk.gov.communities.prsdb.webapp.constants.REGISTER_PROPERTY_JOURNEY_URL
@@ -10,6 +11,7 @@ import uk.gov.communities.prsdb.webapp.constants.enums.JourneyType
 import uk.gov.communities.prsdb.webapp.constants.enums.LicensingType
 import uk.gov.communities.prsdb.webapp.constants.enums.OwnershipType
 import uk.gov.communities.prsdb.webapp.constants.enums.PropertyType
+import uk.gov.communities.prsdb.webapp.controllers.LandlordController
 import uk.gov.communities.prsdb.webapp.forms.JourneyData
 import uk.gov.communities.prsdb.webapp.forms.pages.AlreadyRegisteredPage
 import uk.gov.communities.prsdb.webapp.forms.pages.Page
@@ -162,6 +164,7 @@ class PropertyRegistrationJourney(
                             "houseNameOrNumberLabel" to "forms.lookupAddress.houseNameOrNumber.label",
                             "houseNameOrNumberHint" to "forms.lookupAddress.houseNameOrNumber.hint",
                             "submitButtonText" to "forms.buttons.continue",
+                            BACK_URL_ATTR_NAME to LandlordController.LANDLORD_DASHBOARD_URL,
                         ),
                     shouldDisplaySectionHeader = true,
                 ),


### PR DESCRIPTION
## Ticket number
PRSD-734

## Goal of change
Update back links on the first page of journeys where it is not set.

## Description of main change(s)
* Updated the back url for the first page of registering a property to go to the landlord dashboard.
* Updated the back url for the first page of registering as a landlord to go to the journey intro page.

## Anything you'd like to highlight to the reviewer?
I've left the first page of the register as an LA user without a back link as you have reached it from an email so it's not very useful.
I've currently not added any tests for these back links. Do you think I need to add them?

## Checklist
- [X] Test suite has been run in full locally and is passing
- [X] Branch has been rebased onto main and run locally, with everything working as expected (both for your new feature
  and any related functionality)
