### PR TITLE
PRSD-NONE: Clean up (Filtered) Journey Data usage in Property Compliance Journey

### DIFF
--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/PropertyComplianceJourneyTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/PropertyComplianceJourneyTests.kt
@@ -592,6 +592,7 @@ class PropertyComplianceJourneyTests {
                     certificateNumber = SUPERSEDED_EPC_CERTIFICATE_NUMBER,
                     latestCertificateNumberForThisProperty = CURRENT_EPC_CERTIFICATE_NUMBER,
                 )
+
             val originalJourneyData =
                 JourneyPageDataBuilder
                     .beforePropertyComplianceEpcLookup()
@@ -603,8 +604,6 @@ class PropertyComplianceJourneyTests {
 
             val updatedJourneyData =
                 JourneyDataBuilder(initialJourneyData = originalJourneyData)
-                    .withEpcLookupCertificateNumber(SUPERSEDED_EPC_CERTIFICATE_NUMBER)
-                    .withLookedUpEpcDetails(supersededEPC)
                     .withResetCheckMatchedEpcResult()
                     .build()
 

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/PropertyComplianceJourneyTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/PropertyComplianceJourneyTests.kt
@@ -564,7 +564,8 @@ class PropertyComplianceJourneyTests {
         fun `handleSubmitAndRedirect looks up the latest certificate by certificate number`() {
             // Arrange
             val originalJourneyData =
-                JourneyDataBuilder()
+                JourneyPageDataBuilder
+                    .beforePropertyComplianceEpcLookup()
                     .withEpcLookupCertificateNumber(SUPERSEDED_EPC_CERTIFICATE_NUMBER)
                     .withLookedUpEpcDetails(
                         MockEpcData.createEpcDataModel(
@@ -592,7 +593,8 @@ class PropertyComplianceJourneyTests {
                     latestCertificateNumberForThisProperty = CURRENT_EPC_CERTIFICATE_NUMBER,
                 )
             val originalJourneyData =
-                JourneyDataBuilder()
+                JourneyPageDataBuilder
+                    .beforePropertyComplianceEpcLookup()
                     .withCheckMatchedEpcResult(false)
                     .withEpcLookupCertificateNumber(SUPERSEDED_EPC_CERTIFICATE_NUMBER)
                     .withLookedUpEpcDetails(supersededEPC)
@@ -600,9 +602,10 @@ class PropertyComplianceJourneyTests {
             whenever(mockJourneyDataService.getJourneyDataFromSession()).thenReturn(originalJourneyData)
 
             val updatedJourneyData =
-                JourneyDataBuilder()
+                JourneyDataBuilder(initialJourneyData = originalJourneyData)
                     .withEpcLookupCertificateNumber(SUPERSEDED_EPC_CERTIFICATE_NUMBER)
                     .withLookedUpEpcDetails(supersededEPC)
+                    .withResetCheckMatchedEpcResult()
                     .build()
 
             // Act
@@ -616,7 +619,9 @@ class PropertyComplianceJourneyTests {
         fun `handleSubmitAndRedirect updates the the looked up EPC details in the session`() {
             // Arrange
             val originalJourneyData =
-                JourneyDataBuilder()
+                JourneyPageDataBuilder
+                    .beforePropertyComplianceEpcLookup()
+                    .withEpcLookupCertificateNumber(SUPERSEDED_EPC_CERTIFICATE_NUMBER)
                     .withLookedUpEpcDetails(
                         MockEpcData.createEpcDataModel(
                             certificateNumber = SUPERSEDED_EPC_CERTIFICATE_NUMBER,
@@ -631,7 +636,7 @@ class PropertyComplianceJourneyTests {
                 .thenReturn(latestEpc)
 
             val updatedJourneyData =
-                JourneyDataBuilder()
+                JourneyDataBuilder(initialJourneyData = originalJourneyData)
                     .withEpcSuperseded()
                     .withLookedUpEpcDetails(latestEpc)
                     .build()
@@ -647,7 +652,9 @@ class PropertyComplianceJourneyTests {
         fun `handleSubmitAndRedirect redirects to CheckMatchedEpc`() {
             // Arrange
             val originalJourneyData =
-                JourneyDataBuilder()
+                JourneyPageDataBuilder
+                    .beforePropertyComplianceEpcLookup()
+                    .withEpcLookupCertificateNumber(SUPERSEDED_EPC_CERTIFICATE_NUMBER)
                     .withLookedUpEpcDetails(
                         MockEpcData.createEpcDataModel(SUPERSEDED_EPC_CERTIFICATE_NUMBER),
                     ).build()


### PR DESCRIPTION
## Ticket number

PRSD-NONE

## Goal of change

Use filtered or session journey data where appropriate in the property compliance journey

## Description of main change(s)

- Modifies property compliance journey to use filtered or session journey data where appropriate

## Anything you'd like to highlight to the reviewer?

N/A

## Checklist

Delete any that are not applicable, and add explanation below for any that are applicable but haven't been done

- [X] Test suite has been run in full locally and is passing
- [X] Branch has been rebased onto main and run locally, with everything working as expected (both for your new feature
  and any related functionality)