### PR TITLE
PRSD-1282: Do not add unscanned files to compliance record

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/PropertyComplianceJourney.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/PropertyComplianceJourney.kt
@@ -1504,12 +1504,10 @@ class PropertyComplianceJourney(
         val propertyCompliance =
             propertyComplianceService.createPropertyCompliance(
                 propertyOwnershipId = propertyOwnershipId,
-                gasSafetyCertS3Key = gasSafetyCertFilename,
                 gasSafetyCertIssueDate = filteredJourneyData.getGasSafetyCertIssueDate()?.toJavaLocalDate(),
                 gasSafetyCertEngineerNum = filteredJourneyData.getGasSafetyCertEngineerNum(),
                 gasSafetyCertExemptionReason = filteredJourneyData.getGasSafetyCertExemptionReason(),
                 gasSafetyCertExemptionOtherReason = filteredJourneyData.getGasSafetyCertExemptionOtherReason(),
-                eicrS3Key = eicrFilename,
                 eicrIssueDate = filteredJourneyData.getEicrIssueDate()?.toJavaLocalDate(),
                 eicrExemptionReason = filteredJourneyData.getEicrExemptionReason(),
                 eicrExemptionOtherReason = filteredJourneyData.getEicrExemptionOtherReason(),


### PR DESCRIPTION
## Ticket number
PRSD-1283

## Goal of change
When a file is first uploaded it should not be added to the compliance record.

## Anything you'd like to highlight to the reviewer?
This is the first of several PRs that will result in the eventual scanned and safe uploaded files being re-added to the compliance record.

## Checklist

Delete any that are not applicable, and add explanation below for any that are applicable but haven't been done

- [X] Test suite has been run in full locally and is passing
- [X] Branch has been rebased onto main and run locally, with everything working as expected (both for your new feature
  and any related functionality)
