### PR TITLE
PRSD-1219: Refactor CYA Page

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/pages/CheckAnswersPage.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/pages/CheckAnswersPage.kt
@@ -6,7 +6,6 @@ import uk.gov.communities.prsdb.webapp.exceptions.PrsdbWebException
 import uk.gov.communities.prsdb.webapp.forms.JourneyData
 import uk.gov.communities.prsdb.webapp.forms.PageData
 import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.CheckAnswersFormModel
-import uk.gov.communities.prsdb.webapp.models.viewModels.summaryModels.SummaryListRowViewModel
 import uk.gov.communities.prsdb.webapp.services.JourneyDataService
 
 abstract class CheckAnswersPage(
@@ -25,17 +24,14 @@ abstract class CheckAnswersPage(
         filteredJourneyData: JourneyData?,
     ) {
         filteredJourneyData!!
-        modelAndView.addObject("summaryListData", getSummaryList(filteredJourneyData))
         modelAndView.addObject("submittedFilteredJourneyData", CheckAnswersFormModel.serializeJourneyData(filteredJourneyData))
         furtherEnrichModel(modelAndView, filteredJourneyData)
     }
 
-    protected abstract fun getSummaryList(filteredJourneyData: JourneyData): List<SummaryListRowViewModel>
-
-    protected open fun furtherEnrichModel(
+    protected abstract fun furtherEnrichModel(
         modelAndView: ModelAndView,
         filteredJourneyData: JourneyData,
-    ) {}
+    )
 
     override fun enrichFormData(formData: PageData?): PageData? {
         if (formData == null) return null

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/pages/CheckLicensingAnswersPage.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/pages/CheckLicensingAnswersPage.kt
@@ -20,7 +20,22 @@ class CheckLicensingAnswersPage(
             ),
         journeyDataService = journeyDataService,
     ) {
-    override fun getSummaryList(filteredJourneyData: JourneyData): List<SummaryListRowViewModel> =
+    override fun furtherEnrichModel(
+        modelAndView: ModelAndView,
+        filteredJourneyData: JourneyData,
+    ) {
+        modelAndView.addObject("summaryName", getSummaryName(filteredJourneyData))
+        modelAndView.addObject("summaryListData", getSummaryList(filteredJourneyData))
+    }
+
+    private fun getSummaryName(filteredJourneyData: JourneyData) =
+        if (filteredJourneyData.getLicensingTypeUpdateIfPresent()!! == LicensingType.NO_LICENSING) {
+            "forms.update.checkLicensing.remove.summaryName"
+        } else {
+            "forms.update.checkLicensing.update.summaryName"
+        }
+
+    private fun getSummaryList(filteredJourneyData: JourneyData): List<SummaryListRowViewModel> =
         listOf(
             SummaryListRowViewModel.forCheckYourAnswersPage(
                 "forms.checkPropertyAnswers.propertyDetails.licensing",
@@ -28,13 +43,6 @@ class CheckLicensingAnswersPage(
                 UpdatePropertyDetailsStepId.UpdateLicensingType.urlPathSegment,
             ),
         )
-
-    override fun furtherEnrichModel(
-        modelAndView: ModelAndView,
-        filteredJourneyData: JourneyData,
-    ) {
-        modelAndView.addObject("summaryName", getSummaryName(filteredJourneyData))
-    }
 
     private fun getLicensingSummaryValue(filteredJourneyData: JourneyData): Any {
         val licensingType = filteredJourneyData.getLicensingTypeUpdateIfPresent()!!
@@ -44,11 +52,4 @@ class CheckLicensingAnswersPage(
             listOf(licensingType, filteredJourneyData.getLicenceNumberUpdateIfPresent()!!)
         }
     }
-
-    private fun getSummaryName(filteredJourneyData: JourneyData) =
-        if (filteredJourneyData.getLicensingTypeUpdateIfPresent()!! == LicensingType.NO_LICENSING) {
-            "forms.update.checkLicensing.remove.summaryName"
-        } else {
-            "forms.update.checkLicensing.update.summaryName"
-        }
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/pages/CheckOccupancyAnswersPage.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/pages/CheckOccupancyAnswersPage.kt
@@ -1,5 +1,6 @@
 package uk.gov.communities.prsdb.webapp.forms.pages
 
+import org.springframework.web.servlet.ModelAndView
 import uk.gov.communities.prsdb.webapp.forms.JourneyData
 import uk.gov.communities.prsdb.webapp.forms.steps.UpdatePropertyDetailsGroupIdentifier
 import uk.gov.communities.prsdb.webapp.forms.steps.factories.PropertyDetailsUpdateJourneyStepFactory
@@ -22,7 +23,14 @@ class CheckOccupancyAnswersPage(
             ),
         journeyDataService = journeyDataService,
     ) {
-    override fun getSummaryList(filteredJourneyData: JourneyData) =
+    override fun furtherEnrichModel(
+        modelAndView: ModelAndView,
+        filteredJourneyData: JourneyData,
+    ) {
+        modelAndView.addObject("summaryListData", getSummaryList(filteredJourneyData))
+    }
+
+    private fun getSummaryList(filteredJourneyData: JourneyData) =
         mutableListOf<SummaryListRowViewModel>()
             .apply {
                 val isOccupied = filteredJourneyData.getIsOccupiedUpdateIfPresent(stepGroupId)!!

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/pages/LaUserRegistrationCheckAnswersPage.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/pages/LaUserRegistrationCheckAnswersPage.kt
@@ -1,5 +1,6 @@
 package uk.gov.communities.prsdb.webapp.forms.pages
 
+import org.springframework.web.servlet.ModelAndView
 import uk.gov.communities.prsdb.webapp.exceptions.PrsdbWebException
 import uk.gov.communities.prsdb.webapp.forms.JourneyData
 import uk.gov.communities.prsdb.webapp.forms.steps.RegisterLaUserStepId
@@ -20,7 +21,14 @@ class LaUserRegistrationCheckAnswersPage(
             ),
         journeyDataService = journeyDataService,
     ) {
-    override fun getSummaryList(filteredJourneyData: JourneyData): List<SummaryListRowViewModel> {
+    override fun furtherEnrichModel(
+        modelAndView: ModelAndView,
+        filteredJourneyData: JourneyData,
+    ) {
+        modelAndView.addObject("summaryListData", getSummaryList(filteredJourneyData))
+    }
+
+    private fun getSummaryList(filteredJourneyData: JourneyData): List<SummaryListRowViewModel> {
         val sessionToken = invitationService.getTokenFromSession()
 
         val localAuthority =

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/pages/LandlordRegistrationCheckAnswersPage.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/pages/LandlordRegistrationCheckAnswersPage.kt
@@ -1,5 +1,6 @@
 package uk.gov.communities.prsdb.webapp.forms.pages
 
+import org.springframework.web.servlet.ModelAndView
 import uk.gov.communities.prsdb.webapp.forms.JourneyData
 import uk.gov.communities.prsdb.webapp.forms.steps.LandlordRegistrationStepId
 import uk.gov.communities.prsdb.webapp.helpers.LandlordRegistrationJourneyDataHelper
@@ -18,7 +19,14 @@ class LandlordRegistrationCheckAnswersPage(
         journeyDataService = journeyDataService,
         shouldDisplaySectionHeader = true,
     ) {
-    override fun getSummaryList(filteredJourneyData: JourneyData): List<SummaryListRowViewModel> =
+    override fun furtherEnrichModel(
+        modelAndView: ModelAndView,
+        filteredJourneyData: JourneyData,
+    ) {
+        modelAndView.addObject("summaryListData", getSummaryList(filteredJourneyData))
+    }
+
+    private fun getSummaryList(filteredJourneyData: JourneyData): List<SummaryListRowViewModel> =
         getIdentityRows(filteredJourneyData) +
             getEmailAndPhoneRows(filteredJourneyData) +
             getAddressRows(filteredJourneyData)

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/pages/PropertyComplianceCheckAnswersPage.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/pages/PropertyComplianceCheckAnswersPage.kt
@@ -47,8 +47,6 @@ class PropertyComplianceCheckAnswersPage(
         journeyDataService = journeyDataService,
         templateName = "forms/propertyComplianceCheckAnswersForm",
     ) {
-    override fun getSummaryList(filteredJourneyData: JourneyData): List<SummaryListRowViewModel> = emptyList()
-
     override fun furtherEnrichModel(
         modelAndView: ModelAndView,
         filteredJourneyData: JourneyData,

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/pages/PropertyRegistrationCheckAnswersPage.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/pages/PropertyRegistrationCheckAnswersPage.kt
@@ -24,8 +24,6 @@ class PropertyRegistrationCheckAnswersPage(
         templateName = "forms/propertyRegistrationCheckAnswersForm",
         shouldDisplaySectionHeader = true,
     ) {
-    override fun getSummaryList(filteredJourneyData: JourneyData): List<SummaryListRowViewModel> = emptyList()
-
     override fun furtherEnrichModel(
         modelAndView: ModelAndView,
         filteredJourneyData: JourneyData,

--- a/src/main/resources/templates/forms/propertyRegistrationCheckAnswersForm.html
+++ b/src/main/resources/templates/forms/propertyRegistrationCheckAnswersForm.html
@@ -1,14 +1,14 @@
 <!--/*@thymesVar id="title" type="java.lang.String"*/-->
 <!--/*@thymesVar id="formModel" type="java.lang.Object"*/-->
-<!--/*@thymesVar id="propertyDetails" type="java.lang.Object"*/-->
-<!--/*@thymesVar id="submitButtonText" type="java.lang.String"*/-->
-<!--/*@thymesVar id="propertyName" type="java.lang.String"*/-->
 <!--/*@thymesVar id="backUrl" type="java.lang.String"*/-->
+<!--/*@thymesVar id="sectionHeaderInfo" type="uk.gov.communities.prsdb.webapp.models.viewModels.SectionHeaderViewModel"*/-->
+<!--/*@thymesVar id="propertyName" type="java.lang.String"*/-->
+<!--/*@thymesVar id="propertyDetails" type="java.lang.Object"*/-->
 <!--/*@thymesVar id="showUprnDetail" type="java.lang.Boolean"*/-->
+<!--/*@thymesVar id="submittedFilteredJourneyData" type="java.lang.String"*/-->
+<!--/*@thymesVar id="submitButtonText" type="java.lang.String"*/-->
 <!DOCTYPE html>
-
-<html th:replace="~{fragments/forms/questionPage :: questionPage(#{${title}}, ${formModel}, ~{::#form-content}, ${backUrl}, ${sectionHeaderInfo})}">
-<th:block id="form-content">
+<html id="form-content" th:replace="~{fragments/forms/questionPage :: questionPage(#{${title}}, ${formModel}, ~{::#form-content/content()}, ${backUrl}, ${sectionHeaderInfo})}">
     <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
         <h1 class="govuk-fieldset__heading">
             <span th:text="#{forms.checkPropertyAnswers.headingPrefix}"></span>
@@ -16,47 +16,34 @@
             <span th:text="${propertyName}"></span>
         </h1>
     </legend>
-    <div th:replace="~{fragments/tabs/tabs :: tabs(~{:: #tabs-content})}" >
-        <th:block id="tabs-content">
-            <ul th:replace="~{fragments/tabs/tabsHeadingList :: tabsHeadingList(~{:: #tab-headings})}">
-                <th:block id="tab-headings">
-                    <li th:replace="~{fragments/tabs/tabsListItem :: tabsListItem('property-details', #{forms.checkPropertyAnswers.propertyDetails.heading})}">
-                    </li>
-                    <li th:replace="~{fragments/tabs/tabsListItem :: tabsListItem('additional-landlords', #{forms.checkPropertyAnswers.additionalLandlords.heading})}">
-                    </li>
-                    <li th:replace="~{fragments/tabs/tabsListItem :: tabsListItem('interested-parties', #{forms.checkPropertyAnswers.interestedParties.heading})}">
-                    </li>
-                </th:block>
-            </ul>
-            <div th:replace="~{fragments/tabs/tabsPanel :: tabsPanel('property-details', ~{:: #property-details-panel-content})}">
-                <th:block id="property-details-panel-content">
-                    <div class="govuk-hint" th:text="#{forms.checkPropertyAnswers.propertyDetails.hint}">
-                        forms.checkPropertyAnswers.propertyDetails.hint
+    <div id="tabs-content" th:replace="~{fragments/tabs/tabs :: tabs(~{::#tabs-content/content()})}">
+        <ul id="tab-headings" th:replace="~{fragments/tabs/tabsHeadingList :: tabsHeadingList(~{::#tab-headings/content()})}">
+            <li th:replace="~{fragments/tabs/tabsListItem :: tabsListItem('property-details', #{forms.checkPropertyAnswers.propertyDetails.heading})}"></li>
+            <li th:replace="~{fragments/tabs/tabsListItem :: tabsListItem('additional-landlords', #{forms.checkPropertyAnswers.additionalLandlords.heading})}"></li>
+            <li th:replace="~{fragments/tabs/tabsListItem :: tabsListItem('interested-parties', #{forms.checkPropertyAnswers.interestedParties.heading})}"></li>
+        </ul>
+        <div id="property-details-panel-content" th:replace="~{fragments/tabs/tabsPanel :: tabsPanel('property-details', ~{::#property-details-panel-content/content()})}">
+            <div class="govuk-hint" th:text="#{forms.checkPropertyAnswers.propertyDetails.hint}">
+                forms.checkPropertyAnswers.propertyDetails.hint
+            </div>
+            <dl th:replace="~{fragments/summaryList :: summaryList(${propertyDetails})}"></dl>
+            <th:block th:if="${showUprnDetail}">
+                <details id="details-content"  th:replace="~{fragments/details :: details(#{forms.checkPropertyAnswers.propertyDetails.detail.summary},~{::#details-content/content()})}">
+                    <div class="govuk-details__text" th:text="#{forms.checkPropertyAnswers.propertyDetails.detail.text}">
+                        forms.checkPropertyAnswers.propertyDetails.detail.text
                     </div>
-                    <dl th:replace="~{fragments/summaryList :: summaryList(${propertyDetails})}"></dl>
-                    <th:block th:if="${showUprnDetail}">
-                        <details id="details-content"  th:replace="~{fragments/details :: details(#{forms.checkPropertyAnswers.propertyDetails.detail.summary},~{::#details-content/content()})}">
-                            <div class="govuk-details__text" th:text="#{forms.checkPropertyAnswers.propertyDetails.detail.text}">
-                                forms.checkPropertyAnswers.propertyDetails.detail.text
-                            </div>
-                        </details>
-                    </th:block>
-                </th:block>
-            </div>
-            <div th:replace="~{fragments/tabs/tabsPanel :: tabsPanel('additional-landlords', ~{:: #additional-landlords-panel-content})}">
-                <th:block id="additional-landlords-panel-content">
-                    <h2 class="govuk-heading-m">TODO: PRSD-584</h2>
-                    <p class="govuk-body">This tab will show details of additional landlords, and will be implemented as part of PRSD-584</p>
-                </th:block>
-            </div>
-            <div th:replace="~{fragments/tabs/tabsPanel :: tabsPanel('interested-parties', ~{:: #interested-parties-panel-content})}">
-                <th:block id="interested-parties-panel-content">
-                    <h2 class="govuk-heading-m">TODO: PRSD-585</h2>
-                    <p class="govuk-body">This tab will show details of interested parties, and will be implemented as part of PRSD-585</p>
-                </th:block>
-            </div>
-        </th:block>
+                </details>
+            </th:block>
+        </div>
+        <div id="additional-landlords-panel-content" th:replace="~{fragments/tabs/tabsPanel :: tabsPanel('additional-landlords', ~{::#additional-landlords-panel-content/content()})}">
+            <h2 class="govuk-heading-m">TODO: PRSD-584</h2>
+            <p class="govuk-body">This tab will show details of additional landlords, and will be implemented as part of PRSD-584</p>
+        </div>
+        <div id="interested-parties-panel-content" th:replace="~{fragments/tabs/tabsPanel :: tabsPanel('interested-parties', ~{::#interested-parties-panel-content/content()})}">
+            <h2 class="govuk-heading-m">TODO: PRSD-585</h2>
+            <p class="govuk-body">This tab will show details of interested parties, and will be implemented as part of PRSD-585</p>
+        </div>
     </div>
+    <input type="hidden" name="submittedFilteredJourneyData" th:value="${submittedFilteredJourneyData}"/>
     <button th:replace="~{fragments/buttons/primaryButton :: primaryButton(#{${submitButtonText}})}"></button>
-</th:block>
 </html>

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/forms/pages/CheckAnswersPageTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/forms/pages/CheckAnswersPageTests.kt
@@ -14,7 +14,6 @@ import org.springframework.web.servlet.ModelAndView
 import uk.gov.communities.prsdb.webapp.exceptions.PrsdbWebException
 import uk.gov.communities.prsdb.webapp.forms.JourneyData
 import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.CheckAnswersFormModel
-import uk.gov.communities.prsdb.webapp.models.viewModels.summaryModels.SummaryListRowViewModel
 import uk.gov.communities.prsdb.webapp.services.JourneyDataService
 import uk.gov.communities.prsdb.webapp.testHelpers.mockObjects.AlwaysTrueValidator
 import kotlin.test.assertEquals
@@ -32,13 +31,12 @@ class CheckAnswersPageTests {
     private lateinit var mockBindingResult: BindingResult
 
     @Test
-    fun `enrichModel adds summaryList and filteredJourneyData to the model, then calls furtherEnrichModel`() {
+    fun `enrichModel adds filteredJourneyData to the model, then calls furtherEnrichModel`() {
         val modelAndView = ModelAndView()
-        val filteredJourneyData = mapOf(SUMMARY_ROW_KEY to "summaryRowValue", "furtherEnrichModelKey" to "furtherEnrichModelValue")
+        val filteredJourneyData = mapOf("furtherEnrichModelKey" to "furtherEnrichModelValue")
 
         checkAnswersPage.enrichModel(modelAndView, filteredJourneyData)
 
-        assertEquals(modelAndView.modelMap["summaryListData"], createSummaryList(filteredJourneyData))
         assertEquals(modelAndView.modelMap["submittedFilteredJourneyData"], CheckAnswersFormModel.serializeJourneyData(filteredJourneyData))
         assertEquals(modelAndView.modelMap["furtherEnrichModelKey"], "furtherEnrichModelValue")
     }
@@ -75,24 +73,11 @@ class CheckAnswersPageTests {
     class TestCheckAnswersPage(
         journeyDataService: JourneyDataService,
     ) : CheckAnswersPage(content = emptyMap(), journeyDataService) {
-        override fun getSummaryList(filteredJourneyData: JourneyData) = createSummaryList(filteredJourneyData)
-
         override fun furtherEnrichModel(
             modelAndView: ModelAndView,
             filteredJourneyData: JourneyData,
         ) {
-            filteredJourneyData.entries.forEach { (key, value) ->
-                if (key != SUMMARY_ROW_KEY) {
-                    modelAndView.addObject(key, value)
-                }
-            }
+            filteredJourneyData.entries.forEach { (key, value) -> modelAndView.addObject(key, value) }
         }
-    }
-
-    companion object {
-        const val SUMMARY_ROW_KEY = "summaryListRowKey"
-
-        private fun createSummaryList(journeyData: JourneyData) =
-            listOf(SummaryListRowViewModel(SUMMARY_ROW_KEY, journeyData[SUMMARY_ROW_KEY]!!, action = null))
     }
 }


### PR DESCRIPTION
## Ticket number

PRSD-1219

## Goal of change

Refactors CYA to remove expectation of one summary list

## Description of main change(s)

- Refactors base CYA page class to not expect one summary list by default 
- Adds submitted filtered journey field to property registration CYA page template

## Anything you'd like to highlight to the reviewer?

N/A

## Checklist

Delete any that are not applicable, and add explanation below for any that are applicable but haven't been done

- [X] Unit tests for new logic (e.g. new service methods) have been added
- [X] Test suite has been run in full locally and is passing
- [X] Branch has been rebased onto main and run locally, with everything working as expected (both for your new feature
  and any related functionality)