### PR TITLE
PRSD-1297: fix typo compliance message

### DIFF
--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -565,7 +565,7 @@ propertyDetails.complianceInformation.notificationBanner.gasCert.missing.mainTex
 propertyDetails.complianceInformation.notificationBanner.gasCert.missing.linkText=Upload a certificate
 propertyDetails.complianceInformation.notificationBanner.eicr.expired.mainText=The <strong>Electrical Installation Condition Report (EICR)</strong> for this property has expired.
 propertyDetails.complianceInformation.notificationBanner.eicr.expired.linkText=Upload a new EICR
-propertyDetails.complianceInformation.notificationBanner.eicr.missing.mainText=This property is missing a <strong>Electrical Installation Condition Report (EICR)</strong>.
+propertyDetails.complianceInformation.notificationBanner.eicr.missing.mainText=This property is missing an <strong>Electrical Installation Condition Report (EICR)</strong>.
 propertyDetails.complianceInformation.notificationBanner.eicr.missing.linkText=Upload an EICR
 propertyDetails.complianceInformation.notificationBanner.epc.expired.mainText=The <strong>energy performance certificate (EPC)</strong> for this property has expired.
 propertyDetails.complianceInformation.notificationBanner.epc.expired.linkText=Add a new certificate

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/PropertyDetailsTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/PropertyDetailsTests.kt
@@ -108,7 +108,7 @@ class PropertyDetailsTests : SinglePageTestWithSeedData("data-local.sql") {
                     detailsPage.notificationBanner.content,
                 ).containsText(
                     "This property is missing a gas safety certificate. Upload a certificate as soon as possible.\n" +
-                        "This property is missing a Electrical Installation Condition Report (EICR)." +
+                        "This property is missing an Electrical Installation Condition Report (EICR)." +
                         " Upload an EICR as soon as possible.\n" +
                         "This property is missing an energy performance certificate (EPC). Add a new certificate as soon as possible.",
                 )
@@ -319,7 +319,7 @@ class PropertyDetailsTests : SinglePageTestWithSeedData("data-local.sql") {
                     detailsPage.notificationBanner.content,
                 ).containsText(
                     "This property is missing a gas safety certificate.\n" +
-                        "This property is missing a Electrical Installation Condition Report (EICR).\n" +
+                        "This property is missing an Electrical Installation Condition Report (EICR).\n" +
                         "This property is missing an energy performance certificate (EPC).",
                 )
             }


### PR DESCRIPTION
## Ticket number

PRSD-1297

## Goal of change

Fixed the typo in the missing EICR compliance message on the property record page

## Description of main change(s)

"a" -> "an"

## Screenshots

### After change
<img width="478" height="70" alt="image" src="https://github.com/user-attachments/assets/72ab2da9-0e26-43b0-8c4e-f00ae9125c7a" />

### Before change
<img width="630" height="60" alt="image" src="https://github.com/user-attachments/assets/8f69835b-9f91-41b5-91ac-85f65612283f" />


## Checklist

Delete any that are not applicable, and add explanation below for any that are applicable but haven't been done

- [X] Screenshots of any UI changes have been added
- [X] Test suite has been run in full locally and is passing
- [X] Branch has been rebased onto main and run locally, with everything working as expected (both for your new feature and any related functionality)
