### PR TITLE
Feat/prsd 1140 epc superseded page

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/helpers/extensions/journeyExtensions/PropertyComplianceJourneyDataExtensions.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/helpers/extensions/journeyExtensions/PropertyComplianceJourneyDataExtensions.kt
@@ -173,6 +173,12 @@ class PropertyComplianceJourneyDataExtensions : JourneyDataExtensions() {
                 LOOKED_UP_EPC_JOURNEY_DATA_KEY
             }
 
+        fun JourneyData.getLatestEpcCertificateNumber(): String? =
+            this
+                .getEpcDetails(autoMatched = false)
+                ?.latestCertificateNumberForThisProperty
+                ?.let { EpcDataModel.parseCertificateNumberOrNull(it) }
+
         fun JourneyData.getAcceptedEpcDetails(): EpcDataModel? {
             // Check the automatched EPC first, then the looked up EPC
             if (this.getAutoMatchedEpcIsCorrect() == true) {

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/dataModels/EpcDataModel.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/dataModels/EpcDataModel.kt
@@ -13,7 +13,9 @@ data class EpcDataModel(
     val expiryDate: LocalDate,
     val latestCertificateNumberForThisProperty: String? = null,
 ) {
-    fun isLatestCertificateForThisProperty() = certificateNumber == latestCertificateNumberForThisProperty
+    fun isLatestCertificateForThisProperty() =
+        certificateNumber == latestCertificateNumberForThisProperty ||
+            latestCertificateNumberForThisProperty == null
 
     companion object {
         fun parseCertificateNumberOrNull(certificateNumber: String): String? {

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -538,6 +538,7 @@ forms.buttons.saveAndContinueToLandlordResponsibilities=Save and continue to lan
 forms.buttons.saveAndContinueToEICR=Save and continue to EICR
 forms.buttons.saveAndContinueToEPC=Save and continue to EPC
 forms.buttons.searchAgain=Search again
+forms.buttons.continueToCheckEpc=Continue to check EPC
 
 forms.links.change=Change
 
@@ -995,6 +996,11 @@ forms.epcNotFound.paragraph.two.afterLink=who evaluated the property.
 forms.epcNotFound.paragraph.three.beforeLink=Or 
 forms.epcNotFound.paragraph.three.link=get a new energy certificate (opens in new tab).
 forms.epcNotFound.paragraph.four=In the meantime, you can add other compliance information to the database.
+
+forms.epcSuperseded.heading=This property has a newer EPC available
+forms.epcSuperseded.paragraph.one=The EPC number you entered is not the most recent one for this property. This EPC is out of date.
+forms.epcSuperseded.paragraph.two=We\u2019ve found the latest EPC with the certificate number: {0,,certificateNumber}.
+forms.epcSuperseded.paragraph.three=You can check the newer certificate is correct on the next screen before you save.
 
 forms.landlordResponsibilities.fireSafety.error.missing=Select whether you have followed fire safety responsibilities
 forms.landlordResponsibilities.fireSafety.heading=Fire safety in your property

--- a/src/main/resources/templates/forms/epcSupersededForm.html
+++ b/src/main/resources/templates/forms/epcSupersededForm.html
@@ -1,0 +1,17 @@
+<!--/*@thymesVar id="title" type="java.lang.String"*/-->
+<!--/*@thymesVar id="formModel" type="java.lang.Object"*/-->
+<!--/*@thymesVar id="backUrl" type="java.lang.String"*/-->
+<!--/*@thymesVar id="sectionHeaderInfo" type="uk.gov.communities.prsdb.webapp.models.viewModels.SectionHeaderViewModel"*/-->
+<!--/*@thymesVar id="certificateNumber" type="java.lang.String"*/-->
+<!DOCTYPE html>
+<html id="form-content" th:replace="~{fragments/forms/questionPage :: questionPage(#{${title}}, ${formModel}, ~{::#form-content/content()}, ${backUrl}, ${sectionHeaderInfo})}">
+<header>
+    <h1 class="govuk-heading-l" th:text="#{forms.epcSuperseded.heading}">forms.epcSuperseded.heading</h1>
+</header>
+<section>
+    <p class="govuk-body" th:text="#{forms.epcSuperseded.paragraph.one}">forms.epcSuperseded.paragraph.one</p>
+    <p class="govuk-body" th:text="#{forms.epcSuperseded.paragraph.two(${certificateNumber})}">forms.epcSuperseded.paragraph.two</p>
+    <p class="govuk-body" th:text="#{forms.epcSuperseded.paragraph.three}">forms.epcSuperseded.paragraph.three</p>
+</section>
+<button th:replace="~{fragments/buttons/primaryButton :: primaryButton(#{forms.buttons.continueToCheckEpc})}"></button>
+</html>

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/PropertyComplianceJourneyTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/PropertyComplianceJourneyTests.kt
@@ -502,6 +502,85 @@ class PropertyComplianceJourneyTests {
     }
 
     @Nested
+    inner class EpcSupersededTests {
+        @Test
+        fun `handleSubmitAndRedirect looks up the latest certificate by certificate number`() {
+            // Arrange
+            val originalJourneyData =
+                JourneyDataBuilder()
+                    .withEpcLookupCertificateNumber(SUPERSEDED_EPC_CERTIFICATE_NUMBER)
+                    .withLookedUpEpcDetails(
+                        MockEpcData.createEpcDataModel(
+                            certificateNumber = SUPERSEDED_EPC_CERTIFICATE_NUMBER,
+                            latestCertificateNumberForThisProperty = CURRENT_EPC_CERTIFICATE_NUMBER,
+                        ),
+                    ).build()
+            whenever(mockJourneyDataService.getJourneyDataFromSession()).thenReturn(originalJourneyData)
+            whenever(mockEpcLookupService.getEpcByCertificateNumber(CURRENT_EPC_CERTIFICATE_NUMBER))
+                .thenReturn(MockEpcData.createEpcDataModel(certificateNumber = CURRENT_EPC_CERTIFICATE_NUMBER))
+
+            // Act
+            completeStep(PropertyComplianceStepId.EpcSuperseded, emptyMap(), stubPropertyOwnership = false)
+
+            // Assert
+            verify(mockEpcLookupService).getEpcByCertificateNumber(CURRENT_EPC_CERTIFICATE_NUMBER)
+        }
+
+        @Test
+        fun `handleSubmitAndRedirect resets the CheckMatchedEpc answer and updates the looked up EPC details in the session`() {
+            // Arrange
+            val originalJourneyData =
+                JourneyDataBuilder()
+                    .withCheckMatchedEpcResult(false)
+                    .withEpcLookupCertificateNumber(SUPERSEDED_EPC_CERTIFICATE_NUMBER)
+                    .withLookedUpEpcDetails(
+                        MockEpcData.createEpcDataModel(
+                            certificateNumber = SUPERSEDED_EPC_CERTIFICATE_NUMBER,
+                            latestCertificateNumberForThisProperty = CURRENT_EPC_CERTIFICATE_NUMBER,
+                        ),
+                    ).build()
+            whenever(mockJourneyDataService.getJourneyDataFromSession()).thenReturn(originalJourneyData)
+
+            val latestEpc = MockEpcData.createEpcDataModel(certificateNumber = CURRENT_EPC_CERTIFICATE_NUMBER)
+
+            whenever(mockEpcLookupService.getEpcByCertificateNumber(CURRENT_EPC_CERTIFICATE_NUMBER))
+                .thenReturn(latestEpc)
+
+            val updatedJourneyData =
+                JourneyDataBuilder()
+                    .withEpcLookupCertificateNumber(SUPERSEDED_EPC_CERTIFICATE_NUMBER)
+                    .withLookedUpEpcDetails(latestEpc)
+                    .withEpcSuperseded()
+                    .build()
+
+            // Act
+            completeStep(PropertyComplianceStepId.EpcSuperseded, emptyMap(), stubPropertyOwnership = false)
+
+            // Assert
+            verify(mockJourneyDataService).setJourneyDataInSession(updatedJourneyData)
+        }
+
+        @Test
+        fun `handleSubmitAndRedirect redirects to CheckMatchedEpc`() {
+            // Arrange
+            val originalJourneyData =
+                JourneyDataBuilder()
+                    .withLookedUpEpcDetails(
+                        MockEpcData.createEpcDataModel(SUPERSEDED_EPC_CERTIFICATE_NUMBER),
+                    ).build()
+            whenever(mockJourneyDataService.getJourneyDataFromSession()).thenReturn(originalJourneyData)
+            whenever(mockEpcLookupService.getEpcByCertificateNumber(CURRENT_EPC_CERTIFICATE_NUMBER))
+                .thenReturn(MockEpcData.createEpcDataModel(certificateNumber = CURRENT_EPC_CERTIFICATE_NUMBER))
+
+            // Act
+            val redirectModelAndView = completeStep(PropertyComplianceStepId.EpcSuperseded, emptyMap(), stubPropertyOwnership = false)
+
+            // Assert
+            assertEquals("redirect:${PropertyComplianceStepId.CheckMatchedEpc.urlPathSegment}", redirectModelAndView.viewName)
+        }
+    }
+
+    @Nested
     inner class CheckAndSubmitHandleSubmitAndRedirectTests {
         @Test
         fun `checkAndSubmitHandleSubmitAndRedirect creates a compliance record and deletes the corresponding form context`() {

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/helpers/extensions/journeyExtensions/PropertyComplianceJourneyDataExtensionsTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/helpers/extensions/journeyExtensions/PropertyComplianceJourneyDataExtensionsTests.kt
@@ -44,8 +44,11 @@ import uk.gov.communities.prsdb.webapp.helpers.extensions.journeyExtensions.Prop
 import uk.gov.communities.prsdb.webapp.helpers.extensions.journeyExtensions.PropertyComplianceJourneyDataExtensions.Companion.getIsEicrOutdated
 import uk.gov.communities.prsdb.webapp.helpers.extensions.journeyExtensions.PropertyComplianceJourneyDataExtensions.Companion.getIsGasSafetyCertOutdated
 import uk.gov.communities.prsdb.webapp.helpers.extensions.journeyExtensions.PropertyComplianceJourneyDataExtensions.Companion.getIsGasSafetyExemptionReasonOther
+import uk.gov.communities.prsdb.webapp.helpers.extensions.journeyExtensions.PropertyComplianceJourneyDataExtensions.Companion.getLatestEpcCertificateNumber
 import uk.gov.communities.prsdb.webapp.helpers.extensions.journeyExtensions.PropertyComplianceJourneyDataExtensions.Companion.withEpcDetails
 import uk.gov.communities.prsdb.webapp.helpers.extensions.journeyExtensions.PropertyComplianceJourneyDataExtensions.Companion.withResetCheckMatchedEpc
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyComplianceJourneyPages.EpcLookupPagePropertyCompliance.Companion.CURRENT_EPC_CERTIFICATE_NUMBER
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyComplianceJourneyPages.EpcLookupPagePropertyCompliance.Companion.SUPERSEDED_EPC_CERTIFICATE_NUMBER
 import uk.gov.communities.prsdb.webapp.testHelpers.builders.JourneyDataBuilder
 import uk.gov.communities.prsdb.webapp.testHelpers.mockObjects.MockEpcData
 import java.time.LocalDate
@@ -634,6 +637,22 @@ class PropertyComplianceJourneyDataExtensionsTests {
         val retrievedReason = testJourneyData.getEpcExemptionReason()
 
         assertNull(retrievedReason)
+    }
+
+    @Test
+    fun `getLatestEpcCertificateNumber returns the latestCertificateNumber from a looked up EPC`() {
+        val testJourneyData =
+            journeyDataBuilder
+                .withLookedUpEpcDetails(
+                    MockEpcData.createEpcDataModel(
+                        certificateNumber = SUPERSEDED_EPC_CERTIFICATE_NUMBER,
+                        latestCertificateNumberForThisProperty = CURRENT_EPC_CERTIFICATE_NUMBER,
+                    ),
+                ).build()
+
+        val retrievedCertificateNumber = testJourneyData.getLatestEpcCertificateNumber()
+
+        assertEquals(CURRENT_EPC_CERTIFICATE_NUMBER, retrievedCertificateNumber)
     }
 
     @Test

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/PropertyComplianceJourneyTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/PropertyComplianceJourneyTests.kt
@@ -61,6 +61,7 @@ import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyCom
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyComplianceJourneyPages.TaskListPagePropertyCompliance
 import uk.gov.communities.prsdb.webapp.services.FileUploader
 import uk.gov.communities.prsdb.webapp.testHelpers.mockObjects.MockEpcData
+import kotlin.test.assertTrue
 
 class PropertyComplianceJourneyTests : JourneyTestWithSeedData("data-local.sql") {
     @MockitoBean
@@ -239,8 +240,10 @@ class PropertyComplianceJourneyTests : JourneyTestWithSeedData("data-local.sql")
         epcLookupPage.submitSupersededEpcNumber()
         val epcSupersededPage = assertPageIs(page, EpcSupersededPagePropertyCompliance::class, urlArguments)
 
-        // TODO: PRSD-1140 - update this
         // EPC Superseded page
+        assertTrue(epcSupersededPage.page.content().contains(CURRENT_EPC_CERTIFICATE_NUMBER))
+        whenever(epcRegisterClient.getByRrn(CURRENT_EPC_CERTIFICATE_NUMBER))
+            .thenReturn(MockEpcData.createEpcRegisterClientEpcFoundResponse())
         epcSupersededPage.continueButton.clickAndWait()
         var checkMatchedEpcPage = assertPageIs(page, CheckMatchedEpcPagePropertyCompliance::class, urlArguments)
 

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/propertyComplianceJourneyPages/EpcSupersededPagePropertyCompliance.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/propertyComplianceJourneyPages/EpcSupersededPagePropertyCompliance.kt
@@ -14,6 +14,5 @@ class EpcSupersededPagePropertyCompliance(
         PropertyComplianceController.getPropertyCompliancePath(urlArguments["propertyOwnershipId"]!!.toLong()) +
             "/${PropertyComplianceStepId.EpcSuperseded.urlPathSegment}",
     ) {
-    // TODO: PRSD-1140 - update this
-    val continueButton = Button.byText(page, "Continue")
+    val continueButton = Button.byText(page, "Continue to check EPC")
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/models/dataModels/EpcDataModelTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/models/dataModels/EpcDataModelTests.kt
@@ -24,6 +24,17 @@ class EpcDataModelTests {
     }
 
     @Test
+    fun `isLatestCertificateForThisProperty returns true latestCertificateNumberForThisProperty is null`() {
+        val epcDataModel =
+            MockEpcData.createEpcDataModel(
+                certificateNumber = DEFAULT_EPC_CERTIFICATE_NUMBER,
+                latestCertificateNumberForThisProperty = null,
+            )
+
+        assertTrue(epcDataModel.isLatestCertificateForThisProperty())
+    }
+
+    @Test
     fun `isLatestCertificateForThisProperty returns false if the certificateNumber is not the latestCertificateNumberForThisProperty`() {
         val epcDataModel =
             MockEpcData.createEpcDataModel(

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/testHelpers/builders/JourneyDataBuilder.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/testHelpers/builders/JourneyDataBuilder.kt
@@ -627,6 +627,11 @@ class JourneyDataBuilder(
         return this
     }
 
+    fun withEpcSuperseded(): JourneyDataBuilder {
+        journeyData[PropertyComplianceStepId.EpcSuperseded.urlPathSegment] = emptyMap<String, Any?>()
+        return this
+    }
+
     fun withEpcExemptionReason(epcExemptionReason: EpcExemptionReason): JourneyDataBuilder {
         journeyData[PropertyComplianceStepId.EpcExemptionReason.urlPathSegment] =
             mapOf(EpcExemptionReasonFormModel::exemptionReason.name to epcExemptionReason)

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/testHelpers/mockObjects/MockEpcData.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/testHelpers/mockObjects/MockEpcData.kt
@@ -21,7 +21,7 @@ class MockEpcData {
             singleLineAddress: String = "1 Example Street, Example Town, EX1 1EX",
             energyRating: String = "C",
             expiryDate: LocalDate = LocalDate(2027, 1, 1),
-            latestCertificateNumberForThisProperty: String = DEFAULT_EPC_CERTIFICATE_NUMBER,
+            latestCertificateNumberForThisProperty: String? = DEFAULT_EPC_CERTIFICATE_NUMBER,
         ) = EpcDataModel(
             certificateNumber = certificateNumber,
             singleLineAddress = singleLineAddress,


### PR DESCRIPTION
## Ticket number

PRSD-1140

## Goal of change

Add the EPC superseded page

## Description of main change(s)

Adds the EPC superseded page. On submission, this looks up the latest epc by certificate number and saves the new details to the session.
It also removes the answer to CheckMatchedEpc as this was answered for different EPC details so is no longer valid.
![image](https://github.com/user-attachments/assets/09d652f8-876b-49d3-b988-8814dcd8bf24)

## Anything you'd like to highlight to the reviewer?

N/A

## Checklist

Delete any that are not applicable, and add explanation below for any that are applicable but haven't been done

- [X] Screenshots of any UI changes have been added
- [X] New journey steps have been added to the appropriate journey integration test(s)
- [ ] Test suite has been run in full locally and is passing
- [X] Branch has been rebased onto main and run locally, with everything working as expected (both for your new feature
  and any related functionality)