### PR TITLE
Feat/prsd 1283 update user compliance certificate files

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/application/ProcessScanResultApplicationRunner.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/application/ProcessScanResultApplicationRunner.kt
@@ -45,7 +45,7 @@ class ProcessScanResultApplicationRunner(
 
         val code =
             SpringApplication.exit(context, { 0 }).also {
-                println("Example email sent successfully. Application will exit now.")
+                println("Virus scan result processed successfully. Application will exit now.")
             }
         exitProcess(code)
     }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/VirusScanProcessingService.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/VirusScanProcessingService.kt
@@ -1,21 +1,30 @@
 package uk.gov.communities.prsdb.webapp.services
 
 import org.springframework.stereotype.Service
+import uk.gov.communities.prsdb.webapp.database.entity.PropertyOwnership
+import uk.gov.communities.prsdb.webapp.database.repository.PropertyComplianceRepository
+import uk.gov.communities.prsdb.webapp.database.repository.PropertyOwnershipRepository
 import uk.gov.communities.prsdb.webapp.exceptions.PrsdbWebException
 import uk.gov.communities.prsdb.webapp.models.dataModels.PropertyFileNameInfo
+import uk.gov.communities.prsdb.webapp.models.dataModels.PropertyFileNameInfo.FileCategory
 import uk.gov.communities.prsdb.webapp.models.dataModels.ScanResult
 
 @Service
 class VirusScanProcessingService(
+    private val propertyOwnershipRepository: PropertyOwnershipRepository,
+    private val complianceRepository: PropertyComplianceRepository,
     private val dequarantiner: FileDequarantiner,
 ) {
     fun processScan(
         fileNameInfo: PropertyFileNameInfo,
         scanResultStatus: ScanResult,
     ) {
+        val ownership = getOwnershipForFileInfo(fileNameInfo)
         when (scanResultStatus) {
             ScanResult.NoThreats -> {
-                if (!dequarantiner.dequarantine(fileNameInfo.toString())) {
+                if (dequarantiner.dequarantine(fileNameInfo.toString())) {
+                    addFileToComplianceRecordIfPresent(fileNameInfo, ownership)
+                } else {
                     throw PrsdbWebException("Failed to dequarantine file: $fileNameInfo")
                 }
             }
@@ -23,6 +32,25 @@ class VirusScanProcessingService(
             ScanResult.Unsupported -> TODO("PRSD-1284")
             ScanResult.AccessDenied -> TODO("PRSD-1284")
             ScanResult.Failed -> TODO("PRSD-1284")
+        }
+    }
+
+    private fun getOwnershipForFileInfo(fileNameInfo: PropertyFileNameInfo) =
+        propertyOwnershipRepository
+            .findByIdAndIsActiveTrue(fileNameInfo.propertyOwnershipId)
+            ?: throw PrsdbWebException("No ownership found for $fileNameInfo")
+
+    private fun addFileToComplianceRecordIfPresent(
+        fileNameInfo: PropertyFileNameInfo,
+        ownership: PropertyOwnership,
+    ) {
+        val complianceRecord = complianceRepository.findByPropertyOwnership_Id(ownership.id)
+        if (complianceRecord != null) {
+            when (fileNameInfo.fileCategory) {
+                FileCategory.Eirc -> complianceRecord.eicrS3Key = fileNameInfo.toString()
+                FileCategory.GasSafetyCert -> complianceRecord.gasSafetyCertS3Key = fileNameInfo.toString()
+            }
+            complianceRepository.save(complianceRecord)
         }
     }
 }

--- a/src/main/resources/data-local.sql
+++ b/src/main/resources/data-local.sql
@@ -293,7 +293,7 @@ VALUES (1, true, 0, 1, 1, 2, 6, 1, 1, '01/15/25', '02/02/25', null, 2),
        (5, true, 0, 1, 1, 2, 37, 1, 5, '01/15/25', '01/15/25', null, null),
        (6, false, 0, 1, 1, 2, 38, 1, 6, '01/15/25', '01/15/25', null, null),
        (7, true, 0, 1, 0, 0, 39, 1, 7, '02/02/25', '02/02/25', 1, 4),
-       (8, true, 0, 1, 0, 0, 40, 1, 8, '05/02/25', '01/15/25', null, null),
+       (8, true, 0, 1, 1, 1, 40, 1, 8, '05/02/25', '01/15/25', null, null),
        (9, true, 0, 1, 0, 0, 41, 1, 9, '05/02/25', '01/15/25', null, null),
        (10, true, 0, 1, 0, 0, 42, 1, 10, '05/02/25', '01/15/25', null, null),
        (11, true, 0, 1, 0, 0, 43, 1, 11, '05/02/25', '01/15/25', null, null),
@@ -329,3 +329,8 @@ VALUES (1,'2025-02-19 12:01:07.575927+00',null,'urn:fdc:gov.uk:2022:UVWXY'),
        (2,'2025-05-01 12:01:07.575927+00',null,'urn:fdc:gov.uk:2022:GzFopg--2AyE6XtssVWwQTPELVQFupHJOjpONWS2uz0');
 
 SELECT setval(pg_get_serial_sequence('system_operator', 'id'), (SELECT MAX(id) FROM system_operator));
+
+INSERT INTO property_compliance (id, property_ownership_id, created_date, last_modified_date, has_fire_safety_declaration, has_keep_property_safe_declaration, has_responsibility_to_tenants_declaration)
+VALUES (1, 8, '01/01/25', '01/01/25', true, true, true);
+
+SELECT setval(pg_get_serial_sequence('property_compliance', 'id'), (SELECT MAX(id) FROM property_compliance));

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/VirusScanProcessingServiceTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/VirusScanProcessingServiceTests.kt
@@ -5,9 +5,15 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.EnumSource
+import org.mockito.ArgumentMatchers.anyLong
 import org.mockito.Mockito.mock
+import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
+import uk.gov.communities.prsdb.webapp.database.entity.PropertyCompliance
+import uk.gov.communities.prsdb.webapp.database.entity.PropertyOwnership
+import uk.gov.communities.prsdb.webapp.database.repository.PropertyComplianceRepository
+import uk.gov.communities.prsdb.webapp.database.repository.PropertyOwnershipRepository
 import uk.gov.communities.prsdb.webapp.exceptions.PrsdbWebException
 import uk.gov.communities.prsdb.webapp.models.dataModels.PropertyFileNameInfo
 import uk.gov.communities.prsdb.webapp.models.dataModels.PropertyFileNameInfo.FileCategory
@@ -17,41 +23,87 @@ class VirusScanProcessingServiceTests {
     private lateinit var virusScanProcessingService: VirusScanProcessingService
     private lateinit var dequarantiner: FileDequarantiner
 
+    private lateinit var propertyOwnershipRepository: PropertyOwnershipRepository
+    private lateinit var complianceRepository: PropertyComplianceRepository
+
     @BeforeEach
     fun setup() {
         dequarantiner = mock()
-        virusScanProcessingService = VirusScanProcessingService(dequarantiner)
+        propertyOwnershipRepository = mock()
+        complianceRepository = mock()
+        virusScanProcessingService = VirusScanProcessingService(propertyOwnershipRepository, complianceRepository, dequarantiner)
+
+        whenever(propertyOwnershipRepository.findByIdAndIsActiveTrue(anyLong())).thenAnswer { invocation ->
+            val ownership = mock<PropertyOwnership>()
+            whenever(ownership.id).thenReturn(invocation.getArgument(0))
+            ownership
+        }
     }
 
     @Test
-    fun `processScan calls the dequarantiner when no threats are found`() {
+    fun `when no threats are found, processScan calls the dequarantiner`() {
+        // Arrange
         val fileNameInfo = PropertyFileNameInfo(5L, FileCategory.GasSafetyCert, "txt")
         val scanResultStatus = ScanResult.NoThreats
 
         whenever(dequarantiner.dequarantine(fileNameInfo.toString())).thenReturn(true)
 
+        // Act
         virusScanProcessingService.processScan(fileNameInfo, scanResultStatus)
 
+        // Assert
         verify(dequarantiner).dequarantine(fileNameInfo.toString())
     }
 
+    @EnumSource(FileCategory::class)
+    @ParameterizedTest
+    fun `when the dequarantiner succeeds, processScan adds the certificate to the compliance record if present`(category: FileCategory) {
+        // Arrange
+        val fileNameInfo = PropertyFileNameInfo(5L, category, "jpg")
+        val scanResultStatus = ScanResult.NoThreats
+
+        whenever(dequarantiner.dequarantine(fileNameInfo.toString())).thenReturn(true)
+        whenever(complianceRepository.findByPropertyOwnership_Id(fileNameInfo.propertyOwnershipId)).thenReturn(PropertyCompliance())
+
+        // Act
+        virusScanProcessingService.processScan(fileNameInfo, scanResultStatus)
+
+        // Assert
+        val captor = argumentCaptor<PropertyCompliance>()
+        verify(complianceRepository).save(captor.capture())
+        assert(getKeyFromRecordForCategory(captor.firstValue, category) == fileNameInfo.toString())
+    }
+
+    private fun getKeyFromRecordForCategory(
+        complianceRecord: PropertyCompliance,
+        category: FileCategory,
+    ): String? =
+        when (category) {
+            FileCategory.Eirc -> complianceRecord.eicrS3Key
+            FileCategory.GasSafetyCert -> complianceRecord.gasSafetyCertS3Key
+        }
+
     @Test
     fun `if the dequarantiner fails the processScan throws an exception`() {
+        // Arrange
         val fileNameInfo = PropertyFileNameInfo(5L, FileCategory.GasSafetyCert, "txt")
         val scanResultStatus = ScanResult.NoThreats
 
         whenever(dequarantiner.dequarantine(fileNameInfo.toString())).thenReturn(false)
 
+        // Act & Assert
         assertThrows<PrsdbWebException> { virusScanProcessingService.processScan(fileNameInfo, scanResultStatus) }
     }
 
     @EnumSource(ScanResult::class)
     @ParameterizedTest
     fun `processScan throws an error for each scan result other than NoThreats`(scanResultStatus: ScanResult) {
+        // Ignore NoThreats case since it is already tested
         if (scanResultStatus == ScanResult.NoThreats) {
             return
         }
 
+        // Arrange
         val fileNameInfo = PropertyFileNameInfo(5L, FileCategory.GasSafetyCert, "txt")
         val scanResultStatus = scanResultStatus
 


### PR DESCRIPTION
## Ticket number
PRSD-1283

## Goal of change
When a compliance certificate virus scan is processed after the compliance record is created, then processing should add it to the record.

## Description of main change(s)
When the virus scan processing happens for NO_THREATS_FOUND, the service checks whether the appropriate record exists and if it does it sets the appropriate compliance certificate on the record to match the newly safe file.

## Checklist

Delete any that are not applicable, and add explanation below for any that are applicable but haven't been done

- [X] Unit tests for new logic (e.g. new service methods) have been added
- [X] Test suite has been run in full locally and is passing
- [X] Branch has been rebased onto main and run locally, with everything working as expected (both for your new feature
  and any related functionality)
- [X] Seed data has been updated as needed for your feature to be tested without having to e.g. register a new property
