### PR TITLE
PRSD-962: Use generic submit button when changing answers

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/PropertyComplianceJourney.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/PropertyComplianceJourney.kt
@@ -382,7 +382,7 @@ class PropertyComplianceJourney(
                         content =
                             mapOf(
                                 "title" to "propertyCompliance.title",
-                                "submitButtonText" to "forms.buttons.saveAndContinueToEICR",
+                                "submitButtonText" to getSubmitButtonTextOrDefaultIfChangingAnswer("forms.buttons.saveAndContinueToEICR"),
                             ),
                     ),
                 nextAction = { _, _ -> Pair(eicrTask.startingStepId, null) },
@@ -399,6 +399,7 @@ class PropertyComplianceJourney(
                         content =
                             mapOf(
                                 "title" to "propertyCompliance.title",
+                                "submitButtonText" to getSubmitButtonTextOrDefaultIfChangingAnswer("forms.buttons.saveAndContinueToEICR"),
                             ),
                     ),
                 nextAction = { _, _ -> Pair(eicrTask.startingStepId, null) },
@@ -498,6 +499,7 @@ class PropertyComplianceJourney(
                         content =
                             mapOf(
                                 "title" to "propertyCompliance.title",
+                                "submitButtonText" to getSubmitButtonTextOrDefaultIfChangingAnswer("forms.buttons.saveAndContinueToEICR"),
                             ),
                     ),
                 nextAction = { _, _ -> Pair(eicrTask.startingStepId, null) },
@@ -514,6 +516,7 @@ class PropertyComplianceJourney(
                         content =
                             mapOf(
                                 "title" to "propertyCompliance.title",
+                                "submitButtonText" to getSubmitButtonTextOrDefaultIfChangingAnswer("forms.buttons.saveAndContinueToEICR"),
                             ),
                     ),
                 nextAction = { _, _ -> Pair(eicrTask.startingStepId, null) },
@@ -597,7 +600,7 @@ class PropertyComplianceJourney(
                         content =
                             mapOf(
                                 "title" to "propertyCompliance.title",
-                                "submitButtonText" to "forms.buttons.saveAndContinueToEPC",
+                                "submitButtonText" to getSubmitButtonTextOrDefaultIfChangingAnswer("forms.buttons.saveAndContinueToEPC"),
                             ),
                     ),
                 nextAction = { _, _ -> Pair(epcTask.startingStepId, null) },
@@ -616,6 +619,7 @@ class PropertyComplianceJourney(
                                 "title" to "propertyCompliance.title",
                                 "rcpElectricalInfoUrl" to RCP_ELECTRICAL_INFO_URL,
                                 "rcpElectricalRegisterUrl" to RCP_ELECTRICAL_REGISTER_URL,
+                                "submitButtonText" to getSubmitButtonTextOrDefaultIfChangingAnswer("forms.buttons.saveAndContinueToEPC"),
                             ),
                     ),
                 nextAction = { _, _ -> Pair(epcTask.startingStepId, null) },
@@ -719,6 +723,7 @@ class PropertyComplianceJourney(
                         content =
                             mapOf(
                                 "title" to "propertyCompliance.title",
+                                "submitButtonText" to getSubmitButtonTextOrDefaultIfChangingAnswer("forms.buttons.saveAndContinueToEPC"),
                             ),
                     ),
                 nextAction = { _, _ -> Pair(epcTask.startingStepId, null) },
@@ -737,6 +742,7 @@ class PropertyComplianceJourney(
                                 "title" to "propertyCompliance.title",
                                 "rcpElectricalInfoUrl" to RCP_ELECTRICAL_INFO_URL,
                                 "rcpElectricalRegisterUrl" to RCP_ELECTRICAL_REGISTER_URL,
+                                "submitButtonText" to getSubmitButtonTextOrDefaultIfChangingAnswer("forms.buttons.saveAndContinueToEPC"),
                             ),
                     ),
                 nextAction = { _, _ -> Pair(epcTask.startingStepId, null) },
@@ -792,6 +798,8 @@ class PropertyComplianceJourney(
                                 "title" to "propertyCompliance.title",
                                 "findEpcUrl" to FIND_EPC_URL,
                                 "getNewEpcUrl" to GET_NEW_EPC_URL,
+                                "submitButtonText" to
+                                    getSubmitButtonTextOrDefaultIfChangingAnswer("forms.buttons.saveAndContinueToLandlordResponsibilities"),
                             ),
                     ),
                 nextAction = { _, _ -> Pair(landlordResponsibilities.first().startingStepId, null) },
@@ -935,6 +943,8 @@ class PropertyComplianceJourney(
                         content =
                             mapOf(
                                 "title" to "propertyCompliance.title",
+                                "submitButtonText" to
+                                    getSubmitButtonTextOrDefaultIfChangingAnswer("forms.buttons.saveAndContinueToLandlordResponsibilities"),
                             ),
                     ),
                 nextAction = { _, _ -> Pair(landlordResponsibilities.first().startingStepId, null) },
@@ -1028,6 +1038,10 @@ class PropertyComplianceJourney(
                                 "registerMeesExemptionUrl" to REGISTER_PRS_EXEMPTION_URL,
                                 "epcImprovementGuideUrl" to EPC_IMPROVEMENT_GUIDE_URL,
                                 "expiryDateAsJavaLocalDate" to (getAcceptedEpcDetailsFromSession()?.expiryDateAsJavaLocalDate ?: ""),
+                                "submitButtonText" to
+                                    getSubmitButtonTextOrDefaultIfChangingAnswer(
+                                        "forms.buttons.saveAndContinueToLandlordResponsibilities",
+                                    ),
                             ),
                     ),
                 nextAction = { _, _ -> Pair(landlordResponsibilities.first().startingStepId, null) },
@@ -1135,6 +1149,10 @@ class PropertyComplianceJourney(
                         content =
                             mapOf(
                                 "title" to "propertyCompliance.title",
+                                "submitButtonText" to
+                                    getSubmitButtonTextOrDefaultIfChangingAnswer(
+                                        "forms.buttons.saveAndContinueToLandlordResponsibilities",
+                                    ),
                             ),
                     ),
                 nextAction = { _, _ -> Pair(landlordResponsibilities.first().startingStepId, null) },
@@ -1153,6 +1171,10 @@ class PropertyComplianceJourney(
                                 "title" to "propertyCompliance.title",
                                 "epcImprovementGuideUrl" to EPC_IMPROVEMENT_GUIDE_URL,
                                 "registerPrsExemptionUrl" to REGISTER_PRS_EXEMPTION_URL,
+                                "submitButtonText" to
+                                    getSubmitButtonTextOrDefaultIfChangingAnswer(
+                                        "forms.buttons.saveAndContinueToLandlordResponsibilities",
+                                    ),
                             ),
                     ),
                 nextAction = { _, _ -> Pair(landlordResponsibilities.first().startingStepId, null) },
