### PR TITLE
Feat/prsd 1247 eicr original journey data and cya page

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/PropertyComplianceOriginalJourneyData.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/PropertyComplianceOriginalJourneyData.kt
@@ -89,8 +89,7 @@ class PropertyComplianceOriginalJourneyData private constructor(
                 EicrExemptionOtherReasonFormModel::fromComplianceRecordOrNull,
             PropertyComplianceStepId.EicrExemptionConfirmation toPageData { NoInputFormModel() },
             PropertyComplianceStepId.EicrExemptionMissing toPageData { NoInputFormModel() },
-            // TODO PRSD-1247: Add EICR check your answers step data
-            PropertyComplianceStepId.UpdateEicrCheckYourAnswers toPageData { NoInputFormModel() },
+            PropertyComplianceStepId.UpdateEicrCheckYourAnswers toPageData { CheckAnswersFormModel() },
         )
 
     // TODO: PRSD-1312: Add original EPC step data

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/PropertyComplianceOriginalJourneyData.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/PropertyComplianceOriginalJourneyData.kt
@@ -17,6 +17,7 @@ import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.GasSafety
 import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.GasSafetyUploadCertificateFormModel
 import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.NoInputFormModel
 import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.TodayOrPastDateFormModel
+import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.UpdateEicrFormModel
 import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.UpdateGasSafetyCertificateFormModel
 import kotlin.collections.plus
 
@@ -46,6 +47,17 @@ class PropertyComplianceOriginalJourneyData private constructor(
                 )
         }
 
