### PR TITLE
PRSD-962: View Landlord Responsibilities when CYA

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/constants/UrlParameterNames.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/constants/UrlParameterNames.kt
@@ -1,6 +1,6 @@
 package uk.gov.communities.prsdb.webapp.constants
 
-const val CHANGE_ANSWER_FOR_PARAMETER_NAME = "changingAnswerFor"
+const val CHECKING_ANSWERS_FOR_PARAMETER_NAME = "checkingAnswersFor"
 const val WITH_BACK_URL_PARAMETER_NAME = "withBackUrl"
 const val CONTEXT_ID_URL_PARAMETER = "contextId"
 const val TOKEN = "token"

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/PropertyComplianceController.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/PropertyComplianceController.kt
@@ -21,7 +21,7 @@ import org.springframework.web.servlet.ModelAndView
 import org.springframework.web.util.UriTemplate
 import uk.gov.communities.prsdb.webapp.annotations.PrsdbController
 import uk.gov.communities.prsdb.webapp.config.filters.MultipartFormDataFilter
-import uk.gov.communities.prsdb.webapp.constants.CHANGE_ANSWER_FOR_PARAMETER_NAME
+import uk.gov.communities.prsdb.webapp.constants.CHECKING_ANSWERS_FOR_PARAMETER_NAME
 import uk.gov.communities.prsdb.webapp.constants.CONFIRMATION_PATH_SEGMENT
 import uk.gov.communities.prsdb.webapp.constants.ELECTRICAL_SAFETY_STANDARDS_URL
 import uk.gov.communities.prsdb.webapp.constants.FILE_UPLOAD_URL_SUBSTRING
