### PR TITLE
Fix/prsd 1435 use https

### DIFF
--- a/.github/workflows/build-and-deploy-integration.yml
+++ b/.github/workflows/build-and-deploy-integration.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - main
+      - fix/prsd-1435-use-https
 
 jobs:
   build-and-deploy-integration:

--- a/.github/workflows/build-and-deploy-integration.yml
+++ b/.github/workflows/build-and-deploy-integration.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - main
-      - fix/prsd-1435-use-https
 
 jobs:
   build-and-deploy-integration:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -65,6 +65,9 @@ epc:
 server:
   error:
     path: /error
+  tomcat:
+    redirect-context-root: false
+  forward-headers-strategy: native
 
 aws:
   s3:


### PR DESCRIPTION
## Ticket number

PRSD-1435

## Goal of change

Ensure that the redirect and post-signout urls issued to and used by One Login are using HTTPS and not HTTP

## Description of main change(s)

Some tomcat configuration properties needed to be added for Tomcat to respect the `x-forward-proto` header in the request forwarded from the load balancer.

## Checklist

Delete any that are not applicable, and add explanation below for any that are applicable but haven't been done

- [x] Test suite has been run in full locally and is passing
- [x] Branch has been rebased onto main and run locally, with everything working as expected (both for your new feature
  and any related functionality)
