### PR TITLE
Chore/prsd 458 search register and system operator endpoints

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/InviteLocalAuthorityAdminController.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/InviteLocalAuthorityAdminController.kt
@@ -15,7 +15,9 @@ import org.springframework.web.servlet.mvc.support.RedirectAttributes
 import uk.gov.communities.prsdb.webapp.annotations.PrsdbController
 import uk.gov.communities.prsdb.webapp.constants.CONFIRMATION_PATH_SEGMENT
 import uk.gov.communities.prsdb.webapp.constants.INVITE_LA_ADMIN_PATH_SEGMENT
+import uk.gov.communities.prsdb.webapp.constants.LOCAL_AUTHORITY_PATH_SEGMENT
 import uk.gov.communities.prsdb.webapp.constants.SYSTEM_OPERATOR_PATH_SEGMENT
+import uk.gov.communities.prsdb.webapp.controllers.InviteLocalAuthorityAdminController.Companion.INVITE_LA_ADMIN_ROUTE
 import uk.gov.communities.prsdb.webapp.exceptions.TransientEmailSentException
 import uk.gov.communities.prsdb.webapp.models.requestModels.InviteLocalAuthorityAdminModel
 import uk.gov.communities.prsdb.webapp.models.viewModels.emailModels.LocalAuthorityAdminInvitationEmail
@@ -27,7 +29,7 @@ import uk.gov.communities.prsdb.webapp.services.LocalAuthorityService
 
 @PreAuthorize("hasRole('SYSTEM_OPERATOR')")
 @PrsdbController