@@ -1553,6 +1575,13 @@ class PropertyComplianceJourney(
         propertyOwnershipService
             .getPropertyOwnership(propertyOwnershipId)
             .property.address.singleLineAddress
+
+    private fun getSubmitButtonTextOrDefaultIfChangingAnswer(submitButtonText: String) =
+        if (isChangingAnswer) {
+            "forms.buttons.saveAndContinue"
+        } else {
+            submitButtonText
+        }
 
     private fun sendConfirmationEmail(propertyCompliance: PropertyCompliance) {
         val landlordEmail = propertyCompliance.propertyOwnership.primaryLandlord.email

--- a/src/main/resources/templates/forms/eicrExemptionConfirmationForm.html
+++ b/src/main/resources/templates/forms/eicrExemptionConfirmationForm.html
@@ -2,6 +2,7 @@
 <!--/*@thymesVar id="formModel" type="java.lang.Object"*/-->
 <!--/*@thymesVar id="backUrl" type="java.lang.String"*/-->
 <!--/*@thymesVar id="sectionHeaderInfo" type="uk.gov.communities.prsdb.webapp.models.viewModels.SectionHeaderViewModel"*/-->
+<!--/*@thymesVar id="submitButtonText" type="java.lang.String"*/-->
 <!DOCTYPE html>
 <html id="form-content" th:replace="~{fragments/forms/questionPage :: questionPage(#{${title}}, ${formModel}, ~{::#form-content/content()}, ${backUrl}, ${sectionHeaderInfo})}">
   <header>
@@ -12,5 +13,5 @@
     <p class="govuk-body" th:text="#{forms.eicrExemptionConfirmation.paragraph.two}">forms.eicrExemptionConfirmation.paragraph.two</p>
     <p class="govuk-body" th:text="#{forms.eicrExemptionConfirmation.paragraph.three}">forms.eicrExemptionConfirmation.paragraph.three</p>
   </section>
-  <button th:replace="~{fragments/buttons/primaryButton :: primaryButton(#{forms.buttons.saveAndContinueToEPC})}"></button>
+  <button th:replace="~{fragments/buttons/primaryButton :: primaryButton(#{${submitButtonText}})}"></button>
 </html>

--- a/src/main/resources/templates/forms/eicrExemptionMissingForm.html
+++ b/src/main/resources/templates/forms/eicrExemptionMissingForm.html
@@ -4,6 +4,7 @@
 <!--/*@thymesVar id="sectionHeaderInfo" type="uk.gov.communities.prsdb.webapp.models.viewModels.SectionHeaderViewModel"*/-->
 <!--/*@thymesVar id="rcpElectricalInfoUrl" type="java.lang.String"*/-->
 <!--/*@thymesVar id="rcpElectricalRegisterUrl" type="java.lang.String"*/-->
+<!--/*@thymesVar id="submitButtonText" type="java.lang.String"*/-->
 <!DOCTYPE html>
 <html id="form-content" th:replace="~{fragments/forms/questionPage :: questionPage(#{${title}}, ${formModel}, ~{::#form-content/content()}, ${backUrl}, ${sectionHeaderInfo})}">
     <header>
@@ -34,5 +35,5 @@
         <p class="govuk-body" th:text="#{forms.eicrExemptionMissing.subsection.paragraph.one}">forms.eicrExemptionMissing.subsection.paragraph.one</p>
         <p class="govuk-body" th:text="#{forms.eicrExemptionMissing.subsection.paragraph.two}">forms.eicrExemptionMissing.subsection.paragraph.two</p>
     </section>
-    <button th:replace="~{fragments/buttons/primaryButton :: primaryButton(#{forms.buttons.saveAndContinueToEPC})}"></button>
+    <button th:replace="~{fragments/buttons/primaryButton :: primaryButton(#{${submitButtonText}})}"></button>
 </html>

--- a/src/main/resources/templates/forms/eicrOutdatedForm.html
+++ b/src/main/resources/templates/forms/eicrOutdatedForm.html
@@ -4,6 +4,7 @@
 <!--/*@thymesVar id="sectionHeaderInfo" type="uk.gov.communities.prsdb.webapp.models.viewModels.SectionHeaderViewModel"*/-->
 <!--/*@thymesVar id="rcpElectricalInfoUrl" type="java.lang.String"*/-->
 <!--/*@thymesVar id="rcpElectricalRegisterUrl" type="java.lang.String"*/-->
+<!--/*@thymesVar id="submitButtonText" type="java.lang.String"*/-->
 <!DOCTYPE html>
 <html id="form-content" th:replace="~{fragments/forms/questionPage :: questionPage(#{${title}}, ${formModel}, ~{::#form-content/content()}, ${backUrl}, ${sectionHeaderInfo})}">
     <header>
@@ -30,5 +31,5 @@
         <p class="govuk-body" th:text="#{forms.eicrOutdated.paragraph.four}">forms.eicrOutdated.paragraph.four</p>
         <p class="govuk-body" th:text="#{forms.eicrOutdated.paragraph.five}">forms.eicrOutdated.paragraph.five</p>
     </section>
-    <button th:replace="~{fragments/buttons/primaryButton :: primaryButton(#{forms.buttons.saveAndContinueToEPC})}"></button>
+    <button th:replace="~{fragments/buttons/primaryButton :: primaryButton(#{${submitButtonText}})}"></button>
 </html>

--- a/src/main/resources/templates/forms/epcExemptionConfirmationForm.html
+++ b/src/main/resources/templates/forms/epcExemptionConfirmationForm.html
@@ -2,15 +2,16 @@
 <!--/*@thymesVar id="formModel" type="java.lang.Object"*/-->
 <!--/*@thymesVar id="backUrl" type="java.lang.String"*/-->
 <!--/*@thymesVar id="sectionHeaderInfo" type="uk.gov.communities.prsdb.webapp.models.viewModels.SectionHeaderViewModel"*/-->
+<!--/*@thymesVar id="submitButtonText" type="java.lang.String"*/-->
 <!DOCTYPE html>
 <html id="form-content" th:replace="~{fragments/forms/questionPage :: questionPage(#{${title}}, ${formModel}, ~{::#form-content/content()}, ${backUrl}, ${sectionHeaderInfo})}">
-<header>
-    <h1 class="govuk-heading-l" th:text="#{forms.epcExemptionConfirmation.heading}">forms.epcExemptionConfirmation.heading</h1>
-</header>
-<section>
-    <p class="govuk-body" th:text="#{forms.epcExemptionConfirmation.paragraph.one}">forms.epcExemptionConfirmation.paragraph.one</p>
-    <p class="govuk-body" th:text="#{forms.epcExemptionConfirmation.paragraph.two}">forms.epcExemptionConfirmation.paragraph.two</p>
-    <p class="govuk-body" th:text="#{forms.epcExemptionConfirmation.paragraph.three}">forms.epcExemptionConfirmation.paragraph.three</p>
-</section>
-<button th:replace="~{fragments/buttons/primaryButton :: primaryButton(#{forms.buttons.saveAndContinueToLandlordResponsibilities})}"></button>
+    <header>
+        <h1 class="govuk-heading-l" th:text="#{forms.epcExemptionConfirmation.heading}">forms.epcExemptionConfirmation.heading</h1>
+    </header>
+    <section>
+        <p class="govuk-body" th:text="#{forms.epcExemptionConfirmation.paragraph.one}">forms.epcExemptionConfirmation.paragraph.one</p>
+        <p class="govuk-body" th:text="#{forms.epcExemptionConfirmation.paragraph.two}">forms.epcExemptionConfirmation.paragraph.two</p>
+        <p class="govuk-body" th:text="#{forms.epcExemptionConfirmation.paragraph.three}">forms.epcExemptionConfirmation.paragraph.three</p>
+    </section>
+    <button th:replace="~{fragments/buttons/primaryButton :: primaryButton(#{${submitButtonText}})}"></button>
 </html>

--- a/src/main/resources/templates/forms/epcExpiredForm.html
+++ b/src/main/resources/templates/forms/epcExpiredForm.html
@@ -4,20 +4,21 @@
 <!--/*@thymesVar id="sectionHeaderInfo" type="uk.gov.communities.prsdb.webapp.models.viewModels.SectionHeaderViewModel"*/-->
 <!--/*@thymesVar id="getNewEpcUrl" type="java.lang.String"*/-->
 <!--/*@thymesVar id="expiryDateAsJavaLocalDate" type="java.lang.Object"*/-->
+<!--/*@thymesVar id="submitButtonText" type="java.lang.String"*/-->
 <!DOCTYPE html>
 <html id="form-content" th:replace="~{fragments/forms/questionPage :: questionPage(#{${title}}, ${formModel}, ~{::#form-content/content()}, ${backUrl}, ${sectionHeaderInfo})}">
-<header>
-    <h1 class="govuk-heading-l" th:text="#{forms.epcExpired.heading}">forms.epcExpired.heading</h1>
-</header>
-<section>
-    <p class="govuk-body">
-        <span th:remove="tag" th:text="#{forms.epcExpired.paragraph.one.beforeLink(${{expiryDateAsJavaLocalDate}})}">forms.epcExpired.paragraph.one.beforeLink</span>
-        <a class="govuk-link" th:text="#{forms.epcExpired.paragraph.one.link}" th:href="${getNewEpcUrl}" rel="noreferrer noopener" target="_blank">
-            forms.epcExpired.paragraph.one.link
-        </a>
-    </p>
-    <p class="govuk-body" th:text="#{forms.epcExpired.paragraph.two}">forms.epcExpired.paragraph.two</p>
-    <p class="govuk-body" th:text="#{forms.epcExpired.paragraph.three}">forms.epcExpired.paragraph.three</p>
-</section>
-<button th:replace="~{fragments/buttons/primaryButton :: primaryButton(#{forms.buttons.saveAndContinueToLandlordResponsibilities})}"></button>
+    <header>
+        <h1 class="govuk-heading-l" th:text="#{forms.epcExpired.heading}">forms.epcExpired.heading</h1>
+    </header>
+    <section>
+        <p class="govuk-body">
+            <span th:remove="tag" th:text="#{forms.epcExpired.paragraph.one.beforeLink(${{expiryDateAsJavaLocalDate}})}">forms.epcExpired.paragraph.one.beforeLink</span>
+            <a class="govuk-link" th:text="#{forms.epcExpired.paragraph.one.link}" th:href="${getNewEpcUrl}" rel="noreferrer noopener" target="_blank">
+                forms.epcExpired.paragraph.one.link
+            </a>
+        </p>
+        <p class="govuk-body" th:text="#{forms.epcExpired.paragraph.two}">forms.epcExpired.paragraph.two</p>
+        <p class="govuk-body" th:text="#{forms.epcExpired.paragraph.three}">forms.epcExpired.paragraph.three</p>
+    </section>
+    <button th:replace="~{fragments/buttons/primaryButton :: primaryButton(#{${submitButtonText}})}"></button>
 </html>

--- a/src/main/resources/templates/forms/epcExpiredLowRatingForm.html
+++ b/src/main/resources/templates/forms/epcExpiredLowRatingForm.html
@@ -7,45 +7,48 @@
 <!--/*@thymesVar id="registerMeesExemptionUrl" type="java.lang.String"*/-->
 <!--/*@thymesVar id="epcImprovementGuideUrl" type="java.lang.String"*/-->
 <!--/*@thymesVar id="expiryDateAsJavaLocalDate" type="java.lang.Object"*/-->
+<!--/*@thymesVar id="submitButtonText" type="java.lang.String"*/-->
 <!DOCTYPE html>
 <html id="form-content" th:replace="~{fragments/forms/questionPage :: questionPage(#{${title}}, ${formModel}, ~{::#form-content/content()}, ${backUrl}, ${sectionHeaderInfo})}">
-<header>
-    <h1 class="govuk-heading-l" th:text="#{forms.epcExpiredLowRating.heading}">forms.epcExpired.heading</h1>
-</header>
-<section>
-    <p class="govuk-body" th:text="#{forms.epcExpiredLowRating.paragraph.one(${{expiryDateAsJavaLocalDate}})}">forms.epcExpiredLowRating.paragraph.one</p>
-    <p class="govuk-body" th:text="#{forms.epcExpiredLowRating.paragraph.two(${{expiryDateAsJavaLocalDate}})}">forms.epcExpiredLowRating.paragraph.two</p>
-    <p class="govuk-body">
-        <span th:remove="tag" th:text="#{forms.epcExpiredLowRating.paragraph.three.beforeLink}">forms.epcExpiredLowRating.paragraph.three.beforeLink</span>
-        <a class="govuk-link" th:text="#{forms.epcExpiredLowRating.paragraph.three.link}" th:href="${getNewEpcUrl}" rel="noreferrer noopener" target="_blank">
-            forms.epcExpiredLowRating.paragraph.three.link
-        </a>
-    </p>
-</section>
-<section>
-    <h2 class="govuk-heading-s" th:text="#{forms.epcExpiredLowRating.beforeYouGetNewEpc.heading}">forms.epcExpiredLowRating.beforeYouGetNewEpc.heading</h2>
-    <p class="govuk-body">
-        <span th:remove="tag" th:text="#{forms.epcExpiredLowRating.beforeYouGetNewEpc.paragraph.one.beforeLink}">forms.epcExpiredLowRating.beforeYouGetNewEpc.paragraph.one.beforeLink</span>
-        <a class="govuk-link" th:text="#{forms.epcExpiredLowRating.beforeYouGetNewEpc.paragraph.one.link}" th:href="${meesExemptionGuideUrl}" rel="noreferrer noopener" target="_blank">
-            forms.epcExpiredLowRating.beforeYouGetNewEpc.paragraph.one.link
-        </a>
-        <span th:remove="tag" th:text="#{forms.epcExpiredLowRating.beforeYouGetNewEpc.paragraph.one.afterLink}">forms.epcExpiredLowRating.beforeYouGetNewEpc.paragraph.one.afterLink</span>
-    </p>
-    <p class="govuk-body" th:text="#{forms.epcExpiredLowRating.beforeYouGetNewEpc.paragraph.two}">forms.epcExpiredLowRating.beforeYouGetNewEpc.paragraph.two</p>
-    <p class="govuk-body" th:text="#{forms.epcExpiredLowRating.beforeYouGetNewEpc.paragraph.three}">forms.epcExpiredLowRating.beforeYouGetNewEpc.paragraph.three</p>
-    <ul class="govuk-list govuk-list--bullet">
-        <li th:text="#{forms.epcExpiredLowRating.beforeYouGetNewEpc.bullet.one}">forms.epcExpiredLowRating.beforeYouGetNewEpc.bullet.one</li>
-        <li><a class="govuk-link" th:text="#{forms.epcExpiredLowRating.beforeYouGetNewEpc.bullet.two.link}" th:href="${registerMeesExemptionUrl}" rel="noreferrer noopener" target="_blank">
-            forms.epcExpiredLowRating.beforeYouGetNewEpc.bullet.two.link
-        </a></li>
-    </ul>
-    <p class="govuk-body">
-        <span th:remove="tag" th:text="#{forms.epcExpiredLowRating.beforeYouGetNewEpc.paragraph.four.beforeLink}">forms.epcExpiredLowRating.beforeYouGetNewEpc.paragraph.four.beforeLink</span>
-        <a class="govuk-link" th:text="#{forms.epcExpiredLowRating.beforeYouGetNewEpc.paragraph.four.link}" th:href="${epcImprovementGuideUrl}" rel="noreferrer noopener" target="_blank">
-            forms.epcExpiredLowRating.beforeYouGetNewEpc.paragraph.four.link
-        </a>
-    </p>
-    <p class="govuk-body" th:text="#{forms.epcExpiredLowRating.beforeYouGetNewEpc.paragraph.five}">forms.epcExpiredLowRating.beforeYouGetNewEpc.paragraph.five</p>
-</section>
-<button th:replace="~{fragments/buttons/primaryButton :: primaryButton(#{forms.buttons.saveAndContinueToLandlordResponsibilities})}"></button>
+    <header>
+        <h1 class="govuk-heading-l" th:text="#{forms.epcExpiredLowRating.heading}">forms.epcExpired.heading</h1>
+    </header>
+    <section>
+        <p class="govuk-body" th:text="#{forms.epcExpiredLowRating.paragraph.one(${{expiryDateAsJavaLocalDate}})}">forms.epcExpiredLowRating.paragraph.one</p>
+        <p class="govuk-body" th:text="#{forms.epcExpiredLowRating.paragraph.two(${{expiryDateAsJavaLocalDate}})}">forms.epcExpiredLowRating.paragraph.two</p>
+        <p class="govuk-body">
+            <span th:remove="tag" th:text="#{forms.epcExpiredLowRating.paragraph.three.beforeLink}">forms.epcExpiredLowRating.paragraph.three.beforeLink</span>
+            <a class="govuk-link" th:text="#{forms.epcExpiredLowRating.paragraph.three.link}" th:href="${getNewEpcUrl}" rel="noreferrer noopener" target="_blank">
+                forms.epcExpiredLowRating.paragraph.three.link
+            </a>
+        </p>
+    </section>
+    <section>
+        <h2 class="govuk-heading-s" th:text="#{forms.epcExpiredLowRating.beforeYouGetNewEpc.heading}">forms.epcExpiredLowRating.beforeYouGetNewEpc.heading</h2>
+        <p class="govuk-body">
+            <span th:remove="tag" th:text="#{forms.epcExpiredLowRating.beforeYouGetNewEpc.paragraph.one.beforeLink}">forms.epcExpiredLowRating.beforeYouGetNewEpc.paragraph.one.beforeLink</span>
+            <a class="govuk-link" th:text="#{forms.epcExpiredLowRating.beforeYouGetNewEpc.paragraph.one.link}" th:href="${meesExemptionGuideUrl}" rel="noreferrer noopener" target="_blank">
+                forms.epcExpiredLowRating.beforeYouGetNewEpc.paragraph.one.link
+            </a>
+            <span th:remove="tag" th:text="#{forms.epcExpiredLowRating.beforeYouGetNewEpc.paragraph.one.afterLink}">forms.epcExpiredLowRating.beforeYouGetNewEpc.paragraph.one.afterLink</span>
+        </p>
+        <p class="govuk-body" th:text="#{forms.epcExpiredLowRating.beforeYouGetNewEpc.paragraph.two}">forms.epcExpiredLowRating.beforeYouGetNewEpc.paragraph.two</p>
+        <p class="govuk-body" th:text="#{forms.epcExpiredLowRating.beforeYouGetNewEpc.paragraph.three}">forms.epcExpiredLowRating.beforeYouGetNewEpc.paragraph.three</p>
+        <ul class="govuk-list govuk-list--bullet">
+            <li th:text="#{forms.epcExpiredLowRating.beforeYouGetNewEpc.bullet.one}">forms.epcExpiredLowRating.beforeYouGetNewEpc.bullet.one</li>
+            <li>
+                <a class="govuk-link" th:text="#{forms.epcExpiredLowRating.beforeYouGetNewEpc.bullet.two.link}" th:href="${registerMeesExemptionUrl}" rel="noreferrer noopener" target="_blank">
+                    forms.epcExpiredLowRating.beforeYouGetNewEpc.bullet.two.link
+                </a>
+            </li>
+        </ul>
+        <p class="govuk-body">
+            <span th:remove="tag" th:text="#{forms.epcExpiredLowRating.beforeYouGetNewEpc.paragraph.four.beforeLink}">forms.epcExpiredLowRating.beforeYouGetNewEpc.paragraph.four.beforeLink</span>
+            <a class="govuk-link" th:text="#{forms.epcExpiredLowRating.beforeYouGetNewEpc.paragraph.four.link}" th:href="${epcImprovementGuideUrl}" rel="noreferrer noopener" target="_blank">
+                forms.epcExpiredLowRating.beforeYouGetNewEpc.paragraph.four.link
+            </a>
+        </p>
+        <p class="govuk-body" th:text="#{forms.epcExpiredLowRating.beforeYouGetNewEpc.paragraph.five}">forms.epcExpiredLowRating.beforeYouGetNewEpc.paragraph.five</p>
+    </section>
+    <button th:replace="~{fragments/buttons/primaryButton :: primaryButton(#{${submitButtonText}})}"></button>
 </html>

--- a/src/main/resources/templates/forms/epcMissingForm.html
+++ b/src/main/resources/templates/forms/epcMissingForm.html
@@ -4,27 +4,28 @@
 <!--/*@thymesVar id="sectionHeaderInfo" type="uk.gov.communities.prsdb.webapp.models.viewModels.SectionHeaderViewModel"*/-->
 <!--/*@thymesVar id="findEpcUrl" type="java.lang.String"*/-->
 <!--/*@thymesVar id="getNewEpcUrl" type="java.lang.String"*/-->
+<!--/*@thymesVar id="submitButtonText" type="java.lang.String"*/-->
 <!DOCTYPE html>
 <html id="form-content" th:replace="~{fragments/forms/questionPage :: questionPage(#{${title}}, ${formModel}, ~{::#form-content/content()}, ${backUrl}, ${sectionHeaderInfo})}">
-<header>
-    <h1 class="govuk-heading-l" th:text="#{forms.epcMissing.heading}">forms.epcMissing.heading</h1>
-</header>
-<section>
-    <p class="govuk-body" th:text="#{forms.epcMissing.paragraph.one}">forms.epcMissing.paragraph.one</p>
-    <p class="govuk-body">
-        <span th:remove="tag" th:text="#{forms.epcMissing.paragraph.two.beforeLink}">forms.epcMissing.paragraph.two.beforeLink</span>
-        <a class="govuk-link" th:text="#{forms.epcMissing.paragraph.two.link}" th:href="${findEpcUrl}" rel="noreferrer noopener" target="_blank">
-            forms.epcMissing.paragraph.two.link
-        </a>
-    </p>
-    <p class="govuk-body">
-        <span th:remove="tag" th:text="#{forms.epcMissing.paragraph.three.beforeLink}">forms.epcMissing.paragraph.three.beforeLink</span>
-        <a class="govuk-link" th:text="#{forms.epcMissing.paragraph.three.link}" th:href="${getNewEpcUrl}" rel="noreferrer noopener" target="_blank">
-            forms.epcMissing.paragraph.three.link
-        </a>
-    </p>
-    <p class="govuk-body" th:text="#{forms.epcMissing.paragraph.four}">forms.epcMissing.paragraph.four</p>
-    <p class="govuk-body" th:text="#{forms.epcMissing.paragraph.five}">forms.epcMissing.paragraph.five</p>
-</section>
-<button th:replace="~{fragments/buttons/primaryButton :: primaryButton(#{forms.buttons.saveAndContinueToLandlordResponsibilities})}"></button>
+    <header>
+        <h1 class="govuk-heading-l" th:text="#{forms.epcMissing.heading}">forms.epcMissing.heading</h1>
+    </header>
+    <section>
+        <p class="govuk-body" th:text="#{forms.epcMissing.paragraph.one}">forms.epcMissing.paragraph.one</p>
+        <p class="govuk-body">
+            <span th:remove="tag" th:text="#{forms.epcMissing.paragraph.two.beforeLink}">forms.epcMissing.paragraph.two.beforeLink</span>
+            <a class="govuk-link" th:text="#{forms.epcMissing.paragraph.two.link}" th:href="${findEpcUrl}" rel="noreferrer noopener" target="_blank">
+                forms.epcMissing.paragraph.two.link
+            </a>
+        </p>
+        <p class="govuk-body">
+            <span th:remove="tag" th:text="#{forms.epcMissing.paragraph.three.beforeLink}">forms.epcMissing.paragraph.three.beforeLink</span>
+            <a class="govuk-link" th:text="#{forms.epcMissing.paragraph.three.link}" th:href="${getNewEpcUrl}" rel="noreferrer noopener" target="_blank">
+                forms.epcMissing.paragraph.three.link
+            </a>
+        </p>
+        <p class="govuk-body" th:text="#{forms.epcMissing.paragraph.four}">forms.epcMissing.paragraph.four</p>
+        <p class="govuk-body" th:text="#{forms.epcMissing.paragraph.five}">forms.epcMissing.paragraph.five</p>
+    </section>
+    <button th:replace="~{fragments/buttons/primaryButton :: primaryButton(#{${submitButtonText}})}"></button>
 </html>

--- a/src/main/resources/templates/forms/gasSafetyExemptionConfirmationForm.html
+++ b/src/main/resources/templates/forms/gasSafetyExemptionConfirmationForm.html
@@ -2,15 +2,16 @@
 <!--/*@thymesVar id="formModel" type="java.lang.Object"*/-->
 <!--/*@thymesVar id="backUrl" type="java.lang.String"*/-->
 <!--/*@thymesVar id="sectionHeaderInfo" type="uk.gov.communities.prsdb.webapp.models.viewModels.SectionHeaderViewModel"*/-->
+<!--/*@thymesVar id="submitButtonText" type="java.lang.String"*/-->
 <!DOCTYPE html>
 <html id="form-content" th:replace="~{fragments/forms/questionPage :: questionPage(#{${title}}, ${formModel}, ~{::#form-content/content()}, ${backUrl}, ${sectionHeaderInfo})}">
-  <header>
-    <h1 class="govuk-heading-l" th:text="#{forms.gasSafetyExemptionConfirmation.heading}">forms.gasSafetyExemptionConfirmation.heading</h1>
-  </header>
-  <section>
-    <p class="govuk-body" th:text="#{forms.gasSafetyExemptionConfirmation.paragraph.one}">forms.gasSafetyExemptionConfirmation.paragraph.one</p>
-    <p class="govuk-body" th:text="#{forms.gasSafetyExemptionConfirmation.paragraph.two}">forms.gasSafetyExemptionConfirmation.paragraph.two</p>
-    <p class="govuk-body" th:text="#{forms.gasSafetyExemptionConfirmation.paragraph.three}">forms.gasSafetyExemptionConfirmation.paragraph.three</p>
-  </section>
-  <button th:replace="~{fragments/buttons/primaryButton :: primaryButton(#{forms.buttons.saveAndContinueToEICR})}"></button>
+    <header>
+        <h1 class="govuk-heading-l" th:text="#{forms.gasSafetyExemptionConfirmation.heading}">forms.gasSafetyExemptionConfirmation.heading</h1>
+    </header>
+    <section>
+        <p class="govuk-body" th:text="#{forms.gasSafetyExemptionConfirmation.paragraph.one}">forms.gasSafetyExemptionConfirmation.paragraph.one</p>
+        <p class="govuk-body" th:text="#{forms.gasSafetyExemptionConfirmation.paragraph.two}">forms.gasSafetyExemptionConfirmation.paragraph.two</p>
+        <p class="govuk-body" th:text="#{forms.gasSafetyExemptionConfirmation.paragraph.three}">forms.gasSafetyExemptionConfirmation.paragraph.three</p>
+    </section>
+    <button th:replace="~{fragments/buttons/primaryButton :: primaryButton(#{${submitButtonText}})}"></button>
 </html>

--- a/src/main/resources/templates/forms/gasSafetyExemptionMissingForm.html
+++ b/src/main/resources/templates/forms/gasSafetyExemptionMissingForm.html
@@ -2,22 +2,23 @@
 <!--/*@thymesVar id="formModel" type="java.lang.Object"*/-->
 <!--/*@thymesVar id="backUrl" type="java.lang.String"*/-->
 <!--/*@thymesVar id="sectionHeaderInfo" type="uk.gov.communities.prsdb.webapp.models.viewModels.SectionHeaderViewModel"*/-->
+<!--/*@thymesVar id="submitButtonText" type="java.lang.String"*/-->
 <!DOCTYPE html>
 <html id="form-content" th:replace="~{fragments/forms/questionPage :: questionPage(#{${title}}, ${formModel}, ~{::#form-content/content()}, ${backUrl}, ${sectionHeaderInfo})}">
-<header>
-  <h1 class="govuk-heading-l" th:text="#{forms.gasSafetyExemptionMissing.heading}">forms.gasSafetyExemptionMissing.heading</h1>
-</header>
-<section>
-  <p class="govuk-body" th:text="#{forms.gasSafetyExemptionMissing.paragraph.one}">forms.gasSafetyExemptionMissing.paragraph.one</p>
-  <p class="govuk-body" th:text="#{forms.gasSafetyExemptionMissing.bullet.heading}">forms.gasSafetyExemptionMissing.bullet.heading</p>
-  <ul class="govuk-list govuk-list--bullet">
-    <li th:text="#{forms.gasSafetyExemptionMissing.bullet.one}">forms.gasSafetyExemptionMissing.bullet.one</li>
-    <li th:text="#{forms.gasSafetyExemptionMissing.bullet.two}">forms.gasSafetyExemptionMissing.bullet.two</li>
-    <li th:text="#{forms.gasSafetyExemptionMissing.bullet.three}">forms.gasSafetyExemptionMissing.bullet.three</li>
-    <li th:text="#{forms.gasSafetyExemptionMissing.bullet.four}">forms.gasSafetyExemptionMissing.bullet.four</li>
-  </ul>
-  <p class="govuk-body" th:text="#{forms.gasSafetyExemptionMissing.paragraph.two}">forms.gasSafetyExemptionMissing.paragraph.two</p>
-  <p class="govuk-body" th:text="#{forms.gasSafetyExemptionMissing.paragraph.three}">forms.gasSafetyExemptionMissing.paragraph.three</p>
-</section>
-<button th:replace="~{fragments/buttons/primaryButton :: primaryButton(#{forms.buttons.saveAndContinueToEICR})}"></button>
+    <header>
+        <h1 class="govuk-heading-l" th:text="#{forms.gasSafetyExemptionMissing.heading}">forms.gasSafetyExemptionMissing.heading</h1>
+    </header>
+    <section>
+        <p class="govuk-body" th:text="#{forms.gasSafetyExemptionMissing.paragraph.one}">forms.gasSafetyExemptionMissing.paragraph.one</p>
+        <p class="govuk-body" th:text="#{forms.gasSafetyExemptionMissing.bullet.heading}">forms.gasSafetyExemptionMissing.bullet.heading</p>
+        <ul class="govuk-list govuk-list--bullet">
+            <li th:text="#{forms.gasSafetyExemptionMissing.bullet.one}">forms.gasSafetyExemptionMissing.bullet.one</li>
+            <li th:text="#{forms.gasSafetyExemptionMissing.bullet.two}">forms.gasSafetyExemptionMissing.bullet.two</li>
+            <li th:text="#{forms.gasSafetyExemptionMissing.bullet.three}">forms.gasSafetyExemptionMissing.bullet.three</li>
+            <li th:text="#{forms.gasSafetyExemptionMissing.bullet.four}">forms.gasSafetyExemptionMissing.bullet.four</li>
+        </ul>
+        <p class="govuk-body" th:text="#{forms.gasSafetyExemptionMissing.paragraph.two}">forms.gasSafetyExemptionMissing.paragraph.two</p>
+        <p class="govuk-body" th:text="#{forms.gasSafetyExemptionMissing.paragraph.three}">forms.gasSafetyExemptionMissing.paragraph.three</p>
+    </section>
+    <button th:replace="~{fragments/buttons/primaryButton :: primaryButton(#{${submitButtonText}})}"></button>
 </html>

--- a/src/main/resources/templates/forms/gasSafetyOutdatedForm.html
+++ b/src/main/resources/templates/forms/gasSafetyOutdatedForm.html
@@ -2,6 +2,7 @@
 <!--/*@thymesVar id="formModel" type="java.lang.Object"*/-->
 <!--/*@thymesVar id="backUrl" type="java.lang.String"*/-->
 <!--/*@thymesVar id="sectionHeaderInfo" type="uk.gov.communities.prsdb.webapp.models.viewModels.SectionHeaderViewModel"*/-->
+<!--/*@thymesVar id="submitButtonText" type="java.lang.String"*/-->
 <!DOCTYPE html>
 <html id="form-content" th:replace="~{fragments/forms/questionPage :: questionPage(#{${title}}, ${formModel}, ~{::#form-content/content()}, ${backUrl}, ${sectionHeaderInfo})}">
     <header>
@@ -18,5 +19,5 @@
         <p class="govuk-body" th:text="#{forms.gasSafetyOutdated.paragraph.two}">forms.gasSafetyOutdated.paragraph.two</p>
         <p class="govuk-body" th:text="#{forms.gasSafetyOutdated.paragraph.three}">forms.gasSafetyOutdated.paragraph.three</p>
     </section>
-    <button th:replace="~{fragments/buttons/primaryButton :: primaryButton(#{forms.buttons.saveAndContinueToEICR})}"></button>
+    <button th:replace="~{fragments/buttons/primaryButton :: primaryButton(#{${submitButtonText}})}"></button>
 </html>

--- a/src/main/resources/templates/forms/lowEnergyRatingForm.html
+++ b/src/main/resources/templates/forms/lowEnergyRatingForm.html
@@ -4,45 +4,46 @@
 <!--/*@thymesVar id="sectionHeaderInfo" type="uk.gov.communities.prsdb.webapp.models.viewModels.SectionHeaderViewModel"*/-->
 <!--/*@thymesVar id="epcImprovementGuideUrl" type="java.lang.String"*/-->
 <!--/*@thymesVar id="registerPrsExemptionUrl" type="java.lang.String"*/-->
+<!--/*@thymesVar id="submitButtonText" type="java.lang.String"*/-->
 <!DOCTYPE html>
 <html id="form-content" th:replace="~{fragments/forms/questionPage :: questionPage(#{${title}}, ${formModel}, ~{::#form-content/content()}, ${backUrl}, ${sectionHeaderInfo})}">
-<header>
-    <h1 class="govuk-heading-l" th:text="#{forms.lowEnergyRating.heading}">forms.lowEnergyRating.heading</h1>
-</header>
-<section>
-    <p class="govuk-body" th:text="#{forms.lowEnergyRating.paragraph.one}">forms.lowEnergyRating.paragraph.one</p>
-    <p class="govuk-body" th:text="#{forms.lowEnergyRating.paragraph.two}">forms.lowEnergyRating.paragraph.two</p>
-    <p class="govuk-body" th:text="#{forms.lowEnergyRating.paragraph.three}">forms.lowEnergyRating.paragraph.three</p>
-    <ul class="govuk-list govuk-list--bullet">
-        <li th:text="#{forms.lowEnergyRating.bullet.one}">forms.lowEnergyRating.bullet.one</li>
-        <li th:text="#{forms.lowEnergyRating.bullet.two}">forms.lowEnergyRating.bullet.two</li>
-    </ul>
-</section>
-<section>
-    <h2 class="govuk-heading-s" th:text="#{forms.lowEnergyRating.remedialWork.subheading}">forms.lowEnergyRating.remedialWork.subheading</h2>
-    <p class="govuk-body" th:text="#{forms.lowEnergyRating.remedialWork.paragraph.one}">forms.lowEnergyRating.remedialWork.paragraph.one</p>
-    <p class="govuk-body" th:text="#{forms.lowEnergyRating.remedialWork.paragraph.two}">forms.lowEnergyRating.remedialWork.paragraph.two</p>
-    <p class="govuk-body">
-        <span th:remove="tag" th:text="#{forms.lowEnergyRating.remedialWork.paragraph.three.beforeLink}">forms.lowEnergyRating.remedialWork.paragraph.three.beforeLink</span>
-        <a class="govuk-link" th:text="#{forms.lowEnergyRating.remedialWork.paragraph.three.link}" th:href="${epcImprovementGuideUrl}" rel="noreferrer noopener" target="_blank">
-            forms.lowEnergyRating.remedialWork.paragraph.three.link
-        </a>
-    </p>
-</section>
-<section>
-    <h2 class="govuk-heading-s" th:text="#{forms.lowEnergyRating.registerMees.subheading}">forms.lowEnergyRating.registerMees.subheading</h2>
-    <p class="govuk-body">
-        <span th:remove="tag" th:text="#{forms.lowEnergyRating.registerMees.paragraph.one.beforeLink}">forms.lowEnergyRating.registerMees.paragraph.one.beforeLink</span>
-        <a class="govuk-link" th:text="#{forms.lowEnergyRating.registerMees.paragraph.one.link}" th:href="${registerPrsExemptionUrl}" rel="noreferrer noopener" target="_blank">forms.lowEnergyRating.registerMees.paragraph.one.link</a>
-        <span th:remove="tag" th:text="#{forms.lowEnergyRating.registerMees.paragraph.one.afterLink}">forms.lowEnergyRating.registerMees.paragraph.one.afterLink</span>
-    </p>
-    <p class="govuk-body" th:text="#{forms.lowEnergyRating.registerMees.paragraph.two}">forms.lowEnergyRating.registerMees.paragraph.two</p>
-    <ul class="govuk-list govuk-list--bullet">
-        <li th:text="#{forms.lowEnergyRating.registerMees.bullet.one}">forms.lowEnergyRating.registerMees.bullet.one</li>
-        <li th:text="#{forms.lowEnergyRating.registerMees.bullet.two}">forms.lowEnergyRating.registerMees.bullet.two</li>
-        <li th:text="#{forms.lowEnergyRating.registerMees.bullet.three}">forms.lowEnergyRating.registerMees.bullet.three</li>
-    </ul>
-    <p class="govuk-body" th:text="#{forms.lowEnergyRating.registerMees.paragraph.three}">forms.lowEnergyRating.registerMees.paragraph.three</p>
-</section>
-<button th:replace="~{fragments/buttons/primaryButton :: primaryButton(#{forms.buttons.saveAndContinueToLandlordResponsibilities})}"></button>
+    <header>
+        <h1 class="govuk-heading-l" th:text="#{forms.lowEnergyRating.heading}">forms.lowEnergyRating.heading</h1>
+    </header>
+    <section>
+        <p class="govuk-body" th:text="#{forms.lowEnergyRating.paragraph.one}">forms.lowEnergyRating.paragraph.one</p>
+        <p class="govuk-body" th:text="#{forms.lowEnergyRating.paragraph.two}">forms.lowEnergyRating.paragraph.two</p>
+        <p class="govuk-body" th:text="#{forms.lowEnergyRating.paragraph.three}">forms.lowEnergyRating.paragraph.three</p>
+        <ul class="govuk-list govuk-list--bullet">
+            <li th:text="#{forms.lowEnergyRating.bullet.one}">forms.lowEnergyRating.bullet.one</li>
+            <li th:text="#{forms.lowEnergyRating.bullet.two}">forms.lowEnergyRating.bullet.two</li>
+        </ul>
+    </section>
+    <section>
+        <h2 class="govuk-heading-s" th:text="#{forms.lowEnergyRating.remedialWork.subheading}">forms.lowEnergyRating.remedialWork.subheading</h2>
+        <p class="govuk-body" th:text="#{forms.lowEnergyRating.remedialWork.paragraph.one}">forms.lowEnergyRating.remedialWork.paragraph.one</p>
+        <p class="govuk-body" th:text="#{forms.lowEnergyRating.remedialWork.paragraph.two}">forms.lowEnergyRating.remedialWork.paragraph.two</p>
+        <p class="govuk-body">
+            <span th:remove="tag" th:text="#{forms.lowEnergyRating.remedialWork.paragraph.three.beforeLink}">forms.lowEnergyRating.remedialWork.paragraph.three.beforeLink</span>
+            <a class="govuk-link" th:text="#{forms.lowEnergyRating.remedialWork.paragraph.three.link}" th:href="${epcImprovementGuideUrl}" rel="noreferrer noopener" target="_blank">
+                forms.lowEnergyRating.remedialWork.paragraph.three.link
+            </a>
+        </p>
+    </section>
+    <section>
+        <h2 class="govuk-heading-s" th:text="#{forms.lowEnergyRating.registerMees.subheading}">forms.lowEnergyRating.registerMees.subheading</h2>
+        <p class="govuk-body">
+            <span th:remove="tag" th:text="#{forms.lowEnergyRating.registerMees.paragraph.one.beforeLink}">forms.lowEnergyRating.registerMees.paragraph.one.beforeLink</span>
+            <a class="govuk-link" th:text="#{forms.lowEnergyRating.registerMees.paragraph.one.link}" th:href="${registerPrsExemptionUrl}" rel="noreferrer noopener" target="_blank">forms.lowEnergyRating.registerMees.paragraph.one.link</a>
+            <span th:remove="tag" th:text="#{forms.lowEnergyRating.registerMees.paragraph.one.afterLink}">forms.lowEnergyRating.registerMees.paragraph.one.afterLink</span>
+        </p>
+        <p class="govuk-body" th:text="#{forms.lowEnergyRating.registerMees.paragraph.two}">forms.lowEnergyRating.registerMees.paragraph.two</p>
+        <ul class="govuk-list govuk-list--bullet">
+            <li th:text="#{forms.lowEnergyRating.registerMees.bullet.one}">forms.lowEnergyRating.registerMees.bullet.one</li>
+            <li th:text="#{forms.lowEnergyRating.registerMees.bullet.two}">forms.lowEnergyRating.registerMees.bullet.two</li>
+            <li th:text="#{forms.lowEnergyRating.registerMees.bullet.three}">forms.lowEnergyRating.registerMees.bullet.three</li>
+        </ul>
+        <p class="govuk-body" th:text="#{forms.lowEnergyRating.registerMees.paragraph.three}">forms.lowEnergyRating.registerMees.paragraph.three</p>
+    </section>
+    <button th:replace="~{fragments/buttons/primaryButton :: primaryButton(#{${submitButtonText}})}"></button>
 </html>

--- a/src/main/resources/templates/forms/meesExemptionConfirmationForm.html
+++ b/src/main/resources/templates/forms/meesExemptionConfirmationForm.html
@@ -2,16 +2,17 @@
 <!--/*@thymesVar id="formModel" type="java.lang.Object"*/-->
 <!--/*@thymesVar id="backUrl" type="java.lang.String"*/-->
 <!--/*@thymesVar id="sectionHeaderInfo" type="uk.gov.communities.prsdb.webapp.models.viewModels.SectionHeaderViewModel"*/-->
+<!--/*@thymesVar id="submitButtonText" type="java.lang.String"*/-->
 <!DOCTYPE html>
 <html id="form-content" th:replace="~{fragments/forms/questionPage :: questionPage(#{${title}}, ${formModel}, ~{::#form-content/content()}, ${backUrl}, ${sectionHeaderInfo})}">
-<header>
-    <h1 class="govuk-heading-l" th:text="#{forms.meesExemptionConfirmation.heading}">forms.meesExemptionConfirmation.heading</h1>
-</header>
-<section>
-    <p class="govuk-body" th:text="#{forms.meesExemptionConfirmation.paragraph.one}">forms.meesExemptionConfirmation.paragraph.one</p>
-    <p class="govuk-body" th:text="#{forms.meesExemptionConfirmation.paragraph.two}">forms.meesExemptionConfirmation.paragraph.two</p>
-    <p class="govuk-body" th:text="#{forms.meesExemptionConfirmation.paragraph.three}">forms.meesExemptionConfirmation.paragraph.three</p>
-    <p class="govuk-body" th:text="#{forms.meesExemptionConfirmation.paragraph.four}">forms.meesExemptionConfirmation.paragraph.four</p>
-</section>
-<button th:replace="~{fragments/buttons/primaryButton :: primaryButton(#{forms.buttons.saveAndContinueToLandlordResponsibilities})}"></button>
+    <header>
+        <h1 class="govuk-heading-l" th:text="#{forms.meesExemptionConfirmation.heading}">forms.meesExemptionConfirmation.heading</h1>
+    </header>
+    <section>
+        <p class="govuk-body" th:text="#{forms.meesExemptionConfirmation.paragraph.one}">forms.meesExemptionConfirmation.paragraph.one</p>
+        <p class="govuk-body" th:text="#{forms.meesExemptionConfirmation.paragraph.two}">forms.meesExemptionConfirmation.paragraph.two</p>
+        <p class="govuk-body" th:text="#{forms.meesExemptionConfirmation.paragraph.three}">forms.meesExemptionConfirmation.paragraph.three</p>
+        <p class="govuk-body" th:text="#{forms.meesExemptionConfirmation.paragraph.four}">forms.meesExemptionConfirmation.paragraph.four</p>
+    </section>
+    <button th:replace="~{fragments/buttons/primaryButton :: primaryButton(#{${submitButtonText}})}"></button>
 </html>


### PR DESCRIPTION
## Ticket number

PRSD-962

## Goal of change

Use generic submit buttons when changing property compliance journey answers

## Description of main change(s)

- Passes submit button text as a parameter into compliance journey templates
- Sets submit button text depending on whether the user is changing their answers

## Anything you'd like to highlight to the reviewer?

N/A

## Checklist

Delete any that are not applicable, and add explanation below for any that are applicable but haven't been done

- [X] Screenshots of any UI changes have been added
- [X] Test suite has been run in full locally and is passing
- [X] Branch has been rebased onto main and run locally, with everything working as expected (both for your new feature
  and any related functionality)

## Screenshots
- When not changing your answers:
![image](https://github.com/user-attachments/assets/eee72ee4-dd3b-4ccd-9a9a-a068786f253d)

- When changing your answers:
![image](https://github.com/user-attachments/assets/a591cd2f-5250-4dde-9330-1321ea00d5ba)