### PR TITLE
PRSD-1410: invalid token page

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/RegisterLAUserController.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/RegisterLAUserController.kt
@@ -43,16 +43,15 @@ class RegisterLAUserController(
         // see https://github.com/spring-projects/spring-hateoas/issues/155 for details
         val invitation = invitationService.getInvitationOrNull(token)
 
-        invitation?.let {
-            if (!invitationService.getInvitationHasExpired(it)) {
-                invitationService.storeTokenInSession(token)
-                return "redirect:${LA_USER_REGISTRATION_ROUTE}/${RegisterLaUserStepId.LandingPage.urlPathSegment}"
-            } else {
-                invitationService.deleteInvitation(it)
-            }
+        return if (invitation == null) {
+            "redirect:$LA_USER_REGISTRATION_INVALID_LINK_ROUTE"
+        } else if (invitationService.getInvitationHasExpired(invitation)) {
+            invitationService.deleteInvitation(invitation)
+            "redirect:$LA_USER_REGISTRATION_INVALID_LINK_ROUTE"
+        } else {
+            invitationService.storeTokenInSession(token)
+            return "redirect:${LA_USER_REGISTRATION_ROUTE}/${RegisterLaUserStepId.LandingPage.urlPathSegment}"
         }
-
-        return "redirect:$LA_USER_REGISTRATION_INVALID_LINK_ROUTE"
     }
 
     @GetMapping("/$LANDING_PAGE_PATH_SEGMENT")

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/RegisterLAUserController.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/RegisterLAUserController.kt
@@ -41,14 +41,15 @@ class RegisterLAUserController(
         // This is using a CharSequence instead of returning a String to handle an error that otherwise occurs in
         // the LocalAuthorityInvitationService method that creates the invitation url using MvcUriComponentsBuilder.fromMethodName
         // see https://github.com/spring-projects/spring-hateoas/issues/155 for details
-        if (invitationService.tokenIsValid(token)) {
-            invitationService.storeTokenInSession(token)
-            return "redirect:${LA_USER_REGISTRATION_ROUTE}/${RegisterLaUserStepId.LandingPage.urlPathSegment}"
-        }
+        val invitation = invitationService.getInvitationOrNull(token)
 
-        val invitation = invitationService.getInvitationFromToken(token)
-        if (invitationService.getInvitationHasExpired(invitation)) {
-            invitationService.deleteInvitation(invitation)
+        invitation?.let {
+            if (!invitationService.getInvitationHasExpired(it)) {
+                invitationService.storeTokenInSession(token)
+                return "redirect:${LA_USER_REGISTRATION_ROUTE}/${RegisterLaUserStepId.LandingPage.urlPathSegment}"
+            } else {
+                invitationService.deleteInvitation(it)
+            }
         }
 
         return "redirect:$LA_USER_REGISTRATION_INVALID_LINK_ROUTE"

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/LocalAuthorityInvitationService.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/LocalAuthorityInvitationService.kt
@@ -57,6 +57,13 @@ class LocalAuthorityInvitationService(
         }
     }
 
+    fun getInvitationOrNull(token: String): LocalAuthorityInvitation? =
+        try {
+            getInvitationFromToken(token)
+        } catch (e: TokenNotFoundException) {
+            null
+        }
+
     fun storeTokenInSession(token: String) {
         session.setAttribute(LA_USER_INVITATION_TOKEN, token)
     }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/LaUserRegistrationJourneyTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/LaUserRegistrationJourneyTests.kt
@@ -4,6 +4,7 @@ import com.microsoft.playwright.Page
 import com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.mockito.ArgumentCaptor.captor
 import org.mockito.kotlin.verify
@@ -19,6 +20,7 @@ import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages.B
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.laUserRegistrationJourneyPages.CheckAnswersPageLaUserRegistration
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.laUserRegistrationJourneyPages.ConfirmationPageLaUserRegistration
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.laUserRegistrationJourneyPages.EmailFormPageLaUserRegistration
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.laUserRegistrationJourneyPages.InvalidLinkPageLaUserRegistration
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.laUserRegistrationJourneyPages.LandingPageLaUserRegistration
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.laUserRegistrationJourneyPages.NameFormPageLaUserRegistration
 import uk.gov.communities.prsdb.webapp.services.LocalAuthorityInvitationService
@@ -97,5 +99,19 @@ class LaUserRegistrationJourneyTests : JourneyTestWithSeedData("data-mockuser-no
         val dashboard = assertPageIs(page, LocalAuthorityDashboardPage::class)
 
         assertThat(dashboard.bannerSubHeading).containsText("Local council")
+    }
+
+    @Nested
+    inner class WithExpiredToken : NestedJourneyTestWithSeedData("data-mockuser-with-expired-invitation.sql") {
+        @Test
+        fun `User with an expired token is redirected to the invalid link page`(page: Page) {
+            val expiredToken = "1234abcd-5678-abcd-1234-567abcd1111a"
+            navigator.navigateToLaUserRegistrationAcceptInvitationRoute(expiredToken)
+            val invalidLinkPage = assertPageIs(page, InvalidLinkPageLaUserRegistration::class)
+            assertThat(invalidLinkPage.heading).containsText("This invite link is not valid")
+            assertThat(
+                invalidLinkPage.description,
+            ).containsText("Contact the PRS Database admin user at your local council to ask for another invite.")
+        }
     }
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/LaUserRegistrationJourneyTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/LaUserRegistrationJourneyTests.kt
@@ -19,6 +19,7 @@ import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages.B
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.laUserRegistrationJourneyPages.CheckAnswersPageLaUserRegistration
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.laUserRegistrationJourneyPages.ConfirmationPageLaUserRegistration
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.laUserRegistrationJourneyPages.EmailFormPageLaUserRegistration
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.laUserRegistrationJourneyPages.LandingPageLaUserRegistration
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.laUserRegistrationJourneyPages.NameFormPageLaUserRegistration
 import uk.gov.communities.prsdb.webapp.services.LocalAuthorityInvitationService
 import uk.gov.communities.prsdb.webapp.services.LocalAuthorityService
@@ -51,8 +52,10 @@ class LaUserRegistrationJourneyTests : JourneyTestWithSeedData("data-mockuser-no
 
     @Test
     fun `User can navigate the whole journey if pages are correctly filled in`(page: Page) {
+        // Accept invitation route
+        navigator.navigateToLaUserRegistrationAcceptInvitationRoute(invitation.token.toString())
+        val landingPage = assertPageIs(page, LandingPageLaUserRegistration::class)
         // Landing page - render
-        val landingPage = navigator.skipToLaUserRegistrationLandingPage(invitation.token)
         assertThat(landingPage.headingCaption).containsText("Before you register")
         assertThat(landingPage.heading).containsText("Registering as a local authority user")
         // Submit and go to next page

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/LaUserRegistrationSinglePageTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/LaUserRegistrationSinglePageTests.kt
@@ -37,18 +37,7 @@ class LaUserRegistrationSinglePageTests : SinglePageTestWithSeedData("data-mocku
     }
 
     @Nested
-    inner class LaUserRegistrationAcceptInvitationRoute : NestedSinglePageTestWithSeedData("data-mockuser-with-expired-invitation.sql") {
-        @Test
-        fun `Navigating here with an expired token redirects to the invalid link page`(page: Page) {
-            val expiredToken = "1234abcd-5678-abcd-1234-567abcd1111a"
-            navigator.navigateToLaUserRegistrationAcceptInvitationRoute(expiredToken)
-            val errorPage = BasePage.assertPageIs(page, ErrorPage::class)
-            BaseComponent.assertThat(errorPage.heading).containsText("This invite link is not valid")
-            assertThat(
-                errorPage.description,
-            ).containsText("Contact the PRS Database admin user at your local council to ask for another invite.")
-        }
-
+    inner class LaUserRegistrationAcceptInvitationRoute {
         @Test
         fun `Navigating here with an invalid token redirects to the invalid link page`(page: Page) {
             val invalidToken = "1234abcd-5678-abcd-1234-567abcd1111d"

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/LaUserRegistrationSinglePageTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/LaUserRegistrationSinglePageTests.kt
@@ -37,6 +37,31 @@ class LaUserRegistrationSinglePageTests : SinglePageTestWithSeedData("data-mocku
     }
 
     @Nested
+    inner class LaUserRegistrationAcceptInvitationRoute : NestedSinglePageTestWithSeedData("data-mockuser-with-expired-invitation.sql") {
+        @Test
+        fun `Navigating here with an expired token redirects to the invalid link page`(page: Page) {
+            val expiredToken = "1234abcd-5678-abcd-1234-567abcd1111a"
+            navigator.navigateToLaUserRegistrationAcceptInvitationRoute(expiredToken)
+            val errorPage = BasePage.assertPageIs(page, ErrorPage::class)
+            BaseComponent.assertThat(errorPage.heading).containsText("This invite link is not valid")
+            assertThat(
+                errorPage.description,
+            ).containsText("Contact the PRS Database admin user at your local council to ask for another invite.")
+        }
+
+        @Test
+        fun `Navigating here with an invalid token redirects to the invalid link page`(page: Page) {
+            val invalidToken = "1234abcd-5678-abcd-1234-567abcd1111d"
+            navigator.navigateToLaUserRegistrationAcceptInvitationRoute(invalidToken)
+            val errorPage = BasePage.assertPageIs(page, ErrorPage::class)
+            BaseComponent.assertThat(errorPage.heading).containsText("This invite link is not valid")
+            assertThat(
+                errorPage.description,
+            ).containsText("Contact the PRS Database admin user at your local council to ask for another invite.")
+        }
+    }
+
+    @Nested
     inner class LaUserRegistrationStepLandingPage : NestedSinglePageTestWithSeedData("data-local.sql") {
         @Test
         fun `Navigating here as a registered local authority user redirects to the LA dashboard page`(page: Page) {

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/LaUserRegistrationSinglePageTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/LaUserRegistrationSinglePageTests.kt
@@ -12,6 +12,7 @@ import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.ErrorPage
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.LocalAuthorityDashboardPage
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages.BasePage
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.laUserRegistrationJourneyPages.EmailFormPageLaUserRegistration
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.laUserRegistrationJourneyPages.InvalidLinkPageLaUserRegistration
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.laUserRegistrationJourneyPages.NameFormPageLaUserRegistration
 import uk.gov.communities.prsdb.webapp.services.LocalAuthorityInvitationService
 import uk.gov.communities.prsdb.webapp.services.LocalAuthorityService
@@ -42,10 +43,10 @@ class LaUserRegistrationSinglePageTests : SinglePageTestWithSeedData("data-mocku
         fun `Navigating here with an invalid token redirects to the invalid link page`(page: Page) {
             val invalidToken = "1234abcd-5678-abcd-1234-567abcd1111d"
             navigator.navigateToLaUserRegistrationAcceptInvitationRoute(invalidToken)
-            val errorPage = BasePage.assertPageIs(page, ErrorPage::class)
-            BaseComponent.assertThat(errorPage.heading).containsText("This invite link is not valid")
+            val invalidLinkPage = BasePage.assertPageIs(page, InvalidLinkPageLaUserRegistration::class)
+            BaseComponent.assertThat(invalidLinkPage.heading).containsText("This invite link is not valid")
             assertThat(
-                errorPage.description,
+                invalidLinkPage.description,
             ).containsText("Contact the PRS Database admin user at your local council to ask for another invite.")
         }
     }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/Navigator.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/Navigator.kt
@@ -8,6 +8,7 @@ import uk.gov.communities.prsdb.webapp.constants.CONTEXT_ID_URL_PARAMETER
 import uk.gov.communities.prsdb.webapp.constants.DELETE_INCOMPLETE_PROPERTY_PATH_SEGMENT
 import uk.gov.communities.prsdb.webapp.constants.LANDLORD_PATH_SEGMENT
 import uk.gov.communities.prsdb.webapp.constants.TASK_LIST_PATH_SEGMENT
+import uk.gov.communities.prsdb.webapp.constants.TOKEN
 import uk.gov.communities.prsdb.webapp.controllers.CookiesController.Companion.COOKIES_ROUTE
 import uk.gov.communities.prsdb.webapp.controllers.DeregisterLandlordController
 import uk.gov.communities.prsdb.webapp.controllers.DeregisterPropertyController
@@ -61,7 +62,6 @@ import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.SelectAddre
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages.BasePage.Companion.createValidPage
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.laUserRegistrationJourneyPages.CheckAnswersPageLaUserRegistration
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.laUserRegistrationJourneyPages.EmailFormPageLaUserRegistration
-import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.laUserRegistrationJourneyPages.LandingPageLaUserRegistration
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.laUserRegistrationJourneyPages.NameFormPageLaUserRegistration
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.landlordDeregistrationJourneyPages.AreYouSureFormPageLandlordDeregistration
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.landlordRegistrationJourneyPages.CheckAnswersPageLandlordRegistration
@@ -329,15 +329,13 @@ class Navigator(
         navigate("${RegisterLandlordController.LANDLORD_REGISTRATION_ROUTE}/$CONFIRMATION_PATH_SEGMENT")
     }
 
+    fun navigateToLaUserRegistrationAcceptInvitationRoute(token: String) {
+        navigate("${RegisterLAUserController.LA_USER_REGISTRATION_ROUTE}?$TOKEN=$token")
+    }
+
     fun navigateToLaUserRegistrationLandingPage(token: UUID) {
         storeInvitationTokenInSession(token)
         navigate("${RegisterLAUserController.LA_USER_REGISTRATION_ROUTE}/${RegisterLaUserStepId.LandingPage.urlPathSegment}")
-    }
-
-    fun skipToLaUserRegistrationLandingPage(token: UUID): LandingPageLaUserRegistration {
-        storeInvitationTokenInSession(token)
-        navigate("${RegisterLAUserController.LA_USER_REGISTRATION_ROUTE}/${RegisterLaUserStepId.LandingPage.urlPathSegment}")
-        return createValidPage(page, LandingPageLaUserRegistration::class)
     }
 
     fun skipToLaUserRegistrationNameFormPage(token: UUID): NameFormPageLaUserRegistration {

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/ErrorPage.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/ErrorPage.kt
@@ -1,5 +1,6 @@
 package uk.gov.communities.prsdb.webapp.integration.pageObjects.pages
 
+import com.microsoft.playwright.Locator
 import com.microsoft.playwright.Page
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.Heading
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages.BasePage
@@ -8,4 +9,5 @@ class ErrorPage(
     page: Page,
 ) : BasePage(page) {
     val heading = Heading(page.locator("main h1"))
+    val description: Locator = page.locator("main p.govuk-body")
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/ErrorPage.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/ErrorPage.kt
@@ -1,14 +1,8 @@
 package uk.gov.communities.prsdb.webapp.integration.pageObjects.pages
 
-import com.microsoft.playwright.Locator
 import com.microsoft.playwright.Page
-import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.Heading
-import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages.BasePage
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages.ErrorBasePage
 
-abstract class ErrorPage(
+class ErrorPage(
     page: Page,
-    urlSegment: String? = null,
-) : BasePage(page, urlSegment) {
-    val heading = Heading(page.locator("main h1"))
-    val description: Locator = page.locator("main p.govuk-body")
-}
+) : ErrorBasePage(page)

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/ErrorPage.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/ErrorPage.kt
@@ -5,9 +5,10 @@ import com.microsoft.playwright.Page
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.Heading
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages.BasePage
 
-class ErrorPage(
+abstract class ErrorPage(
     page: Page,
-) : BasePage(page) {
+    urlSegment: String? = null,
+) : BasePage(page, urlSegment) {
     val heading = Heading(page.locator("main h1"))
     val description: Locator = page.locator("main p.govuk-body")
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/basePages/ErrorBasePage.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/basePages/ErrorBasePage.kt
@@ -1,0 +1,13 @@
+package uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages
+
+import com.microsoft.playwright.Locator
+import com.microsoft.playwright.Page
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.Heading
+
+abstract class ErrorBasePage(
+    page: Page,
+    urlSegment: String? = null,
+) : BasePage(page, urlSegment) {
+    val heading = Heading(page.locator("main h1"))
+    val description: Locator = page.locator("main p.govuk-body")
+}

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/laUserRegistrationJourneyPages/InvalidLinkPageLaUserRegistration.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/laUserRegistrationJourneyPages/InvalidLinkPageLaUserRegistration.kt
@@ -1,0 +1,9 @@
+package uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.laUserRegistrationJourneyPages
+
+import com.microsoft.playwright.Page
+import uk.gov.communities.prsdb.webapp.controllers.RegisterLAUserController
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.ErrorPage
+
+class InvalidLinkPageLaUserRegistration(
+    page: Page,
+) : ErrorPage(page, RegisterLAUserController.LA_USER_REGISTRATION_INVALID_LINK_ROUTE)

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/laUserRegistrationJourneyPages/InvalidLinkPageLaUserRegistration.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/laUserRegistrationJourneyPages/InvalidLinkPageLaUserRegistration.kt
@@ -2,8 +2,8 @@ package uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.laUserRegi
 
 import com.microsoft.playwright.Page
 import uk.gov.communities.prsdb.webapp.controllers.RegisterLAUserController
-import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.ErrorPage
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages.ErrorBasePage
 
 class InvalidLinkPageLaUserRegistration(
     page: Page,
-) : ErrorPage(page, RegisterLAUserController.LA_USER_REGISTRATION_INVALID_LINK_ROUTE)
+) : ErrorBasePage(page, RegisterLAUserController.LA_USER_REGISTRATION_INVALID_LINK_ROUTE)

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/LocalAuthorityInvitationServiceTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/LocalAuthorityInvitationServiceTests.kt
@@ -110,7 +110,7 @@ class LocalAuthorityInvitationServiceTests {
     }
 
     @Test
-    fun `getInvitationOrNull returns null if hee token is not in the database`() {
+    fun `getInvitationOrNull returns null if the token is not in the database`() {
         val testUuid = UUID.randomUUID()
         whenever(mockLaInviteRepository.findByToken(testUuid)).thenReturn(null)
 

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/LocalAuthorityInvitationServiceTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/LocalAuthorityInvitationServiceTests.kt
@@ -5,6 +5,7 @@ import kotlinx.datetime.Clock
 import kotlinx.datetime.toJavaInstant
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
@@ -94,6 +95,27 @@ class LocalAuthorityInvitationServiceTests {
 
         val thrown = assertThrows(TokenNotFoundException::class.java) { inviteService.getInvitationFromToken(testUuid.toString()) }
         assertEquals("Invitation token not found in database", thrown.message)
+    }
+
+    @Test
+    fun `getInvitationOrNull returns an invitation if the token is in the database`() {
+        val testUuid = UUID.randomUUID()
+        val testInvitation = MockLocalAuthorityData.createLocalAuthorityInvitation(token = testUuid)
+        whenever(mockLaInviteRepository.findByToken(testUuid))
+            .thenReturn(testInvitation)
+
+        val invitation = inviteService.getInvitationOrNull(testUuid.toString())
+
+        assertEquals(invitation, testInvitation)
+    }
+
+    @Test
+    fun `getInvitationOrNull returns null if hee token is not in the database`() {
+        val testUuid = UUID.randomUUID()
+        whenever(mockLaInviteRepository.findByToken(testUuid)).thenReturn(null)
+
+        val invitation = inviteService.getInvitationOrNull(testUuid.toString())
+        assertNull(invitation)
     }
 
     @Test

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/urlProviders/InvitationUrlTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/urlProviders/InvitationUrlTests.kt
@@ -114,7 +114,7 @@ class InvitationUrlTests(
             .andExpect { status { is3xxRedirection() } }
 
         // Assert
-        verify(localAuthorityInvitationService).tokenIsValid(testToken)
+        verify(localAuthorityInvitationService).getInvitationOrNull(testToken)
     }
 
     @Suppress("SameParameterValue")

--- a/src/test/resources/data-mockuser-with-expired-invitation.sql
+++ b/src/test/resources/data-mockuser-with-expired-invitation.sql
@@ -1,0 +1,5 @@
+INSERT INTO one_login_user (id, created_date)
+VALUES ('urn:fdc:gov.uk:2022:UVWXY', '10/14/24');
+
+INSERT INTO local_authority_invitation (invited_email, inviting_authority_id, token, invited_as_admin, created_date)
+VALUES ('expired.invitation+a@example.com', 2, '1234abcd-5678-abcd-1234-567abcd1111a', false, current_timestamp - interval '49 hour');


### PR DESCRIPTION
## Ticket number

PRSD-1410

## Goal of change

Make sure user can reach Invalid Link error page when using an Invalid Token

## Description of main change(s)

I changed the logic in the controller to check for a valid token (without checking for expiry) first and then to have the expiry check happen separately.

Added to tests to catch this bug if it reoccurs.


## Checklist

- [x] Unit tests for new logic (e.g. new service methods) have been added
- [x] Controller tests for any new endpoints, including testing the relevant permissions
- [x] Single page integration tests have been added for any unhappy-flow UI features, e.g. validation errors
- [x] Test suite has been run in full locally and is passing
- [x] Branch has been rebased onto main and run locally, with everything working as expected (both for your new feature
  and any related functionality)
