### PR TITLE
PRSD-1357: fix content invite la user page

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/constants/AlphabetConstants.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/constants/AlphabetConstants.kt
@@ -1,0 +1,3 @@
+package uk.gov.communities.prsdb.webapp.constants
+
+val VOWELS = setOf("A", "E", "I", "O", "U")

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/ManageLocalAuthorityUsersController.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/ManageLocalAuthorityUsersController.kt
@@ -27,6 +27,7 @@ import uk.gov.communities.prsdb.webapp.constants.ROLE_LA_ADMIN
 import uk.gov.communities.prsdb.webapp.constants.ROLE_LA_USER
 import uk.gov.communities.prsdb.webapp.constants.ROLE_SYSTEM_OPERATOR
 import uk.gov.communities.prsdb.webapp.constants.SUCCESS_PATH_SEGMENT
+import uk.gov.communities.prsdb.webapp.constants.VOWELS
 import uk.gov.communities.prsdb.webapp.controllers.LocalAuthorityDashboardController.Companion.LOCAL_AUTHORITY_DASHBOARD_URL
 import uk.gov.communities.prsdb.webapp.controllers.ManageLocalAuthorityUsersController.Companion.LOCAL_AUTHORITY_ROUTE
 import uk.gov.communities.prsdb.webapp.database.entity.LocalAuthority
@@ -217,7 +218,11 @@ class ManageLocalAuthorityUsersController(
         principal: Principal,
         request: HttpServletRequest,
     ): String {
-        model.addAttribute("councilName", getLocalAuthority(principal, localAuthorityId, request).name)
+        val councilName = getLocalAuthority(principal, localAuthorityId, request).name
+        val councilNameBeginsWithVowel = councilName[0].uppercase() in VOWELS
+
+        model.addAttribute("councilName", councilName)
+        model.addAttribute("councilNameBeginsWithVowel", councilNameBeginsWithVowel)
         model.addAttribute("confirmedEmailRequestModel", ConfirmedEmailRequestModel())
 
         return "inviteLAUser"

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -217,12 +217,14 @@ manageLAUsers.noUsersText=No local authority users or admins were found.
 
 addLAUser.title=Invite a new user
 
-addLAUser.heading=Invite someone from {0,,localAuthority} to the database
-addLAUser.paragraph.one=Once you send an invite this person can register an account on the database.
+addLAUser.heading=Invite someone from {0,,localAuthority} to the PRS Database
+addLAUser.paragraph.one=Once you send an invite, this person can register an account on the database.
 addLAUser.paragraph.two=They can view and edit information related to:
 addLAUser.paragraph.two.bullet.one=landlords in the local area
 addLAUser.paragraph.two.bullet.two=properties in the local area
-addLAUser.form.primaryEmailLabel=Enter their email address
+addLAUser.paragraph.three.a=They must have a {0,,localAuthority} email address to get an invite.
+addLAUser.paragraph.three.an=They must have an {0,,localAuthority} email address to get an invite.
+addLAUser.form.primaryEmailLabel=Enter their email address ending in [@nameofcouncil.co.uk]
 addLAUser.form.confirmEmailLabel=Confirm their email address
 
 addLAUser.error.missingEmail=You must enter an email address

--- a/src/main/resources/templates/inviteLAUser.html
+++ b/src/main/resources/templates/inviteLAUser.html
@@ -24,6 +24,12 @@
                     addLAUser.paragraph.two.bullet.two
                 </li>
             </ul>
+            <p th:if="${councilNameBeginsWithVowel}" th:text="#{addLAUser.paragraph.three.an(${councilName})}" class="govuk-body">
+                addLAUser.paragraph.three
+            </p>
+            <p th:unless="${councilNameBeginsWithVowel}" th:text="#{addLAUser.paragraph.three.a(${councilName})}" class="govuk-body">
+                addLAUser.paragraph.three
+            </p>
         </section>
         <form th:action="@{''}" class="form" id="email-form" method="post" th:object="${confirmedEmailRequestModel}"
               novalidate>


### PR DESCRIPTION
## Ticket number

PRSD-1357

## Goal of change

Fix content on the invite LA user page

## Description of main change(s)

Update heading text
Add the line "They must have a/an {localCouncilName} email address to get an invite."


## Screenshots

### Council starting with a consonant 
<img width="1200" height="1194" alt="image" src="https://github.com/user-attachments/assets/58aae59b-fdfb-44de-984c-e921e22d1dcb" />

### Council starting with a vowel
<img width="1310" height="1256" alt="image" src="https://github.com/user-attachments/assets/1f90973b-95ac-4d52-840e-92cc8365c780" />


## Checklist

- [X] Screenshots of any UI changes have been added
- [X] Test suite has been run in full locally and is passing
- [x] Branch has been rebased onto main and run locally, with everything working as expected (both for your new feature
  and any related functionality)