@@ -96,7 +96,7 @@ class PropertyComplianceController(
         @PathVariable propertyOwnershipId: Long,
         @PathVariable("stepName") stepName: String,
         @RequestParam(value = "subpage", required = false) subpage: Int?,
-        @RequestParam(value = CHANGE_ANSWER_FOR_PARAMETER_NAME, required = false) changingAnswerFor: String? = null,
+        @RequestParam(value = CHECKING_ANSWERS_FOR_PARAMETER_NAME, required = false) checkingAnswersForStep: String? = null,
         principal: Principal,
         request: HttpServletRequest,
         response: HttpServletResponse,
@@ -105,8 +105,8 @@ class PropertyComplianceController(
 
         val stepModelAndView =
             propertyComplianceJourneyFactory
-                .create(propertyOwnershipId, changingAnswerFor)
-                .getModelAndViewForStep(stepName, subpage, changingAnswersForStep = changingAnswerFor)
+                .create(propertyOwnershipId, checkingAnswersForStep)
+                .getModelAndViewForStep(stepName, subpage, checkingAnswersForStep = checkingAnswersForStep)
 
         if (stepName.contains(FILE_UPLOAD_URL_SUBSTRING)) {
             val cookie = tokenCookieService.createCookieForValue(FILE_UPLOAD_COOKIE_NAME, request.requestURI)
@@ -121,7 +121,7 @@ class PropertyComplianceController(
         @PathVariable propertyOwnershipId: Long,
         @PathVariable("stepName") stepName: String,
         @RequestParam(value = "subpage", required = false) subpage: Int?,
-        @RequestParam(value = CHANGE_ANSWER_FOR_PARAMETER_NAME, required = false) changingAnswerFor: String? = null,
+        @RequestParam(value = CHECKING_ANSWERS_FOR_PARAMETER_NAME, required = false) checkingAnswersForStep: String? = null,
         @RequestParam formData: PageData,
         principal: Principal,
     ): ModelAndView {
@@ -132,8 +132,8 @@ class PropertyComplianceController(
         val annotatedFormData = formData + (UploadCertificateFormModel::isMetadataOnly.name to true)
 
         return propertyComplianceJourneyFactory
-            .create(propertyOwnershipId, changingAnswerFor)
-            .completeStep(stepName, annotatedFormData, subpage, principal, changingAnswerFor)
+            .create(propertyOwnershipId, checkingAnswersForStep)
+            .completeStep(stepName, annotatedFormData, subpage, principal, checkingAnswersForStep)
     }
 
     @PostMapping("/{stepName}", consumes = [MediaType.MULTIPART_FORM_DATA_VALUE])
@@ -141,7 +141,7 @@ class PropertyComplianceController(
         @PathVariable propertyOwnershipId: Long,
         @PathVariable("stepName") stepName: String,
         @RequestParam(value = "subpage", required = false) subpage: Int?,
-        @RequestParam(value = CHANGE_ANSWER_FOR_PARAMETER_NAME, required = false) changingAnswerFor: String? = null,
+        @RequestParam(value = CHECKING_ANSWERS_FOR_PARAMETER_NAME, required = false) checkingAnswersForStep: String? = null,
         @RequestAttribute(MultipartFormDataFilter.ITERATOR_ATTRIBUTE) fileInputIterator: FileItemInputIterator,
         @CookieValue(name = FILE_UPLOAD_COOKIE_NAME) token: String,
         principal: Principal,
@@ -187,13 +187,13 @@ class PropertyComplianceController(
                 ).toPageData()
 
         return propertyComplianceJourneyFactory
-            .create(propertyOwnershipId, changingAnswerFor)
+            .create(propertyOwnershipId, checkingAnswersForStep)
             .completeStep(
                 stepName,
                 formData,
                 subpage,
                 principal,
-                changingAnswerFor,
+                checkingAnswersForStep,
             )
     }
 

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/PropertyDetailsController.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/PropertyDetailsController.kt
@@ -15,7 +15,7 @@ import org.springframework.web.servlet.ModelAndView
 import org.springframework.web.util.UriTemplate
 import uk.gov.communities.prsdb.webapp.annotations.PrsdbController
 import uk.gov.communities.prsdb.webapp.config.interceptors.BackLinkInterceptor.Companion.overrideBackLinkForUrl
-import uk.gov.communities.prsdb.webapp.constants.CHANGE_ANSWER_FOR_PARAMETER_NAME
+import uk.gov.communities.prsdb.webapp.constants.CHECKING_ANSWERS_FOR_PARAMETER_NAME
 import uk.gov.communities.prsdb.webapp.constants.COMPLIANCE_INFO_FRAGMENT
 import uk.gov.communities.prsdb.webapp.constants.LANDLORD_PATH_SEGMENT
 import uk.gov.communities.prsdb.webapp.constants.LOCAL_AUTHORITY_PATH_SEGMENT
@@ -81,12 +81,12 @@ class PropertyDetailsController(
         principal: Principal,
         @PathVariable propertyOwnershipId: Long,
         @PathVariable("stepName") stepName: String,
-        @RequestParam(CHANGE_ANSWER_FOR_PARAMETER_NAME, required = false) changingAnswerForStep: String?,
+        @RequestParam(CHECKING_ANSWERS_FOR_PARAMETER_NAME, required = false) checkingAnswersForStep: String?,
     ): ModelAndView =
         if (propertyOwnershipService.getIsAuthorizedToEditRecord(propertyOwnershipId, principal.name)) {
             propertyDetailsUpdateJourneyFactory
-                .create(propertyOwnershipId, stepName, isChangingAnswer = changingAnswerForStep != null)
-                .getModelAndViewForStep(changingAnswersForStep = changingAnswerForStep)
+                .create(propertyOwnershipId, stepName, isCheckingAnswer = checkingAnswersForStep != null)
+                .getModelAndViewForStep(checkingAnswersForStep = checkingAnswersForStep)
         } else {
             throw ResponseStatusException(
                 HttpStatus.NOT_FOUND,
@@ -102,12 +102,12 @@ class PropertyDetailsController(
         @PathVariable propertyOwnershipId: Long,
         @PathVariable("stepName") stepName: String,
         @RequestParam formData: PageData,
-        @RequestParam(CHANGE_ANSWER_FOR_PARAMETER_NAME, required = false) changingAnswerForStep: String?,
+        @RequestParam(CHECKING_ANSWERS_FOR_PARAMETER_NAME, required = false) checkingAnswersForStep: String?,
     ): ModelAndView =
         if (propertyOwnershipService.getIsAuthorizedToEditRecord(propertyOwnershipId, principal.name)) {
             propertyDetailsUpdateJourneyFactory
-                .create(propertyOwnershipId, stepName, isChangingAnswer = changingAnswerForStep != null)
-                .completeStep(formData, principal, changingAnswerForStep)
+                .create(propertyOwnershipId, stepName, isCheckingAnswer = checkingAnswersForStep != null)
+                .completeStep(formData, principal, checkingAnswersForStep)
         } else {
             throw ResponseStatusException(
                 HttpStatus.NOT_FOUND,

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/RegisterLandlordController.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/RegisterLandlordController.kt
@@ -10,7 +10,7 @@ import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.servlet.ModelAndView
 import uk.gov.communities.prsdb.webapp.annotations.PrsdbController
-import uk.gov.communities.prsdb.webapp.constants.CHANGE_ANSWER_FOR_PARAMETER_NAME
+import uk.gov.communities.prsdb.webapp.constants.CHECKING_ANSWERS_FOR_PARAMETER_NAME
 import uk.gov.communities.prsdb.webapp.constants.CONFIRMATION_PATH_SEGMENT
 import uk.gov.communities.prsdb.webapp.constants.LANDLORD_PATH_SEGMENT
 import uk.gov.communities.prsdb.webapp.constants.REGISTER_LANDLORD_JOURNEY_URL
@@ -73,11 +73,11 @@ class RegisterLandlordController(
         @PathVariable("stepName") stepName: String,
         @RequestParam(value = "subpage", required = false) subpage: Int?,
         model: Model,
-        @RequestParam(value = CHANGE_ANSWER_FOR_PARAMETER_NAME, required = false) changingAnswerFor: String? = null,
+        @RequestParam(value = CHECKING_ANSWERS_FOR_PARAMETER_NAME, required = false) checkingAnswersForStep: String? = null,
     ): ModelAndView =
         landlordRegistrationJourneyFactory
             .create()
-            .getModelAndViewForStep(stepName, subpage, changingAnswersForStep = changingAnswerFor)
+            .getModelAndViewForStep(stepName, subpage, checkingAnswersForStep = checkingAnswersForStep)
 
     @PostMapping("/{stepName}")
     fun postJourneyData(
@@ -86,7 +86,7 @@ class RegisterLandlordController(
         @RequestParam formData: PageData,
         model: Model,
         principal: Principal,
-        @RequestParam(value = CHANGE_ANSWER_FOR_PARAMETER_NAME, required = false) changingAnswerFor: String? = null,
+        @RequestParam(value = CHECKING_ANSWERS_FOR_PARAMETER_NAME, required = false) checkingAnswersForStep: String? = null,
     ): ModelAndView =
         landlordRegistrationJourneyFactory
             .create()
@@ -95,7 +95,7 @@ class RegisterLandlordController(
                 formData,
                 subpage,
                 principal,
-                changingAnswersForStep = changingAnswerFor,
+                checkingAnswersForStep = checkingAnswersForStep,
             )
 
     @GetMapping("/$CONFIRMATION_PATH_SEGMENT")

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/RegisterPropertyController.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/RegisterPropertyController.kt
@@ -12,7 +12,7 @@ import org.springframework.web.server.ResponseStatusException
 import org.springframework.web.servlet.ModelAndView
 import org.springframework.web.util.UriTemplate
 import uk.gov.communities.prsdb.webapp.annotations.PrsdbController
-import uk.gov.communities.prsdb.webapp.constants.CHANGE_ANSWER_FOR_PARAMETER_NAME
+import uk.gov.communities.prsdb.webapp.constants.CHECKING_ANSWERS_FOR_PARAMETER_NAME
 import uk.gov.communities.prsdb.webapp.constants.CONFIRMATION_PATH_SEGMENT
 import uk.gov.communities.prsdb.webapp.constants.CONTEXT_ID_URL_PARAMETER
 import uk.gov.communities.prsdb.webapp.constants.LANDLORD_PATH_SEGMENT
@@ -77,7 +77,7 @@ class RegisterPropertyController(
     fun getJourneyStep(
         @PathVariable("stepName") stepName: String,
         @RequestParam(value = "subpage", required = false) subpage: Int?,
-        @RequestParam(value = CHANGE_ANSWER_FOR_PARAMETER_NAME, required = false) changingAnswerFor: String? = null,
+        @RequestParam(value = CHECKING_ANSWERS_FOR_PARAMETER_NAME, required = false) checkingAnswersForStep: String? = null,
         model: Model,
         principal: Principal,
     ): ModelAndView =
@@ -86,7 +86,7 @@ class RegisterPropertyController(
             .getModelAndViewForStep(
                 stepName,
                 subpage,
-                changingAnswersForStep = changingAnswerFor,
+                checkingAnswersForStep = checkingAnswersForStep,
             )
 
     @GetMapping("/$TASK_LIST_PATH_SEGMENT")
@@ -99,7 +99,7 @@ class RegisterPropertyController(
     fun postJourneyData(
         @PathVariable("stepName") stepName: String,
         @RequestParam(value = "subpage", required = false) subpage: Int?,
-        @RequestParam(value = CHANGE_ANSWER_FOR_PARAMETER_NAME, required = false) changingAnswerFor: String? = null,
+        @RequestParam(value = CHECKING_ANSWERS_FOR_PARAMETER_NAME, required = false) checkingAnswersForStep: String? = null,
         @RequestParam formData: PageData,
         model: Model,
         principal: Principal,
@@ -111,7 +111,7 @@ class RegisterPropertyController(
                 formData,
                 subpage,
                 principal,
-                changingAnswerFor,
+                checkingAnswersForStep,
             )
 
     @GetMapping("/$CONFIRMATION_PATH_SEGMENT")

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/GroupedUpdateJourney.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/GroupedUpdateJourney.kt
@@ -14,7 +14,7 @@ abstract class GroupedUpdateJourney<T : GroupedUpdateStepId<*>>(
     validator: Validator,
     journeyDataService: JourneyDataService,
     stepName: String,
-    protected val isChangingAnswer: Boolean,
+    protected val isCheckingAnswers: Boolean,
 ) : UpdateJourney<T>(journeyType, initialStepId, validator, journeyDataService, stepName) {
     abstract override val stepRouter: GroupedUpdateStepRouter<T>
 
@@ -26,12 +26,12 @@ abstract class GroupedUpdateJourney<T : GroupedUpdateStepId<*>>(
 
     fun getModelAndViewForStep(
         submittedPageData: PageData? = null,
-        changingAnswersForStep: String? = null,
-    ): ModelAndView = getModelAndViewForStep(stepName, null, submittedPageData, changingAnswersForStep)
+        checkingAnswersForStep: String? = null,
+    ): ModelAndView = getModelAndViewForStep(stepName, null, submittedPageData, checkingAnswersForStep)
 
     fun completeStep(
         formData: PageData,
         principal: Principal,
-        changingAnswersForStep: String? = null,
-    ): ModelAndView = completeStep(stepName, formData, null, principal, changingAnswersForStep)
+        checkingAnswersForStep: String? = null,
+    ): ModelAndView = completeStep(stepName, formData, null, principal, checkingAnswersForStep)
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/LandlordRegistrationJourney.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/LandlordRegistrationJourney.kt
@@ -62,15 +62,15 @@ class LandlordRegistrationJourney(
     protected class LandlordRegistrationStepRouter(
         journey: Iterable<StepDetails<LandlordRegistrationStepId>>,
     ) : GroupedStepRouter<LandlordRegistrationStepId>(journey) {
-        override fun isDestinationAllowedWhenChangingAnswerTo(
+        override fun isDestinationAllowedWhenCheckingAnswersFor(
             destinationStep: LandlordRegistrationStepId?,
-            stepBeingChanged: LandlordRegistrationStepId?,
+            stepBeingChecked: LandlordRegistrationStepId?,
         ): Boolean =
-            when (stepBeingChanged) {
+            when (stepBeingChecked) {
                 LandlordRegistrationStepId.NonEnglandOrWalesAddress ->
                     destinationStep ==
                         LandlordRegistrationStepId.NonEnglandOrWalesAddress
-                else -> super.isDestinationAllowedWhenChangingAnswerTo(destinationStep, stepBeingChanged)
+                else -> super.isDestinationAllowedWhenCheckingAnswersFor(destinationStep, stepBeingChecked)
             }
     }
 

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/PropertyComplianceJourney.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/PropertyComplianceJourney.kt
@@ -43,7 +43,7 @@ import uk.gov.communities.prsdb.webapp.forms.tasks.JourneySection
 import uk.gov.communities.prsdb.webapp.forms.tasks.JourneyTask
 import uk.gov.communities.prsdb.webapp.helpers.PropertyComplianceJourneyHelper
 import uk.gov.communities.prsdb.webapp.helpers.extensions.MessageSourceExtensions.Companion.getMessageForKey
-import uk.gov.communities.prsdb.webapp.helpers.extensions.journeyExtensions.GroupedJourneyExtensions.Companion.withBackUrlIfNotNullAndNotChangingAnswer
+import uk.gov.communities.prsdb.webapp.helpers.extensions.journeyExtensions.GroupedJourneyExtensions.Companion.withBackUrlIfNotNullAndNotCheckingAnswers
 import uk.gov.communities.prsdb.webapp.helpers.extensions.journeyExtensions.PropertyComplianceJourneyDataExtensions.Companion.getAcceptedEpcDetails
 import uk.gov.communities.prsdb.webapp.helpers.extensions.journeyExtensions.PropertyComplianceJourneyDataExtensions.Companion.getAutoMatchedEpcIsCorrect
 import uk.gov.communities.prsdb.webapp.helpers.extensions.journeyExtensions.PropertyComplianceJourneyDataExtensions.Companion.getDidTenancyStartBeforeEpcExpiry
@@ -126,7 +126,7 @@ class PropertyComplianceJourney(
     private val fullPropertyComplianceConfirmationEmailService: EmailNotificationService<FullPropertyComplianceConfirmationEmail>,
     private val partialPropertyComplianceConfirmationEmailService: EmailNotificationService<PartialPropertyComplianceConfirmationEmail>,
     private val urlProvider: AbsoluteUrlProvider,
-    changingAnswerFor: String?,
+    checkingAnswersForStep: String?,
 ) : JourneyWithTaskList<PropertyComplianceStepId>(
         journeyType = JourneyType.PROPERTY_COMPLIANCE,
         initialStepId = initialStepId,
@@ -150,8 +150,8 @@ class PropertyComplianceJourney(
         }
     }
 
-    private val isChangingAnswer = changingAnswerFor != null
-    private val changingAnswerForStep = PropertyComplianceStepId.entries.find { it.urlPathSegment == changingAnswerFor }
+    private val isCheckingAnswers = checkingAnswersForStep != null
+    private val checkingAnswersFor = PropertyComplianceStepId.entries.find { it.urlPathSegment == checkingAnswersForStep }
 
     override val stepRouter = GroupedStepRouter(this)
     override val checkYourAnswersStepId = PropertyComplianceStepId.CheckAndSubmit
@@ -311,7 +311,7 @@ class PropertyComplianceJourney(
                                             labelMsgKey = "forms.radios.option.no.label",
                                         ),
                                     ),
-                            ).withBackUrlIfNotNullAndNotChangingAnswer(taskListUrlSegment, isChangingAnswer),
+                            ).withBackUrlIfNotNullAndNotCheckingAnswers(taskListUrlSegment, isCheckingAnswers),
                     ) { mapOf("address" to getPropertyAddress()) },
                 nextAction = { filteredJourneyData, _ -> gasSafetyStepNextAction(filteredJourneyData) },
             )
@@ -382,7 +382,7 @@ class PropertyComplianceJourney(
                         content =
                             mapOf(
                                 "title" to "propertyCompliance.title",
-                                "submitButtonText" to getSubmitButtonTextOrDefaultIfChangingAnswer("forms.buttons.saveAndContinueToEICR"),
+                                "submitButtonText" to getSubmitButtonTextOrDefaultIfCheckingAnswers("forms.buttons.saveAndContinueToEICR"),
                             ),
                     ),
                 nextAction = { _, _ -> Pair(eicrTask.startingStepId, null) },
@@ -399,7 +399,7 @@ class PropertyComplianceJourney(
                         content =
                             mapOf(
                                 "title" to "propertyCompliance.title",
-                                "submitButtonText" to getSubmitButtonTextOrDefaultIfChangingAnswer("forms.buttons.saveAndContinueToEICR"),
+                                "submitButtonText" to getSubmitButtonTextOrDefaultIfCheckingAnswers("forms.buttons.saveAndContinueToEICR"),
                             ),
                     ),
                 nextAction = { _, _ -> Pair(eicrTask.startingStepId, null) },
@@ -499,7 +499,7 @@ class PropertyComplianceJourney(
                         content =
                             mapOf(
                                 "title" to "propertyCompliance.title",
-                                "submitButtonText" to getSubmitButtonTextOrDefaultIfChangingAnswer("forms.buttons.saveAndContinueToEICR"),
+                                "submitButtonText" to getSubmitButtonTextOrDefaultIfCheckingAnswers("forms.buttons.saveAndContinueToEICR"),
                             ),
                     ),
                 nextAction = { _, _ -> Pair(eicrTask.startingStepId, null) },
@@ -516,7 +516,7 @@ class PropertyComplianceJourney(
                         content =
                             mapOf(
                                 "title" to "propertyCompliance.title",
-                                "submitButtonText" to getSubmitButtonTextOrDefaultIfChangingAnswer("forms.buttons.saveAndContinueToEICR"),
+                                "submitButtonText" to getSubmitButtonTextOrDefaultIfCheckingAnswers("forms.buttons.saveAndContinueToEICR"),
                             ),
                     ),
                 nextAction = { _, _ -> Pair(eicrTask.startingStepId, null) },
@@ -548,7 +548,7 @@ class PropertyComplianceJourney(
                                             labelMsgKey = "forms.radios.option.no.label",
                                         ),
                                     ),
-                            ).withBackUrlIfNotNullAndNotChangingAnswer(taskListUrlSegment, isChangingAnswer),
+                            ).withBackUrlIfNotNullAndNotCheckingAnswers(taskListUrlSegment, isCheckingAnswers),
                     ) { mapOf("address" to getPropertyAddress()) },
                 nextAction = { filteredJourneyData, _ -> eicrStepNextAction(filteredJourneyData) },
             )
@@ -600,7 +600,7 @@ class PropertyComplianceJourney(
                         content =
                             mapOf(
                                 "title" to "propertyCompliance.title",
-                                "submitButtonText" to getSubmitButtonTextOrDefaultIfChangingAnswer("forms.buttons.saveAndContinueToEPC"),
+                                "submitButtonText" to getSubmitButtonTextOrDefaultIfCheckingAnswers("forms.buttons.saveAndContinueToEPC"),
                             ),
                     ),
                 nextAction = { _, _ -> Pair(epcTask.startingStepId, null) },
@@ -619,7 +619,7 @@ class PropertyComplianceJourney(
                                 "title" to "propertyCompliance.title",
                                 "rcpElectricalInfoUrl" to RCP_ELECTRICAL_INFO_URL,
                                 "rcpElectricalRegisterUrl" to RCP_ELECTRICAL_REGISTER_URL,
-                                "submitButtonText" to getSubmitButtonTextOrDefaultIfChangingAnswer("forms.buttons.saveAndContinueToEPC"),
+                                "submitButtonText" to getSubmitButtonTextOrDefaultIfCheckingAnswers("forms.buttons.saveAndContinueToEPC"),
                             ),
                     ),
                 nextAction = { _, _ -> Pair(epcTask.startingStepId, null) },
@@ -723,7 +723,7 @@ class PropertyComplianceJourney(
                         content =
                             mapOf(
                                 "title" to "propertyCompliance.title",
-                                "submitButtonText" to getSubmitButtonTextOrDefaultIfChangingAnswer("forms.buttons.saveAndContinueToEPC"),
+                                "submitButtonText" to getSubmitButtonTextOrDefaultIfCheckingAnswers("forms.buttons.saveAndContinueToEPC"),
                             ),
                     ),
                 nextAction = { _, _ -> Pair(epcTask.startingStepId, null) },
@@ -742,7 +742,7 @@ class PropertyComplianceJourney(
                                 "title" to "propertyCompliance.title",
                                 "rcpElectricalInfoUrl" to RCP_ELECTRICAL_INFO_URL,
                                 "rcpElectricalRegisterUrl" to RCP_ELECTRICAL_REGISTER_URL,
-                                "submitButtonText" to getSubmitButtonTextOrDefaultIfChangingAnswer("forms.buttons.saveAndContinueToEPC"),
+                                "submitButtonText" to getSubmitButtonTextOrDefaultIfCheckingAnswers("forms.buttons.saveAndContinueToEPC"),
                             ),
                     ),
                 nextAction = { _, _ -> Pair(epcTask.startingStepId, null) },
@@ -779,7 +779,7 @@ class PropertyComplianceJourney(
                                             labelMsgKey = "forms.epc.radios.option.notRequired.label",
                                         ),
                                     ),
-                            ).withBackUrlIfNotNullAndNotChangingAnswer(taskListUrlSegment, isChangingAnswer),
+                            ).withBackUrlIfNotNullAndNotCheckingAnswers(taskListUrlSegment, isCheckingAnswers),
                     ) { mapOf("address" to getPropertyAddress()) },
                 handleSubmitAndRedirect = { filteredJourneyData, _, _ -> epcStepHandleSubmitAndRedirect(filteredJourneyData) },
                 nextAction = { filteredJourneyData, _ -> epcStepNextAction(filteredJourneyData) },
