### PR TITLE
PRSD-1357: removed incorrect content

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/LocalAuthorityDashboardController.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/LocalAuthorityDashboardController.kt
@@ -57,8 +57,6 @@ class LocalAuthorityDashboardController(
             "rentersRightsBillUrl",
             RENTERS_RIGHTS_BILL_URL,
         )
-        // TODO: link to content
-        model.addAttribute("aboutPilotUrl", "#")
         return "localAuthorityDashboard"
     }
 

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -563,8 +563,6 @@ localAuthority.dashboard.action.privacyNotice.linkText=Privacy notice TODO PRSD-
 localAuthority.dashboard.action.privacyNotice.descriptionText=How the database uses the data collected about landlords for local councils
 localAuthority.dashboard.action.rentersRightsBill.linkText=Renters' Rights Bill
 localAuthority.dashboard.action.rentersRightsBill.descriptionText=View the guidelines related to the database and the Renters' Rights Bill
-localAuthority.dashboard.action.aboutPilot.linkText=About this pilot TODO: LINK TO CONTENT
-localAuthority.dashboard.action.aboutPilot.descriptionText=Understand the goals for the pilot version of the database
 
 landlord.dashboard.banner.subheading=Landlord registration number: 
 landlord.dashboard.registerProperties.heading=You must register your properties

--- a/src/main/resources/templates/localAuthorityDashboard.html
+++ b/src/main/resources/templates/localAuthorityDashboard.html
@@ -37,12 +37,6 @@
                 'localAuthority.dashboard.action.rentersRightsBill.descriptionText')}">
                     View Renters' Rights Bill action
                 </div>
-                <div th:replace="~{fragments/dashboardAction :: dashboardAction(
-                'localAuthority.dashboard.action.aboutPilot.linkText',
-                ${aboutPilotUrl},
-                'localAuthority.dashboard.action.aboutPilot.descriptionText')}">
-                    View About pilot action
-                </div>
             </div>
         </section>
     </div>


### PR DESCRIPTION
## Ticket number

PRSD-1357

## Goal of change

Remove the ‘About the pilot’ link and description from the local authority dashboard

## Description of main change(s)

Per this [comment](https://mhclgdigital.atlassian.net/browse/PRSD-1357?focusedCommentId=711343) in QA remove the incorrect content from the LA dashboard

## Screenshots

### After change
<img width="720" height="411" alt="image" src="https://github.com/user-attachments/assets/37e44be1-562f-4753-90f8-6e5611240c4f" />


### Before changes
<img width="1722" height="1003" alt="image" src="https://github.com/user-attachments/assets/bd626392-21ff-4bbf-b258-b0f5aabb8429" />


## Checklist

- [X] Screenshots of any UI changes have been added
- [X] Test suite has been run in full locally and is passing
- [X] Branch has been rebased onto main and run locally, with everything working as expected (both for your new feature
  and any related functionality)