+    // We need to include a route through the update journey if the user did not previously add an eicr or exemption.
+    private val updateEicrFormModel =
+        object : FormModel {
+            override fun toPageData() =
+                mapOf(
+                    UpdateEicrFormModel::hasNewCertificate.name to (propertyCompliance.eicrIssueDate != null),
+                    ORIGINALLY_NOT_INCLUDED_KEY to
+                        (propertyCompliance.eicrIssueDate == null && propertyCompliance.eicrExemptionReason == null),
+                )
+        }
+
     private val originalGasSafetyJourneyData: JourneyData =
         mapOf(
             PropertyComplianceStepId.UpdateGasSafety toPageData { _ -> updateGasCertificateFormModel },
@@ -66,7 +78,7 @@ class PropertyComplianceOriginalJourneyData private constructor(
 
     private val originalEicrJourneyData =
         mapOf(
-            PropertyComplianceStepId.UpdateEICR toPageData { NoInputFormModel() },
+            PropertyComplianceStepId.UpdateEICR toPageData { _ -> updateEicrFormModel },
             PropertyComplianceStepId.EicrIssueDate toPageData
                 { TodayOrPastDateFormModel.fromDateOrNull(it.eicrIssueDate) },
             PropertyComplianceStepId.EicrUpload toPageData EicrUploadCertificateFormModel::fromComplianceRecordOrNull,

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/PropertyComplianceUpdateJourney.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/PropertyComplianceUpdateJourney.kt
@@ -25,7 +25,8 @@ import uk.gov.communities.prsdb.webapp.helpers.extensions.journeyExtensions.Prop
 import uk.gov.communities.prsdb.webapp.helpers.extensions.journeyExtensions.PropertyComplianceJourneyDataExtensions.Companion.getHasNewEICR
 import uk.gov.communities.prsdb.webapp.helpers.extensions.journeyExtensions.PropertyComplianceJourneyDataExtensions.Companion.getHasNewEPC
 import uk.gov.communities.prsdb.webapp.helpers.extensions.journeyExtensions.PropertyComplianceJourneyDataExtensions.Companion.getHasNewGasSafetyCertificate
-import uk.gov.communities.prsdb.webapp.helpers.extensions.journeyExtensions.PropertyComplianceJourneyDataExtensions.Companion.getStillHasNoCertOrExemption
+import uk.gov.communities.prsdb.webapp.helpers.extensions.journeyExtensions.PropertyComplianceJourneyDataExtensions.Companion.getStillHasNoEicrOrExemption
+import uk.gov.communities.prsdb.webapp.helpers.extensions.journeyExtensions.PropertyComplianceJourneyDataExtensions.Companion.getStillHasNoGasCertOrExemption
 import uk.gov.communities.prsdb.webapp.models.dataModels.updateModels.GasSafetyCertUpdateModel
 import uk.gov.communities.prsdb.webapp.models.dataModels.updateModels.PropertyComplianceUpdateModel
 import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.NoInputFormModel
@@ -314,16 +315,17 @@ class PropertyComplianceUpdateJourney(
     private fun updateGasSafetyNextAction(filteredJourneyData: JourneyData): Pair<PropertyComplianceStepId, Int?> =
         if (filteredJourneyData.getHasNewGasSafetyCertificate()!!) {
             Pair(PropertyComplianceStepId.GasSafetyIssueDate, null)
-        } else if (filteredJourneyData.getStillHasNoCertOrExemption() ?: false) {
+        } else if (filteredJourneyData.getStillHasNoGasCertOrExemption() ?: false) {
             Pair(PropertyComplianceStepId.GasSafetyExemptionMissing, null)
         } else {
             Pair(PropertyComplianceStepId.GasSafetyExemptionReason, null)
         }
 
-    // TODO PRSD-1246: Update this to match GasSafety version after PRSD-1245 is implemented
     private fun updateEicrNextAction(filteredJourneyData: JourneyData) =
-        if (filteredJourneyData.getHasNewEICR()) {
+        if (filteredJourneyData.getHasNewEICR()!!) {
             Pair(PropertyComplianceStepId.EicrIssueDate, null)
+        } else if (filteredJourneyData.getStillHasNoEicrOrExemption() ?: false) {
+            Pair(PropertyComplianceStepId.EicrExemptionMissing, null)
         } else {
             Pair(PropertyComplianceStepId.EicrExemptionReason, null)
         }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/PropertyComplianceUpdateJourney.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/PropertyComplianceUpdateJourney.kt
@@ -404,7 +404,7 @@ class PropertyComplianceUpdateJourney(
         return getRedirectForNextStep(epcLookupStep, newFilteredJourneyData, null, checkingAnswersFor)
     }
 
-    // TODO 1247, 1313 - add this as the handleSubmitAndRedirect method and test
+    // TODO 1313 - add this as the handleSubmitAndRedirect method and test
     private fun updateComplianceAndRedirect(filteredJourneyData: JourneyData): String {
         val submittedJourneyData = journeyDataService.getJourneyDataFromSession()
         val relevantJourneyData = submittedJourneyData.filterKeys { it in filteredJourneyData.keys }
@@ -452,7 +452,7 @@ class PropertyComplianceUpdateJourney(
                     journeyData.getEicrOriginalName()?.let {
                         PropertyComplianceJourneyHelper.getCertFilename(
                             propertyOwnershipId,
-                            PropertyComplianceStepId.GasSafetyUpload.urlPathSegment,
+                            PropertyComplianceStepId.EicrUpload.urlPathSegment,
                             it,
                         )
                     },

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/PropertyComplianceUpdateJourney.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/PropertyComplianceUpdateJourney.kt
@@ -225,8 +225,7 @@ class PropertyComplianceUpdateJourney(
                 id = PropertyComplianceStepId.GasSafetyUpdateCheckYourAnswers,
                 page = CheckUpdateGasSafetyAnswersPage(journeyDataService, unreachableStepRedirect),
                 saveAfterSubmit = false,
-                // TODO: PRSD-1247 - restore next action once EICR original journey data is implemented
-                // nextAction = { _, _ -> Pair(eicrTask.startingStepId, null) },
+                nextAction = { _, _ -> Pair(eicrTask.startingStepId, null) },
                 handleSubmitAndRedirect = { filteredJourneyData, _, _ ->
                     updateComplianceAndRedirect(filteredJourneyData)
                 },
@@ -271,8 +270,9 @@ class PropertyComplianceUpdateJourney(
         get() =
             Step(
                 id = PropertyComplianceStepId.UpdateEicrCheckYourAnswers,
-                page = CheckUpdateEicrAnswersPage(journeyDataService),
-                nextAction = { _, _ -> Pair(epcTask.startingStepId, null) },
+                page = CheckUpdateEicrAnswersPage(journeyDataService, unreachableStepRedirect),
+                // TODO: PRSD-1312 - restore next action once EPC CYA step is implemented
+                // nextAction = { _, _ -> Pair(epcTask.startingStepId, null) },
                 saveAfterSubmit = false,
                 handleSubmitAndRedirect = { filteredJourneyData, _, _ ->
                     updateComplianceAndRedirect(filteredJourneyData)

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/PropertyComplianceUpdateJourney.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/PropertyComplianceUpdateJourney.kt
@@ -266,7 +266,6 @@ class PropertyComplianceUpdateJourney(
                 saveAfterSubmit = false,
             )
 
-    // TODO: PRSD-1247: Implement EICR check your answers step
     private val eicrCheckYourAnswersStep
         get() =
             Step(

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/PropertyComplianceUpdateJourney.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/PropertyComplianceUpdateJourney.kt
@@ -7,6 +7,7 @@ import uk.gov.communities.prsdb.webapp.controllers.PropertyDetailsController
 import uk.gov.communities.prsdb.webapp.forms.JourneyData
 import uk.gov.communities.prsdb.webapp.forms.journeys.PropertyComplianceJourney.Companion.getAutomatchedEpc
 import uk.gov.communities.prsdb.webapp.forms.journeys.PropertyComplianceJourney.Companion.updateEpcDetailsInSessionAndReturnUpdatedJourneyData
+import uk.gov.communities.prsdb.webapp.forms.pages.CheckUpdateEicrAnswersPage
 import uk.gov.communities.prsdb.webapp.forms.pages.CheckUpdateGasSafetyAnswersPage
 import uk.gov.communities.prsdb.webapp.forms.pages.Page
 import uk.gov.communities.prsdb.webapp.forms.steps.PropertyComplianceStepId
@@ -270,15 +271,12 @@ class PropertyComplianceUpdateJourney(
         get() =
             Step(
                 id = PropertyComplianceStepId.UpdateEicrCheckYourAnswers,
-                page =
-                    Page(
-                        formModel = NoInputFormModel::class,
-                        templateName = "forms/todo",
-                        content =
-                            mapOf("todoComment" to "TODO PRSD-1247:: Implement EICR Check Your Answers step"),
-                    ),
+                page = CheckUpdateEicrAnswersPage(journeyDataService),
                 nextAction = { _, _ -> Pair(epcTask.startingStepId, null) },
                 saveAfterSubmit = false,
+                handleSubmitAndRedirect = { filteredJourneyData, _, _ ->
+                    updateComplianceAndRedirect(filteredJourneyData)
+                },
             )
 
     private val updateEPCStep

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/pages/CheckUpdateEicrAnswersPage.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/pages/CheckUpdateEicrAnswersPage.kt
@@ -8,6 +8,7 @@ import uk.gov.communities.prsdb.webapp.services.JourneyDataService
 
 class CheckUpdateEicrAnswersPage(
     journeyDataService: JourneyDataService,
+    missingAnswersRedirect: String,
 ) : BasicCheckAnswersPage(
         content =
             mapOf(
@@ -17,6 +18,7 @@ class CheckUpdateEicrAnswersPage(
                 "submitButtonText" to "forms.buttons.confirmAndSubmitUpdate",
             ),
         journeyDataService = journeyDataService,
+        missingAnswersRedirect = missingAnswersRedirect,
     ) {
     val eicrDataFactory =
         EicrSummaryRowsFactory(

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/pages/CheckUpdateEicrAnswersPage.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/pages/CheckUpdateEicrAnswersPage.kt
@@ -1,0 +1,29 @@
+package uk.gov.communities.prsdb.webapp.forms.pages
+
+import uk.gov.communities.prsdb.webapp.forms.JourneyData
+import uk.gov.communities.prsdb.webapp.forms.pages.cya.EicrSummaryRowsFactory
+import uk.gov.communities.prsdb.webapp.forms.steps.PropertyComplianceStepId
+import uk.gov.communities.prsdb.webapp.helpers.extensions.journeyExtensions.PropertyComplianceJourneyDataExtensions.Companion.getHasNewEICR
+import uk.gov.communities.prsdb.webapp.services.JourneyDataService
+
+class CheckUpdateEicrAnswersPage(
+    journeyDataService: JourneyDataService,
+) : BasicCheckAnswersPage(
+        content =
+            mapOf(
+                "title" to "propertyDetails.update.title",
+                "summaryName" to "forms.update.checkOccupancy.summaryName",
+                "showWarning" to true,
+                "submitButtonText" to "forms.buttons.confirmAndSubmitUpdate",
+            ),
+        journeyDataService = journeyDataService,
+    ) {
+    val eicrDataFactory =
+        EicrSummaryRowsFactory(
+            doesDataHaveEicr = { data -> data.getHasNewEICR()!! },
+            eicrSafetyStartingStep = PropertyComplianceStepId.UpdateEICR,
+            changeExemptionStep = PropertyComplianceStepId.EicrExemptionReason,
+        )
+
+    override fun getSummaryList(filteredJourneyData: JourneyData) = eicrDataFactory.createRows(filteredJourneyData)
+}

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/pages/CheckUpdateEicrAnswersPage.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/pages/CheckUpdateEicrAnswersPage.kt
@@ -23,7 +23,7 @@ class CheckUpdateEicrAnswersPage(
     val eicrDataFactory =
         EicrSummaryRowsFactory(
             doesDataHaveEicr = { data -> data.getHasNewEICR()!! },
-            eicrSafetyStartingStep = PropertyComplianceStepId.UpdateEICR,
+            eicrStartingStep = PropertyComplianceStepId.UpdateEICR,
             changeExemptionStep = PropertyComplianceStepId.EicrExemptionReason,
         )
 

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/pages/PropertyComplianceCheckAnswersPage.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/pages/PropertyComplianceCheckAnswersPage.kt
@@ -41,7 +41,7 @@ class PropertyComplianceCheckAnswersPage(
     val eicrDataFactory =
         EicrSummaryRowsFactory(
             doesDataHaveEicr = { data -> data.getHasEICR()!! },
-            eicrSafetyStartingStep = PropertyComplianceStepId.EICR,
+            eicrStartingStep = PropertyComplianceStepId.EICR,
             changeExemptionStep = PropertyComplianceStepId.EicrExemption,
         )
 

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/pages/PropertyComplianceCheckAnswersPage.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/pages/PropertyComplianceCheckAnswersPage.kt
@@ -1,23 +1,14 @@
 package uk.gov.communities.prsdb.webapp.forms.pages
 
-import kotlinx.datetime.DatePeriod
-import kotlinx.datetime.plus
 import org.springframework.web.servlet.ModelAndView
-import uk.gov.communities.prsdb.webapp.constants.EICR_VALIDITY_YEARS
 import uk.gov.communities.prsdb.webapp.constants.EPC_ACCEPTABLE_RATING_RANGE
-import uk.gov.communities.prsdb.webapp.constants.enums.EicrExemptionReason
 import uk.gov.communities.prsdb.webapp.forms.JourneyData
+import uk.gov.communities.prsdb.webapp.forms.pages.cya.EicrSummaryRowsFactory
 import uk.gov.communities.prsdb.webapp.forms.pages.cya.GasSafetySummaryRowsFactory
 import uk.gov.communities.prsdb.webapp.forms.steps.PropertyComplianceStepId
 import uk.gov.communities.prsdb.webapp.helpers.extensions.journeyExtensions.PropertyComplianceJourneyDataExtensions.Companion.getAcceptedEpcDetails
 import uk.gov.communities.prsdb.webapp.helpers.extensions.journeyExtensions.PropertyComplianceJourneyDataExtensions.Companion.getDidTenancyStartBeforeEpcExpiry
-import uk.gov.communities.prsdb.webapp.helpers.extensions.journeyExtensions.PropertyComplianceJourneyDataExtensions.Companion.getEicrExemptionOtherReason
-import uk.gov.communities.prsdb.webapp.helpers.extensions.journeyExtensions.PropertyComplianceJourneyDataExtensions.Companion.getEicrExemptionReason
-import uk.gov.communities.prsdb.webapp.helpers.extensions.journeyExtensions.PropertyComplianceJourneyDataExtensions.Companion.getEicrIssueDate
 import uk.gov.communities.prsdb.webapp.helpers.extensions.journeyExtensions.PropertyComplianceJourneyDataExtensions.Companion.getEpcExemptionReason
-import uk.gov.communities.prsdb.webapp.helpers.extensions.journeyExtensions.PropertyComplianceJourneyDataExtensions.Companion.getHasCompletedEicrExemptionConfirmation
-import uk.gov.communities.prsdb.webapp.helpers.extensions.journeyExtensions.PropertyComplianceJourneyDataExtensions.Companion.getHasCompletedEicrExemptionMissing
-import uk.gov.communities.prsdb.webapp.helpers.extensions.journeyExtensions.PropertyComplianceJourneyDataExtensions.Companion.getHasCompletedEicrUploadConfirmation
 import uk.gov.communities.prsdb.webapp.helpers.extensions.journeyExtensions.PropertyComplianceJourneyDataExtensions.Companion.getHasCompletedEpcExemptionConfirmation
 import uk.gov.communities.prsdb.webapp.helpers.extensions.journeyExtensions.PropertyComplianceJourneyDataExtensions.Companion.getHasCompletedEpcExpired
 import uk.gov.communities.prsdb.webapp.helpers.extensions.journeyExtensions.PropertyComplianceJourneyDataExtensions.Companion.getHasCompletedEpcMissing
@@ -45,6 +36,12 @@ class PropertyComplianceCheckAnswersPage(
             gasSafetyStartingStep = PropertyComplianceStepId.GasSafety,
             changeExemptionStep = PropertyComplianceStepId.GasSafetyExemption,
         )
+    val eicrDataFactory =
+        EicrSummaryRowsFactory(
+            doesDataHaveEicr = { data -> data.getHasEICR()!! },
+            eicrSafetyStartingStep = PropertyComplianceStepId.EICR,
+            changeExemptionStep = PropertyComplianceStepId.EicrExemption,
+        )
 
     override fun addPageContentToModel(
         modelAndView: ModelAndView,
@@ -52,21 +49,10 @@ class PropertyComplianceCheckAnswersPage(
     ) {
         modelAndView.addObject("propertyAddress", propertyAddressProvider())
         modelAndView.addObject("gasSafetyData", gasSafetyDataFactory.createRows(filteredJourneyData))
-        modelAndView.addObject("eicrData", getEicrData(filteredJourneyData))
+        modelAndView.addObject("eicrData", eicrDataFactory.createRows(filteredJourneyData))
         modelAndView.addObject("epcData", getEpcData(filteredJourneyData))
         modelAndView.addObject("responsibilityData", getResponsibilityData(filteredJourneyData))
     }
-
-    private fun getEicrData(filteredJourneyData: JourneyData) =
-        mutableListOf<SummaryListRowViewModel>()
-            .apply {
-                add(getEicrStatusRow(filteredJourneyData))
-                if (filteredJourneyData.getHasEICR()!!) {
-                    addAll(getEicrDetailRows(filteredJourneyData))
-                } else {
-                    add(getEicrExemptionRow(filteredJourneyData))
-                }
-            }.toList()
 
     private fun getEpcData(filteredJourneyData: JourneyData) =
         mutableListOf<SummaryListRowViewModel>()
@@ -99,57 +85,6 @@ class PropertyComplianceCheckAnswersPage(
                 actionValue = "forms.links.view",
             ),
         )
-
-    private fun getEicrStatusRow(filteredJourneyData: JourneyData): SummaryListRowViewModel {
-        val fieldValue =
-            // TODO PRSD-976: Add link to gas safety cert (or appropriate message if virus scan failed)
-            if (filteredJourneyData.getHasCompletedEicrUploadConfirmation()) {
-                "forms.checkComplianceAnswers.eicr.download"
-            } else if (filteredJourneyData.getHasCompletedEicrExemptionConfirmation()) {
-                "forms.checkComplianceAnswers.certificate.notRequired"
-            } else if (filteredJourneyData.getHasCompletedEicrExemptionMissing()) {
-                "forms.checkComplianceAnswers.certificate.notAdded"
-            } else {
-                "forms.checkComplianceAnswers.certificate.expired"
-            }
-
-        return SummaryListRowViewModel.forCheckYourAnswersPage(
-            "forms.checkComplianceAnswers.eicr.certificate",
-            fieldValue,
-            PropertyComplianceStepId.EICR.urlPathSegment,
-        )
-    }
-
-    private fun getEicrDetailRows(filteredJourneyData: JourneyData): List<SummaryListRowViewModel> {
-        val issueDate = filteredJourneyData.getEicrIssueDate()!!
-        return listOf(
-            SummaryListRowViewModel.forCheckYourAnswersPage(
-                "forms.checkComplianceAnswers.certificate.issueDate",
-                issueDate,
-                PropertyComplianceStepId.EicrIssueDate.urlPathSegment,
-            ),
-            SummaryListRowViewModel.forCheckYourAnswersPage(
-                "forms.checkComplianceAnswers.certificate.validUntil",
-                issueDate.plus(DatePeriod(years = EICR_VALIDITY_YEARS)),
-                null,
-            ),
-        )
-    }
-
-    private fun getEicrExemptionRow(filteredJourneyData: JourneyData): SummaryListRowViewModel {
-        val fieldValue: Any =
-            when (val exemptionReason = filteredJourneyData.getEicrExemptionReason()) {
-                null -> "commonText.none"
-                EicrExemptionReason.OTHER -> listOf(exemptionReason, filteredJourneyData.getEicrExemptionOtherReason())
-                else -> exemptionReason
-            }
-
-        return SummaryListRowViewModel.forCheckYourAnswersPage(
-            "forms.checkComplianceAnswers.certificate.exemption",
-            fieldValue,
-            PropertyComplianceStepId.EicrExemption.urlPathSegment,
-        )
-    }
 
     private fun getEpcStatusRow(filteredJourneyData: JourneyData): SummaryListRowViewModel {
         val fieldValue =

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/pages/cya/EicrSummaryRowsFactory.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/pages/cya/EicrSummaryRowsFactory.kt
@@ -1,0 +1,83 @@
+package uk.gov.communities.prsdb.webapp.forms.pages.cya
+
+import kotlinx.datetime.DatePeriod
+import kotlinx.datetime.plus
+import uk.gov.communities.prsdb.webapp.constants.EICR_VALIDITY_YEARS
+import uk.gov.communities.prsdb.webapp.constants.enums.EicrExemptionReason
+import uk.gov.communities.prsdb.webapp.forms.JourneyData
+import uk.gov.communities.prsdb.webapp.forms.steps.PropertyComplianceStepId
+import uk.gov.communities.prsdb.webapp.helpers.extensions.journeyExtensions.PropertyComplianceJourneyDataExtensions.Companion.getEicrExemptionOtherReason
+import uk.gov.communities.prsdb.webapp.helpers.extensions.journeyExtensions.PropertyComplianceJourneyDataExtensions.Companion.getEicrExemptionReason
+import uk.gov.communities.prsdb.webapp.helpers.extensions.journeyExtensions.PropertyComplianceJourneyDataExtensions.Companion.getEicrIssueDate
+import uk.gov.communities.prsdb.webapp.helpers.extensions.journeyExtensions.PropertyComplianceJourneyDataExtensions.Companion.getHasCompletedEicrExemptionConfirmation
+import uk.gov.communities.prsdb.webapp.helpers.extensions.journeyExtensions.PropertyComplianceJourneyDataExtensions.Companion.getHasCompletedEicrExemptionMissing
+import uk.gov.communities.prsdb.webapp.helpers.extensions.journeyExtensions.PropertyComplianceJourneyDataExtensions.Companion.getHasCompletedEicrUploadConfirmation
+import uk.gov.communities.prsdb.webapp.models.viewModels.summaryModels.SummaryListRowViewModel
+
+class EicrSummaryRowsFactory(
+    val doesDataHaveEicr: (JourneyData) -> Boolean,
+    val eicrSafetyStartingStep: PropertyComplianceStepId,
+    val changeExemptionStep: PropertyComplianceStepId,
+) {
+    fun createRows(filteredJourneyData: JourneyData) =
+        mutableListOf<SummaryListRowViewModel>()
+            .apply {
+                add(getEicrStatusRow(filteredJourneyData))
+                if (doesDataHaveEicr(filteredJourneyData)) {
+                    addAll(getEicrDetailRows(filteredJourneyData))
+                } else {
+                    add(getEicrExemptionRow(filteredJourneyData))
+                }
+            }.toList()
+
+    private fun getEicrStatusRow(filteredJourneyData: JourneyData): SummaryListRowViewModel {
+        val fieldValue =
+            // TODO PRSD-976: Add link to gas safety cert (or appropriate message if virus scan failed)
+            if (filteredJourneyData.getHasCompletedEicrUploadConfirmation()) {
+                "forms.checkComplianceAnswers.eicr.download"
+            } else if (filteredJourneyData.getHasCompletedEicrExemptionConfirmation()) {
+                "forms.checkComplianceAnswers.certificate.notRequired"
+            } else if (filteredJourneyData.getHasCompletedEicrExemptionMissing()) {
+                "forms.checkComplianceAnswers.certificate.notAdded"
+            } else {
+                "forms.checkComplianceAnswers.certificate.expired"
+            }
+
+        return SummaryListRowViewModel.forCheckYourAnswersPage(
+            "forms.checkComplianceAnswers.eicr.certificate",
+            fieldValue,
+            eicrSafetyStartingStep.urlPathSegment,
+        )
+    }
+
+    private fun getEicrDetailRows(filteredJourneyData: JourneyData): List<SummaryListRowViewModel> {
+        val issueDate = filteredJourneyData.getEicrIssueDate()!!
+        return listOf(
+            SummaryListRowViewModel.forCheckYourAnswersPage(
+                "forms.checkComplianceAnswers.certificate.issueDate",
+                issueDate,
+                PropertyComplianceStepId.EicrIssueDate.urlPathSegment,
+            ),
+            SummaryListRowViewModel.forCheckYourAnswersPage(
+                "forms.checkComplianceAnswers.certificate.validUntil",
+                issueDate.plus(DatePeriod(years = EICR_VALIDITY_YEARS)),
+                null,
+            ),
+        )
+    }
+
+    private fun getEicrExemptionRow(filteredJourneyData: JourneyData): SummaryListRowViewModel {
+        val fieldValue: Any =
+            when (val exemptionReason = filteredJourneyData.getEicrExemptionReason()) {
+                null -> "commonText.none"
+                EicrExemptionReason.OTHER -> listOf(exemptionReason, filteredJourneyData.getEicrExemptionOtherReason())
+                else -> exemptionReason
+            }
+
+        return SummaryListRowViewModel.forCheckYourAnswersPage(
+            "forms.checkComplianceAnswers.certificate.exemption",
+            fieldValue,
+            changeExemptionStep.urlPathSegment,
+        )
+    }
+}

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/pages/cya/EicrSummaryRowsFactory.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/pages/cya/EicrSummaryRowsFactory.kt
@@ -4,6 +4,7 @@ import kotlinx.datetime.DatePeriod
 import kotlinx.datetime.plus
 import uk.gov.communities.prsdb.webapp.constants.EICR_VALIDITY_YEARS
 import uk.gov.communities.prsdb.webapp.constants.enums.EicrExemptionReason
+import uk.gov.communities.prsdb.webapp.exceptions.PrsdbWebException
 import uk.gov.communities.prsdb.webapp.forms.JourneyData
 import uk.gov.communities.prsdb.webapp.forms.steps.PropertyComplianceStepId
 import uk.gov.communities.prsdb.webapp.helpers.extensions.journeyExtensions.PropertyComplianceJourneyDataExtensions.Companion.getEicrExemptionOtherReason
@@ -11,12 +12,13 @@ import uk.gov.communities.prsdb.webapp.helpers.extensions.journeyExtensions.Prop
 import uk.gov.communities.prsdb.webapp.helpers.extensions.journeyExtensions.PropertyComplianceJourneyDataExtensions.Companion.getEicrIssueDate
 import uk.gov.communities.prsdb.webapp.helpers.extensions.journeyExtensions.PropertyComplianceJourneyDataExtensions.Companion.getHasCompletedEicrExemptionConfirmation
 import uk.gov.communities.prsdb.webapp.helpers.extensions.journeyExtensions.PropertyComplianceJourneyDataExtensions.Companion.getHasCompletedEicrExemptionMissing
+import uk.gov.communities.prsdb.webapp.helpers.extensions.journeyExtensions.PropertyComplianceJourneyDataExtensions.Companion.getHasCompletedEicrOutdated
 import uk.gov.communities.prsdb.webapp.helpers.extensions.journeyExtensions.PropertyComplianceJourneyDataExtensions.Companion.getHasCompletedEicrUploadConfirmation
 import uk.gov.communities.prsdb.webapp.models.viewModels.summaryModels.SummaryListRowViewModel
 
 class EicrSummaryRowsFactory(
     val doesDataHaveEicr: (JourneyData) -> Boolean,
-    val eicrSafetyStartingStep: PropertyComplianceStepId,
+    val eicrStartingStep: PropertyComplianceStepId,
     val changeExemptionStep: PropertyComplianceStepId,
 ) {
     fun createRows(filteredJourneyData: JourneyData) =
@@ -35,18 +37,20 @@ class EicrSummaryRowsFactory(
             // TODO PRSD-976: Add link to gas safety cert (or appropriate message if virus scan failed)
             if (filteredJourneyData.getHasCompletedEicrUploadConfirmation()) {
                 "forms.checkComplianceAnswers.eicr.download"
+            } else if (filteredJourneyData.getHasCompletedEicrOutdated()) {
+                "forms.checkComplianceAnswers.certificate.expired"
             } else if (filteredJourneyData.getHasCompletedEicrExemptionConfirmation()) {
                 "forms.checkComplianceAnswers.certificate.notRequired"
             } else if (filteredJourneyData.getHasCompletedEicrExemptionMissing()) {
                 "forms.checkComplianceAnswers.certificate.notAdded"
             } else {
-                "forms.checkComplianceAnswers.certificate.expired"
+                throw PrsdbWebException("Unexpected EICR status in journey data.")
             }
 
         return SummaryListRowViewModel.forCheckYourAnswersPage(
             "forms.checkComplianceAnswers.eicr.certificate",
             fieldValue,
-            eicrSafetyStartingStep.urlPathSegment,
+            eicrStartingStep.urlPathSegment,
         )
     }
 

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/helpers/extensions/journeyExtensions/PropertyComplianceJourneyDataExtensions.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/helpers/extensions/journeyExtensions/PropertyComplianceJourneyDataExtensions.kt
@@ -56,7 +56,7 @@ class PropertyComplianceJourneyDataExtensions : JourneyDataExtensions() {
 
         const val ORIGINALLY_NOT_INCLUDED_KEY = "originallyNotIncluded"
 
-        fun JourneyData.getStillHasNoCertOrExemption() =
+        fun JourneyData.getStillHasNoGasCertOrExemption() =
             JourneyDataHelper.getFieldBooleanValue(
                 this,
                 PropertyComplianceStepId.UpdateGasSafety.urlPathSegment,
@@ -122,7 +122,14 @@ class PropertyComplianceJourneyDataExtensions : JourneyDataExtensions() {
                 this,
                 PropertyComplianceStepId.UpdateEICR.urlPathSegment,
                 UpdateEicrFormModel::hasNewCertificate.name,
-            ) ?: false
+            )
+
+        fun JourneyData.getStillHasNoEicrOrExemption() =
+            JourneyDataHelper.getFieldBooleanValue(
+                this,
+                PropertyComplianceStepId.UpdateEICR.urlPathSegment,
+                ORIGINALLY_NOT_INCLUDED_KEY,
+            )
 
         fun JourneyData.getEicrIssueDate() = this.getFieldSetLocalDateValue(PropertyComplianceStepId.EicrIssueDate.urlPathSegment)
 

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/helpers/extensions/journeyExtensions/PropertyComplianceJourneyDataExtensions.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/helpers/extensions/journeyExtensions/PropertyComplianceJourneyDataExtensions.kt
@@ -337,7 +337,7 @@ class PropertyComplianceJourneyDataExtensions : JourneyDataExtensions() {
         fun JourneyData.getHasCompletedEicrExemptionMissing() =
             this.containsKey(PropertyComplianceStepId.EicrExemptionMissing.urlPathSegment)
 
-        private fun JourneyData.getHasCompletedEicrOutdated() = this.containsKey(PropertyComplianceStepId.EicrOutdated.urlPathSegment)
+        fun JourneyData.getHasCompletedEicrOutdated() = this.containsKey(PropertyComplianceStepId.EicrOutdated.urlPathSegment)
 
         fun JourneyData.getHasCompletedEpcExemptionConfirmation() =
             this.containsKey(PropertyComplianceStepId.EpcExemptionConfirmation.urlPathSegment)

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/requestModels/formModels/EicrUploadCertificateFormModel.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/requestModels/formModels/EicrUploadCertificateFormModel.kt
@@ -39,7 +39,9 @@ class EicrUploadCertificateFormModel : UploadCertificateFormModel() {
             record.eicrS3Key?.let {
                 EicrUploadCertificateFormModel().apply {
                     this.name = it
+                    // The following are not stored in the database, and are only required for validation
                     this.isMetadataOnly = false
+                    this.contentType = validMimeTypes.first()
                 }
             }
     }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/requestModels/formModels/UpdateEicrFormModel.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/requestModels/formModels/UpdateEicrFormModel.kt
@@ -1,7 +1,8 @@
 package uk.gov.communities.prsdb.webapp.models.requestModels.formModels
 
+import jakarta.validation.constraints.NotNull
+
 class UpdateEicrFormModel : FormModel {
-    // TODO PRSD-1245 or PRSD-1246: Add ths validation back in when originalJourneyData is being loaded correctly
-//    @NotNull(message = "forms.update.eicr.error.missing")
+    @NotNull(message = "forms.update.eicr.error.missing")
     var hasNewCertificate: Boolean? = null
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/forms/pages/PropertyComplianceCheckAnswersPageTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/forms/pages/PropertyComplianceCheckAnswersPageTests.kt
@@ -275,6 +275,7 @@ class PropertyComplianceCheckAnswersPageTests {
                 .withGasSafetyIssueDate(gasCertIssueDate)
                 .withEicrStatus(true)
                 .withEicrIssueDate(eicrIssueDate)
+                .withEicrOutdatedConfirmation()
                 .withAutoMatchedEpcDetails(epcDetails)
                 .withCheckAutoMatchedEpcResult(true)
                 .withEpcExpiryCheckStep(tenancyStartedBeforeExpiry)

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/helpers/extensions/journeyExtensions/PropertyComplianceJourneyDataExtensionsTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/helpers/extensions/journeyExtensions/PropertyComplianceJourneyDataExtensionsTests.kt
@@ -357,12 +357,12 @@ class PropertyComplianceJourneyDataExtensionsTests {
     }
 
     @Test
-    fun `getHasNewEICR returns false if the corresponding page is not in journeyData`() {
+    fun `getHasNewEICR returns null if the corresponding page is not in journeyData`() {
         val testJourneyData = journeyDataBuilder.build()
 
         val retrievedHasEICR = testJourneyData.getHasNewEICR()
 
-        assertEquals(false, retrievedHasEICR)
+        assertNull(retrievedHasEICR)
     }
 
     @Test

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/PropertyComplianceOriginalJourneyDataTest.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/PropertyComplianceOriginalJourneyDataTest.kt
@@ -59,7 +59,7 @@ class PropertyComplianceOriginalJourneyDataTest {
         val namedExactlyTheSame = Named.of("exactly the same", ::areAllComplianceValuesTheSame)
 
         // TODO PRSD-1313 - Update to use the final submission step ID from the journey factory as prior submissions will be included
-        val finalSubmissionStepId = PropertyComplianceStepId.GasSafetyUpdateCheckYourAnswers
+        val finalSubmissionStepId = PropertyComplianceStepId.UpdateEicrCheckYourAnswers
 
         fun areAllComplianceValuesTheSame(
             original: PropertyCompliance,

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/PropertyComplianceOriginalJourneyDataTest.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/PropertyComplianceOriginalJourneyDataTest.kt
@@ -69,8 +69,11 @@ class PropertyComplianceOriginalJourneyDataTest {
                 original.gasSafetyCertIssueDate == updated.gasSafetyCertIssueDate &&
                 original.gasSafetyCertEngineerNum == updated.gasSafetyCertEngineerNum &&
                 original.gasSafetyCertExemptionReason == updated.gasSafetyCertExemptionReason &&
-                original.gasSafetyCertExemptionOtherReason == updated.gasSafetyCertExemptionOtherReason
-            // TODO PRSD-1248 - check EICR values match the original record
+                original.gasSafetyCertExemptionOtherReason == updated.gasSafetyCertExemptionOtherReason &&
+                original.eicrS3Key == updated.eicrS3Key &&
+                original.eicrIssueDate == updated.eicrIssueDate &&
+                original.eicrExemptionReason == updated.eicrExemptionReason &&
+                original.eicrExemptionOtherReason == updated.eicrExemptionOtherReason
             // TODO PRSD-1313 - check EPC values match the orignal record
         }
 
@@ -82,8 +85,10 @@ class PropertyComplianceOriginalJourneyDataTest {
                 original.gasSafetyCertIssueDate == updated.gasSafetyCertIssueDate &&
                 updated.gasSafetyCertEngineerNum == null &&
                 original.gasSafetyCertExemptionReason == updated.gasSafetyCertExemptionReason &&
-                original.gasSafetyCertExemptionOtherReason == updated.gasSafetyCertExemptionOtherReason
-            // TODO PRSD-1248 - check EICR values match the original record
+                original.gasSafetyCertExemptionOtherReason == updated.gasSafetyCertExemptionOtherReason &&
+                updated.eicrS3Key == null &&
+                original.eicrExemptionReason == updated.eicrExemptionReason &&
+                original.eicrExemptionOtherReason == updated.eicrExemptionOtherReason
             // TODO PRSD-1313 - check EPC values match the orignal record
         }
     }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/PropertyComplianceUpdateJourneyTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/PropertyComplianceUpdateJourneyTests.kt
@@ -70,11 +70,13 @@ class PropertyComplianceUpdateJourneyTests : JourneyTestWithSeedData("data-local
         // Update certificate or add exemption page
         val updateGasSafetyPage = navigator.goToPropertyComplianceUpdateUpdateGasSafetyPage(PROPERTY_OWNERSHIP_ID)
         updateGasSafetyPage.submitHasNewCertificate()
-        val gasSafetyIssueDatePage = assertPageIs(page, GasSafetyIssueDatePagePropertyComplianceUpdate::class, urlArguments)
+        val gasSafetyIssueDatePage =
+            assertPageIs(page, GasSafetyIssueDatePagePropertyComplianceUpdate::class, urlArguments)
 
         // Gas Safety Cert. Issue Date page
         gasSafetyIssueDatePage.submitDate(currentDate)
-        val gasSafeEngineerNumPage = assertPageIs(page, GasSafeEngineerNumPagePropertyComplianceUpdate::class, urlArguments)
+        val gasSafeEngineerNumPage =
+            assertPageIs(page, GasSafeEngineerNumPagePropertyComplianceUpdate::class, urlArguments)
 
         // Gas Safe Engineer Num. page
         gasSafeEngineerNumPage.submitEngineerNum("1234567")
@@ -119,12 +121,14 @@ class PropertyComplianceUpdateJourneyTests : JourneyTestWithSeedData("data-local
         // Update certificate or add exemption page
         val updateGasSafetyPage = navigator.goToPropertyComplianceUpdateUpdateGasSafetyPage(PROPERTY_OWNERSHIP_ID)
         updateGasSafetyPage.submitHasNewCertificate()
-        val gasSafetyIssueDatePage = assertPageIs(page, GasSafetyIssueDatePagePropertyComplianceUpdate::class, urlArguments)
+        val gasSafetyIssueDatePage =
+            assertPageIs(page, GasSafetyIssueDatePagePropertyComplianceUpdate::class, urlArguments)
 
         // Gas Safety Cert. Issue Date page
         val outdatedIssueDate = currentDate.minus(DatePeriod(years = 1))
         gasSafetyIssueDatePage.submitDate(outdatedIssueDate)
-        val gasSafetyOutdatedPage = assertPageIs(page, GasSafetyOutdatedPagePropertyComplianceUpdate::class, urlArguments)
+        val gasSafetyOutdatedPage =
+            assertPageIs(page, GasSafetyOutdatedPagePropertyComplianceUpdate::class, urlArguments)
 
         // Gas Safety Outdated page
         assertThat(gasSafetyOutdatedPage.heading).containsText("Your gas safety certificate is out of date")
@@ -143,7 +147,8 @@ class PropertyComplianceUpdateJourneyTests : JourneyTestWithSeedData("data-local
         // Update certificate or add exemption page
         val updateGasSafetyPage = navigator.goToPropertyComplianceUpdateUpdateGasSafetyPage(PROPERTY_OWNERSHIP_ID)
         updateGasSafetyPage.submitHasNewExemption()
-        val gasSafetyExemptionReasonPage = assertPageIs(page, GasSafetyExemptionReasonPagePropertyComplianceUpdate::class, urlArguments)
+        val gasSafetyExemptionReasonPage =
+            assertPageIs(page, GasSafetyExemptionReasonPagePropertyComplianceUpdate::class, urlArguments)
 
         // Gas Safety Exemption Reason page
         gasSafetyExemptionReasonPage.submitExemptionReason(GasSafetyExemptionReason.NO_GAS_SUPPLY)
@@ -170,7 +175,8 @@ class PropertyComplianceUpdateJourneyTests : JourneyTestWithSeedData("data-local
         // Update certificate or add exemption page
         val updateGasSafetyPage = navigator.goToPropertyComplianceUpdateUpdateGasSafetyPage(PROPERTY_OWNERSHIP_ID)
         updateGasSafetyPage.submitHasNewExemption()
-        val gasSafetyExemptionReasonPage = assertPageIs(page, GasSafetyExemptionReasonPagePropertyComplianceUpdate::class, urlArguments)
+        val gasSafetyExemptionReasonPage =
+            assertPageIs(page, GasSafetyExemptionReasonPagePropertyComplianceUpdate::class, urlArguments)
 
         // Gas Safety Exemption Reason page
         gasSafetyExemptionReasonPage.submitExemptionReason(GasSafetyExemptionReason.OTHER)
@@ -230,7 +236,8 @@ class PropertyComplianceUpdateJourneyTests : JourneyTestWithSeedData("data-local
             ),
         ).thenReturn(true)
         eicrUploadPage.uploadCertificate("validFile.png")
-        val eicrUploadConfirmationPage = assertPageIs(page, EicrUploadConfirmationPagePropertyComplianceUpdate::class, urlArguments)
+        val eicrUploadConfirmationPage =
+            assertPageIs(page, EicrUploadConfirmationPagePropertyComplianceUpdate::class, urlArguments)
 
         // EICR Upload Confirmation page
         assertThat(eicrUploadConfirmationPage.heading).containsText("Your file is being scanned")
@@ -239,7 +246,12 @@ class PropertyComplianceUpdateJourneyTests : JourneyTestWithSeedData("data-local
         assertPageIs(page, EicrCheckYourAnswersPagePropertyComplianceUpdate::class, urlArguments)
 
         // EICR Check Your Answers page
-        // TODO PRSD-1247 - submit page, should return to the Property Record page
+        val cyaPage = assertPageIs(page, EicrCheckYourAnswersPagePropertyComplianceUpdate::class, urlArguments)
+        assertThat(cyaPage.form.summaryList.eicrRow.value).containsText("TODO PRSD-976")
+        assertThat(cyaPage.form.summaryList.issueDateRow.value).containsText(dateFormat.format(currentDate))
+        cyaPage.form.submit()
+
+        assertPageIs(page, PropertyDetailsPageLandlordView::class, urlArguments)
     }
 
     @Test
@@ -267,7 +279,12 @@ class PropertyComplianceUpdateJourneyTests : JourneyTestWithSeedData("data-local
         assertPageIs(page, EicrCheckYourAnswersPagePropertyComplianceUpdate::class, urlArguments)
 
         // EICR Check Your Answers page
-        // TODO PRSD-1247 - submit page, should return to the Property Record page
+        val cyaPage = assertPageIs(page, EicrCheckYourAnswersPagePropertyComplianceUpdate::class, urlArguments)
+        assertThat(cyaPage.form.summaryList.eicrRow.value).containsText("Expired")
+        assertThat(cyaPage.form.summaryList.issueDateRow.value).containsText(dateFormat.format(outdatedIssueDate))
+        cyaPage.form.submit()
+
+        assertPageIs(page, PropertyDetailsPageLandlordView::class, urlArguments)
     }
 
     @Test
@@ -282,11 +299,13 @@ class PropertyComplianceUpdateJourneyTests : JourneyTestWithSeedData("data-local
 
         // Update certificate or add exemption page
         updateEicrPage.submitHasNewExemption()
-        val eicrExemptionReasonPage = assertPageIs(page, EicrExemptionReasonPagePropertyComplianceUpdate::class, urlArguments)
+        val eicrExemptionReasonPage =
+            assertPageIs(page, EicrExemptionReasonPagePropertyComplianceUpdate::class, urlArguments)
 
         // EICR Exemption Reason page
         eicrExemptionReasonPage.submitExemptionReason(EicrExemptionReason.LIVE_IN_LANDLORD)
-        val eicrExemptionConfirmationPage = assertPageIs(page, EicrExemptionConfirmationPagePropertyComplianceUpdate::class, urlArguments)
+        val eicrExemptionConfirmationPage =
+            assertPageIs(page, EicrExemptionConfirmationPagePropertyComplianceUpdate::class, urlArguments)
 
         // EICR Exemption Confirmation page
         assertThat(eicrExemptionConfirmationPage.heading).containsText("You’ve marked this property as exempt from needing an EICR")
@@ -295,7 +314,12 @@ class PropertyComplianceUpdateJourneyTests : JourneyTestWithSeedData("data-local
         assertPageIs(page, EicrCheckYourAnswersPagePropertyComplianceUpdate::class, urlArguments)
 
         // EICR Check Your Answers page
-        // TODO: PRSD-1247 - submit page, should return to the Property Record page
+        val cyaPage = assertPageIs(page, EicrCheckYourAnswersPagePropertyComplianceUpdate::class, urlArguments)
+        assertThat(cyaPage.form.summaryList.eicrRow.value).containsText("Not required")
+        assertThat(cyaPage.form.summaryList.exemptionRow.value).containsText("You live in the property with the tenant")
+        cyaPage.form.submit()
+
+        assertPageIs(page, PropertyDetailsPageLandlordView::class, urlArguments)
     }
 
     @Test
@@ -310,15 +334,18 @@ class PropertyComplianceUpdateJourneyTests : JourneyTestWithSeedData("data-local
 
         // Update certificate or add exemption page
         updateEicrPage.submitHasNewExemption()
-        val eicrExemptionReasonPage = assertPageIs(page, EicrExemptionReasonPagePropertyComplianceUpdate::class, urlArguments)
+        val eicrExemptionReasonPage =
+            assertPageIs(page, EicrExemptionReasonPagePropertyComplianceUpdate::class, urlArguments)
 
         // EICR Exemption Reason page
         eicrExemptionReasonPage.submitExemptionReason(EicrExemptionReason.OTHER)
-        val eicrExemptionOtherReasonPage = assertPageIs(page, EicrExemptionOtherReasonPagePropertyComplianceUpdate::class, urlArguments)
+        val eicrExemptionOtherReasonPage =
+            assertPageIs(page, EicrExemptionOtherReasonPagePropertyComplianceUpdate::class, urlArguments)
 
         // EICR Exemption Other Reason page
         eicrExemptionOtherReasonPage.submitReason("valid reason")
-        val eicrExemptionConfirmationPage = assertPageIs(page, EicrExemptionConfirmationPagePropertyComplianceUpdate::class, urlArguments)
+        val eicrExemptionConfirmationPage =
+            assertPageIs(page, EicrExemptionConfirmationPagePropertyComplianceUpdate::class, urlArguments)
 
         // EICR Exemption Confirmation page
         assertThat(eicrExemptionConfirmationPage.heading).containsText("You’ve marked this property as exempt from needing an EICR")
@@ -327,7 +354,13 @@ class PropertyComplianceUpdateJourneyTests : JourneyTestWithSeedData("data-local
         assertPageIs(page, EicrCheckYourAnswersPagePropertyComplianceUpdate::class, urlArguments)
 
         // EICR Check Your Answers page
-        // TODO: PRSD-1247 - submit page, should return to the Property Record page
+        val cyaPage = assertPageIs(page, EicrCheckYourAnswersPagePropertyComplianceUpdate::class, urlArguments)
+        assertThat(cyaPage.form.summaryList.eicrRow.value).containsText("Not required")
+        assertThat(cyaPage.form.summaryList.exemptionRow.value).containsText("Other")
+        assertThat(cyaPage.form.summaryList.exemptionRow.value).containsText("valid reason")
+        cyaPage.form.submit()
+
+        assertPageIs(page, PropertyDetailsPageLandlordView::class, urlArguments)
     }
 
     @Test

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/PropertyComplianceUpdateJourneyTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/PropertyComplianceUpdateJourneyTests.kt
@@ -205,8 +205,6 @@ class PropertyComplianceUpdateJourneyTests : JourneyTestWithSeedData("data-local
         assertPageIs(page, PropertyDetailsPageLandlordView::class, urlArguments)
     }
 
-    // TODO PRSD-1247 - remove @Disabled when Gas Safety completion links to the rest of the journey
-    @Disabled
     @Test
     fun `User can navigate the EICR update task if pages are filled in correctly (add new in-date certificate)`(page: Page) {
         // Property details before update
@@ -257,8 +255,6 @@ class PropertyComplianceUpdateJourneyTests : JourneyTestWithSeedData("data-local
         assertPageIs(page, PropertyDetailsPageLandlordView::class, urlArguments)
     }
 
-    // TODO: PRSD-1247 - remove @Disabled when Gas Safety completion links to the rest of the journey
-    @Disabled
     @Test
     fun `User can navigate the EICR update task if pages are filled in correctly (add new expired certificate)`(page: Page) {
         // Property details before update
@@ -292,8 +288,6 @@ class PropertyComplianceUpdateJourneyTests : JourneyTestWithSeedData("data-local
         assertPageIs(page, PropertyDetailsPageLandlordView::class, urlArguments)
     }
 
-    // TODO: PRSD-1247 - remove @Disabled when Gas Safety completion links to the rest of the journey
-    @Disabled
     @Test
     fun `User can add a new EICR exemption if the pages are filled in correctly`(page: Page) {
         // Property details before update
@@ -329,8 +323,6 @@ class PropertyComplianceUpdateJourneyTests : JourneyTestWithSeedData("data-local
         assertPageIs(page, PropertyDetailsPageLandlordView::class, urlArguments)
     }
 
-    // TODO: PRSD-1247 - remove @Disabled when Gas Safety completion links to the rest of the journey
-    @Disabled
     @Test
     fun `User can add a new EICR exemption if the pages are filled in correctly (with 'other' exemption reason)`(page: Page) {
         // Property details before update

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/UpdatePropertyComplianceSinglePageTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/UpdatePropertyComplianceSinglePageTests.kt
@@ -1,6 +1,7 @@
 package uk.gov.communities.prsdb.webapp.integration
 
 import com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat
+import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/UpdatePropertyComplianceSinglePageTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/UpdatePropertyComplianceSinglePageTests.kt
@@ -1,7 +1,6 @@
 package uk.gov.communities.prsdb.webapp.integration
 
 import com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat
-import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
@@ -20,8 +19,6 @@ class UpdatePropertyComplianceSinglePageTests : SinglePageTestWithSeedData("data
 
     @Nested
     inner class UpdateEicrStep {
-        // TODO PRSD-1245 or PRSD-1246: Re-enable this test when UpdateEicrCertificateFormModel validation is re-enabled
-        @Disabled
         @Test
         fun `Submitting with no option selected returns an error`() {
             val updateEicrPage = navigator.goToPropertyComplianceUpdateUpdateEicrPage(PROPERTY_OWNERSHIP_ID)

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/propertyComplianceJourneyPages/updatePages/EicrCheckYourAnswersPagePropertyComplianceUpdate.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/propertyComplianceJourneyPages/updatePages/EicrCheckYourAnswersPagePropertyComplianceUpdate.kt
@@ -1,9 +1,11 @@
 package uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyComplianceJourneyPages.updatePages
 
+import com.microsoft.playwright.Locator
 import com.microsoft.playwright.Page
 import uk.gov.communities.prsdb.webapp.controllers.PropertyComplianceController
 import uk.gov.communities.prsdb.webapp.forms.steps.PropertyComplianceStepId
-import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.Button
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.Form
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.SummaryList
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages.BasePage
 
 class EicrCheckYourAnswersPagePropertyComplianceUpdate(
@@ -16,5 +18,19 @@ class EicrCheckYourAnswersPagePropertyComplianceUpdate(
             PropertyComplianceStepId.UpdateEicrCheckYourAnswers,
         ),
     ) {
-    val continueButton = Button.byText(page, "Continue")
+    val form = EicrCheckYourAnswersForm(page)
+
+    class EicrCheckYourAnswersForm(
+        page: Page,
+    ) : Form(page) {
+        val summaryList = EicrCheckYourAnswersSummaryList(locator)
+    }
+
+    class EicrCheckYourAnswersSummaryList(
+        locator: Locator,
+    ) : SummaryList(locator) {
+        val eicrRow = getRow("Electrical Installation Condition Report")
+        val issueDateRow = getRow("Issue date")
+        val exemptionRow = getRow("Exemption")
+    }
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/testHelpers/builders/JourneyDataBuilder.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/testHelpers/builders/JourneyDataBuilder.kt
@@ -639,6 +639,11 @@ class JourneyDataBuilder(
         return this
     }
 
+    fun withEicrOutdatedConfirmation(): JourneyDataBuilder {
+        journeyData[PropertyComplianceStepId.EicrOutdated.urlPathSegment] = emptyMap<String, Any>()
+        return this
+    }
+
     fun withEicrExemptionStatus(hasEicrExemption: Boolean): JourneyDataBuilder {
         journeyData[PropertyComplianceStepId.EicrExemption.urlPathSegment] =
             mapOf(EicrExemptionFormModel::hasExemption.name to hasEicrExemption)


### PR DESCRIPTION
## Ticket number

PRSD-1247

## Goal of change

Create the EICR update CYA page and correctly populate the originalJourneyData so the CYA page is always reachable

## Description of main change(s)

Update originalJourneyData (using same approach as the GasSafety Update task) so that there is a route through the journey if the property compliance originally had no EICR or exemption. This is needed to get to the CYA page, but also to ensure the EPC update task is reachable for any given property compliance.

## Anything you'd like to highlight to the reviewer?

Include e.g. anything unusual about the PR, where there was some debate over how to implement it, or anywhere you were
unsure of the approach to take and would like specific feedback.

## Checklist

Delete any that are not applicable, and add explanation below for any that are applicable but haven't been done

- [X] Screenshots of any UI changes have been added
- [X] Unit tests for new logic (e.g. new service methods) have been added
- [X] Single page integration tests have been added for any unhappy-flow UI features, e.g. validation errors
- [X] New journey steps have been added to the appropriate journey integration test(s)
- [X] Test suite has been run in full locally and is passing
- [X] Branch has been rebased onto main and run locally, with everything working as expected (both for your new feature
  and any related functionality)
- [x] Re-enabled any tests disabled in [this PR](https://github.com/communitiesuk/prsdb-webapp/pull/583/files#diff-643c014b69646dd8de53375a73606f97d0aaab23c759c847eb6a26a1d3996dd6)

<img width="1515" height="1225" alt="image" src="https://github.com/user-attachments/assets/d9510913-fa04-409e-9999-4b74db744033" />
<img width="1515" height="1198" alt="image" src="https://github.com/user-attachments/assets/d0ba8536-780a-4c92-8627-b3f73621c941" />
