### PR TITLE
PRSD-NONE: Fix CYA pages using off journey logic

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/pages/CheckAnswersPage.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/pages/CheckAnswersPage.kt
@@ -25,7 +25,7 @@ abstract class CheckAnswersPage(
         modelAndView: ModelAndView,
         filteredJourneyData: JourneyData?,
     ) {
-        val submittableJourneyData = journeyDataService.getJourneyDataFromSession()
+        val submittableJourneyData = journeyDataService.getJourneyDataFromSession().filterKeys { it in filteredJourneyData!!.keys }
         modelAndView.addObject(
             "submittedFilteredJourneyData",
             CheckAnswersFormModel.serializeJourneyData(submittableJourneyData),


### PR DESCRIPTION
## Ticket number
PRSD-NONE

## Goal of change
CYA pages logic should only depend on the 'active route' through the journey.

## Description of main change(s)
Without the change on a CYA page for a journey that has been filled in multiple times down multiple routes (e.g. upload a gas safety cert then change to list an exemption then change to say no exemption) the logic of what the show and where to link can be influenced by data that's not currently 'active' (same e.g. the presence of an issue date). This ensures that the only data available to a CYA page is both submittable AND active.