-@RequestMapping("/$SYSTEM_OPERATOR_PATH_SEGMENT/$INVITE_LA_ADMIN_PATH_SEGMENT")
+@RequestMapping(INVITE_LA_ADMIN_ROUTE)
 class InviteLocalAuthorityAdminController(
     private val localAuthorityService: LocalAuthorityService,
     private val invitationEmailSender: EmailNotificationService<LocalAuthorityAdminInvitationEmail>,
@@ -73,7 +75,7 @@ class InviteLocalAuthorityAdminController(
 
             redirectAttributes.addFlashAttribute("invitedEmailAddress", inviteLocalAuthorityAdminModel.email)
             redirectAttributes.addFlashAttribute("localAuthorityName", localAuthority.name)
-            return "redirect:/$SYSTEM_OPERATOR_PATH_SEGMENT/$INVITE_LA_ADMIN_PATH_SEGMENT/$CONFIRMATION_PATH_SEGMENT"
+            return "redirect:$INVITE_LA_ADMIN_CONFIRMATION_ROUTE"
         } catch (retryException: TransientEmailSentException) {
             bindingResult.reject("addLAUser.error.retryable")
             return "inviteLocalAuthorityAdminUser"
@@ -105,7 +107,7 @@ class InviteLocalAuthorityAdminController(
     }
 
     companion object {
-        const val INVITE_LA_ADMIN_ROUTE = "/$SYSTEM_OPERATOR_PATH_SEGMENT/$INVITE_LA_ADMIN_PATH_SEGMENT"
+        const val INVITE_LA_ADMIN_ROUTE = "/$LOCAL_AUTHORITY_PATH_SEGMENT/$SYSTEM_OPERATOR_PATH_SEGMENT/$INVITE_LA_ADMIN_PATH_SEGMENT"
 
         const val INVITE_LA_ADMIN_CONFIRMATION_ROUTE = "$INVITE_LA_ADMIN_ROUTE/$CONFIRMATION_PATH_SEGMENT"
     }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/SearchRegisterController.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/SearchRegisterController.kt
@@ -131,6 +131,6 @@ class SearchRegisterController(
     companion object {
         const val SEARCH_ROUTE = "/$LOCAL_AUTHORITY_PATH_SEGMENT/$SEARCH_PATH_SEGMENT"
         const val SEARCH_LANDLORD_URL = "$SEARCH_ROUTE/$LANDLORD_PATH_SEGMENT"
-        const val SEARCH_PROPERTY_URL = "$SEARCH_ROUTE//$PROPERTY_PATH_SEGMENT"
+        const val SEARCH_PROPERTY_URL = "$SEARCH_ROUTE/$PROPERTY_PATH_SEGMENT"
     }
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/SearchRegisterController.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/SearchRegisterController.kt
@@ -10,10 +10,12 @@ import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import uk.gov.communities.prsdb.webapp.annotations.PrsdbController
 import uk.gov.communities.prsdb.webapp.constants.LANDLORD_PATH_SEGMENT
+import uk.gov.communities.prsdb.webapp.constants.LOCAL_AUTHORITY_PATH_SEGMENT
 import uk.gov.communities.prsdb.webapp.constants.PROPERTY_PATH_SEGMENT
 import uk.gov.communities.prsdb.webapp.constants.SEARCH_PATH_SEGMENT
 import uk.gov.communities.prsdb.webapp.constants.enums.LicensingType
 import uk.gov.communities.prsdb.webapp.controllers.LocalAuthorityDashboardController.Companion.LOCAL_AUTHORITY_DASHBOARD_URL
+import uk.gov.communities.prsdb.webapp.controllers.SearchRegisterController.Companion.SEARCH_ROUTE
 import uk.gov.communities.prsdb.webapp.helpers.URIQueryBuilder
 import uk.gov.communities.prsdb.webapp.models.requestModels.searchModels.LandlordSearchRequestModel
 import uk.gov.communities.prsdb.webapp.models.requestModels.searchModels.PropertySearchRequestModel
@@ -25,7 +27,7 @@ import uk.gov.communities.prsdb.webapp.services.PropertyOwnershipService
 import java.security.Principal
 
 @PrsdbController
-@RequestMapping("/$SEARCH_PATH_SEGMENT")
+@RequestMapping(SEARCH_ROUTE)
 @PreAuthorize("hasAnyRole('LA_USER', 'LA_ADMIN')")
 class SearchRegisterController(
     private val landlordService: LandlordService,
@@ -128,7 +130,8 @@ class SearchRegisterController(
         }"
 
     companion object {
-        const val SEARCH_LANDLORD_URL = "/$SEARCH_PATH_SEGMENT/$LANDLORD_PATH_SEGMENT"
-        const val SEARCH_PROPERTY_URL = "/$SEARCH_PATH_SEGMENT/$PROPERTY_PATH_SEGMENT"
+        const val SEARCH_ROUTE = "/$LOCAL_AUTHORITY_PATH_SEGMENT/$SEARCH_PATH_SEGMENT"
+        const val SEARCH_LANDLORD_URL = "$SEARCH_ROUTE/$LANDLORD_PATH_SEGMENT"
+        const val SEARCH_PROPERTY_URL = "$SEARCH_ROUTE//$PROPERTY_PATH_SEGMENT"
     }
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/controllers/SearchRegisterControllerTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/controllers/SearchRegisterControllerTests.kt
@@ -30,7 +30,7 @@ class SearchRegisterControllerTests(
 
     @Test
     fun `SearchRegisterController returns a redirect for unauthenticated user`() {
-        mvc.get("/search/landlord").andExpect {
+        mvc.get(SearchRegisterController.SEARCH_LANDLORD_URL).andExpect {
             status { is3xxRedirection() }
         }
     }
@@ -39,7 +39,7 @@ class SearchRegisterControllerTests(
     @WithMockUser
     fun `SearchRegisterController returns 403 for unauthorized user`() {
         mvc
-            .get("/search/landlord")
+            .get(SearchRegisterController.SEARCH_LANDLORD_URL)
             .andExpect {
                 status { isForbidden() }
             }
@@ -49,7 +49,7 @@ class SearchRegisterControllerTests(
     @WithMockUser(roles = ["LA_USER"])
     fun `SearchRegisterController returns 200 for authorized user`() {
         mvc
-            .get("/search/landlord")
+            .get(SearchRegisterController.SEARCH_LANDLORD_URL)
             .andExpect {
                 status { isOk() }
             }
@@ -80,7 +80,7 @@ class SearchRegisterControllerTests(
                 ),
             )
 
-        mvc.get("/search/landlord?searchTerm=PRSDB&page=2").andExpect {
+        mvc.get("${SearchRegisterController.SEARCH_LANDLORD_URL}?searchTerm=PRSDB&page=2").andExpect {
             status { isOk() }
         }
     }
@@ -88,7 +88,7 @@ class SearchRegisterControllerTests(
     @Test
     @WithMockUser(roles = ["LA_USER"])
     fun `searchForLandlords returns 404 if the requested page number is less than 1`() {
-        mvc.get("/search/landlord?searchTerm=PRSDB&page=0").andExpect {
+        mvc.get("${SearchRegisterController.SEARCH_LANDLORD_URL}?searchTerm=PRSDB&page=0").andExpect {
             status { isNotFound() }
         }
     }
@@ -108,7 +108,7 @@ class SearchRegisterControllerTests(
                 ),
             )
 
-        mvc.get("/search/landlord?searchTerm=PRSDB&page=3").andExpect {
+        mvc.get("${SearchRegisterController.SEARCH_LANDLORD_URL}?searchTerm=PRSDB&page=3").andExpect {
             status { is3xxRedirection() }
         }
     }
@@ -130,7 +130,7 @@ class SearchRegisterControllerTests(
             ),
         )
 
-        mvc.get("/search/property?searchTerm=PRSDB&page=2").andExpect {
+        mvc.get("${SearchRegisterController.SEARCH_PROPERTY_URL}?searchTerm=PRSDB&page=2").andExpect {
             status { isOk() }
         }
     }
@@ -138,7 +138,7 @@ class SearchRegisterControllerTests(
     @Test
     @WithMockUser(roles = ["LA_USER"])
     fun `searchForProperties returns 404 if the requested page number is less than 1`() {
-        mvc.get("/search/property?searchTerm=PRSDB&page=0").andExpect {
+        mvc.get("${SearchRegisterController.SEARCH_PROPERTY_URL}?searchTerm=PRSDB&page=0").andExpect {
             status { isNotFound() }
         }
     }
@@ -160,7 +160,7 @@ class SearchRegisterControllerTests(
             ),
         )
 
-        mvc.get("/search/property?searchTerm=PRSDB&page=3").andExpect {
+        mvc.get("${SearchRegisterController.SEARCH_PROPERTY_URL}?searchTerm=PRSDB&page=3").andExpect {
             status { is3xxRedirection() }
         }
     }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/Navigator.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/Navigator.kt
@@ -8,10 +8,10 @@ import uk.gov.communities.prsdb.webapp.constants.CONTEXT_ID_URL_PARAMETER
 import uk.gov.communities.prsdb.webapp.constants.DELETE_INCOMPLETE_PROPERTY_PATH_SEGMENT
 import uk.gov.communities.prsdb.webapp.constants.LANDLORD_PATH_SEGMENT
 import uk.gov.communities.prsdb.webapp.constants.REGISTER_LA_USER_JOURNEY_URL
-import uk.gov.communities.prsdb.webapp.constants.SYSTEM_OPERATOR_PATH_SEGMENT
 import uk.gov.communities.prsdb.webapp.constants.TASK_LIST_PATH_SEGMENT
 import uk.gov.communities.prsdb.webapp.controllers.DeregisterLandlordController
 import uk.gov.communities.prsdb.webapp.controllers.DeregisterPropertyController
+import uk.gov.communities.prsdb.webapp.controllers.InviteLocalAuthorityAdminController
 import uk.gov.communities.prsdb.webapp.controllers.LandlordController.Companion.INCOMPLETE_COMPLIANCES_URL
 import uk.gov.communities.prsdb.webapp.controllers.LandlordController.Companion.INCOMPLETE_PROPERTIES_URL
 import uk.gov.communities.prsdb.webapp.controllers.LandlordController.Companion.LANDLORD_DASHBOARD_URL
@@ -1101,7 +1101,7 @@ class Navigator(
     }
 
     fun goToInviteLaAdmin(): InviteLaAdminPage {
-        navigate("/$SYSTEM_OPERATOR_PATH_SEGMENT/invite-la-admin")
+        navigate(InviteLocalAuthorityAdminController.INVITE_LA_ADMIN_ROUTE)
         return createValidPage(page, InviteLaAdminPage::class)
     }
 

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/Navigator.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/Navigator.kt
@@ -23,6 +23,7 @@ import uk.gov.communities.prsdb.webapp.controllers.PropertyComplianceController
 import uk.gov.communities.prsdb.webapp.controllers.PropertyDetailsController
 import uk.gov.communities.prsdb.webapp.controllers.RegisterLandlordController
 import uk.gov.communities.prsdb.webapp.controllers.RegisterPropertyController
+import uk.gov.communities.prsdb.webapp.controllers.SearchRegisterController
 import uk.gov.communities.prsdb.webapp.forms.JourneyData
 import uk.gov.communities.prsdb.webapp.forms.journeys.factories.LaUserRegistrationJourneyFactory
 import uk.gov.communities.prsdb.webapp.forms.journeys.factories.LandlordDetailsUpdateJourneyFactory
@@ -152,12 +153,12 @@ class Navigator(
     }
 
     fun goToLandlordSearchPage(): SearchLandlordRegisterPage {
-        navigate("/search/landlord")
+        navigate(SearchRegisterController.SEARCH_LANDLORD_URL)
         return createValidPage(page, SearchLandlordRegisterPage::class)
     }
 
     fun goToPropertySearchPage(): SearchPropertyRegisterPage {
-        navigate("/search/property")
+        navigate(SearchRegisterController.SEARCH_PROPERTY_URL)
         return createValidPage(page, SearchPropertyRegisterPage::class)
     }
 

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/SearchLandlordRegisterPage.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/SearchLandlordRegisterPage.kt
@@ -1,13 +1,14 @@
 package uk.gov.communities.prsdb.webapp.integration.pageObjects.pages
 
 import com.microsoft.playwright.Page
+import uk.gov.communities.prsdb.webapp.controllers.SearchRegisterController
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.BackLink
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.Link
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages.SearchRegisterBasePage
 
 class SearchLandlordRegisterPage(
     page: Page,
-) : SearchRegisterBasePage(page, "/search/landlord") {
+) : SearchRegisterBasePage(page, SearchRegisterController.SEARCH_LANDLORD_URL) {
     fun getLandlordLink(rowIndex: Int) = resultTable.getClickableCell(rowIndex, LANDLORD_COL_INDEX).link
 
     fun getPropertySearchLink() = Link(noResultErrorMessage.locator("a"))

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/SearchPropertyRegisterPage.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/SearchPropertyRegisterPage.kt
@@ -1,12 +1,13 @@
 package uk.gov.communities.prsdb.webapp.integration.pageObjects.pages
 
 import com.microsoft.playwright.Page
+import uk.gov.communities.prsdb.webapp.controllers.SearchRegisterController
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.Link
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages.SearchRegisterBasePage
 
 class SearchPropertyRegisterPage(
     page: Page,
-) : SearchRegisterBasePage(page, "/search/property") {
+) : SearchRegisterBasePage(page, SearchRegisterController.SEARCH_PROPERTY_URL) {
     fun getPropertyLink(rowIndex: Int) = resultTable.getClickableCell(rowIndex, PROPERTY_COL_INDEX).link
 
     fun getLandlordLink(rowIndex: Int) = resultTable.getClickableCell(rowIndex, PROPERTY_LANDLORD_COL_INDEX).link


### PR DESCRIPTION
## Ticket number

PRSD-458

## Goal of change

Start every local authority endpoint with `/local_authority`. In this PR: SearchRegister endpoints.
We're also adding  `/local_authority` to the system operator's endpoints for now.

## Description of main change(s)

Add /local-authority to the start of the endpoints in SearchRegister 
`/local_authority` to the system operator's endpoints (this is just InviteLocalAuthorityAdminController)

## Anything you'd like to highlight to the reviewer?

This does not complete the ticket

## Checklist

Delete any that are not applicable, and add explanation below for any that are applicable but haven't been done

- [x] Test suite has been run in full locally and is passing
- [x] Branch has been rebased onto main and run locally, with everything working as expected (both for your new feature
  and any related functionality)
