### PR TITLE
PRSD-458: Precede DeregisterPropertyController endpoints with /landlord

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/DeregisterPropertyController.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/DeregisterPropertyController.kt
@@ -14,6 +14,7 @@ import org.springframework.web.util.UriTemplate
 import uk.gov.communities.prsdb.webapp.annotations.PrsdbController
 import uk.gov.communities.prsdb.webapp.constants.CONFIRMATION_PATH_SEGMENT
 import uk.gov.communities.prsdb.webapp.constants.DEREGISTER_PROPERTY_JOURNEY_URL
+import uk.gov.communities.prsdb.webapp.constants.LANDLORD_PATH_SEGMENT
 import uk.gov.communities.prsdb.webapp.controllers.DeregisterPropertyController.Companion.PROPERTY_DEREGISTRATION_ROUTE
 import uk.gov.communities.prsdb.webapp.controllers.LandlordController.Companion.LANDLORD_DASHBOARD_URL
 import uk.gov.communities.prsdb.webapp.forms.PageData
@@ -144,7 +145,7 @@ class DeregisterPropertyController(
     }
 
     companion object {
-        const val PROPERTY_DEREGISTRATION_ROUTE = "/$DEREGISTER_PROPERTY_JOURNEY_URL/{propertyOwnershipId}"
+        const val PROPERTY_DEREGISTRATION_ROUTE = "/$LANDLORD_PATH_SEGMENT/$DEREGISTER_PROPERTY_JOURNEY_URL/{propertyOwnershipId}"
 
         fun getPropertyDeregistrationBasePath(propertyOwnershipId: Long): String =
             UriTemplate(PROPERTY_DEREGISTRATION_ROUTE)

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/controllers/DeregisterPropertyControllerTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/controllers/DeregisterPropertyControllerTests.kt
@@ -13,11 +13,9 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean
 import org.springframework.test.web.servlet.get
 import org.springframework.web.context.WebApplicationContext
 import uk.gov.communities.prsdb.webapp.constants.CONFIRMATION_PATH_SEGMENT
-import uk.gov.communities.prsdb.webapp.constants.DEREGISTER_PROPERTY_JOURNEY_URL
 import uk.gov.communities.prsdb.webapp.controllers.DeregisterPropertyController.Companion.getPropertyDeregistrationPath
 import uk.gov.communities.prsdb.webapp.forms.journeys.PropertyDeregistrationJourney
 import uk.gov.communities.prsdb.webapp.forms.journeys.factories.PropertyDeregistrationJourneyFactory
-import uk.gov.communities.prsdb.webapp.forms.steps.DeregisterPropertyStepId
 import uk.gov.communities.prsdb.webapp.services.PropertyDeregistrationService
 import uk.gov.communities.prsdb.webapp.services.PropertyOwnershipService
 import uk.gov.communities.prsdb.webapp.services.PropertyService
@@ -45,7 +43,7 @@ class DeregisterPropertyControllerTests(
     @Test
     fun `getJourneyStep for the initial step returns a redirect for an unauthenticated user`() {
         mvc
-            .get("/$DEREGISTER_PROPERTY_JOURNEY_URL/1/$initialStepIdUrlSegment")
+            .get(DeregisterPropertyController.getPropertyDeregistrationPath(1))
             .andExpect {
                 status { is3xxRedirection() }
             }
@@ -55,7 +53,7 @@ class DeregisterPropertyControllerTests(
     @WithMockUser
     fun `getJourneyStep for the initial step returns 403 for a user who is not a landlord`() {
         mvc
-            .get("/$DEREGISTER_PROPERTY_JOURNEY_URL/1/$initialStepIdUrlSegment")
+            .get(DeregisterPropertyController.getPropertyDeregistrationPath(1))
             .andExpect {
                 status { isForbidden() }
             }
@@ -73,7 +71,7 @@ class DeregisterPropertyControllerTests(
 
         // Act, Assert
         mvc
-            .get("/$DEREGISTER_PROPERTY_JOURNEY_URL/$propertyOwnershipId/$initialStepIdUrlSegment")
+            .get(DeregisterPropertyController.getPropertyDeregistrationPath(1))
             .andExpect {
                 status { isNotFound() }
             }
@@ -91,7 +89,7 @@ class DeregisterPropertyControllerTests(
 
         // Act, Assert
         mvc
-            .get("/$DEREGISTER_PROPERTY_JOURNEY_URL/$propertyOwnershipId/$initialStepIdUrlSegment")
+            .get(DeregisterPropertyController.getPropertyDeregistrationPath(1))
             .andExpect {
                 status { isOk() }
             }
@@ -107,7 +105,7 @@ class DeregisterPropertyControllerTests(
 
         // Assert
         assertEquals(
-            "/$DEREGISTER_PROPERTY_JOURNEY_URL/$propertyOwnershipId/${DeregisterPropertyStepId.AreYouSure.urlPathSegment}",
+            DeregisterPropertyController.getPropertyDeregistrationPath(1),
             propertyDeregistrationPath,
         )
     }
@@ -122,7 +120,7 @@ class DeregisterPropertyControllerTests(
         ).thenReturn(mutableListOf(Pair(propertyOwnershipId, propertyId)))
 
         mvc
-            .get("/$DEREGISTER_PROPERTY_JOURNEY_URL/$propertyOwnershipId/$CONFIRMATION_PATH_SEGMENT")
+            .get("${DeregisterPropertyController.getPropertyDeregistrationBasePath(propertyOwnershipId)}/$CONFIRMATION_PATH_SEGMENT")
             .andExpect {
                 status { isOk() }
             }
@@ -137,7 +135,7 @@ class DeregisterPropertyControllerTests(
         val propertyOwnershipId = 1.toLong()
 
         mvc
-            .get("/$DEREGISTER_PROPERTY_JOURNEY_URL/$propertyOwnershipId/$CONFIRMATION_PATH_SEGMENT")
+            .get("${DeregisterPropertyController.getPropertyDeregistrationBasePath(propertyOwnershipId)}/$CONFIRMATION_PATH_SEGMENT")
             .andExpect {
                 status { isNotFound() }
             }
@@ -152,7 +150,7 @@ class DeregisterPropertyControllerTests(
             .thenReturn(deregisteredPropertyEntities)
 
         mvc
-            .get("/$DEREGISTER_PROPERTY_JOURNEY_URL/$propertyOwnershipId/$CONFIRMATION_PATH_SEGMENT")
+            .get("${DeregisterPropertyController.getPropertyDeregistrationBasePath(propertyOwnershipId)}/$CONFIRMATION_PATH_SEGMENT")
             .andExpect {
                 status { isNotFound() }
             }
@@ -171,7 +169,7 @@ class DeregisterPropertyControllerTests(
 
         // Act, Assert
         mvc
-            .get("/$DEREGISTER_PROPERTY_JOURNEY_URL/$propertyOwnershipId/$CONFIRMATION_PATH_SEGMENT")
+            .get("${DeregisterPropertyController.getPropertyDeregistrationBasePath(propertyOwnershipId)}/$CONFIRMATION_PATH_SEGMENT")
             .andExpect {
                 status { is5xxServerError() }
             }
@@ -192,7 +190,7 @@ class DeregisterPropertyControllerTests(
 
         // Act, Assert
         mvc
-            .get("/$DEREGISTER_PROPERTY_JOURNEY_URL/$propertyOwnershipId/$CONFIRMATION_PATH_SEGMENT")
+            .get("${DeregisterPropertyController.getPropertyDeregistrationBasePath(propertyOwnershipId)}/$CONFIRMATION_PATH_SEGMENT")
             .andExpect {
                 status { is5xxServerError() }
             }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/propertyDeregistrationJourneyPages/AreYouSureFormPagePropertyDeregistration.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/propertyDeregistrationJourneyPages/AreYouSureFormPagePropertyDeregistration.kt
@@ -2,6 +2,7 @@ package uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyDe
 
 import com.microsoft.playwright.Page
 import uk.gov.communities.prsdb.webapp.constants.DEREGISTER_PROPERTY_JOURNEY_URL
+import uk.gov.communities.prsdb.webapp.constants.LANDLORD_PATH_SEGMENT
 import uk.gov.communities.prsdb.webapp.forms.steps.DeregisterPropertyStepId
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages.AreYouSureFormBasePage
 
@@ -10,5 +11,6 @@ class AreYouSureFormPagePropertyDeregistration(
     urlArguments: Map<String, String>,
 ) : AreYouSureFormBasePage(
         page,
-        "/$DEREGISTER_PROPERTY_JOURNEY_URL/${urlArguments["propertyOwnershipId"]}/${DeregisterPropertyStepId.AreYouSure.urlPathSegment}",
+        "/$LANDLORD_PATH_SEGMENT/$DEREGISTER_PROPERTY_JOURNEY_URL/${urlArguments["propertyOwnershipId"]}" +
+            "/${DeregisterPropertyStepId.AreYouSure.urlPathSegment}",
     )

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/propertyDeregistrationJourneyPages/AreYouSureFormPagePropertyDeregistration.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/propertyDeregistrationJourneyPages/AreYouSureFormPagePropertyDeregistration.kt
@@ -1,8 +1,7 @@
 package uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyDeregistrationJourneyPages
 
 import com.microsoft.playwright.Page
-import uk.gov.communities.prsdb.webapp.constants.DEREGISTER_PROPERTY_JOURNEY_URL
-import uk.gov.communities.prsdb.webapp.constants.LANDLORD_PATH_SEGMENT
+import uk.gov.communities.prsdb.webapp.controllers.DeregisterPropertyController
 import uk.gov.communities.prsdb.webapp.forms.steps.DeregisterPropertyStepId
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages.AreYouSureFormBasePage
 
@@ -11,6 +10,6 @@ class AreYouSureFormPagePropertyDeregistration(
     urlArguments: Map<String, String>,
 ) : AreYouSureFormBasePage(
         page,
-        "/$LANDLORD_PATH_SEGMENT/$DEREGISTER_PROPERTY_JOURNEY_URL/${urlArguments["propertyOwnershipId"]}" +
+        DeregisterPropertyController.getPropertyDeregistrationBasePath(urlArguments["propertyOwnershipId"]!!.toLong()) +
             "/${DeregisterPropertyStepId.AreYouSure.urlPathSegment}",
     )

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/propertyDeregistrationJourneyPages/ConfirmationPagePropertyDeregistration.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/propertyDeregistrationJourneyPages/ConfirmationPagePropertyDeregistration.kt
@@ -3,6 +3,7 @@ package uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyDe
 import com.microsoft.playwright.Page
 import uk.gov.communities.prsdb.webapp.constants.CONFIRMATION_PATH_SEGMENT
 import uk.gov.communities.prsdb.webapp.constants.DEREGISTER_PROPERTY_JOURNEY_URL
+import uk.gov.communities.prsdb.webapp.constants.LANDLORD_PATH_SEGMENT
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.Button
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.ConfirmationBanner
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages.BasePage
@@ -10,7 +11,10 @@ import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages.B
 class ConfirmationPagePropertyDeregistration(
     page: Page,
     urlArguments: Map<String, String>,
-) : BasePage(page, "$DEREGISTER_PROPERTY_JOURNEY_URL/${urlArguments["propertyOwnershipId"]}/$CONFIRMATION_PATH_SEGMENT") {
+) : BasePage(
+        page,
+        "$LANDLORD_PATH_SEGMENT/$DEREGISTER_PROPERTY_JOURNEY_URL/${urlArguments["propertyOwnershipId"]}/$CONFIRMATION_PATH_SEGMENT",
+    ) {
     val confirmationBanner = ConfirmationBanner(page)
     val goToDashboardButton = Button.byText(page, "Go to Dashboard")
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/propertyDeregistrationJourneyPages/ConfirmationPagePropertyDeregistration.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/propertyDeregistrationJourneyPages/ConfirmationPagePropertyDeregistration.kt
@@ -2,8 +2,7 @@ package uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyDe
 
 import com.microsoft.playwright.Page
 import uk.gov.communities.prsdb.webapp.constants.CONFIRMATION_PATH_SEGMENT
-import uk.gov.communities.prsdb.webapp.constants.DEREGISTER_PROPERTY_JOURNEY_URL
-import uk.gov.communities.prsdb.webapp.constants.LANDLORD_PATH_SEGMENT
+import uk.gov.communities.prsdb.webapp.controllers.DeregisterPropertyController
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.Button
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.ConfirmationBanner
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages.BasePage
@@ -13,7 +12,8 @@ class ConfirmationPagePropertyDeregistration(
     urlArguments: Map<String, String>,
 ) : BasePage(
         page,
-        "$LANDLORD_PATH_SEGMENT/$DEREGISTER_PROPERTY_JOURNEY_URL/${urlArguments["propertyOwnershipId"]}/$CONFIRMATION_PATH_SEGMENT",
+        DeregisterPropertyController.getPropertyDeregistrationBasePath(urlArguments["propertyOwnershipId"]!!.toLong()) +
+            "/$CONFIRMATION_PATH_SEGMENT",
     ) {
     val confirmationBanner = ConfirmationBanner(page)
     val goToDashboardButton = Button.byText(page, "Go to Dashboard")

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/propertyDeregistrationJourneyPages/ReasonPagePropertyDeregistration.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/propertyDeregistrationJourneyPages/ReasonPagePropertyDeregistration.kt
@@ -2,6 +2,7 @@ package uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyDe
 
 import com.microsoft.playwright.Page
 import uk.gov.communities.prsdb.webapp.constants.DEREGISTER_PROPERTY_JOURNEY_URL
+import uk.gov.communities.prsdb.webapp.constants.LANDLORD_PATH_SEGMENT
 import uk.gov.communities.prsdb.webapp.forms.steps.DeregisterPropertyStepId
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages.ReasonFormPage
 
@@ -10,5 +11,6 @@ class ReasonPagePropertyDeregistration(
     urlArguments: Map<String, String>,
 ) : ReasonFormPage(
         page,
-        "/$DEREGISTER_PROPERTY_JOURNEY_URL/${urlArguments["propertyOwnershipId"]}/${DeregisterPropertyStepId.Reason.urlPathSegment}",
+        "/$LANDLORD_PATH_SEGMENT/$DEREGISTER_PROPERTY_JOURNEY_URL/${urlArguments["propertyOwnershipId"]}" +
+            "/${DeregisterPropertyStepId.Reason.urlPathSegment}",
     )

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/propertyDeregistrationJourneyPages/ReasonPagePropertyDeregistration.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/propertyDeregistrationJourneyPages/ReasonPagePropertyDeregistration.kt
@@ -1,8 +1,7 @@
 package uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyDeregistrationJourneyPages
 
 import com.microsoft.playwright.Page
-import uk.gov.communities.prsdb.webapp.constants.DEREGISTER_PROPERTY_JOURNEY_URL
-import uk.gov.communities.prsdb.webapp.constants.LANDLORD_PATH_SEGMENT
+import uk.gov.communities.prsdb.webapp.controllers.DeregisterPropertyController
 import uk.gov.communities.prsdb.webapp.forms.steps.DeregisterPropertyStepId
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages.ReasonFormPage
 
@@ -11,6 +10,6 @@ class ReasonPagePropertyDeregistration(
     urlArguments: Map<String, String>,
 ) : ReasonFormPage(
         page,
-        "/$LANDLORD_PATH_SEGMENT/$DEREGISTER_PROPERTY_JOURNEY_URL/${urlArguments["propertyOwnershipId"]}" +
+        DeregisterPropertyController.getPropertyDeregistrationBasePath(urlArguments["propertyOwnershipId"]!!.toLong()) +
             "/${DeregisterPropertyStepId.Reason.urlPathSegment}",
     )


### PR DESCRIPTION
## Ticket number

PRSD-458

## Goal of change

Start every landlord endpoint with `/landlord`. In this PR: DeregisterPropertyController endpoints

## Description of main change(s)

Add /landlord to the start of the endpoints in DeregisterPropertyController

## Anything you'd like to highlight to the reviewer?

This does not complete the ticket (it might be one PR per controller as they could get long otherwise)

## Checklist

Delete any that are not applicable, and add explanation below for any that are applicable but haven't been done

- [x] Test suite has been run in full locally and is passing
- [x] Branch has been rebased onto main and run locally, with everything working as expected (both for your new feature
  and any related functionality)