### PR TITLE
Fix/prsd 1281 use condition for logic

### DIFF
--- a/.run/local-no-server.run.xml
+++ b/.run/local-no-server.run.xml
@@ -1,6 +1,6 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="local-no-server" type="SpringBootApplicationConfigurationType" factoryName="Spring Boot">
-    <option name="ACTIVE_PROFILES" value="local, web-server-deactivated" />
+    <option name="ACTIVE_PROFILES" value="local, web-server-deactivated, example-email-sender" />
     <option name="envFilePaths">
       <option value="$PROJECT_DIR$/.env" />
     </option>

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/annotations/PrsdbController.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/annotations/PrsdbController.kt
@@ -1,10 +1,10 @@
 package uk.gov.communities.prsdb.webapp.annotations
 
-import org.springframework.context.annotation.Profile
+import org.springframework.context.annotation.Conditional
 import org.springframework.core.annotation.AliasFor
 import org.springframework.stereotype.Controller
 
-@Profile("!web-server-deactivated")
+@Conditional(WebServerOnly::class)
 @Controller
 @Target(AnnotationTarget.CLASS)
 @Retention(AnnotationRetention.RUNTIME)

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/annotations/PrsdbRestController.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/annotations/PrsdbRestController.kt
@@ -1,14 +1,14 @@
 package uk.gov.communities.prsdb.webapp.annotations
 
-import org.springframework.context.annotation.Profile
+import org.springframework.context.annotation.Conditional
 import org.springframework.core.annotation.AliasFor
 import org.springframework.stereotype.Controller
 import org.springframework.web.bind.annotation.RestController
 
-@Profile("!web-server-deactivated")
 @RestController
 @Target(AnnotationTarget.CLASS)
 @Retention(AnnotationRetention.RUNTIME)
+@Conditional(WebServerOnly::class)
 annotation class PrsdbRestController(
     @get:AliasFor(annotation = Controller::class) val value: String = "",
 )

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/annotations/PrsdbWebComponent.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/annotations/PrsdbWebComponent.kt
@@ -1,10 +1,10 @@
 package uk.gov.communities.prsdb.webapp.annotations
 
-import org.springframework.context.annotation.Profile
+import org.springframework.context.annotation.Conditional
 import org.springframework.core.annotation.AliasFor
 import org.springframework.stereotype.Component
 
-@Profile("!web-server-deactivated")
+@Conditional(WebServerOnly::class)
 @Component
 @Retention(AnnotationRetention.RUNTIME)
 @Target(AnnotationTarget.CLASS)

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/annotations/PrsdbWebConfiguration.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/annotations/PrsdbWebConfiguration.kt
@@ -1,10 +1,10 @@
 package uk.gov.communities.prsdb.webapp.annotations
 
+import org.springframework.context.annotation.Conditional
 import org.springframework.context.annotation.Configuration
-import org.springframework.context.annotation.Profile
 import org.springframework.core.annotation.AliasFor
 
-@Profile("!web-server-deactivated")
+@Conditional(WebServerOnly::class)
 @Configuration
 @Retention(AnnotationRetention.RUNTIME)
 @Target(AnnotationTarget.CLASS)

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/annotations/PrsdbWebService.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/annotations/PrsdbWebService.kt
@@ -1,10 +1,10 @@
 package uk.gov.communities.prsdb.webapp.annotations
 
-import org.springframework.context.annotation.Profile
+import org.springframework.context.annotation.Conditional
 import org.springframework.core.annotation.AliasFor
 import org.springframework.stereotype.Service
 
-@Profile("!web-server-deactivated")
+@Conditional(WebServerOnly::class)
 @Service
 @Retention(AnnotationRetention.RUNTIME)
 @Target(AnnotationTarget.CLASS)

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/annotations/WebServerOnly.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/annotations/WebServerOnly.kt
@@ -1,0 +1,12 @@
+package uk.gov.communities.prsdb.webapp.annotations
+
+import org.springframework.context.annotation.Condition
+import org.springframework.context.annotation.ConditionContext
+import org.springframework.core.type.AnnotatedTypeMetadata
+
+class WebServerOnly : Condition {
+    override fun matches(
+        context: ConditionContext,
+        metadata: AnnotatedTypeMetadata,
+    ): Boolean = !context.environment.activeProfiles.contains("web-server-deactivated")
+}

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/examples/ExampleEmailSendingApplicationRunner.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/examples/ExampleEmailSendingApplicationRunner.kt
@@ -10,7 +10,7 @@ import uk.gov.communities.prsdb.webapp.models.viewModels.emailModels.ExampleEmai
 import uk.gov.communities.prsdb.webapp.services.EmailNotificationService
 
 @Component
-@Profile("web-server-deactivated")
+@Profile("web-server-deactivated & example-email-sender")
 class ExampleEmailSendingApplicationRunner(
     private val emailSender: EmailNotificationService<ExampleEmail>,
     private val context: ApplicationContext,

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/local/api/controllers/OSPlacesAPIStubController.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/local/api/controllers/OSPlacesAPIStubController.kt
@@ -9,7 +9,7 @@ import uk.gov.communities.prsdb.webapp.constants.MAX_ADDRESSES
 import uk.gov.communities.prsdb.webapp.services.LocalAuthorityService
 import kotlin.math.min
 
-@Profile("local-mock-os-places, !web-server-deactivated")
+@Profile("local-mock-os-places")
 @PrsdbRestController
 @RequestMapping("/local/os-places")
 class OSPlacesAPIStubController(


### PR DESCRIPTION
## Ticket number
PRSD-1281

## Goal of change
Ensure that when the server is deployed that `local` services are not created.


## Anything you'd like to highlight to the reviewer?
The default logic for separate instances of the profile annotation is that if any match the class is added by spring. This means that a `PrsdbWebService` annotated with `@Profile("local")` will (when deployed) still be created because it matches the profile annotation `@Profile("!web-server-deactivated"). This change instead uses an `@Conditional` annotation which defaults to AND logic to be created.

This is why the service is currently down.

## Checklist
- [x] Test suite has been run in full locally and is passing
- [X] Branch has been rebased onto main and run locally, with everything working as expected (both for your new feature
  and any related functionality)
