### PR TITLE
feat/PRSD-1156-fix-hint-text-incomplete-compliance-page

### DIFF
--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -514,7 +514,7 @@ landlord.incompleteProperties.none.text.afterLinks=.
 
 landlord.incompleteCompliances.title=Incomplete compliances
 landlord.incompleteCompliances.heading=Properties without compliance information
-landlord.incompleteCompliances.text=You must add compliance certificates for each property and confirm your landlord responsibilities
+landlord.incompleteCompliances.hintText=You must add compliance certificates for each property and confirm your landlord responsibilities
 landlord.incompleteCompliances.summaryCardTitlePrefix=Property
 landlord.incompleteCompliances.summaryRow.propertyAddress=Property address
 landlord.incompleteCompliances.summaryRow.localAuthority=Local authority

--- a/src/main/resources/templates/incompleteCompliancesView.html
+++ b/src/main/resources/templates/incompleteCompliancesView.html
@@ -6,7 +6,7 @@
         <h1 class="govuk-heading-l" th:text="#{landlord.incompleteCompliances.heading}">landlord.incompleteCompliances.heading</h1>
 
         <th:block th:unless="${#lists.isEmpty(incompleteCompliances)}">
-            <p class="govuk-body-l" th:text="#{landlord.incompleteCompliances.text}">landlord.incompleteCompliances.text</p>
+            <p class="govuk-body-l govuk-hint" th:text="#{landlord.incompleteCompliances.hintText}">landlord.incompleteCompliances.hintText</p>
             <th:block th:each="property: ${incompleteCompliances}">
                 <div th:replace="~{fragments/summaryCard :: summaryCard(${property.title}, ${property.cardNumber}, ${property.actions}, ${property.summaryList})}" ></div>
             </th:block>

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/LandlordIncompleteCompliancesPageTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/LandlordIncompleteCompliancesPageTests.kt
@@ -25,7 +25,7 @@ class LandlordIncompleteCompliancesPageTests : IntegrationTest() {
             val incompleteCompliancesPage = navigator.goToLandlordIncompleteCompliances()
             assertThat(incompleteCompliancesPage.heading).containsText("Properties without compliance information")
             assertThat(
-                incompleteCompliancesPage.subHeading,
+                incompleteCompliancesPage.hintText,
             ).containsText("You must add compliance certificates for each property and confirm your landlord responsibilities")
         }
 

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/LandlordIncompleteCompiancesPage.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/LandlordIncompleteCompiancesPage.kt
@@ -13,7 +13,6 @@ class LandlordIncompleteCompiancesPage(
     page: Page,
 ) : BasePage(page, INCOMPLETE_COMPLIANCES_URL) {
     val heading = Heading(page.locator("h1.govuk-heading-l"))
-    val subHeading = Heading(page.locator("p.govuk-body-l"))
     val hintText = Heading(page.locator("p.govuk-hint"))
     val viewRegisteredPropertiesLink = Link.byText(page, "View your property records")
 


### PR DESCRIPTION
## Ticket number

PRSD-1156

## Goal of change

Change some text to hint-text on the incomplete compliances page

## Description of main change(s)

As above and updated tests

## Screenshots

### Before
![image](https://github.com/user-attachments/assets/884ad86d-38ce-4306-8423-232ae0d4b12f)

### After
![image](https://github.com/user-attachments/assets/018e8761-5b9e-4ea6-8a38-355e157430e6)

## Checklist

- [X] Screenshots of any UI changes have been added
- [X] Test suite has been run in full locally and is passing
- [X] Branch has been rebased onto main and run locally, with everything working as expected (both for your new feature
  and any related functionality)
