### PR TITLE
Feat/prsd 1282 move scanned files

### DIFF
--- a/.run/local-no-server.run.xml
+++ b/.run/local-no-server.run.xml
@@ -1,6 +1,6 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="local-no-server" type="SpringBootApplicationConfigurationType" factoryName="Spring Boot">
-    <option name="ACTIVE_PROFILES" value="local, web-server-deactivated, example-scan-processor" />
+    <option name="ACTIVE_PROFILES" value="local, web-server-deactivated, scan-processor" />
     <option name="envFilePaths">
       <option value="$PROJECT_DIR$/.env" />
     </option>

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/application/ProcessScanResultApplicationRunner.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/application/ProcessScanResultApplicationRunner.kt
@@ -1,0 +1,52 @@
+package uk.gov.communities.prsdb.webapp.application
+
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.boot.ApplicationArguments
+import org.springframework.boot.ApplicationRunner
+import org.springframework.boot.SpringApplication
+import org.springframework.context.ApplicationContext
+import org.springframework.context.annotation.Profile
+import org.springframework.stereotype.Component
+import uk.gov.communities.prsdb.webapp.exceptions.PrsdbWebException
+import uk.gov.communities.prsdb.webapp.models.dataModels.ScanResult
+import uk.gov.communities.prsdb.webapp.services.UploadedFilenameParser
+import uk.gov.communities.prsdb.webapp.services.VirusScanProcessingService
+import kotlin.system.exitProcess
+
+@Component
+@Profile("web-server-deactivated & scan-processor")
+class ProcessScanResultApplicationRunner(
+    private val context: ApplicationContext,
+    private val service: VirusScanProcessingService,
+) : ApplicationRunner {
+    @Value("\${SCAN_RESULT_STATUS:DEFAULT}")
+    private lateinit var scanResultStatus: String
+
+    @Value("\${S3_OBJECT_KEY:noObjectSet}")
+    private lateinit var objectKey: String
+
+    @Value("\${S3_QUARANTINE_BUCKET_KEY:noBucketSet}")
+    private lateinit var eventBucketName: String
+
+    @Value("\${aws.s3.quarantineBucket}")
+    private lateinit var quarantineBucketName: String
+
+    override fun run(args: ApplicationArguments?) {
+        if (quarantineBucketName != eventBucketName) {
+            throw PrsdbWebException("Invocation from scan on unexpected bucket: $eventBucketName")
+        }
+
+        val fileNameInfo = UploadedFilenameParser.parse(objectKey)
+        val scanStatus =
+            ScanResult.fromStringValueOrNull(scanResultStatus)
+                ?: throw PrsdbWebException("Unknown guard duty status: $scanResultStatus")
+
+        service.processScan(fileNameInfo, scanStatus)
+
+        val code =
+            SpringApplication.exit(context, { 0 }).also {
+                println("Example email sent successfully. Application will exit now.")
+            }
+        exitProcess(code)
+    }
+}

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/config/S3Config.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/config/S3Config.kt
@@ -1,15 +1,15 @@
 package uk.gov.communities.prsdb.webapp.config
 
 import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
 import software.amazon.awssdk.services.s3.S3AsyncClient
 import software.amazon.awssdk.transfer.s3.S3TransferManager
-import uk.gov.communities.prsdb.webapp.annotations.PrsdbWebConfiguration
 
