### PR TITLE
PRSD-1357: fix styling confirmation la user registration

### DIFF
--- a/src/main/resources/templates/registerLAUserSuccess.html
+++ b/src/main/resources/templates/registerLAUserSuccess.html
@@ -6,7 +6,7 @@
         <div id="confirmation-banner"
              th:replace="~{fragments/banners/confirmationPageBanner :: confirmationPageBanner(#{registerLaUser.success.banner.title(${localAuthority})}, ~{::#confirmation-banner/content()})}">
         </div>
-        <h2 class="govuk-heading-m" th:text="#{common.confirmationPage.whatHappensNext}">common.whatHappensNext</h2>
+        <h2 class="govuk-heading-l" th:text="#{common.confirmationPage.whatHappensNext}">common.whatHappensNext</h2>
         <p class="govuk-body" th:text="#{registerLaUser.success.whatHappensNext.paragraph.one}">
             registerLaUser.success.whatHappensNext.paragraph.one
         </p>


### PR DESCRIPTION
 page

## Ticket number

PRSD-1357

## Goal of change

fix styling on the confirmation la user registration page

## Description of main change(s)

As above

## Screenshots

### After
<img width="720" height="642" alt="image" src="https://github.com/user-attachments/assets/a18adf31-7142-47f8-a396-be10dc7990b6" />


### Before
<img width="720" height="632" alt="image" src="https://github.com/user-attachments/assets/ee454708-f19b-412c-9ecd-9edb1757c217" />

## Checklist

- [X] Screenshots of any UI changes have been added
- [ ] Test suite has been run in full locally and is passing
- [ ] Branch has been rebased onto main and run locally, with everything working as expected (both for your new feature
  and any related functionality)