@@ -799,7 +799,9 @@ class PropertyComplianceJourney(
                                 "findEpcUrl" to FIND_EPC_URL,
                                 "getNewEpcUrl" to GET_NEW_EPC_URL,
                                 "submitButtonText" to
-                                    getSubmitButtonTextOrDefaultIfChangingAnswer("forms.buttons.saveAndContinueToLandlordResponsibilities"),
+                                    getSubmitButtonTextOrDefaultIfCheckingAnswers(
+                                        "forms.buttons.saveAndContinueToLandlordResponsibilities",
+                                    ),
                             ),
                     ),
                 nextAction = { _, _ -> Pair(landlordResponsibilities.first().startingStepId, null) },
@@ -944,7 +946,9 @@ class PropertyComplianceJourney(
                             mapOf(
                                 "title" to "propertyCompliance.title",
                                 "submitButtonText" to
-                                    getSubmitButtonTextOrDefaultIfChangingAnswer("forms.buttons.saveAndContinueToLandlordResponsibilities"),
+                                    getSubmitButtonTextOrDefaultIfCheckingAnswers(
+                                        "forms.buttons.saveAndContinueToLandlordResponsibilities",
+                                    ),
                             ),
                     ),
                 nextAction = { _, _ -> Pair(landlordResponsibilities.first().startingStepId, null) },
@@ -1039,7 +1043,7 @@ class PropertyComplianceJourney(
                                 "epcImprovementGuideUrl" to EPC_IMPROVEMENT_GUIDE_URL,
                                 "expiryDateAsJavaLocalDate" to (getAcceptedEpcDetailsFromSession()?.expiryDateAsJavaLocalDate ?: ""),
                                 "submitButtonText" to
-                                    getSubmitButtonTextOrDefaultIfChangingAnswer(
+                                    getSubmitButtonTextOrDefaultIfCheckingAnswers(
                                         "forms.buttons.saveAndContinueToLandlordResponsibilities",
                                     ),
                             ),
@@ -1150,7 +1154,7 @@ class PropertyComplianceJourney(
                             mapOf(
                                 "title" to "propertyCompliance.title",
                                 "submitButtonText" to
-                                    getSubmitButtonTextOrDefaultIfChangingAnswer(
+                                    getSubmitButtonTextOrDefaultIfCheckingAnswers(
                                         "forms.buttons.saveAndContinueToLandlordResponsibilities",
                                     ),
                             ),
@@ -1172,7 +1176,7 @@ class PropertyComplianceJourney(
                                 "epcImprovementGuideUrl" to EPC_IMPROVEMENT_GUIDE_URL,
                                 "registerPrsExemptionUrl" to REGISTER_PRS_EXEMPTION_URL,
                                 "submitButtonText" to
-                                    getSubmitButtonTextOrDefaultIfChangingAnswer(
+                                    getSubmitButtonTextOrDefaultIfCheckingAnswers(
                                         "forms.buttons.saveAndContinueToLandlordResponsibilities",
                                     ),
                             ),
@@ -1205,7 +1209,7 @@ class PropertyComplianceJourney(
                                             labelMsgKey = "forms.radios.option.no.label",
                                         ),
                                     ),
-                            ).withBackUrlIfNotNullAndNotChangingAnswer(taskListUrlSegment, isChangingAnswer),
+                            ).withBackUrlIfNotNullAndNotCheckingAnswers(taskListUrlSegment, isCheckingAnswers),
                     ),
                 nextAction = { filteredJourneyData, _ -> fireSafetyDeclarationStepNextAction(filteredJourneyData) },
             )
