### PR TITLE
PRSD-965: Renames Property Compliance Confirmation Message Model

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/PropertyComplianceController.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/PropertyComplianceController.kt
@@ -215,7 +215,7 @@ class PropertyComplianceController(
         val confirmationMessageKeys = PropertyComplianceConfirmationMessageKeys(propertyCompliance)
 
         model.addAttribute("propertyAddress", propertyCompliance.propertyOwnership.property.address.singleLineAddress)
-        model.addAttribute("confirmationMessages", confirmationMessageKeys)
+        model.addAttribute("confirmationMessageKeys", confirmationMessageKeys)
         model.addAttribute("gasSafeRegisterUrl", GAS_SAFE_REGISTER)
         model.addAttribute("rcpElectricalInfoUrl", RCP_ELECTRICAL_INFO_URL)
         model.addAttribute("rcpElectricalRegisterUrl", RCP_ELECTRICAL_REGISTER_URL)

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/PropertyComplianceController.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/PropertyComplianceController.kt
@@ -42,7 +42,7 @@ import uk.gov.communities.prsdb.webapp.helpers.PropertyComplianceJourneyHelper
 import uk.gov.communities.prsdb.webapp.helpers.extensions.FileItemInputIteratorExtensions.Companion.discardRemainingFields
 import uk.gov.communities.prsdb.webapp.helpers.extensions.FileItemInputIteratorExtensions.Companion.getFirstFileField
 import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.UploadCertificateFormModel
-import uk.gov.communities.prsdb.webapp.models.viewModels.PropertyComplianceConfirmationMessages
+import uk.gov.communities.prsdb.webapp.models.viewModels.PropertyComplianceConfirmationMessageKeys
 import uk.gov.communities.prsdb.webapp.services.FileUploader
 import uk.gov.communities.prsdb.webapp.services.PropertyComplianceService
 import uk.gov.communities.prsdb.webapp.services.PropertyOwnershipService
@@ -212,10 +212,10 @@ class PropertyComplianceController(
                 "No property compliance found for property ownership $propertyOwnershipId",
             )
 
-        val confirmationMessages = PropertyComplianceConfirmationMessages(propertyCompliance)
+        val confirmationMessageKeys = PropertyComplianceConfirmationMessageKeys(propertyCompliance)
 
         model.addAttribute("propertyAddress", propertyCompliance.propertyOwnership.property.address.singleLineAddress)
-        model.addAttribute("confirmationMessages", confirmationMessages)
+        model.addAttribute("confirmationMessages", confirmationMessageKeys)
         model.addAttribute("gasSafeRegisterUrl", GAS_SAFE_REGISTER)
         model.addAttribute("rcpElectricalInfoUrl", RCP_ELECTRICAL_INFO_URL)
         model.addAttribute("rcpElectricalRegisterUrl", RCP_ELECTRICAL_REGISTER_URL)
@@ -225,7 +225,7 @@ class PropertyComplianceController(
         model.addAttribute("propertiesWithoutComplianceUrl", INCOMPLETE_COMPLIANCES_URL)
         model.addAttribute("dashboardUrl", LANDLORD_DASHBOARD_URL)
 
-        return if (confirmationMessages.nonCompliantMsgs.isEmpty()) {
+        return if (confirmationMessageKeys.nonCompliantMsgKeys.isEmpty()) {
             "fullyCompliantPropertyConfirmation"
         } else {
             "partiallyCompliantPropertyConfirmation"

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/PropertyComplianceConfirmationMessageKeys.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/PropertyComplianceConfirmationMessageKeys.kt
@@ -2,12 +2,12 @@ package uk.gov.communities.prsdb.webapp.models.viewModels
 
 import uk.gov.communities.prsdb.webapp.database.entity.PropertyCompliance
 
-class PropertyComplianceConfirmationMessages(
+class PropertyComplianceConfirmationMessageKeys(
     private val propertyCompliance: PropertyCompliance,
 ) {
-    val nonCompliantMsgs = listOfNotNull(nonCompliantGasSafetyMsg, nonCompliantEicrMsg, nonCompliantEpcMsg)
+    val nonCompliantMsgKeys = listOfNotNull(nonCompliantGasSafetyMsg, nonCompliantEicrMsg, nonCompliantEpcMsg)
 
-    val compliantMsgs = listOfNotNull(compliantGasSafetyMsg, compliantEicrMsg, compliantEpcMsg, compliantLandlordResponsibilitiesMsg)
+    val compliantMsgKeys = listOfNotNull(compliantGasSafetyMsg, compliantEicrMsg, compliantEpcMsg, compliantLandlordResponsibilitiesMsg)
 
     private val nonCompliantGasSafetyMsg get() =
         when {

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/PropertyComplianceConfirmationMessageKeys.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/PropertyComplianceConfirmationMessageKeys.kt
@@ -5,39 +5,40 @@ import uk.gov.communities.prsdb.webapp.database.entity.PropertyCompliance
 class PropertyComplianceConfirmationMessageKeys(
     private val propertyCompliance: PropertyCompliance,
 ) {
-    val nonCompliantMsgKeys = listOfNotNull(nonCompliantGasSafetyMsg, nonCompliantEicrMsg, nonCompliantEpcMsg)
+    val nonCompliantMsgKeys = listOfNotNull(nonCompliantGasSafetyMsgKey, nonCompliantEicrMsgKey, nonCompliantEpcMsgKey)
 
-    val compliantMsgKeys = listOfNotNull(compliantGasSafetyMsg, compliantEicrMsg, compliantEpcMsg, compliantLandlordResponsibilitiesMsg)
+    val compliantMsgKeys =
+        listOfNotNull(compliantGasSafetyMsgKey, compliantEicrMsgKey, compliantEpcMsgKey, compliantLandlordResponsibilitiesMsgKey)
 
-    private val nonCompliantGasSafetyMsg get() =
+    private val nonCompliantGasSafetyMsgKey get() =
         when {
             propertyCompliance.isGasSafetyCertExpired == true -> "propertyCompliance.confirmation.nonCompliant.bullet.gasSafety.expired"
             propertyCompliance.isGasSafetyCertMissing -> "propertyCompliance.confirmation.nonCompliant.bullet.gasSafety.missing"
             else -> null
         }
 
-    private val compliantGasSafetyMsg get() =
-        if (nonCompliantGasSafetyMsg == null) {
+    private val compliantGasSafetyMsgKey get() =
+        if (nonCompliantGasSafetyMsgKey == null) {
             "propertyCompliance.confirmation.compliant.bullet.gasSafety"
         } else {
             null
         }
 
-    private val nonCompliantEicrMsg get() =
+    private val nonCompliantEicrMsgKey get() =
         when {
             propertyCompliance.isEicrExpired == true -> "propertyCompliance.confirmation.nonCompliant.bullet.eicr.expired"
             propertyCompliance.isEicrMissing -> "propertyCompliance.confirmation.nonCompliant.bullet.eicr.missing"
             else -> null
         }
 
-    private val compliantEicrMsg get() =
-        if (nonCompliantEicrMsg == null) {
+    private val compliantEicrMsgKey get() =
+        if (nonCompliantEicrMsgKey == null) {
             "propertyCompliance.confirmation.compliant.bullet.eicr"
         } else {
             null
         }
 
-    private val nonCompliantEpcMsg get() =
+    private val nonCompliantEpcMsgKey get() =
         when {
             propertyCompliance.isEpcExpiredAndLowRated() -> "propertyCompliance.confirmation.nonCompliant.bullet.epc.expiredAndLowRating"
             propertyCompliance.isEpcExpired == true -> "propertyCompliance.confirmation.nonCompliant.bullet.epc.expired"
@@ -46,14 +47,14 @@ class PropertyComplianceConfirmationMessageKeys(
             else -> null
         }
 
-    private val compliantEpcMsg get() =
-        if (nonCompliantEpcMsg == null) {
+    private val compliantEpcMsgKey get() =
+        if (nonCompliantEpcMsgKey == null) {
             "propertyCompliance.confirmation.compliant.bullet.epc"
         } else {
             null
         }
 
-    private val compliantLandlordResponsibilitiesMsg get() =
+    private val compliantLandlordResponsibilitiesMsgKey get() =
         "propertyCompliance.confirmation.compliant.bullet.responsibilities"
 
     private fun PropertyCompliance.isEpcExpiredAndLowRated(): Boolean = isEpcExpired == true && isEpcRatingLow == true

--- a/src/main/resources/templates/fullyCompliantPropertyConfirmation.html
+++ b/src/main/resources/templates/fullyCompliantPropertyConfirmation.html
@@ -1,5 +1,5 @@
 <!--/*@thymesVar id="propertyAddress" type="java.lang.String"*/-->
-<!--/*@thymesVar id="confirmationMessages" type="uk.gov.communities.prsdb.webapp.models.viewModels.PropertyComplianceConfirmationMessageKeys"*/-->
+<!--/*@thymesVar id="confirmationMessageKeys" type="uk.gov.communities.prsdb.webapp.models.viewModels.PropertyComplianceConfirmationMessageKeys"*/-->
 <!--/*@thymesVar id="propertiesWithoutComplianceUrl" type="java.lang.String"*/-->
 <!--/*@thymesVar id="dashboardUrl" type="java.lang.String"*/-->
 <!DOCTYPE html>
@@ -12,7 +12,7 @@
             <p class="govuk-inset-text" th:text="${propertyAddress}">propertyAddress</p>
             <p class="govuk-body" th:text="#{propertyCompliance.confirmation.compliant.bullet.heading}">propertyCompliance.confirmation.compliant.bullet.heading</p>
             <ul class="govuk-list govuk-list--bullet" data-testid="compliant-messages">
-                <li th:each="compliantMsg : ${confirmationMessages.compliantMsgKeys}" th:text="#{${compliantMsg}}"></li>
+                <li th:each="compliantMsg : ${confirmationMessageKeys.compliantMsgKeys}" th:text="#{${compliantMsg}}"></li>
             </ul>
             <p class="govuk-body" th:text="#{propertyCompliance.fullyCompliantConfirmation.paragraph.two}">propertyCompliance.fullyCompliantConfirmation.paragraph.two</p>
             <section>

--- a/src/main/resources/templates/fullyCompliantPropertyConfirmation.html
+++ b/src/main/resources/templates/fullyCompliantPropertyConfirmation.html
@@ -12,7 +12,7 @@
             <p class="govuk-inset-text" th:text="${propertyAddress}">propertyAddress</p>
             <p class="govuk-body" th:text="#{propertyCompliance.confirmation.compliant.bullet.heading}">propertyCompliance.confirmation.compliant.bullet.heading</p>
             <ul class="govuk-list govuk-list--bullet" data-testid="compliant-messages">
-                <li th:each="compliantMsg : ${confirmationMessageKeys.compliantMsgKeys}" th:text="#{${compliantMsg}}"></li>
+                <li th:each="compliantMsgKey : ${confirmationMessageKeys.compliantMsgKeys}" th:text="#{${compliantMsgKey}}"></li>
             </ul>
             <p class="govuk-body" th:text="#{propertyCompliance.fullyCompliantConfirmation.paragraph.two}">propertyCompliance.fullyCompliantConfirmation.paragraph.two</p>
             <section>

--- a/src/main/resources/templates/fullyCompliantPropertyConfirmation.html
+++ b/src/main/resources/templates/fullyCompliantPropertyConfirmation.html
@@ -1,5 +1,5 @@
 <!--/*@thymesVar id="propertyAddress" type="java.lang.String"*/-->
-<!--/*@thymesVar id="confirmationMessages" type="uk.gov.communities.prsdb.webapp.models.viewModels.PropertyComplianceConfirmationMessages"*/-->
+<!--/*@thymesVar id="confirmationMessages" type="uk.gov.communities.prsdb.webapp.models.viewModels.PropertyComplianceConfirmationMessageKeys"*/-->
 <!--/*@thymesVar id="propertiesWithoutComplianceUrl" type="java.lang.String"*/-->
 <!--/*@thymesVar id="dashboardUrl" type="java.lang.String"*/-->
 <!DOCTYPE html>
@@ -12,7 +12,7 @@
             <p class="govuk-inset-text" th:text="${propertyAddress}">propertyAddress</p>
             <p class="govuk-body" th:text="#{propertyCompliance.confirmation.compliant.bullet.heading}">propertyCompliance.confirmation.compliant.bullet.heading</p>
             <ul class="govuk-list govuk-list--bullet" data-testid="compliant-messages">
-                <li th:each="compliantMsg : ${confirmationMessages.compliantMsgs}" th:text="#{${compliantMsg}}"></li>
+                <li th:each="compliantMsg : ${confirmationMessages.compliantMsgKeys}" th:text="#{${compliantMsg}}"></li>
             </ul>
             <p class="govuk-body" th:text="#{propertyCompliance.fullyCompliantConfirmation.paragraph.two}">propertyCompliance.fullyCompliantConfirmation.paragraph.two</p>
             <section>

--- a/src/main/resources/templates/partiallyCompliantPropertyConfirmation.html
+++ b/src/main/resources/templates/partiallyCompliantPropertyConfirmation.html
@@ -1,5 +1,5 @@
 <!--/*@thymesVar id="propertyAddress" type="java.lang.String"*/-->
-<!--/*@thymesVar id="confirmationMessages" type="uk.gov.communities.prsdb.webapp.models.viewModels.PropertyComplianceConfirmationMessageKeys"*/-->
+<!--/*@thymesVar id="confirmationMessageKeys" type="uk.gov.communities.prsdb.webapp.models.viewModels.PropertyComplianceConfirmationMessageKeys"*/-->
 <!--/*@thymesVar id="gasSafeRegisterUrl" type="java.lang.String"*/-->
 <!--/*@thymesVar id="rcpElectricalInfoUrl" type="java.lang.String"*/-->
 <!--/*@thymesVar id="rcpElectricalRegisterUrl" type="java.lang.String"*/-->
@@ -21,14 +21,14 @@
             <h2 class="govuk-heading-s" th:text="#{propertyCompliance.partiallyCompliantConfirmation.compliant.heading}">propertyCompliance.partiallyCompliantConfirmation.compliant.heading</h2>
             <p class="govuk-body" th:text="#{propertyCompliance.confirmation.compliant.bullet.heading}">propertyCompliance.confirmation.compliant.bullet.heading</p>
             <ul class="govuk-list govuk-list--bullet" data-testid="compliant-messages">
-                <li th:each="compliantMsg : ${confirmationMessages.compliantMsgKeys}" th:text="#{${compliantMsg}}"></li>
+                <li th:each="compliantMsg : ${confirmationMessageKeys.compliantMsgKeys}" th:text="#{${compliantMsg}}"></li>
             </ul>
         </section>
         <section>
             <h2 class="govuk-heading-s" th:text="#{propertyCompliance.partiallyCompliantConfirmation.nonCompliant.heading}">propertyCompliance.partiallyCompliantConfirmation.nonCompliant.heading</h2>
             <p class="govuk-body" th:text="#{propertyCompliance.confirmation.nonCompliant.bullet.heading}">propertyCompliance.confirmation.nonCompliant.bullet.heading</p>
             <ul class="govuk-list govuk-list--bullet" data-testid="non-compliant-messages">
-                <li th:each="nonCompliantMsg : ${confirmationMessages.nonCompliantMsgKeys}" th:text="#{${nonCompliantMsg}}"></li>
+                <li th:each="nonCompliantMsg : ${confirmationMessageKeys.nonCompliantMsgKeys}" th:text="#{${nonCompliantMsg}}"></li>
             </ul>
             <p class="govuk-body" th:text="#{propertyCompliance.partiallyCompliantConfirmation.paragraph.two}">propertyCompliance.partiallyCompliantConfirmation.paragraph.two</p>
             <p class="govuk-body" th:text="#{propertyCompliance.partiallyCompliantConfirmation.paragraph.three}">propertyCompliance.partiallyCompliantConfirmation.paragraph.three</p>

--- a/src/main/resources/templates/partiallyCompliantPropertyConfirmation.html
+++ b/src/main/resources/templates/partiallyCompliantPropertyConfirmation.html
@@ -1,5 +1,5 @@
 <!--/*@thymesVar id="propertyAddress" type="java.lang.String"*/-->
-<!--/*@thymesVar id="confirmationMessages" type="uk.gov.communities.prsdb.webapp.models.viewModels.PropertyComplianceConfirmationMessages"*/-->
+<!--/*@thymesVar id="confirmationMessages" type="uk.gov.communities.prsdb.webapp.models.viewModels.PropertyComplianceConfirmationMessageKeys"*/-->
 <!--/*@thymesVar id="gasSafeRegisterUrl" type="java.lang.String"*/-->
 <!--/*@thymesVar id="rcpElectricalInfoUrl" type="java.lang.String"*/-->
 <!--/*@thymesVar id="rcpElectricalRegisterUrl" type="java.lang.String"*/-->
@@ -21,14 +21,14 @@
             <h2 class="govuk-heading-s" th:text="#{propertyCompliance.partiallyCompliantConfirmation.compliant.heading}">propertyCompliance.partiallyCompliantConfirmation.compliant.heading</h2>
             <p class="govuk-body" th:text="#{propertyCompliance.confirmation.compliant.bullet.heading}">propertyCompliance.confirmation.compliant.bullet.heading</p>
             <ul class="govuk-list govuk-list--bullet" data-testid="compliant-messages">
-                <li th:each="compliantMsg : ${confirmationMessages.compliantMsgs}" th:text="#{${compliantMsg}}"></li>
+                <li th:each="compliantMsg : ${confirmationMessages.compliantMsgKeys}" th:text="#{${compliantMsg}}"></li>
             </ul>
         </section>
         <section>
             <h2 class="govuk-heading-s" th:text="#{propertyCompliance.partiallyCompliantConfirmation.nonCompliant.heading}">propertyCompliance.partiallyCompliantConfirmation.nonCompliant.heading</h2>
             <p class="govuk-body" th:text="#{propertyCompliance.confirmation.nonCompliant.bullet.heading}">propertyCompliance.confirmation.nonCompliant.bullet.heading</p>
             <ul class="govuk-list govuk-list--bullet" data-testid="non-compliant-messages">
-                <li th:each="nonCompliantMsg : ${confirmationMessages.nonCompliantMsgs}" th:text="#{${nonCompliantMsg}}"></li>
+                <li th:each="nonCompliantMsg : ${confirmationMessages.nonCompliantMsgKeys}" th:text="#{${nonCompliantMsg}}"></li>
             </ul>
             <p class="govuk-body" th:text="#{propertyCompliance.partiallyCompliantConfirmation.paragraph.two}">propertyCompliance.partiallyCompliantConfirmation.paragraph.two</p>
             <p class="govuk-body" th:text="#{propertyCompliance.partiallyCompliantConfirmation.paragraph.three}">propertyCompliance.partiallyCompliantConfirmation.paragraph.three</p>

--- a/src/main/resources/templates/partiallyCompliantPropertyConfirmation.html
+++ b/src/main/resources/templates/partiallyCompliantPropertyConfirmation.html
@@ -21,14 +21,14 @@
             <h2 class="govuk-heading-s" th:text="#{propertyCompliance.partiallyCompliantConfirmation.compliant.heading}">propertyCompliance.partiallyCompliantConfirmation.compliant.heading</h2>
             <p class="govuk-body" th:text="#{propertyCompliance.confirmation.compliant.bullet.heading}">propertyCompliance.confirmation.compliant.bullet.heading</p>
             <ul class="govuk-list govuk-list--bullet" data-testid="compliant-messages">
-                <li th:each="compliantMsg : ${confirmationMessageKeys.compliantMsgKeys}" th:text="#{${compliantMsg}}"></li>
+                <li th:each="compliantMsgKey : ${confirmationMessageKeys.compliantMsgKeys}" th:text="#{${compliantMsgKey}}"></li>
             </ul>
         </section>
         <section>
             <h2 class="govuk-heading-s" th:text="#{propertyCompliance.partiallyCompliantConfirmation.nonCompliant.heading}">propertyCompliance.partiallyCompliantConfirmation.nonCompliant.heading</h2>
             <p class="govuk-body" th:text="#{propertyCompliance.confirmation.nonCompliant.bullet.heading}">propertyCompliance.confirmation.nonCompliant.bullet.heading</p>
             <ul class="govuk-list govuk-list--bullet" data-testid="non-compliant-messages">
-                <li th:each="nonCompliantMsg : ${confirmationMessageKeys.nonCompliantMsgKeys}" th:text="#{${nonCompliantMsg}}"></li>
+                <li th:each="nonCompliantMsgKey : ${confirmationMessageKeys.nonCompliantMsgKeys}" th:text="#{${nonCompliantMsgKey}}"></li>
             </ul>
             <p class="govuk-body" th:text="#{propertyCompliance.partiallyCompliantConfirmation.paragraph.two}">propertyCompliance.partiallyCompliantConfirmation.paragraph.two</p>
             <p class="govuk-body" th:text="#{propertyCompliance.partiallyCompliantConfirmation.paragraph.three}">propertyCompliance.partiallyCompliantConfirmation.paragraph.three</p>

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/controllers/PropertyComplianceControllerTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/controllers/PropertyComplianceControllerTests.kt
@@ -34,7 +34,7 @@ import uk.gov.communities.prsdb.webapp.forms.journeys.PropertyComplianceJourney
 import uk.gov.communities.prsdb.webapp.forms.journeys.factories.PropertyComplianceJourneyFactory
 import uk.gov.communities.prsdb.webapp.forms.steps.PropertyComplianceStepId
 import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.UploadCertificateFormModel
-import uk.gov.communities.prsdb.webapp.models.viewModels.PropertyComplianceConfirmationMessages
+import uk.gov.communities.prsdb.webapp.models.viewModels.PropertyComplianceConfirmationMessageKeys
 import uk.gov.communities.prsdb.webapp.services.FileUploader
 import uk.gov.communities.prsdb.webapp.services.PropertyComplianceService
 import uk.gov.communities.prsdb.webapp.services.PropertyOwnershipService
@@ -499,14 +499,14 @@ class PropertyComplianceControllerTests(
         @WithMockUser(roles = ["LANDLORD"])
         fun `getConfirmation returns 200 for if the landlord added compliance details for the property this session`() {
             val propertyCompliance = MockPropertyComplianceData.createPropertyCompliance()
-            val expectedConfirmationMessages = PropertyComplianceConfirmationMessages(propertyCompliance)
+            val expectedConfirmationMessageKeys = PropertyComplianceConfirmationMessageKeys(propertyCompliance)
 
             whenever(propertyComplianceService.wasPropertyComplianceAddedThisSession(validPropertyOwnershipId)).thenReturn(true)
             whenever(propertyComplianceService.getComplianceForProperty(validPropertyOwnershipId)).thenReturn(propertyCompliance)
 
             mvc.get(validPropertyComplianceConfirmationUrl).andExpect {
                 status { isOk() }
-                model { attribute("confirmationMessages", samePropertyValuesAs(expectedConfirmationMessages)) }
+                model { attribute("confirmationMessageKeys", samePropertyValuesAs(expectedConfirmationMessageKeys)) }
                 view { name("fullyCompliantPropertyConfirmation") }
             }
         }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/PropertyComplianceConfirmationMessageKeysTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/PropertyComplianceConfirmationMessageKeysTests.kt
@@ -1,8 +1,8 @@
 package uk.gov.communities.prsdb.webapp.models.viewModels
 
-import org.junit.jupiter.api.Named
+import org.junit.jupiter.api.Named.named
 import org.junit.jupiter.params.ParameterizedTest
-import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.Arguments.arguments
 import org.junit.jupiter.params.provider.MethodSource
 import uk.gov.communities.prsdb.webapp.database.entity.PropertyCompliance
 import uk.gov.communities.prsdb.webapp.testHelpers.builders.PropertyComplianceBuilder
@@ -10,76 +10,61 @@ import kotlin.test.assertEquals
 
 class PropertyComplianceConfirmationMessageKeysTests {
     @ParameterizedTest(name = "when {0}")
-    @MethodSource("providePropertyCompliancesWithNonCompliantMsgs")
-    fun `nonCompliantMsgs align with the PropertyCompliance's status`(
+    @MethodSource("providePropertyCompliancesWithNonCompliantMsgKeys")
+    fun `nonCompliantMsgKeys align with the PropertyCompliance's status`(
         propertyCompliance: PropertyCompliance,
-        expectedNonCompliantMsgs: List<String>,
+        expectedNonCompliantMsgKeys: List<String>,
     ) {
         val viewModel = PropertyComplianceConfirmationMessageKeys(propertyCompliance)
-        assertEquals(expectedNonCompliantMsgs, viewModel.nonCompliantMsgKeys)
+        assertEquals(expectedNonCompliantMsgKeys, viewModel.nonCompliantMsgKeys)
     }
 
     @ParameterizedTest(name = "when {0} certificates are compliant")
-    @MethodSource("providePropertyCompliancesWithCompliantMsgs")
-    fun `compliantMsgs align with the PropertyCompliance's status`(
+    @MethodSource("providePropertyCompliancesWithCompliantMsgKeys")
+    fun `compliantMsgKeys align with the PropertyCompliance's status`(
         propertyCompliance: PropertyCompliance,
-        expectedCompliantMsgs: List<String>,
+        expectedCompliantMsgKeys: List<String>,
     ) {
         val viewModel = PropertyComplianceConfirmationMessageKeys(propertyCompliance)
-        assertEquals(expectedCompliantMsgs, viewModel.compliantMsgKeys)
+        assertEquals(expectedCompliantMsgKeys, viewModel.compliantMsgKeys)
     }
 
     companion object {
         @JvmStatic
-        private fun providePropertyCompliancesWithNonCompliantMsgs() =
+        private fun providePropertyCompliancesWithNonCompliantMsgKeys() =
             arrayOf(
-                Arguments.arguments(
-                    Named.named(
-                        "certificates are in date",
-                        PropertyComplianceBuilder.createWithInDateCerts(),
-                    ),
+                arguments(
+                    named("certificates are in date", PropertyComplianceBuilder.createWithInDateCerts()),
                     emptyList<String>(),
                 ),
-                Arguments.arguments(
-                    Named.named(
-                        "certificates are expired",
-                        PropertyComplianceBuilder.createWithExpiredCerts(),
-                    ),
-                    expiredCertMsgs,
+                arguments(
+                    named("certificates are expired", PropertyComplianceBuilder.createWithExpiredCerts()),
+                    expiredCertMsgKeys,
                 ),
-                Arguments.arguments(
-                    Named.named(
-                        "certificates have exemptions",
-                        PropertyComplianceBuilder.createWithCertExemptions(),
-                    ),
+                arguments(
+                    named("certificates have exemptions", PropertyComplianceBuilder.createWithCertExemptions()),
                     emptyList<String>(),
                 ),
-                Arguments.arguments(
-                    Named.named(
-                        "certificates are missing",
-                        PropertyComplianceBuilder.createWithMissingCerts(),
-                    ),
-                    missingCertMsgs,
+                arguments(
+                    named("certificates are missing", PropertyComplianceBuilder.createWithMissingCerts()),
+                    missingCertMsgKeys,
                 ),
-                Arguments.arguments(Named.named("EPC is low rated", lowRatingEpcPropertyCompliance), lowRatingEpcMsgs),
-                Arguments.arguments(
-                    Named.named(
-                        "EPC is low rated and expired",
-                        expiredAndLowRatingEpcPropertyCompliance,
-                    ),
-                    expiredAndLowRatingEpcMsgs,
+                arguments(
+                    named("EPC is low rated", lowRatingEpcPropertyCompliance),
+                    lowRatingEpcMsgKeys,
+                ),
+                arguments(
+                    named("EPC is low rated and expired", expiredAndLowRatingEpcPropertyCompliance),
+                    expiredAndLowRatingEpcMsgKeys,
                 ),
             )
 
         @JvmStatic
-        private fun providePropertyCompliancesWithCompliantMsgs() =
+        private fun providePropertyCompliancesWithCompliantMsgKeys() =
             arrayOf(
-                Arguments.arguments(
-                    Named.named("all", PropertyComplianceBuilder.createWithInDateCerts()),
-                    allCompliantCertMsgs,
-                ),
-                Arguments.arguments(Named.named("some", lowRatingEpcPropertyCompliance), someCompliantCertMsgs),
-                Arguments.arguments(Named.named("no", PropertyComplianceBuilder().build()), noCompliantCertMsgs),
+                arguments(named("all", PropertyComplianceBuilder.createWithInDateCerts()), allCompliantCertMsgKeys),
+                arguments(named("some", lowRatingEpcPropertyCompliance), someCompliantCertMsgKeys),
+                arguments(named("no", PropertyComplianceBuilder().build()), noCompliantCertMsgKeys),
             )
 
         private val lowRatingEpcPropertyCompliance =
@@ -98,25 +83,25 @@ class PropertyComplianceConfirmationMessageKeysTests {
                 .withLowEpcRating()
                 .build()
 
-        private val expiredCertMsgs =
+        private val expiredCertMsgKeys =
             listOf(
                 "propertyCompliance.confirmation.nonCompliant.bullet.gasSafety.expired",
                 "propertyCompliance.confirmation.nonCompliant.bullet.eicr.expired",
                 "propertyCompliance.confirmation.nonCompliant.bullet.epc.expired",
             )
 
-        private val missingCertMsgs =
+        private val missingCertMsgKeys =
             listOf(
                 "propertyCompliance.confirmation.nonCompliant.bullet.gasSafety.missing",
                 "propertyCompliance.confirmation.nonCompliant.bullet.eicr.missing",
                 "propertyCompliance.confirmation.nonCompliant.bullet.epc.missing",
             )
 
-        private val lowRatingEpcMsgs = listOf("propertyCompliance.confirmation.nonCompliant.bullet.epc.lowRating")
+        private val lowRatingEpcMsgKeys = listOf("propertyCompliance.confirmation.nonCompliant.bullet.epc.lowRating")
 
-        private val expiredAndLowRatingEpcMsgs = listOf("propertyCompliance.confirmation.nonCompliant.bullet.epc.expiredAndLowRating")
+        private val expiredAndLowRatingEpcMsgKeys = listOf("propertyCompliance.confirmation.nonCompliant.bullet.epc.expiredAndLowRating")
 
-        private val allCompliantCertMsgs =
+        private val allCompliantCertMsgKeys =
             listOf(
                 "propertyCompliance.confirmation.compliant.bullet.gasSafety",
                 "propertyCompliance.confirmation.compliant.bullet.eicr",
@@ -124,8 +109,8 @@ class PropertyComplianceConfirmationMessageKeysTests {
                 "propertyCompliance.confirmation.compliant.bullet.responsibilities",
             )
 
-        private val someCompliantCertMsgs = allCompliantCertMsgs - "propertyCompliance.confirmation.compliant.bullet.epc"
+        private val someCompliantCertMsgKeys = allCompliantCertMsgKeys - "propertyCompliance.confirmation.compliant.bullet.epc"
 
-        private val noCompliantCertMsgs = listOf("propertyCompliance.confirmation.compliant.bullet.responsibilities")
+        private val noCompliantCertMsgKeys = listOf("propertyCompliance.confirmation.compliant.bullet.responsibilities")
     }
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/PropertyComplianceConfirmationMessageKeysTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/PropertyComplianceConfirmationMessageKeysTests.kt
@@ -8,15 +8,15 @@ import uk.gov.communities.prsdb.webapp.database.entity.PropertyCompliance
 import uk.gov.communities.prsdb.webapp.testHelpers.builders.PropertyComplianceBuilder
 import kotlin.test.assertEquals
 
-class PropertyComplianceConfirmationMessagesTests {
+class PropertyComplianceConfirmationMessageKeysTests {
     @ParameterizedTest(name = "when {0}")
     @MethodSource("providePropertyCompliancesWithNonCompliantMsgs")
     fun `nonCompliantMsgs align with the PropertyCompliance's status`(
         propertyCompliance: PropertyCompliance,
         expectedNonCompliantMsgs: List<String>,
     ) {
-        val viewModel = PropertyComplianceConfirmationMessages(propertyCompliance)
-        assertEquals(expectedNonCompliantMsgs, viewModel.nonCompliantMsgs)
+        val viewModel = PropertyComplianceConfirmationMessageKeys(propertyCompliance)
+        assertEquals(expectedNonCompliantMsgs, viewModel.nonCompliantMsgKeys)
     }
 
     @ParameterizedTest(name = "when {0} certificates are compliant")
@@ -25,8 +25,8 @@ class PropertyComplianceConfirmationMessagesTests {
         propertyCompliance: PropertyCompliance,
         expectedCompliantMsgs: List<String>,
     ) {
-        val viewModel = PropertyComplianceConfirmationMessages(propertyCompliance)
-        assertEquals(expectedCompliantMsgs, viewModel.compliantMsgs)
+        val viewModel = PropertyComplianceConfirmationMessageKeys(propertyCompliance)
+        assertEquals(expectedCompliantMsgs, viewModel.compliantMsgKeys)
     }
 
     companion object {


### PR DESCRIPTION
## Ticket number

PRSD-965

## Goal of change

Renames property compliance confirmation message model for clarity

## Description of main change(s)

- Clarifies that property compliance confirmation message model "messages" are "message keys"

## Anything you'd like to highlight to the reviewer?

N/A

## Checklist

Delete any that are not applicable, and add explanation below for any that are applicable but haven't been done

- [X] Test suite has been run in full locally and is passing
- [X] Branch has been rebased onto main and run locally, with everything working as expected (both for your new feature
  and any related functionality)