### PR TITLE
PRSD-NONE: Combine URL Parameter Constant Files

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/constants/UrlParameterConstants.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/constants/UrlParameterConstants.kt
@@ -1,3 +1,0 @@
-package uk.gov.communities.prsdb.webapp.constants
-
-const val CONTEXT_ID_URL_PARAMETER = "contextId"

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/constants/UrlParameterNames.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/constants/UrlParameterNames.kt
@@ -2,3 +2,4 @@ package uk.gov.communities.prsdb.webapp.constants
 
 const val CHANGE_ANSWER_FOR_PARAMETER_NAME = "changingAnswerFor"
 const val WITH_BACK_URL_PARAMETER_NAME = "withBackUrl"
+const val CONTEXT_ID_URL_PARAMETER = "contextId"

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/LandlordController.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/LandlordController.kt
@@ -102,7 +102,7 @@ class LandlordController(
     fun deleteIncompletePropertyAreYouSure(
         model: Model,
         principal: Principal,
-        @RequestParam(value = "contextId", required = true) contextId: Long,
+        @RequestParam(value = CONTEXT_ID_URL_PARAMETER, required = true) contextId: Long,
     ): String {
         populateDeleteIncompletePropertyRegistrationModel(model, contextId, principal.name)
         model.addAttribute(
@@ -117,7 +117,7 @@ class LandlordController(
     fun deleteIncompletePropertyAreYouSure(
         model: Model,
         principal: Principal,
-        @RequestParam(value = "contextId", required = true) contextId: Long,
+        @RequestParam(value = CONTEXT_ID_URL_PARAMETER, required = true) contextId: Long,
         @Valid
         @ModelAttribute
         formModel: DeleteIncompletePropertyRegistrationAreYouSureFormModel,
@@ -129,7 +129,7 @@ class LandlordController(
         }
 
         if (formModel.wantsToProceed == true) {
-            propertyRegistrationService.deleteIncompleteProperty(contextId.toLong(), principal.name)
+            propertyRegistrationService.deleteIncompleteProperty(contextId, principal.name)
         }
 
         return "redirect:$INCOMPLETE_PROPERTIES_URL"

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/RegisterPropertyController.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/RegisterPropertyController.kt
@@ -57,7 +57,7 @@ class RegisterPropertyController(
     @GetMapping("/$RESUME_PAGE_PATH_SEGMENT")
     fun getResume(
         principal: Principal,
-        @RequestParam(value = "contextId", required = true) contextId: String,
+        @RequestParam(value = CONTEXT_ID_URL_PARAMETER, required = true) contextId: String,
     ): String {
         val formContext =
             propertyRegistrationService.getIncompletePropertyFormContextForLandlordIfNotExpired(

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/config/BackLinkInterceptorTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/config/BackLinkInterceptorTests.kt
@@ -8,6 +8,7 @@ import org.mockito.kotlin.whenever
 import org.springframework.ui.ModelMap
 import org.springframework.web.servlet.ModelAndView
 import uk.gov.communities.prsdb.webapp.config.interceptors.BackLinkInterceptor
+import uk.gov.communities.prsdb.webapp.constants.WITH_BACK_URL_PARAMETER_NAME
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
@@ -17,7 +18,7 @@ class BackLinkInterceptorTests {
     @Test
     fun `postHandle sets a back url if the urlParameter has been set`() {
         val request: HttpServletRequest = mock()
-        whenever(request.getParameter("withBackUrl")).thenReturn("123")
+        whenever(request.getParameter(WITH_BACK_URL_PARAMETER_NAME)).thenReturn("123")
 
         val modelAndView: ModelAndView = mock()
         val modelMap = ModelMap()
@@ -47,7 +48,7 @@ class BackLinkInterceptorTests {
     @Test
     fun `postHandle overrides back url if the urlParameter has been set`() {
         val request: HttpServletRequest = mock()
-        whenever(request.getParameter("withBackUrl")).thenReturn("123")
+        whenever(request.getParameter(WITH_BACK_URL_PARAMETER_NAME)).thenReturn("123")
 
         val modelAndView: ModelAndView = mock()
         val modelMap = ModelMap()
@@ -78,7 +79,7 @@ class BackLinkInterceptorTests {
     @Test
     fun `postHandle does not set the back url if the urlParameter has not been set`() {
         val request: HttpServletRequest = mock()
-        whenever(request.getParameter("withBackUrl")).thenReturn(null)
+        whenever(request.getParameter(WITH_BACK_URL_PARAMETER_NAME)).thenReturn(null)
 
         val initialBackUrl = "http://example.com/old-back"
         val modelAndView: ModelAndView = mock()
@@ -101,7 +102,7 @@ class BackLinkInterceptorTests {
     @Test
     fun `postHandle does not override the back url if the urlParameter has not been set`() {
         val request: HttpServletRequest = mock()
-        whenever(request.getParameter("withBackUrl")).thenReturn(null)
+        whenever(request.getParameter(WITH_BACK_URL_PARAMETER_NAME)).thenReturn(null)
 
         val modelAndView: ModelAndView = mock()
         val modelMap = ModelMap()
@@ -122,7 +123,7 @@ class BackLinkInterceptorTests {
     @Test
     fun `postHandle does not set the back url if the urlParameter does not correspond to a saved url`() {
         val request: HttpServletRequest = mock()
-        whenever(request.getParameter("withBackUrl")).thenReturn("123")
+        whenever(request.getParameter(WITH_BACK_URL_PARAMETER_NAME)).thenReturn("123")
 
         val modelAndView: ModelAndView = mock()
         val modelMap = ModelMap()


### PR DESCRIPTION
## Ticket number

PRSD-NONE

## Goal of change

Combines URL Parameter Constant Files

## Description of main change(s)

- Moves `UrlParameterConstants` into `UrlParameterNames`
- Uses URL parameter constants in place of literals

## Anything you'd like to highlight to the reviewer?

N/A

## Checklist

Delete any that are not applicable, and add explanation below for any that are applicable but haven't been done

- [X] Test suite has been run in full locally and is passing
- [X] Branch has been rebased onto main and run locally, with everything working as expected (both for your new feature
  and any related functionality)