### PR TITLE
PRSD-NONE: Order Integration Tests

### DIFF
--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/IntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/IntegrationTest.kt
@@ -4,6 +4,9 @@ import com.microsoft.playwright.BrowserContext
 import com.microsoft.playwright.Page
 import com.microsoft.playwright.junit.UsePlaywright
 import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.ClassOrderer
+import org.junit.jupiter.api.ClassOrdererContext
+import org.junit.jupiter.api.TestClassOrder
 import org.junit.jupiter.api.TestInstance
 import org.mockito.kotlin.whenever
 import org.springframework.boot.test.context.SpringBootTest
@@ -23,6 +26,7 @@ import uk.gov.communities.prsdb.webapp.integration.pageObjects.Navigator
 import uk.gov.communities.prsdb.webapp.services.AbsoluteUrlProvider
 import uk.gov.communities.prsdb.webapp.services.OneLoginIdentityService
 import uk.gov.service.notify.NotificationClient
+import kotlin.reflect.full.isSubclassOf
 
 @Import(TestcontainersConfiguration::class)
 @SpringBootTest(
@@ -32,6 +36,7 @@ import uk.gov.service.notify.NotificationClient
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @UsePlaywright
 @ActiveProfiles(profiles = ["local", "local-no-auth"])
+@TestClassOrder(IntegrationTest.IntegrationTestOrderer::class)
 abstract class IntegrationTest {
     @LocalServerPort
     val port: Int = 0
@@ -104,6 +109,13 @@ abstract class IntegrationTest {
 
     @TestInstance(TestInstance.Lifecycle.PER_CLASS)
     abstract class NestedIntegrationTest
+
+    class IntegrationTestOrderer : ClassOrderer {
+        override fun orderClasses(context: ClassOrdererContext?) {
+            // Makes NestedIntegrationTests run last
+            context?.classDescriptors?.sortBy { it.testClass.kotlin.isSubclassOf(NestedIntegrationTest::class) }
+        }
+    }
 
     fun createPageAndNavigator(browserContext: BrowserContext): Pair<Page, Navigator> {
         val page = browserContext.newPage()

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/LandlordRegistrationSinglePageTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/LandlordRegistrationSinglePageTests.kt
@@ -6,17 +6,13 @@ import com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat
 import kotlinx.datetime.DatePeriod
 import kotlinx.datetime.minus
 import kotlinx.datetime.plus
-import org.junit.jupiter.api.ClassOrderer
 import org.junit.jupiter.api.Nested
-import org.junit.jupiter.api.Order
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.TestClassOrder
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.CsvSource
 import org.junit.jupiter.params.provider.ValueSource
 import org.mockito.kotlin.any
 import org.mockito.kotlin.whenever
-import org.springframework.core.Ordered
 import uk.gov.communities.prsdb.webapp.helpers.DateTimeHelper
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.BaseComponent
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.ErrorPage
@@ -38,14 +34,10 @@ import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.VerifiedI
 import uk.gov.communities.prsdb.webapp.testHelpers.extensions.getFormattedInternationalPhoneNumber
 import java.time.LocalDate
 
-// We are specifying the order the some of these tests run in to make sure that tests using "data-mockuser-not-landlord.sql"
-// are run before the database is re-seeded with "data-local.sql"
-@TestClassOrder(ClassOrderer.OrderAnnotation::class)
 class LandlordRegistrationSinglePageTests : SinglePageTestWithSeedData("data-mockuser-not-landlord.sql") {
     private val phoneNumberUtil = PhoneNumberUtil.getInstance()
 
     @Nested
-    @Order(1)
     inner class LandlordRegistrationStartPage {
         @Test
         fun `registerAsALandlord page renders`(page: Page) {
@@ -77,7 +69,6 @@ class LandlordRegistrationSinglePageTests : SinglePageTestWithSeedData("data-moc
     }
 
     @Nested
-    @Order(Ordered.LOWEST_PRECEDENCE)
     inner class AlreadyRegistered : NestedSinglePageTestWithSeedData("data-local.sql") {
         @Test
         fun `the 'Start Now' button directs a registered landlord to the landlord dashboard page`(page: Page) {
@@ -89,7 +80,6 @@ class LandlordRegistrationSinglePageTests : SinglePageTestWithSeedData("data-moc
     }
 
     @Nested
-    @Order(Ordered.LOWEST_PRECEDENCE)
     inner class LandlordRegistrationStepVerifyIdentity : NestedSinglePageTestWithSeedData("data-local.sql") {
         @Test
         fun `Navigating here as a registered landlord redirects to the landlord dashboard page`(page: Page) {
@@ -444,7 +434,6 @@ class LandlordRegistrationSinglePageTests : SinglePageTestWithSeedData("data-moc
     }
 
     @Nested
-    @Order(2)
     inner class LandlordRegistrationConfirmation {
         @Test
         fun `Navigating here with an incomplete form returns a 500 error page`(page: Page) {


### PR DESCRIPTION
## Ticket number

PRSD-NONE

## Goal of change

Orders integration tests so ones with different seed data run last

## Description of main change(s)

- Gives integration tests a custom orderer that makes nested tests with seed data run last
- Removes custom `LandlordRegistrationSinglePageTests` as no longer needed

## Anything you'd like to highlight to the reviewer?

N/A

## Checklist

Delete any that are not applicable, and add explanation below for any that are applicable but haven't been done

- [X] Test suite has been run in full locally and is passing
- [X] Branch has been rebased onto main and run locally, with everything working as expected (both for your new feature
  and any related functionality)