### PR TITLE
PRSD-1357: content update la screens

### DIFF
--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -243,7 +243,7 @@ addLAUser.paragraph.two.bullet.one=landlords in the local area
 addLAUser.paragraph.two.bullet.two=properties in the local area
 addLAUser.paragraph.three.a=They must have a {0,,localAuthority} email address to get an invite.
 addLAUser.paragraph.three.an=They must have an {0,,localAuthority} email address to get an invite.
-addLAUser.form.primaryEmailLabel=Enter their email address ending in [@nameofcouncil.co.uk]
+addLAUser.form.primaryEmailLabel=Enter their email address
 addLAUser.form.confirmEmailLabel=Confirm their email address
 
 addLAUser.error.missingEmail=You must enter an email address

--- a/src/main/resources/templates/registerLAUserSuccess.html
+++ b/src/main/resources/templates/registerLAUserSuccess.html
@@ -6,7 +6,7 @@
         <div id="confirmation-banner"
              th:replace="~{fragments/banners/confirmationPageBanner :: confirmationPageBanner(#{registerLaUser.success.banner.title(${localAuthority})}, ~{::#confirmation-banner/content()})}">
         </div>
-        <h2 class="govuk-heading-l" th:text="#{common.confirmationPage.whatHappensNext}">common.whatHappensNext</h2>
+        <h2 class="govuk-heading-xl" th:text="#{common.confirmationPage.whatHappensNext}">common.whatHappensNext</h2>
         <p class="govuk-body" th:text="#{registerLaUser.success.whatHappensNext.paragraph.one}">
             registerLaUser.success.whatHappensNext.paragraph.one
         </p>

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/laUserRegistrationJourneyPages/ConfirmationPageLaUserRegistration.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/laUserRegistrationJourneyPages/ConfirmationPageLaUserRegistration.kt
@@ -4,12 +4,13 @@ import com.microsoft.playwright.Page
 import uk.gov.communities.prsdb.webapp.constants.CONFIRMATION_PATH_SEGMENT
 import uk.gov.communities.prsdb.webapp.controllers.RegisterLAUserController
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.Button
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.Heading
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages.BasePage
 
 class ConfirmationPageLaUserRegistration(
     page: Page,
 ) : BasePage(page, "${RegisterLAUserController.LA_USER_REGISTRATION_ROUTE}/$CONFIRMATION_PATH_SEGMENT") {
-    val bannerHeading = page.locator(".govuk-panel__title")
-    val bodyHeading = page.locator(".govuk-heading-xl")
+    val bannerHeading = Heading(page.locator(".govuk-panel__title"))
+    val bodyHeading = Heading(page.locator(".govuk-heading-xl"))
     val returnToDashboardButton = Button.byText(page, "Go to dashboard")
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/laUserRegistrationJourneyPages/ConfirmationPageLaUserRegistration.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/laUserRegistrationJourneyPages/ConfirmationPageLaUserRegistration.kt
@@ -10,6 +10,6 @@ class ConfirmationPageLaUserRegistration(
     page: Page,
 ) : BasePage(page, "${RegisterLAUserController.LA_USER_REGISTRATION_ROUTE}/$CONFIRMATION_PATH_SEGMENT") {
     val bannerHeading = page.locator(".govuk-panel__title")
-    val bodyHeading = page.locator(".govuk-heading-l")
+    val bodyHeading = page.locator(".govuk-heading-xl")
     val returnToDashboardButton = Button.byText(page, "Go to dashboard")
 }


### PR DESCRIPTION
## Ticket number

PRSD-1357

## Goal of change

Content and style changes for LA screens

## Description of main change(s)

Update the heading 2 size on the confirmation screen - and update tests
Remove some text from the invite LA user screen

## Screenshots

### LA Registration Confirmation Screen

#### After
<img width="720" height="667" alt="image" src="https://github.com/user-attachments/assets/56adfe91-6227-4463-b11f-e1818aa9b1bb" />

#### Before
<img width="720" height="621" alt="image" src="https://github.com/user-attachments/assets/4a98c183-ec77-434d-a0d2-d17b4584a9e4" />

### LA User invite Screen

#### After
<img width="720" height="717" alt="image" src="https://github.com/user-attachments/assets/ab61e4f1-b5bd-45b2-a405-91e46cab8302" />

#### Before
<img width="720" height="717" alt="image" src="https://github.com/user-attachments/assets/f04f3fd0-7fce-431a-94b1-3cdbc9f43ca9" />


## Checklist

- [X] Screenshots of any UI changes have been added
- [x] Test suite has been run in full locally and is passing
- [x] Branch has been rebased onto main and run locally, with everything working as expected (both for your new feature
  and any related functionality)