@@ -1357,7 +1361,7 @@ class PropertyComplianceJourney(
             return updateEpcDetailsInSessionAndRedirectToNextStep(epcStep, filteredJourneyData, epcDetails, autoMatchedEpc = true)
         }
 
-        return getRedirectForNextStep(epcStep, filteredJourneyData, null, changingAnswerForStep)
+        return getRedirectForNextStep(epcStep, filteredJourneyData, null, checkingAnswersFor)
     }
 
     private fun updateEpcDetailsInSessionAndRedirectToNextStep(
@@ -1368,7 +1372,7 @@ class PropertyComplianceJourney(
     ): String {
         val newFilteredJourneyData = filteredJourneyData.withEpcDetails(epcDetails, autoMatchedEpc)
         journeyDataService.addToJourneyDataIntoSession(newFilteredJourneyData)
-        return getRedirectForNextStep(currentStep, newFilteredJourneyData, null, changingAnswerForStep)
+        return getRedirectForNextStep(currentStep, newFilteredJourneyData, null, checkingAnswersFor)
     }
 
     private fun resetCheckMatchedEpcInSessionIfChangedEpcDetails(newEpcDetails: EpcDataModel?) {
@@ -1430,11 +1434,11 @@ class PropertyComplianceJourney(
                 checkMatchedEpcStep,
                 filteredJourneyData,
                 null,
-                changingAnswerForStep,
+                checkingAnswersFor,
                 PropertyComplianceStepId.EpcLookup,
             )
         }
-        return getRedirectForNextStep(checkMatchedEpcStep, filteredJourneyData, null, changingAnswerForStep)
+        return getRedirectForNextStep(checkMatchedEpcStep, filteredJourneyData, null, checkingAnswersFor)
     }
 
     private fun epcLookupStepHandleSubmitAndRedirect(filteredJourneyData: JourneyData): String {
@@ -1576,8 +1580,8 @@ class PropertyComplianceJourney(
             .getPropertyOwnership(propertyOwnershipId)
             .property.address.singleLineAddress
 
-    private fun getSubmitButtonTextOrDefaultIfChangingAnswer(submitButtonText: String) =
-        if (isChangingAnswer) {
+    private fun getSubmitButtonTextOrDefaultIfCheckingAnswers(submitButtonText: String) =
+        if (isCheckingAnswers) {
             "forms.buttons.saveAndContinue"
         } else {
             submitButtonText

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/PropertyDetailsUpdateJourney.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/PropertyDetailsUpdateJourney.kt
@@ -17,7 +17,7 @@ import uk.gov.communities.prsdb.webapp.forms.steps.StepId
 import uk.gov.communities.prsdb.webapp.forms.steps.UpdatePropertyDetailsStepId
 import uk.gov.communities.prsdb.webapp.forms.steps.factories.PropertyDetailsUpdateJourneyStepFactory
 import uk.gov.communities.prsdb.webapp.helpers.JourneyDataHelper
-import uk.gov.communities.prsdb.webapp.helpers.extensions.journeyExtensions.GroupedJourneyExtensions.Companion.withBackUrlIfNotNullAndNotChangingAnswer
+import uk.gov.communities.prsdb.webapp.helpers.extensions.journeyExtensions.GroupedJourneyExtensions.Companion.withBackUrlIfNotNullAndNotCheckingAnswers
 import uk.gov.communities.prsdb.webapp.helpers.extensions.journeyExtensions.PropertyDetailsUpdateJourneyExtensions
 import uk.gov.communities.prsdb.webapp.helpers.extensions.journeyExtensions.PropertyDetailsUpdateJourneyExtensions.Companion.getLicenceNumberStepIdAndFormModel
 import uk.gov.communities.prsdb.webapp.helpers.extensions.journeyExtensions.PropertyDetailsUpdateJourneyExtensions.Companion.getLicenceNumberUpdateIfPresent
@@ -55,7 +55,7 @@ class PropertyDetailsUpdateJourney(
         validator = validator,
         journeyDataService = journeyDataServiceFactory.create(getJourneyDataKey(propertyOwnershipId, stepName)),
         stepName = stepName,
-        isChangingAnswer = isChangingAnswer,
+        isCheckingAnswers = isChangingAnswer,
     ) {
     override val stepRouter = GroupedUpdateStepRouter(this)
 
@@ -192,7 +192,7 @@ class PropertyDetailsUpdateJourney(
                                         labelMsgKey = "forms.licensingType.radios.option.noLicensing.label",
                                     ),
                                 ),
-                        ).withBackUrlIfNotNullAndNotChangingAnswer(RELATIVE_PROPERTY_DETAILS_PATH, isChangingAnswer),
+                        ).withBackUrlIfNotNullAndNotCheckingAnswers(RELATIVE_PROPERTY_DETAILS_PATH, isChangingAnswer),
                 ),
             nextAction = { filteredJourneyData, _ -> licensingTypeNextAction(filteredJourneyData) },
             saveAfterSubmit = false,

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/StepRouter.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/StepRouter.kt
@@ -6,29 +6,29 @@ import uk.gov.communities.prsdb.webapp.forms.steps.StepDetails
 import uk.gov.communities.prsdb.webapp.forms.steps.StepId
 
 interface StepRouter<T : StepId> {
-    fun isDestinationAllowedWhenChangingAnswerTo(
+    fun isDestinationAllowedWhenCheckingAnswersFor(
         destinationStep: T?,
-        stepBeingChanged: T?,
+        stepBeingChecked: T?,
     ): Boolean
 }
 
 open class IsolatedStepRouter<T : StepId> : StepRouter<T> {
-    override fun isDestinationAllowedWhenChangingAnswerTo(
+    override fun isDestinationAllowedWhenCheckingAnswersFor(
         destinationStep: T?,
-        stepBeingChanged: T?,
-    ): Boolean = destinationStep != null && destinationStep == stepBeingChanged
+        stepBeingChecked: T?,
+    ): Boolean = destinationStep != null && destinationStep == stepBeingChecked
 }
 
 open class GroupedStepRouter<T : GroupedStepId<*>>(
     private val steps: Iterable<StepDetails<T>>,
 ) : StepRouter<T> {
-    override fun isDestinationAllowedWhenChangingAnswerTo(
+    override fun isDestinationAllowedWhenCheckingAnswersFor(
         destinationStep: T?,
-        stepBeingChanged: T?,
+        stepBeingChecked: T?,
     ): Boolean =
         destinationStep != null &&
-            destinationStep.groupIdentifier == stepBeingChanged?.groupIdentifier &&
-            isDestinationNotBeforeOtherStep(destinationStep, stepBeingChanged)
+            destinationStep.groupIdentifier == stepBeingChecked?.groupIdentifier &&
+            isDestinationNotBeforeOtherStep(destinationStep, stepBeingChecked)
 
     private fun isDestinationNotBeforeOtherStep(
         destinationStep: T?,
@@ -48,10 +48,10 @@ open class GroupedStepRouter<T : GroupedStepId<*>>(
 open class GroupedUpdateStepRouter<T : GroupedUpdateStepId<*>>(
     steps: Iterable<StepDetails<T>>,
 ) : GroupedStepRouter<T>(steps) {
-    override fun isDestinationAllowedWhenChangingAnswerTo(
+    override fun isDestinationAllowedWhenCheckingAnswersFor(
         destinationStep: T?,
-        stepBeingChanged: T?,
+        stepBeingChecked: T?,
     ): Boolean =
         destinationStep?.isCheckYourAnswersStepId != true &&
-            super.isDestinationAllowedWhenChangingAnswerTo(destinationStep, stepBeingChanged)
+            super.isDestinationAllowedWhenCheckingAnswersFor(destinationStep, stepBeingChecked)
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/factories/PropertyComplianceJourneyFactory.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/factories/PropertyComplianceJourneyFactory.kt
@@ -30,7 +30,7 @@ class PropertyComplianceJourneyFactory(
 ) {
     fun create(
         propertyOwnershipId: Long,
-        changingAnswerFor: String? = null,
+        checkingAnswersFor: String? = null,
     ) = PropertyComplianceJourney(
         validator,
         journeyDataService = journeyDataServiceFactory.create(getJourneyDataKey(propertyOwnershipId)),
@@ -43,7 +43,7 @@ class PropertyComplianceJourneyFactory(
         fullPropertyComplianceConfirmationEmailService,
         partialPropertyComplianceConfirmationEmailService,
         absoluteUrlProvider,
-        changingAnswerFor,
+        checkingAnswersFor,
     )
 
     companion object {

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/factories/PropertyDetailsUpdateJourneyFactory.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/factories/PropertyDetailsUpdateJourneyFactory.kt
@@ -20,14 +20,14 @@ class PropertyDetailsUpdateJourneyFactory(
     fun create(
         propertyOwnershipId: Long,
         stepName: String,
-        isChangingAnswer: Boolean,
+        isCheckingAnswer: Boolean,
     ) = PropertyDetailsUpdateJourney(
         validator,
         journeyDataServiceFactory,
         propertyOwnershipService,
         propertyOwnershipId,
         stepName,
-        isChangingAnswer,
+        isCheckingAnswer,
     )
 
     companion object {

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/pages/PropertyComplianceCheckAnswersPage.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/pages/PropertyComplianceCheckAnswersPage.kt
@@ -104,11 +104,13 @@ class PropertyComplianceCheckAnswersPage(
                 "forms.checkComplianceAnswers.responsibilities.keepPropertySafe",
                 true,
                 PropertyComplianceStepId.KeepPropertySafe.urlPathSegment,
+                actionValue = "forms.links.view",
             ),
             SummaryListRowViewModel.forCheckYourAnswersPage(
                 "forms.checkComplianceAnswers.responsibilities.responsibilityToTenants",
                 true,
                 PropertyComplianceStepId.ResponsibilityToTenants.urlPathSegment,
+                actionValue = "forms.links.view",
             ),
         )
 

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/steps/LookupAddressStep.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/steps/LookupAddressStep.kt
@@ -23,12 +23,12 @@ class LookupAddressStep<T : StepId>(
             Pair(getNextStep(filteredJourneyData, nextStepIfAddressesFound, nextStepIfNoAddressesFound), subPageNumber)
         },
         saveAfterSubmit = saveAfterSubmit,
-        handleSubmitAndRedirect = { filteredJourneyData: JourneyData, subPageNumber: Int?, changingAnswersForStep: T? ->
+        handleSubmitAndRedirect = { filteredJourneyData: JourneyData, subPageNumber: Int?, checkingAnswersFor: T? ->
             performAddressLookupCacheResultsAndGetRedirect(
                 filteredJourneyData,
                 subPageNumber,
                 id,
-                changingAnswersForStep,
+                checkingAnswersFor,
                 nextStepIfAddressesFound,
                 nextStepIfNoAddressesFound,
                 journeyDataService,
@@ -52,7 +52,7 @@ class LookupAddressStep<T : StepId>(
             filteredJourneyData: JourneyData,
             subPageNumber: Int?,
             id: T,
-            changingAnswersForStep: T?,
+            checkingAnswersFor: T?,
             nextStepIfAddressesFound: T,
             nextStepIfNoAddressesFound: T,
             journeyDataService: JourneyDataService,
@@ -69,7 +69,7 @@ class LookupAddressStep<T : StepId>(
             journeyDataService.addToJourneyDataIntoSession(updatedFilteredJourneyData)
 
             val nextStepId = getNextStep(updatedFilteredJourneyData, nextStepIfAddressesFound, nextStepIfNoAddressesFound)
-            return generateUrl(nextStepId, subPageNumber, changingAnswersForStep)
+            return generateUrl(nextStepId, subPageNumber, checkingAnswersFor)
         }
     }
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/steps/Step.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/steps/Step.kt
@@ -2,7 +2,7 @@ package uk.gov.communities.prsdb.webapp.forms.steps
 
 import org.springframework.validation.BindingResult
 import org.springframework.web.util.UriComponentsBuilder
-import uk.gov.communities.prsdb.webapp.constants.CHANGE_ANSWER_FOR_PARAMETER_NAME
+import uk.gov.communities.prsdb.webapp.constants.CHECKING_ANSWERS_FOR_PARAMETER_NAME
 import uk.gov.communities.prsdb.webapp.forms.JourneyData
 import uk.gov.communities.prsdb.webapp.forms.PageData
 import uk.gov.communities.prsdb.webapp.forms.objectToStringKeyedMap
@@ -13,7 +13,7 @@ import java.util.Optional
 open class Step<T : StepId>(
     val id: T,
     val page: AbstractPage,
-    val handleSubmitAndRedirect: ((filteredJourneyData: JourneyData, subPageNumber: Int?, changingAnswersForStep: T?) -> String)? = null,
+    val handleSubmitAndRedirect: ((filteredJourneyData: JourneyData, subPageNumber: Int?, checkingAnswersFor: T?) -> String)? = null,
     val isSatisfied: (bindingResult: BindingResult) -> Boolean = { bindingResult -> page.isSatisfied(bindingResult) },
     val nextAction: (filteredJourneyData: JourneyData, subPageNumber: Int?) -> Pair<T?, Int?> = { _, _ -> Pair(null, null) },
     val saveAfterSubmit: Boolean = true,
@@ -51,13 +51,13 @@ open class Step<T : StepId>(
         fun generateUrl(
             stepId: StepId,
             subPageNumber: Int?,
-            changingAnswersFor: StepId? = null,
+            checkingAnswersFor: StepId? = null,
         ): String =
             UriComponentsBuilder
                 .newInstance()
                 .path(stepId.urlPathSegment)
                 .queryParamIfPresent("subpage", Optional.ofNullable(subPageNumber))
-                .queryParamIfPresent(CHANGE_ANSWER_FOR_PARAMETER_NAME, Optional.ofNullable(changingAnswersFor?.urlPathSegment))
+                .queryParamIfPresent(CHECKING_ANSWERS_FOR_PARAMETER_NAME, Optional.ofNullable(checkingAnswersFor?.urlPathSegment))
                 .build(true)
                 .toUriString()
     }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/steps/factories/PropertyDetailsUpdateJourneyStepFactory.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/steps/factories/PropertyDetailsUpdateJourneyStepFactory.kt
@@ -7,7 +7,7 @@ import uk.gov.communities.prsdb.webapp.forms.pages.PropertyRegistrationNumberOfP
 import uk.gov.communities.prsdb.webapp.forms.steps.Step
 import uk.gov.communities.prsdb.webapp.forms.steps.UpdatePropertyDetailsGroupIdentifier
 import uk.gov.communities.prsdb.webapp.forms.steps.UpdatePropertyDetailsStepId
-import uk.gov.communities.prsdb.webapp.helpers.extensions.journeyExtensions.GroupedJourneyExtensions.Companion.withBackUrlIfNotNullAndNotChangingAnswer
+import uk.gov.communities.prsdb.webapp.helpers.extensions.journeyExtensions.GroupedJourneyExtensions.Companion.withBackUrlIfNotNullAndNotCheckingAnswers
 import uk.gov.communities.prsdb.webapp.helpers.extensions.journeyExtensions.PropertyDetailsUpdateJourneyExtensions.Companion.getIsOccupiedUpdateIfPresent
 import uk.gov.communities.prsdb.webapp.helpers.extensions.journeyExtensions.PropertyDetailsUpdateJourneyExtensions.Companion.getLatestNumberOfHouseholds
 import uk.gov.communities.prsdb.webapp.helpers.extensions.journeyExtensions.PropertyDetailsUpdateJourneyExtensions.Companion.getOriginalIsOccupied
@@ -29,7 +29,7 @@ import uk.gov.communities.prsdb.webapp.services.JourneyDataService
  */
 class PropertyDetailsUpdateJourneyStepFactory(
     stepName: String,
-    private val isChangingAnswer: Boolean,
+    private val isCheckingAnswers: Boolean,
     private val propertyDetailsPath: String,
     private val journeyDataService: JourneyDataService,
 ) {
@@ -81,7 +81,7 @@ class PropertyDetailsUpdateJourneyStepFactory(
                                         hintMsgKey = "forms.occupancy.radios.option.no.hint",
                                     ),
                                 ),
-                        ).withBackUrlIfNotNullAndNotChangingAnswer(propertyDetailsPath, isChangingAnswer),
+                        ).withBackUrlIfNotNullAndNotCheckingAnswers(propertyDetailsPath, isCheckingAnswers),
                 ),
             nextAction = { filteredJourneyData, _ -> occupancyNextAction(filteredJourneyData) },
             saveAfterSubmit = false,
@@ -137,7 +137,7 @@ class PropertyDetailsUpdateJourneyStepFactory(
                         "title" to "propertyDetails.update.title",
                         "fieldSetHeading" to fieldSetHeadingKey,
                         "label" to "forms.numberOfHouseholds.label",
-                    ).withBackUrlIfNotNullAndNotChangingAnswer(backUrl, isChangingAnswer),
+                    ).withBackUrlIfNotNullAndNotCheckingAnswers(backUrl, isCheckingAnswers),
             ),
         nextAction = { _, _ -> Pair(numberOfPeopleStepId, null) },
         saveAfterSubmit = false,
@@ -158,7 +158,7 @@ class PropertyDetailsUpdateJourneyStepFactory(
                         "fieldSetHeading" to fieldSetHeadingKey,
                         "fieldSetHint" to "forms.numberOfPeople.fieldSetHint",
                         "label" to "forms.numberOfPeople.label",
-                    ).withBackUrlIfNotNullAndNotChangingAnswer(backUrl, isChangingAnswer),
+                    ).withBackUrlIfNotNullAndNotCheckingAnswers(backUrl, isCheckingAnswers),
                 latestNumberOfHouseholds = getLatestNumberOfHouseholds(),
             ),
         nextAction = { _, _ -> Pair(checkOccupancyAnswersStepId, null) },

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/helpers/extensions/journeyExtensions/GroupedJourneyExtensions.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/helpers/extensions/journeyExtensions/GroupedJourneyExtensions.kt
@@ -4,10 +4,10 @@ import uk.gov.communities.prsdb.webapp.constants.BACK_URL_ATTR_NAME
 
 class GroupedJourneyExtensions {
     companion object {
-        fun Map<String, Any>.withBackUrlIfNotNullAndNotChangingAnswer(
+        fun Map<String, Any>.withBackUrlIfNotNullAndNotCheckingAnswers(
             backUrl: String?,
-            isChangingAnswer: Boolean,
-        ) = if (backUrl == null || isChangingAnswer) {
+            isCheckingAnswers: Boolean,
+        ) = if (backUrl == null || isCheckingAnswers) {
             this
         } else {
             this + (BACK_URL_ATTR_NAME to backUrl)

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/summaryModels/SummaryListRowViewModel.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/summaryModels/SummaryListRowViewModel.kt
@@ -34,6 +34,7 @@ data class SummaryListRowViewModel(
             fieldValue: Any?,
             actionUrl: String?,
             valueUrl: String? = null,
+            actionValue: String = "forms.links.change",
         ): SummaryListRowViewModel =
             SummaryListRowViewModel(
                 fieldHeading = fieldHeading,
@@ -41,7 +42,7 @@ data class SummaryListRowViewModel(
                 action =
                     actionUrl?.let {
                         SummaryListRowActionViewModel(
-                            "forms.links.change",
+                            actionValue,
                             "$it?$CHECKING_ANSWERS_FOR_PARAMETER_NAME=$it",
                         )
                     },

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/summaryModels/SummaryListRowViewModel.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/summaryModels/SummaryListRowViewModel.kt
@@ -2,7 +2,7 @@ package uk.gov.communities.prsdb.webapp.models.viewModels.summaryModels
 
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.toJavaLocalDate
-import uk.gov.communities.prsdb.webapp.constants.CHANGE_ANSWER_FOR_PARAMETER_NAME
+import uk.gov.communities.prsdb.webapp.constants.CHECKING_ANSWERS_FOR_PARAMETER_NAME
 import uk.gov.communities.prsdb.webapp.helpers.converters.MessageKeyConverter
 import uk.gov.communities.prsdb.webapp.models.dataModels.RegistrationNumberDataModel
 
@@ -42,7 +42,7 @@ data class SummaryListRowViewModel(
                     actionUrl?.let {
                         SummaryListRowActionViewModel(
                             "forms.links.change",
-                            "$it?$CHANGE_ANSWER_FOR_PARAMETER_NAME=$it",
+                            "$it?$CHECKING_ANSWERS_FOR_PARAMETER_NAME=$it",
                         )
                     },
                 valueUrl = valueUrl,

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -620,6 +620,7 @@ forms.buttons.continueToSearch=Continue to search
 forms.buttons.confirmAndSubmitCompliance=Confirm and submit compliance information
 
 forms.links.change=Change
+forms.links.view=View
 
 forms.textArea.infoText=You can enter up to {0,,limit} characters
 

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/controllers/PropertyDetailsControllerTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/controllers/PropertyDetailsControllerTests.kt
@@ -158,7 +158,7 @@ class PropertyDetailsControllerTests(
                 propertyDetailsUpdateJourneyFactory.create(
                     propertyOwnership.id,
                     UpdatePropertyDetailsStepId.UpdateOwnershipType.urlPathSegment,
-                    isChangingAnswer = false,
+                    isCheckingAnswer = false,
                 ),
             ).thenReturn(propertyDetailsUpdateJourney)
         }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/GroupedJourneyTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/GroupedJourneyTests.kt
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.mockito.Mockito.mock
 import org.springframework.validation.beanvalidation.SpringValidatorAdapter
+import uk.gov.communities.prsdb.webapp.constants.CHECKING_ANSWERS_FOR_PARAMETER_NAME
 import uk.gov.communities.prsdb.webapp.constants.enums.JourneyType
 import uk.gov.communities.prsdb.webapp.forms.PageData
 import uk.gov.communities.prsdb.webapp.forms.pages.Page
@@ -72,9 +73,9 @@ class GroupedJourneyTests {
     }
 
     @Nested
-    inner class ChangingAnswersTests {
+    inner class CheckingAnswersTests {
         @Test
-        fun `completeStep redirects to next step with same changingAnswerFor when within group`() {
+        fun `completeStep redirects to next step with same checkingAnswersFor when within group`() {
             // Arrange
             val groupedJourney =
                 TestGroupedJourney(
@@ -111,7 +112,7 @@ class GroupedJourneyTests {
             // Assert
             assertEquals(
                 "redirect:${TestGroupedStepId.GroupOneStepTwo.urlPathSegment}?" +
-                    "changingAnswerFor=${TestGroupedStepId.GroupOneStepOne.urlPathSegment}",
+                    "$CHECKING_ANSWERS_FOR_PARAMETER_NAME=${TestGroupedStepId.GroupOneStepOne.urlPathSegment}",
                 result.viewName,
             )
         }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/GroupedUpdateJourneyTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/GroupedUpdateJourneyTests.kt
@@ -8,7 +8,7 @@ import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.whenever
 import org.springframework.web.util.UriComponentsBuilder
 import uk.gov.communities.prsdb.webapp.constants.BACK_URL_ATTR_NAME
-import uk.gov.communities.prsdb.webapp.constants.CHANGE_ANSWER_FOR_PARAMETER_NAME
+import uk.gov.communities.prsdb.webapp.constants.CHECKING_ANSWERS_FOR_PARAMETER_NAME
 import uk.gov.communities.prsdb.webapp.constants.enums.JourneyType
 import uk.gov.communities.prsdb.webapp.forms.JourneyData
 import uk.gov.communities.prsdb.webapp.forms.pages.Page
@@ -50,7 +50,7 @@ class GroupedUpdateJourneyTests {
             AlwaysTrueValidator(),
             journeyDataService,
             currentStep.urlPathSegment,
-            isChangingAnswer = true,
+            isCheckingAnswers = true,
         ) {
         override val sections =
             createSingleSectionWithSingleTaskFromSteps(
@@ -86,9 +86,9 @@ class GroupedUpdateJourneyTests {
     }
 
     @Nested
-    inner class ChangingAnswersTests {
+    inner class CheckingAnswersTests {
         @Test
-        fun `completeStep redirects to next step with same changingAnswerFor when not reaching end of group`() {
+        fun `completeStep redirects to next step with same checkingAnswersFor when not reaching end of group`() {
             // Arrange
             val groupedUpdateJourney = TestGroupedUpdateJourney(mockJourneyDataService, TestGroupedUpdateStepId.GroupOneStepOne)
 
@@ -98,12 +98,12 @@ class GroupedUpdateJourneyTests {
                     .completeStep(
                         formData = emptyMap(),
                         principal = { "testPrincipalId" },
-                        changingAnswersForStep = TestGroupedUpdateStepId.GroupOneStepOne.urlPathSegment,
+                        checkingAnswersForStep = TestGroupedUpdateStepId.GroupOneStepOne.urlPathSegment,
                     ).viewName!!
 
             // Assert
             assertEquals(TestGroupedUpdateStepId.GroupOneStepTwo.urlPathSegment, result.getPath())
-            assertEquals(TestGroupedUpdateStepId.GroupOneStepOne.urlPathSegment, result.getQueryParam(CHANGE_ANSWER_FOR_PARAMETER_NAME))
+            assertEquals(TestGroupedUpdateStepId.GroupOneStepOne.urlPathSegment, result.getQueryParam(CHECKING_ANSWERS_FOR_PARAMETER_NAME))
         }
 
         @Test
@@ -117,16 +117,16 @@ class GroupedUpdateJourneyTests {
                     .completeStep(
                         formData = emptyMap(),
                         principal = { "testPrincipalId" },
-                        changingAnswersForStep = TestGroupedUpdateStepId.GroupOneStepOne.urlPathSegment,
+                        checkingAnswersForStep = TestGroupedUpdateStepId.GroupOneStepOne.urlPathSegment,
                     ).viewName!!
 
             // Assert
             assertEquals(TestGroupedUpdateStepId.GroupOneCyaStep.urlPathSegment, result.getPath())
-            assertNull(result.getQueryParam(CHANGE_ANSWER_FOR_PARAMETER_NAME))
+            assertNull(result.getQueryParam(CHECKING_ANSWERS_FOR_PARAMETER_NAME))
         }
 
         @Test
-        fun `getModelAndViewForStep yields a back link to the previous step with same changingAnswerFor if not at start of group`() {
+        fun `getModelAndViewForStep yields a back link to the previous step with same checkingAnswersFor if not at start of group`() {
             // Arrange
             whenever(mockJourneyDataService.getJourneyDataFromSession())
                 .thenReturn(mapOf(TestGroupedUpdateStepId.GroupOneStepOne.urlPathSegment to emptyMap<String, Any>()))
@@ -137,13 +137,13 @@ class GroupedUpdateJourneyTests {
                 groupedUpdateJourney
                     .getModelAndViewForStep(
                         submittedPageData = null,
-                        changingAnswersForStep = TestGroupedUpdateStepId.GroupOneStepOne.urlPathSegment,
+                        checkingAnswersForStep = TestGroupedUpdateStepId.GroupOneStepOne.urlPathSegment,
                     ).model[BACK_URL_ATTR_NAME]
                     .toString()
 
             // Assert
             assertEquals(TestGroupedUpdateStepId.GroupOneStepOne.urlPathSegment, result.getPath())
-            assertEquals(TestGroupedUpdateStepId.GroupOneStepOne.urlPathSegment, result.getQueryParam(CHANGE_ANSWER_FOR_PARAMETER_NAME))
+            assertEquals(TestGroupedUpdateStepId.GroupOneStepOne.urlPathSegment, result.getQueryParam(CHECKING_ANSWERS_FOR_PARAMETER_NAME))
         }
 
         @Test
@@ -156,13 +156,13 @@ class GroupedUpdateJourneyTests {
                 groupedUpdateJourney
                     .getModelAndViewForStep(
                         submittedPageData = null,
-                        changingAnswersForStep = TestGroupedUpdateStepId.GroupOneStepOne.urlPathSegment,
+                        checkingAnswersForStep = TestGroupedUpdateStepId.GroupOneStepOne.urlPathSegment,
                     ).model[BACK_URL_ATTR_NAME]
                     .toString()
 
             // Assert
             assertEquals(TestGroupedUpdateStepId.GroupOneCyaStep.urlPathSegment, result.getPath())
-            assertNull(result.getQueryParam(CHANGE_ANSWER_FOR_PARAMETER_NAME))
+            assertNull(result.getQueryParam(CHECKING_ANSWERS_FOR_PARAMETER_NAME))
         }
     }
 

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/JourneyTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/JourneyTests.kt
@@ -857,7 +857,7 @@ class JourneyTests {
     }
 
     @Nested
-    inner class ChangingAnswersTests {
+    inner class CheckingAnswersTests {
         @Test
         fun `getModelAndViewForStep returns back button to check your answers page when changing answers`() {
             // Arrange

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/PropertyComplianceJourneyTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/PropertyComplianceJourneyTests.kt
@@ -904,7 +904,7 @@ class PropertyComplianceJourneyTests {
             fullPropertyComplianceConfirmationEmailService = mockFullComplianceEmailService,
             partialPropertyComplianceConfirmationEmailService = mockPartialComplianceEmailService,
             urlProvider = mockUrlProvider,
-            changingAnswerFor = null,
+            checkingAnswersForStep = null,
         )
 
     private fun completeStep(

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/forms/pages/LandlordRegistrationCheckAnswersPageTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/forms/pages/LandlordRegistrationCheckAnswersPageTests.kt
@@ -8,6 +8,7 @@ import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 import org.springframework.validation.Validator
+import uk.gov.communities.prsdb.webapp.constants.CHECKING_ANSWERS_FOR_PARAMETER_NAME
 import uk.gov.communities.prsdb.webapp.forms.JourneyData
 import uk.gov.communities.prsdb.webapp.forms.PageData
 import uk.gov.communities.prsdb.webapp.forms.steps.LandlordRegistrationStepId
@@ -96,7 +97,7 @@ class LandlordRegistrationCheckAnswersPageTests {
                 name,
                 SummaryListRowActionViewModel(
                     "forms.links.change",
-                    "${LandlordRegistrationStepId.Name.urlPathSegment}?changingAnswerFor=" +
+                    "${LandlordRegistrationStepId.Name.urlPathSegment}?$CHECKING_ANSWERS_FOR_PARAMETER_NAME=" +
                         LandlordRegistrationStepId.Name.urlPathSegment,
                 ),
             ),
@@ -110,7 +111,7 @@ class LandlordRegistrationCheckAnswersPageTests {
                 dob,
                 SummaryListRowActionViewModel(
                     "forms.links.change",
-                    "${LandlordRegistrationStepId.DateOfBirth.urlPathSegment}?changingAnswerFor=" +
+                    "${LandlordRegistrationStepId.DateOfBirth.urlPathSegment}?$CHECKING_ANSWERS_FOR_PARAMETER_NAME=" +
                         LandlordRegistrationStepId.DateOfBirth.urlPathSegment,
                 ),
             ),
@@ -134,7 +135,7 @@ class LandlordRegistrationCheckAnswersPageTests {
                 emailAddress,
                 SummaryListRowActionViewModel(
                     "forms.links.change",
-                    "${LandlordRegistrationStepId.Email.urlPathSegment}?changingAnswerFor=" +
+                    "${LandlordRegistrationStepId.Email.urlPathSegment}?$CHECKING_ANSWERS_FOR_PARAMETER_NAME=" +
                         LandlordRegistrationStepId.Email.urlPathSegment,
                 ),
             ),
@@ -148,7 +149,7 @@ class LandlordRegistrationCheckAnswersPageTests {
                 phoneNumber,
                 SummaryListRowActionViewModel(
                     "forms.links.change",
-                    "${LandlordRegistrationStepId.PhoneNumber.urlPathSegment}?changingAnswerFor=" +
+                    "${LandlordRegistrationStepId.PhoneNumber.urlPathSegment}?$CHECKING_ANSWERS_FOR_PARAMETER_NAME=" +
                         LandlordRegistrationStepId.PhoneNumber.urlPathSegment,
                 ),
             ),
@@ -170,7 +171,7 @@ class LandlordRegistrationCheckAnswersPageTests {
                 true,
                 SummaryListRowActionViewModel(
                     "forms.links.change",
-                    "${LandlordRegistrationStepId.CountryOfResidence.urlPathSegment}?changingAnswerFor=" +
+                    "${LandlordRegistrationStepId.CountryOfResidence.urlPathSegment}?$CHECKING_ANSWERS_FOR_PARAMETER_NAME=" +
                         LandlordRegistrationStepId.CountryOfResidence.urlPathSegment,
                 ),
             ),
@@ -192,7 +193,7 @@ class LandlordRegistrationCheckAnswersPageTests {
                 DEFAULT_ADDRESS,
                 SummaryListRowActionViewModel(
                     "forms.links.change",
-                    "${LandlordRegistrationStepId.LookupAddress.urlPathSegment}?changingAnswerFor=" +
+                    "${LandlordRegistrationStepId.LookupAddress.urlPathSegment}?$CHECKING_ANSWERS_FOR_PARAMETER_NAME=" +
                         LandlordRegistrationStepId.LookupAddress.urlPathSegment,
                 ),
             ),
@@ -220,7 +221,7 @@ class LandlordRegistrationCheckAnswersPageTests {
                 AddressDataModel.fromManualAddressData(addressLineOne, townOrCity, postcode).singleLineAddress,
                 SummaryListRowActionViewModel(
                     "forms.links.change",
-                    "${LandlordRegistrationStepId.ManualAddress.urlPathSegment}?changingAnswerFor=" +
+                    "${LandlordRegistrationStepId.ManualAddress.urlPathSegment}?$CHECKING_ANSWERS_FOR_PARAMETER_NAME=" +
                         LandlordRegistrationStepId.ManualAddress.urlPathSegment,
                 ),
             ),
@@ -252,7 +253,7 @@ class LandlordRegistrationCheckAnswersPageTests {
                 SummaryListRowActionViewModel(
                     "forms.links.change",
                     LandlordRegistrationStepId.CountryOfResidence.urlPathSegment +
-                        "?changingAnswerFor=${LandlordRegistrationStepId.CountryOfResidence.urlPathSegment}",
+                        "?$CHECKING_ANSWERS_FOR_PARAMETER_NAME=${LandlordRegistrationStepId.CountryOfResidence.urlPathSegment}",
                 ),
             ),
             summaryListData.single {
@@ -266,7 +267,7 @@ class LandlordRegistrationCheckAnswersPageTests {
                 SummaryListRowActionViewModel(
                     "forms.links.change",
                     LandlordRegistrationStepId.NonEnglandOrWalesAddress.urlPathSegment +
-                        "?changingAnswerFor=${LandlordRegistrationStepId.NonEnglandOrWalesAddress.urlPathSegment}",
+                        "?$CHECKING_ANSWERS_FOR_PARAMETER_NAME=${LandlordRegistrationStepId.NonEnglandOrWalesAddress.urlPathSegment}",
                 ),
             ),
             summaryListData.single {
@@ -280,7 +281,7 @@ class LandlordRegistrationCheckAnswersPageTests {
                 SummaryListRowActionViewModel(
                     "forms.links.change",
                     LandlordRegistrationStepId.LookupContactAddress.urlPathSegment +
-                        "?changingAnswerFor=${LandlordRegistrationStepId.LookupContactAddress.urlPathSegment}",
+                        "?$CHECKING_ANSWERS_FOR_PARAMETER_NAME=${LandlordRegistrationStepId.LookupContactAddress.urlPathSegment}",
                 ),
             ),
             summaryListData.single {
@@ -315,7 +316,7 @@ class LandlordRegistrationCheckAnswersPageTests {
                 SummaryListRowActionViewModel(
                     "forms.links.change",
                     LandlordRegistrationStepId.CountryOfResidence.urlPathSegment +
-                        "?changingAnswerFor=${LandlordRegistrationStepId.CountryOfResidence.urlPathSegment}",
+                        "?$CHECKING_ANSWERS_FOR_PARAMETER_NAME=${LandlordRegistrationStepId.CountryOfResidence.urlPathSegment}",
                 ),
             ),
             summaryListData.single {
@@ -329,7 +330,7 @@ class LandlordRegistrationCheckAnswersPageTests {
                 SummaryListRowActionViewModel(
                     "forms.links.change",
                     LandlordRegistrationStepId.NonEnglandOrWalesAddress.urlPathSegment +
-                        "?changingAnswerFor=${LandlordRegistrationStepId.NonEnglandOrWalesAddress.urlPathSegment}",
+                        "?$CHECKING_ANSWERS_FOR_PARAMETER_NAME=${LandlordRegistrationStepId.NonEnglandOrWalesAddress.urlPathSegment}",
                 ),
             ),
             summaryListData.single {
@@ -342,7 +343,7 @@ class LandlordRegistrationCheckAnswersPageTests {
                 AddressDataModel.fromManualAddressData(addressLineOne, townOrCity, postcode).singleLineAddress,
                 SummaryListRowActionViewModel(
                     "forms.links.change",
-                    "${LandlordRegistrationStepId.ManualContactAddress.urlPathSegment}?changingAnswerFor=" +
+                    "${LandlordRegistrationStepId.ManualContactAddress.urlPathSegment}?$CHECKING_ANSWERS_FOR_PARAMETER_NAME=" +
                         LandlordRegistrationStepId.ManualContactAddress.urlPathSegment,
                 ),
             ),

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/forms/pages/PropertyComplianceCheckAnswersPageTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/forms/pages/PropertyComplianceCheckAnswersPageTests.kt
@@ -146,11 +146,13 @@ class PropertyComplianceCheckAnswersPageTests {
                     "forms.checkComplianceAnswers.responsibilities.keepPropertySafe",
                     true,
                     PropertyComplianceStepId.KeepPropertySafe.urlPathSegment,
+                    actionValue = "forms.links.view",
                 ),
                 SummaryListRowViewModel.forCheckYourAnswersPage(
                     "forms.checkComplianceAnswers.responsibilities.responsibilityToTenants",
                     true,
                     PropertyComplianceStepId.ResponsibilityToTenants.urlPathSegment,
+                    actionValue = "forms.links.view",
                 ),
             )
 
@@ -232,11 +234,13 @@ class PropertyComplianceCheckAnswersPageTests {
                     "forms.checkComplianceAnswers.responsibilities.keepPropertySafe",
                     true,
                     PropertyComplianceStepId.KeepPropertySafe.urlPathSegment,
+                    actionValue = "forms.links.view",
                 ),
                 SummaryListRowViewModel.forCheckYourAnswersPage(
                     "forms.checkComplianceAnswers.responsibilities.responsibilityToTenants",
                     true,
                     PropertyComplianceStepId.ResponsibilityToTenants.urlPathSegment,
+                    actionValue = "forms.links.view",
                 ),
             )
 

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/forms/pages/PropertyRegistrationCheckAnswersPageTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/forms/pages/PropertyRegistrationCheckAnswersPageTests.kt
@@ -8,6 +8,7 @@ import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 import org.springframework.validation.Validator
+import uk.gov.communities.prsdb.webapp.constants.CHECKING_ANSWERS_FOR_PARAMETER_NAME
 import uk.gov.communities.prsdb.webapp.constants.enums.LicensingType
 import uk.gov.communities.prsdb.webapp.constants.enums.OwnershipType
 import uk.gov.communities.prsdb.webapp.constants.enums.PropertyType
@@ -72,7 +73,7 @@ class PropertyRegistrationCheckAnswersPageTests {
                 SummaryListRowActionViewModel(
                     "forms.links.change",
                     RegisterPropertyStepId.LookupAddress.urlPathSegment +
-                        "?changingAnswerFor=${RegisterPropertyStepId.LookupAddress.urlPathSegment}",
+                        "?$CHECKING_ANSWERS_FOR_PARAMETER_NAME=${RegisterPropertyStepId.LookupAddress.urlPathSegment}",
                 ),
             ),
             propertyDetails.single {
@@ -125,7 +126,7 @@ class PropertyRegistrationCheckAnswersPageTests {
                 SummaryListRowActionViewModel(
                     "forms.links.change",
                     RegisterPropertyStepId.ManualAddress.urlPathSegment +
-                        "?changingAnswerFor=${RegisterPropertyStepId.ManualAddress.urlPathSegment}",
+                        "?$CHECKING_ANSWERS_FOR_PARAMETER_NAME=${RegisterPropertyStepId.ManualAddress.urlPathSegment}",
                 ),
             ),
             propertyDetails.single {
@@ -139,7 +140,7 @@ class PropertyRegistrationCheckAnswersPageTests {
                 SummaryListRowActionViewModel(
                     "forms.links.change",
                     RegisterPropertyStepId.LocalAuthority.urlPathSegment +
-                        "?changingAnswerFor=${RegisterPropertyStepId.LocalAuthority.urlPathSegment}",
+                        "?$CHECKING_ANSWERS_FOR_PARAMETER_NAME=${RegisterPropertyStepId.LocalAuthority.urlPathSegment}",
                 ),
             ),
             propertyDetails.single {
@@ -169,7 +170,7 @@ class PropertyRegistrationCheckAnswersPageTests {
                 SummaryListRowActionViewModel(
                     "forms.links.change",
                     RegisterPropertyStepId.PropertyType.urlPathSegment +
-                        "?changingAnswerFor=${RegisterPropertyStepId.PropertyType.urlPathSegment}",
+                        "?$CHECKING_ANSWERS_FOR_PARAMETER_NAME=${RegisterPropertyStepId.PropertyType.urlPathSegment}",
                 ),
             ),
             propertyDetails.single {
@@ -195,7 +196,7 @@ class PropertyRegistrationCheckAnswersPageTests {
                 SummaryListRowActionViewModel(
                     "forms.links.change",
                     RegisterPropertyStepId.PropertyType.urlPathSegment +
-                        "?changingAnswerFor=${RegisterPropertyStepId.PropertyType.urlPathSegment}",
+                        "?$CHECKING_ANSWERS_FOR_PARAMETER_NAME=${RegisterPropertyStepId.PropertyType.urlPathSegment}",
                 ),
             ),
             propertyDetails.single {
@@ -220,7 +221,7 @@ class PropertyRegistrationCheckAnswersPageTests {
                 SummaryListRowActionViewModel(
                     "forms.links.change",
                     RegisterPropertyStepId.OwnershipType.urlPathSegment +
-                        "?changingAnswerFor=${RegisterPropertyStepId.OwnershipType.urlPathSegment}",
+                        "?$CHECKING_ANSWERS_FOR_PARAMETER_NAME=${RegisterPropertyStepId.OwnershipType.urlPathSegment}",
                 ),
             ),
             propertyDetails.single {
@@ -245,7 +246,7 @@ class PropertyRegistrationCheckAnswersPageTests {
                 SummaryListRowActionViewModel(
                     "forms.links.change",
                     RegisterPropertyStepId.LicensingType.urlPathSegment +
-                        "?changingAnswerFor=${RegisterPropertyStepId.LicensingType.urlPathSegment}",
+                        "?$CHECKING_ANSWERS_FOR_PARAMETER_NAME=${RegisterPropertyStepId.LicensingType.urlPathSegment}",
                 ),
             ),
             propertyDetails.single {
@@ -271,7 +272,7 @@ class PropertyRegistrationCheckAnswersPageTests {
                 SummaryListRowActionViewModel(
                     "forms.links.change",
                     RegisterPropertyStepId.LicensingType.urlPathSegment +
-                        "?changingAnswerFor=${RegisterPropertyStepId.LicensingType.urlPathSegment}",
+                        "?$CHECKING_ANSWERS_FOR_PARAMETER_NAME=${RegisterPropertyStepId.LicensingType.urlPathSegment}",
                 ),
             ),
             propertyDetails.single {
@@ -296,7 +297,7 @@ class PropertyRegistrationCheckAnswersPageTests {
                 SummaryListRowActionViewModel(
                     "forms.links.change",
                     RegisterPropertyStepId.Occupancy.urlPathSegment +
-                        "?changingAnswerFor=${RegisterPropertyStepId.Occupancy.urlPathSegment}",
+                        "?$CHECKING_ANSWERS_FOR_PARAMETER_NAME=${RegisterPropertyStepId.Occupancy.urlPathSegment}",
                 ),
             ),
             propertyDetails.single {
@@ -323,7 +324,7 @@ class PropertyRegistrationCheckAnswersPageTests {
                 SummaryListRowActionViewModel(
                     "forms.links.change",
                     RegisterPropertyStepId.Occupancy.urlPathSegment +
-                        "?changingAnswerFor=${RegisterPropertyStepId.Occupancy.urlPathSegment}",
+                        "?$CHECKING_ANSWERS_FOR_PARAMETER_NAME=${RegisterPropertyStepId.Occupancy.urlPathSegment}",
                 ),
             ),
             propertyDetails.single {
@@ -337,7 +338,7 @@ class PropertyRegistrationCheckAnswersPageTests {
                 SummaryListRowActionViewModel(
                     "forms.links.change",
                     RegisterPropertyStepId.NumberOfHouseholds.urlPathSegment +
-                        "?changingAnswerFor=${RegisterPropertyStepId.NumberOfHouseholds.urlPathSegment}",
+                        "?$CHECKING_ANSWERS_FOR_PARAMETER_NAME=${RegisterPropertyStepId.NumberOfHouseholds.urlPathSegment}",
                 ),
             ),
             propertyDetails
@@ -352,7 +353,7 @@ class PropertyRegistrationCheckAnswersPageTests {
                 SummaryListRowActionViewModel(
                     "forms.links.change",
                     RegisterPropertyStepId.NumberOfPeople.urlPathSegment +
-                        "?changingAnswerFor=${RegisterPropertyStepId.NumberOfPeople.urlPathSegment}",
+                        "?$CHECKING_ANSWERS_FOR_PARAMETER_NAME=${RegisterPropertyStepId.NumberOfPeople.urlPathSegment}",
                 ),
             ),
             propertyDetails.single {

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/urlProviders/LandlordDashboardUrlTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/urlProviders/LandlordDashboardUrlTests.kt
@@ -278,7 +278,7 @@ class LandlordDashboardUrlTests(
                 mockEmailNotificationService,
                 mockEmailNotificationService,
                 AbsoluteUrlProvider(),
-                changingAnswerFor = null,
+                checkingAnswersForStep = null,
             )
         whenever(mockPropertyComplianceJourneyFactory.create(any(), anyOrNull())).thenReturn(propertyComplianceJourney)
 

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/urlProviders/PropertyComplianceInfoUrlTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/urlProviders/PropertyComplianceInfoUrlTests.kt
@@ -129,7 +129,7 @@ class PropertyComplianceInfoUrlTests(
                 mockEmailNotificationService,
                 mockEmailNotificationService,
                 AbsoluteUrlProvider(),
-                changingAnswerFor = null,
+                checkingAnswersForStep = null,
             )
         whenever(mockPropertyComplianceJourneyFactory.create(any(), anyOrNull())).thenReturn(propertyComplianceJourney)
 


### PR DESCRIPTION
## Ticket number

PRSD-962

## Goal of change

Show 'View' link instead of 'Change' for landlord responsibility declarations

## Description of main change(s)

- Updates references to 'changing answers' to 'checking answers' instead
- Shows 'View' link instead of 'Change' for landlord responsibility declarations

## Anything you'd like to highlight to the reviewer?

N/A

## Checklist

Delete any that are not applicable, and add explanation below for any that are applicable but haven't been done

- [X] Screenshots of any UI changes have been added
- [X] Unit tests for new logic (e.g. new service methods) have been added
- [X] Test suite has been run in full locally and is passing
- [X] Branch has been rebased onto main and run locally, with everything working as expected (both for your new feature
  and any related functionality)

## Screenshots
![image](https://github.com/user-attachments/assets/62f776bd-949a-4719-9e40-57b591bb1ad6)