### PR TITLE
PRSD-1281: Add bean registration test for non web mode

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/config/NotifyConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/config/NotifyConfig.kt
@@ -2,10 +2,10 @@ package uk.gov.communities.prsdb.webapp.config
 
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Bean
-import uk.gov.communities.prsdb.webapp.annotations.PrsdbWebConfiguration
+import org.springframework.context.annotation.Configuration
 import uk.gov.service.notify.NotificationClient
 
-@PrsdbWebConfiguration
+@Configuration
 class NotifyConfig {
     @Value("\${notify.api-key}")
     lateinit var apiKey: String

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/NotifyEmailNotificationService.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/NotifyEmailNotificationService.kt
@@ -3,14 +3,14 @@ package uk.gov.communities.prsdb.webapp.services
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
-import uk.gov.communities.prsdb.webapp.annotations.PrsdbWebService
+import org.springframework.stereotype.Service
 import uk.gov.communities.prsdb.webapp.exceptions.PersistentEmailSendException
 import uk.gov.communities.prsdb.webapp.exceptions.TransientEmailSentException
 import uk.gov.communities.prsdb.webapp.models.viewModels.emailModels.EmailTemplateModel
 import uk.gov.service.notify.NotificationClient
 import uk.gov.service.notify.NotificationClientException
 
-@PrsdbWebService
+@Service
 class NotifyEmailNotificationService<EmailModel : EmailTemplateModel>(
     var notificationClient: NotificationClient,
 ) : EmailNotificationService<EmailModel> {

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/PrsdbProcessApplicationTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/PrsdbProcessApplicationTests.kt
@@ -1,0 +1,90 @@
+package uk.gov.communities.prsdb.webapp
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.context.ConfigurableApplicationContext
+import org.springframework.context.annotation.Import
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.context.TestPropertySource
+
+@Import(TestcontainersConfiguration::class)
+@SpringBootTest
+@ActiveProfiles("web-server-deactivated", "local")
+// The EMAILNOTIFICATIONS_APIKEY property is required for the Notify config to load, and even with no value set the beans can be created
+@TestPropertySource(properties = ["EMAILNOTIFICATIONS_APIKEY"])
+class PrsdbProcessApplicationTests {
+    @Autowired
+    private var context: ConfigurableApplicationContext? = null
+
+    @Test
+    fun `only necessary PRSDB beans are available in non web mode`() {
+        val expectedBeanMap =
+            mapOf(
+                "prsdbWebappApplication" to "uk.gov.communities.prsdb.webapp.PrsdbWebappApplication",
+                "notifyConfig" to "uk.gov.communities.prsdb.webapp.config.NotifyConfig$\$SpringCGLIB$$0",
+                "uk.gov.communities.prsdb.webapp.TestcontainersConfiguration" to
+                    "uk.gov.communities.prsdb.webapp.TestcontainersConfiguration",
+                "emailNotificationStubService" to "uk.gov.communities.prsdb.webapp.local.services.EmailNotificationStubService",
+                "notifyEmailNotificationService" to "uk.gov.communities.prsdb.webapp.services.NotifyEmailNotificationService",
+            )
+
+        val beanNameAndClassMap =
+            context!!
+                .beanDefinitionNames
+                .mapNotNull { name -> (name to context!!.beanFactory.getBeanDefinition(name).beanClassName) }
+                .filter { it.second?.contains("uk.gov.communities.prsdb.webapp") ?: false }
+                .associate { it }
+
+        assertEquals(
+            expectedBeanMap,
+            beanNameAndClassMap,
+        ) { buildHelpfulErrorMessage(expectedBeanMap, beanNameAndClassMap) }
+    }
+
+    fun buildHelpfulErrorMessage(
+        expected: Map<String, String>,
+        actual: Map<String, String?>,
+    ): String {
+        val expectedBeansMissing =
+            expected.keys.filter { !actual.containsKey(it) }
+        val unexpectedBeans =
+            actual.keys.filter { !expected.containsKey(it) }
+
+        val combinedMessage =
+            if (expectedBeansMissing.isNotEmpty() && unexpectedBeans.isNotEmpty()) {
+                """There are beans missing that are expected and unexpected beans present in non web server mode.
+                |This could be because some beans have been renamed, or there may be multiple problems that need addressing:
+                """.trimMargin()
+            } else {
+                ""
+            }
+        val missingBeansMessage =
+            if (expectedBeansMissing.isNotEmpty()) {
+                """The following beans expected for non web server mode are missing - check they haven't been changed to web only or removed (or remove them from the expected list):
+                |$expectedBeansMissing
+                """.trimMargin()
+            } else {
+                ""
+            }
+        val unexpectedBeansMessage =
+            if (unexpectedBeans.isNotEmpty()) {
+                """The following beans are being created in non web server mode but have not been added to the expected list. 
+                |For convenience they are formatted as map entries so IF RELEVANT can be copied and pasted into the expected map:
+                |${
+                    unexpectedBeans.joinToString(",\n") { missingName ->
+                        "\"$missingName\" to \"${actual[missingName]}\""
+                    }}
+                |You may need to escape special characters like $.
+                """.trimMargin()
+            } else {
+                ""
+            }
+        return listOfNotNull(
+            combinedMessage,
+            missingBeansMessage,
+            unexpectedBeansMessage,
+        ).joinToString("\n\n")
+    }
+}


### PR DESCRIPTION
## Ticket number
PRSD-1281

## Goal of change
A test to ensure only non-web beans are registered in non-web mode

## Checklist
Delete any that are not applicable, and add explanation below for any that are applicable but haven't been done

- [X] Unit tests for new logic (e.g. new service methods) have been added
- [X] Test suite has been run in full locally and is passing
- [X] Branch has been rebased onto main and run locally, with everything working as expected (both for your new feature
  and any related functionality)