-@PrsdbWebConfiguration
+@Configuration
 class S3Config {
     @Bean
-    fun s3(): S3TransferManager {
-        val client = S3AsyncClient.crtBuilder().build()
-        return S3TransferManager.builder().s3Client(client).build()
-    }
+    fun s3Client(): S3AsyncClient = S3AsyncClient.crtBuilder().build()
+
+    @Bean
+    fun s3(client: S3AsyncClient): S3TransferManager = S3TransferManager.builder().s3Client(client).build()
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/dataModels/ScanResult.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/dataModels/ScanResult.kt
@@ -1,0 +1,16 @@
+package uk.gov.communities.prsdb.webapp.models.dataModels
+
+enum class ScanResult(
+    val value: String,
+) {
+    NoThreats("NO_THREATS_FOUND"),
+    Threats(" THREATS_FOUND"),
+    Unsupported("UNSUPPORTED"),
+    AccessDenied("ACCESS_DENIED"),
+    Failed("FAILED"),
+    ;
+
+    companion object {
+        fun fromStringValueOrNull(value: String) = ScanResult.entries.singleOrNull { it.value == value }
+    }
+}

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/AwsS3FileDequarantiner.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/AwsS3FileDequarantiner.kt
@@ -4,7 +4,6 @@ import org.springframework.beans.factory.annotation.Value
 import org.springframework.stereotype.Service
 import software.amazon.awssdk.services.s3.S3AsyncClient
 import software.amazon.awssdk.transfer.s3.S3TransferManager
-import uk.gov.communities.prsdb.webapp.exceptions.PrsdbWebException
 
 @Service
 class AwsS3FileDequarantiner(
@@ -33,7 +32,7 @@ class AwsS3FileDequarantiner(
                 .response()
 
         if (!copyResponse.sdkHttpResponse().isSuccessful) {
-            throw PrsdbWebException("Failed to transfer $objectKey to $safeBucketName")
+            return false
         }
 
         val deleteResponse =

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/AwsS3FileDequarantiner.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/AwsS3FileDequarantiner.kt
@@ -1,0 +1,47 @@
+package uk.gov.communities.prsdb.webapp.services
+
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Service
+import software.amazon.awssdk.services.s3.S3AsyncClient
+import software.amazon.awssdk.transfer.s3.S3TransferManager
+import uk.gov.communities.prsdb.webapp.exceptions.PrsdbWebException
+
+@Service
+class AwsS3FileDequarantiner(
+    private val transferManager: S3TransferManager,
+    private val s3Client: S3AsyncClient,
+) : FileDequarantiner {
+    @Value("\${aws.s3.quarantineBucket}")
+    lateinit var quarantineBucketName: String
+
+    @Value("\${S3_SAFE_BUCKET_KEY:noBucketSet}")
+    lateinit var safeBucketName: String
+
+    override fun dequarantine(objectKey: String): Boolean {
+        val copyResponse =
+            transferManager
+                .copy { builder ->
+                    builder.copyObjectRequest { requestBuilder ->
+                        requestBuilder
+                            .sourceBucket(quarantineBucketName)
+                            .sourceKey(objectKey)
+                            .destinationBucket(safeBucketName)
+                            .destinationKey(objectKey)
+                    }
+                }.completionFuture()
+                .join()
+                .response()
+
+        if (!copyResponse.sdkHttpResponse().isSuccessful) {
+            throw PrsdbWebException("Failed to transfer $objectKey to $safeBucketName")
+        }
+
+        val deleteResponse =
+            s3Client
+                .deleteObject { request ->
+                    request.bucket(quarantineBucketName).key(objectKey)
+                }.join()
+
+        return deleteResponse.sdkHttpResponse().isSuccessful
+    }
+}

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/FileDequarantiner.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/FileDequarantiner.kt
@@ -1,0 +1,5 @@
+package uk.gov.communities.prsdb.webapp.services
+
+interface FileDequarantiner {
+    fun dequarantine(objectKey: String): Boolean
+}

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/LocalFileDequarantiner.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/LocalFileDequarantiner.kt
@@ -1,0 +1,18 @@
+package uk.gov.communities.prsdb.webapp.services
+
+import org.springframework.context.annotation.Primary
+import org.springframework.context.annotation.Profile
+import org.springframework.stereotype.Service
+import java.io.File
+
+@Service
+@Primary
+@Profile("local")
+class LocalFileDequarantiner : FileDequarantiner {
+    override fun dequarantine(objectKey: String): Boolean {
+        File(".local-uploads").mkdir()
+        val destinationRoute = ".local-uploads/$objectKey"
+        val destinationFile = File(destinationRoute)
+        return destinationFile.isFile
+    }
+}

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/UploadedFilenameParser.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/UploadedFilenameParser.kt
@@ -1,0 +1,53 @@
+package uk.gov.communities.prsdb.webapp.services
+
+import uk.gov.communities.prsdb.webapp.exceptions.PrsdbWebException
+
+class UploadedFilenameParser {
+    companion object {
+        fun parse(fileName: String): FileNameInfo {
+            val nameAndExtension = fileName.split('.')
+            if (nameAndExtension.size != 2) {
+                throw invalidFilenameException(fileName)
+            }
+
+            val extension = nameAndExtension[1]
+            val nameParts = nameAndExtension[0].split("_")
+            if (nameParts.size < 3) {
+                throw invalidFilenameException(fileName)
+            }
+            val propertyOwnershipId = nameParts[1].toLongOrNull() ?: throw invalidFilenameException(fileName)
+
+            val categoryString = nameParts.drop(2).joinToString("_") { it }
+            val fileCategory = FileCategory.fromCategoryNameOrNull(categoryString) ?: throw invalidFilenameException(fileName)
+
+            return FileNameInfo(
+                propertyOwnershipId,
+                fileCategory,
+                extension,
+            )
+        }
+
+        private fun invalidFilenameException(fileName: String): PrsdbWebException =
+            PrsdbWebException("Filename \"$fileName\" does not have form \"property_{propertyOwnershipId}_{fileCategory}.{extension}\"")
+
+        data class FileNameInfo(
+            val propertyOwnershipId: Long,
+            val fileCategory: FileCategory,
+            val extension: String,
+        ) {
+            fun toObjectKey() = "property_${propertyOwnershipId}_${fileCategory.categoryName}.$extension"
+        }
+
+        enum class FileCategory(
+            val categoryName: String,
+        ) {
+            Eirc("eicr"),
+            GasSafetyCert("gas_safety_certificate"),
+            ;
+
+            companion object {
+                fun fromCategoryNameOrNull(name: String): FileCategory? = FileCategory.entries.singleOrNull { it.categoryName == name }
+            }
+        }
+    }
+}

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/VirusScanProcessingService.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/VirusScanProcessingService.kt
@@ -1,0 +1,25 @@
+package uk.gov.communities.prsdb.webapp.services
+
+import org.springframework.stereotype.Service
+import uk.gov.communities.prsdb.webapp.models.dataModels.ScanResult
+import uk.gov.communities.prsdb.webapp.services.UploadedFilenameParser.Companion.FileNameInfo
+
+@Service
+class VirusScanProcessingService(
+    private val dequarantiner: FileDequarantiner,
+) {
+    fun processScan(
+        fileNameInfo: FileNameInfo,
+        scanResultStatus: ScanResult,
+    ) {
+        when (scanResultStatus) {
+            ScanResult.NoThreats -> {
+                dequarantiner.dequarantine(fileNameInfo.toObjectKey())
+            }
+            ScanResult.Threats -> TODO("PRSD-1284")
+            ScanResult.Unsupported -> TODO("PRSD-1284")
+            ScanResult.AccessDenied -> TODO("PRSD-1284")
+            ScanResult.Failed -> TODO("PRSD-1284")
+        }
+    }
+}

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/VirusScanProcessingService.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/VirusScanProcessingService.kt
@@ -1,6 +1,7 @@
 package uk.gov.communities.prsdb.webapp.services
 
 import org.springframework.stereotype.Service
+import uk.gov.communities.prsdb.webapp.exceptions.PrsdbWebException
 import uk.gov.communities.prsdb.webapp.models.dataModels.ScanResult
 import uk.gov.communities.prsdb.webapp.services.UploadedFilenameParser.Companion.FileNameInfo
 
@@ -14,7 +15,9 @@ class VirusScanProcessingService(
     ) {
         when (scanResultStatus) {
             ScanResult.NoThreats -> {
-                dequarantiner.dequarantine(fileNameInfo.toObjectKey())
+                if (!dequarantiner.dequarantine(fileNameInfo.toObjectKey())) {
+                    throw PrsdbWebException("Failed to dequarantine file: ${fileNameInfo.toObjectKey()}")
+                }
             }
             ScanResult.Threats -> TODO("PRSD-1284")
             ScanResult.Unsupported -> TODO("PRSD-1284")

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/UploadedFilenameParserTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/UploadedFilenameParserTests.kt
@@ -1,0 +1,65 @@
+package uk.gov.communities.prsdb.webapp.services
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Named.named
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.FieldSource
+import org.mockito.Mockito.times
+import uk.gov.communities.prsdb.webapp.exceptions.PrsdbWebException
+import uk.gov.communities.prsdb.webapp.services.UploadedFilenameParser.Companion.FileCategory
+import uk.gov.communities.prsdb.webapp.services.UploadedFilenameParser.Companion.FileNameInfo
+
+class UploadedFilenameParserTests {
+    companion object {
+        @JvmStatic
+        val validFilenames =
+            listOf(
+                Arguments.of(
+                    "property_123_eicr.pdf",
+                    FileNameInfo(
+                        propertyOwnershipId = 123L,
+                        fileCategory = FileCategory.Eirc,
+                        extension = "pdf",
+                    ),
+                ),
+                Arguments.of(
+                    "ignored_456_gas_safety_certificate.jpg",
+                    FileNameInfo(
+                        propertyOwnershipId = 456L,
+                        fileCategory = FileCategory.GasSafetyCert,
+                        extension = "jpg",
+                    ),
+                ),
+            )
+
+        @JvmStatic
+        val invalidFilenames =
+            listOf(
+                named("Missing extension", "property_123_eicr"),
+                named("Has multiple extensions", "property_123_eicr.pdf.txt"),
+                named("Too few name sections", "property_123.pdf"),
+                named("Invalid property ownership ID", "property_abc_eicr.pdf"),
+                named("Invalid file category", "property_123_invalid_category.pdf"),
+                named("Missing first section", "123_gas_safety_certificate.pdf"),
+            )
+    }
+
+    @ParameterizedTest
+    @FieldSource("validFilenames")
+    fun `correctly parses valid filenames`(
+        filename: String,
+        expected: FileNameInfo,
+    ) {
+        val fileNameInfo = UploadedFilenameParser.parse(filename)
+
+        assertEquals(expected, fileNameInfo)
+    }
+
+    @ParameterizedTest
+    @FieldSource("invalidFilenames")
+    fun `throws for invalid filenames`(filename: String) {
+        assertThrows<PrsdbWebException> { UploadedFilenameParser.parse(filename) }
+    }
+}

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/VirusScanProcessingServiceTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/VirusScanProcessingServiceTests.kt
@@ -1,0 +1,60 @@
+package uk.gov.communities.prsdb.webapp.services
+
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.EnumSource
+import org.mockito.Mockito.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import uk.gov.communities.prsdb.webapp.exceptions.PrsdbWebException
+import uk.gov.communities.prsdb.webapp.models.dataModels.ScanResult
+import uk.gov.communities.prsdb.webapp.services.UploadedFilenameParser.Companion.FileCategory
+import uk.gov.communities.prsdb.webapp.services.UploadedFilenameParser.Companion.FileNameInfo
+
+class VirusScanProcessingServiceTests {
+    private lateinit var virusScanProcessingService: VirusScanProcessingService
+    private lateinit var dequarantiner: FileDequarantiner
+
+    @BeforeEach
+    fun setup() {
+        dequarantiner = mock()
+        virusScanProcessingService = VirusScanProcessingService(dequarantiner)
+    }
+
+    @Test
+    fun `processScan calls the dequarantiner when no threats are found`() {
+        val fileNameInfo = FileNameInfo(5L, FileCategory.GasSafetyCert, "txt")
+        val scanResultStatus = ScanResult.NoThreats
+
+        whenever(dequarantiner.dequarantine(fileNameInfo.toObjectKey())).thenReturn(true)
+
+        virusScanProcessingService.processScan(fileNameInfo, scanResultStatus)
+
+        verify(dequarantiner).dequarantine(fileNameInfo.toObjectKey())
+    }
+
+    @Test
+    fun `if the dequarantiner fails the processScan throws an exception`() {
+        val fileNameInfo = FileNameInfo(5L, FileCategory.GasSafetyCert, "txt")
+        val scanResultStatus = ScanResult.NoThreats
+
+        whenever(dequarantiner.dequarantine(fileNameInfo.toObjectKey())).thenReturn(false)
+
+        assertThrows<PrsdbWebException> { virusScanProcessingService.processScan(fileNameInfo, scanResultStatus) }
+    }
+
+    @EnumSource(ScanResult::class)
+    @ParameterizedTest
+    fun `processScan throws an error for each scan result other than NoThreats`(scanResultStatus: ScanResult) {
+        if (scanResultStatus == ScanResult.NoThreats) {
+            return
+        }
+
+        val fileNameInfo = FileNameInfo(5L, FileCategory.GasSafetyCert, "txt")
+        val scanResultStatus = scanResultStatus
+
+        assertThrows<NotImplementedError> { virusScanProcessingService.processScan(fileNameInfo, scanResultStatus) }
+    }
+}


### PR DESCRIPTION
## Ticket number
PRSD-1283

## Goal of change
When a file in the quarantine bucket is scanned and the result is "NO_THREATS_FOUND", that file is copied to the safe bucket and deleted from the quarantine bucket. 

## Description of main change(s)
Adds a new way to run in "web-server-deactivated" mode, by adding the "scan-processor" profile which will look for the relevant event information in environment variables and move the file from the quarantine bucket to the safe bucket.

## Anything you'd like to highlight to the reviewer?
More PRs will follow this to:
* Update the infrastructure to use this new profile setting
* Ensure that the quarantined file name is added to the compliance record where one exists (i.e. virus scanning takes longer than completing the form)
* Ensure that the file name is only added to the compliance record on creation if it is already available in the safe bucket

## Checklist

Delete any that are not applicable, and add explanation below for any that are applicable but haven't been done

- [X] Unit tests for new logic (e.g. new service methods) have been added
- [X] Test suite has been run in full locally and is passing
- [X] Branch has been rebased onto main and run locally, with everything working as expected (both for your new feature
  and any related functionality)
