### PR TITLE
PRSD-458: Precede DeregisterLandlordController endpoints with /landlord

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/DeregisterLandlordController.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/DeregisterLandlordController.kt
@@ -13,6 +13,8 @@ import org.springframework.web.servlet.ModelAndView
 import uk.gov.communities.prsdb.webapp.annotations.PrsdbController
 import uk.gov.communities.prsdb.webapp.constants.CONFIRMATION_PATH_SEGMENT
 import uk.gov.communities.prsdb.webapp.constants.DEREGISTER_LANDLORD_JOURNEY_URL
+import uk.gov.communities.prsdb.webapp.constants.LANDLORD_PATH_SEGMENT
+import uk.gov.communities.prsdb.webapp.controllers.DeregisterLandlordController.Companion.LANDLORD_DEREGISTRATION_ROUTE
 import uk.gov.communities.prsdb.webapp.forms.PageData
 import uk.gov.communities.prsdb.webapp.forms.journeys.LandlordDeregistrationJourney
 import uk.gov.communities.prsdb.webapp.forms.journeys.factories.LandlordDeregistrationJourneyFactory
@@ -23,7 +25,7 @@ import uk.gov.communities.prsdb.webapp.services.LandlordService
 import java.security.Principal
 
 @PrsdbController
-@RequestMapping("/$DEREGISTER_LANDLORD_JOURNEY_URL")
+@RequestMapping(LANDLORD_DEREGISTRATION_ROUTE)
 class DeregisterLandlordController(
     private val landlordDeregistrationJourneyFactory: LandlordDeregistrationJourneyFactory,
     private val landlordService: LandlordService,
@@ -108,6 +110,8 @@ class DeregisterLandlordController(
     companion object {
         const val CHECK_FOR_REGISTERED_PROPERTIES_PATH_SEGMENT = "check-user-properties"
 
-        val LANDLORD_DEREGISTRATION_PATH = "/$DEREGISTER_LANDLORD_JOURNEY_URL/${LandlordDeregistrationJourney.initialStepId.urlPathSegment}"
+        const val LANDLORD_DEREGISTRATION_ROUTE = "/$LANDLORD_PATH_SEGMENT/$DEREGISTER_LANDLORD_JOURNEY_URL"
+
+        val LANDLORD_DEREGISTRATION_PATH = "$LANDLORD_DEREGISTRATION_ROUTE/${LandlordDeregistrationJourney.initialStepId.urlPathSegment}"
     }
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/factories/LandlordDeregistrationJourneyFactory.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/factories/LandlordDeregistrationJourneyFactory.kt
@@ -2,7 +2,7 @@ package uk.gov.communities.prsdb.webapp.forms.journeys.factories
 
 import org.springframework.validation.Validator
 import uk.gov.communities.prsdb.webapp.annotations.PrsdbWebComponent
-import uk.gov.communities.prsdb.webapp.constants.DEREGISTER_LANDLORD_JOURNEY_URL
+import uk.gov.communities.prsdb.webapp.controllers.DeregisterLandlordController
 import uk.gov.communities.prsdb.webapp.forms.journeys.LandlordDeregistrationJourney
 import uk.gov.communities.prsdb.webapp.models.viewModels.emailModels.LandlordNoPropertiesDeregistrationConfirmationEmail
 import uk.gov.communities.prsdb.webapp.models.viewModels.emailModels.LandlordWithPropertiesDeregistrationConfirmationEmail
@@ -25,11 +25,15 @@ class LandlordDeregistrationJourneyFactory(
     fun create() =
         LandlordDeregistrationJourney(
             validator,
-            journeyDataServiceFactory.create(DEREGISTER_LANDLORD_JOURNEY_URL),
+            journeyDataServiceFactory.create(JOURNEY_DATA_KEY),
             landlordDeregistrationService,
             landlordService,
             securityContextService,
             confirmationWithNoPropertiesEmailSender,
             confirmationWithPropertiesEmailSender,
         )
+
+    companion object {
+        const val JOURNEY_DATA_KEY = DeregisterLandlordController.LANDLORD_DEREGISTRATION_ROUTE
+    }
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/controllers/DeregisterLandlordControllerTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/controllers/DeregisterLandlordControllerTests.kt
@@ -14,7 +14,6 @@ import org.springframework.test.web.servlet.get
 import org.springframework.web.context.WebApplicationContext
 import org.springframework.web.servlet.ModelAndView
 import uk.gov.communities.prsdb.webapp.constants.CONFIRMATION_PATH_SEGMENT
-import uk.gov.communities.prsdb.webapp.constants.DEREGISTER_LANDLORD_JOURNEY_URL
 import uk.gov.communities.prsdb.webapp.forms.journeys.LandlordDeregistrationJourney
 import uk.gov.communities.prsdb.webapp.forms.journeys.factories.LandlordDeregistrationJourneyFactory
 import uk.gov.communities.prsdb.webapp.forms.steps.DeregisterLandlordStepId
@@ -91,7 +90,7 @@ class DeregisterLandlordControllerTests(
         whenever(landlordDeregistrationService.getLandlordHadActivePropertiesFromSession()).thenReturn(false)
 
         mvc
-            .get("/$DEREGISTER_LANDLORD_JOURNEY_URL/$CONFIRMATION_PATH_SEGMENT")
+            .get("${DeregisterLandlordController.LANDLORD_DEREGISTRATION_ROUTE}/$CONFIRMATION_PATH_SEGMENT")
             .andExpect { status { isOk() } }
     }
 
@@ -102,7 +101,7 @@ class DeregisterLandlordControllerTests(
             .thenReturn(MockLandlordData.createLandlord())
 
         mvc
-            .get("/$DEREGISTER_LANDLORD_JOURNEY_URL/$CONFIRMATION_PATH_SEGMENT")
+            .get("${DeregisterLandlordController.LANDLORD_DEREGISTRATION_ROUTE}/$CONFIRMATION_PATH_SEGMENT")
             .andExpect { status { is5xxServerError() } }
     }
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/LandlordDeregistrationJourneyTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/LandlordDeregistrationJourneyTests.kt
@@ -9,7 +9,7 @@ import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.springframework.test.context.bean.override.mockito.MockitoBean
 import org.springframework.test.context.bean.override.mockito.MockitoSpyBean
-import uk.gov.communities.prsdb.webapp.constants.DEREGISTER_LANDLORD_JOURNEY_URL
+import uk.gov.communities.prsdb.webapp.controllers.DeregisterLandlordController
 import uk.gov.communities.prsdb.webapp.forms.JourneyData
 import uk.gov.communities.prsdb.webapp.forms.journeys.factories.LandlordDeregistrationJourneyFactory
 import uk.gov.communities.prsdb.webapp.forms.steps.DeregisterLandlordStepId
@@ -179,7 +179,9 @@ class LandlordDeregistrationJourneyTests {
             ) as JourneyData
 
         whenever(mockJourneyDataService.getJourneyDataFromSession()).thenReturn(journeyData)
-        whenever(mockJourneyDataServiceFactory.create(DEREGISTER_LANDLORD_JOURNEY_URL)).thenReturn(mockJourneyDataService)
+        whenever(
+            mockJourneyDataServiceFactory.create(DeregisterLandlordController.LANDLORD_DEREGISTRATION_ROUTE),
+        ).thenReturn(mockJourneyDataService)
         whenever(mockLandlordService.retrieveLandlordByBaseUserId(baseUserId))
             .thenReturn(MockLandlordData.createLandlord(email = "example@email.com"))
 

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/Navigator.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/Navigator.kt
@@ -6,13 +6,13 @@ import com.microsoft.playwright.options.RequestOptions
 import uk.gov.communities.prsdb.webapp.constants.CONFIRMATION_PATH_SEGMENT
 import uk.gov.communities.prsdb.webapp.constants.CONTEXT_ID_URL_PARAMETER
 import uk.gov.communities.prsdb.webapp.constants.DELETE_INCOMPLETE_PROPERTY_PATH_SEGMENT
-import uk.gov.communities.prsdb.webapp.constants.DEREGISTER_LANDLORD_JOURNEY_URL
 import uk.gov.communities.prsdb.webapp.constants.LANDLORD_PATH_SEGMENT
 import uk.gov.communities.prsdb.webapp.constants.REGISTER_LANDLORD_JOURNEY_URL
 import uk.gov.communities.prsdb.webapp.constants.REGISTER_LA_USER_JOURNEY_URL
 import uk.gov.communities.prsdb.webapp.constants.REGISTER_PROPERTY_JOURNEY_URL
 import uk.gov.communities.prsdb.webapp.constants.SYSTEM_OPERATOR_PATH_SEGMENT
 import uk.gov.communities.prsdb.webapp.constants.TASK_LIST_PATH_SEGMENT
+import uk.gov.communities.prsdb.webapp.controllers.DeregisterLandlordController
 import uk.gov.communities.prsdb.webapp.controllers.DeregisterPropertyController
 import uk.gov.communities.prsdb.webapp.controllers.LandlordController.Companion.INCOMPLETE_COMPLIANCES_URL
 import uk.gov.communities.prsdb.webapp.controllers.LandlordController.Companion.INCOMPLETE_PROPERTIES_URL
@@ -1049,7 +1049,7 @@ class Navigator(
     }
 
     fun goToLandlordDeregistrationAreYouSurePage(): AreYouSureFormPageLandlordDeregistration {
-        navigate("/$DEREGISTER_LANDLORD_JOURNEY_URL/${DeregisterLandlordStepId.AreYouSure.urlPathSegment}")
+        navigate("${DeregisterLandlordController.LANDLORD_DEREGISTRATION_ROUTE}/${DeregisterLandlordStepId.AreYouSure.urlPathSegment}")
         return createValidPage(page, AreYouSureFormPageLandlordDeregistration::class)
     }
 

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/landlordDeregistrationJourneyPages/AreYouSureFormPageLandlordDeregistration.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/landlordDeregistrationJourneyPages/AreYouSureFormPageLandlordDeregistration.kt
@@ -1,7 +1,7 @@
 package uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.landlordDeregistrationJourneyPages
 
 import com.microsoft.playwright.Page
-import uk.gov.communities.prsdb.webapp.constants.DEREGISTER_LANDLORD_JOURNEY_URL
+import uk.gov.communities.prsdb.webapp.controllers.DeregisterLandlordController
 import uk.gov.communities.prsdb.webapp.forms.steps.DeregisterLandlordStepId
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages.AreYouSureFormBasePage
 
@@ -9,5 +9,5 @@ class AreYouSureFormPageLandlordDeregistration(
     page: Page,
 ) : AreYouSureFormBasePage(
         page,
-        "/$DEREGISTER_LANDLORD_JOURNEY_URL/${DeregisterLandlordStepId.AreYouSure.urlPathSegment}",
+        "${DeregisterLandlordController.LANDLORD_DEREGISTRATION_ROUTE}/${DeregisterLandlordStepId.AreYouSure.urlPathSegment}",
     )

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/landlordDeregistrationJourneyPages/ConfirmationPageLandlordDeregistration.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/landlordDeregistrationJourneyPages/ConfirmationPageLandlordDeregistration.kt
@@ -2,12 +2,12 @@ package uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.landlordDe
 
 import com.microsoft.playwright.Page
 import uk.gov.communities.prsdb.webapp.constants.CONFIRMATION_PATH_SEGMENT
-import uk.gov.communities.prsdb.webapp.constants.DEREGISTER_LANDLORD_JOURNEY_URL
+import uk.gov.communities.prsdb.webapp.controllers.DeregisterLandlordController
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.ConfirmationBanner
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages.BasePage
 
 class ConfirmationPageLandlordDeregistration(
     page: Page,
-) : BasePage(page, "$DEREGISTER_LANDLORD_JOURNEY_URL/$CONFIRMATION_PATH_SEGMENT") {
+) : BasePage(page, "${DeregisterLandlordController.LANDLORD_DEREGISTRATION_ROUTE}/$CONFIRMATION_PATH_SEGMENT") {
     val confirmationBanner = ConfirmationBanner(page)
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/landlordDeregistrationJourneyPages/ReasonFormPageLandlordDeregistration.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/landlordDeregistrationJourneyPages/ReasonFormPageLandlordDeregistration.kt
@@ -1,10 +1,10 @@
 package uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.landlordDeregistrationJourneyPages
 
 import com.microsoft.playwright.Page
-import uk.gov.communities.prsdb.webapp.constants.DEREGISTER_LANDLORD_JOURNEY_URL
+import uk.gov.communities.prsdb.webapp.controllers.DeregisterLandlordController
 import uk.gov.communities.prsdb.webapp.forms.steps.DeregisterLandlordStepId
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages.ReasonFormPage
 
 class ReasonFormPageLandlordDeregistration(
     page: Page,
-) : ReasonFormPage(page, "/$DEREGISTER_LANDLORD_JOURNEY_URL/${DeregisterLandlordStepId.Reason.urlPathSegment}")
+) : ReasonFormPage(page, "${DeregisterLandlordController.LANDLORD_DEREGISTRATION_ROUTE}/${DeregisterLandlordStepId.Reason.urlPathSegment}")


### PR DESCRIPTION
## Ticket number

PRSD-458

## Goal of change

Start every landlord endpoint with `/landlord`. In this PR: DeregisterLandlordController endpoints

## Description of main change(s)

Add /landlord to the start of the endpoints in DeregisterLandlordController 

## Anything you'd like to highlight to the reviewer?

This does not complete the ticket (it might be one PR per controller as they could get long otherwise)

## Checklist

Delete any that are not applicable, and add explanation below for any that are applicable but haven't been done

- [x] Test suite has been run in full locally and is passing
- [x] Branch has been rebased onto main and run locally, with everything working as expected (both for your new feature
  and any related functionality)