### PR TITLE
PRSD-NONE: Only saves filtered journey data to the DB

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/Journey.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/Journey.kt
@@ -71,8 +71,6 @@ abstract class Journey<T : StepId>(
         checkingAnswersForStep: String? = null,
     ): ModelAndView {
         val currentStep = getStep(stepPathSegment)
-
-        val filteredJourneyData = getPrevStep(currentStep, subPageNumber)?.filteredJourneyData ?: emptyMap()
         val bindingResult = currentStep.page.bindDataToFormModel(validator, formData)
 
         if (!currentStep.isSatisfied(bindingResult)) {
@@ -83,16 +81,16 @@ abstract class Journey<T : StepId>(
             )
         }
 
+        val filteredJourneyData = getPrevStep(currentStep, subPageNumber)?.filteredJourneyData ?: emptyMap()
         val formModel = currentStep.page.formModel.cast(bindingResult.target)
-
         val newStepDataPair = currentStep.stepDataPair(filteredJourneyData, formModel, subPageNumber)
-        val newFilteredJourneyData = filteredJourneyData + newStepDataPair
         journeyDataService.addToJourneyDataIntoSession(mapOf(newStepDataPair))
+
+        val newFilteredJourneyData = filteredJourneyData + newStepDataPair
 
         if (currentStep.saveAfterSubmit) {
             val journeyDataContextId = journeyDataService.getContextId()
-            val journeyData = journeyDataService.getJourneyDataFromSession()
-            journeyDataService.saveJourneyData(journeyDataContextId, journeyData, journeyType, principal)
+            journeyDataService.saveJourneyData(journeyDataContextId, newFilteredJourneyData, journeyType, principal)
         }
 
         val checkingAnswersForId = checkingAnswersForStep?.let { getStep(it).id }


### PR DESCRIPTION
## Ticket number

PRSD-NONE

## Goal of change

Only saves filtered journey data to the DB

## Description of main change(s)

- Uses filtered journey data (instead of full journey data) when saving to the DB

## Anything you'd like to highlight to the reviewer?

- This PR enables us to determine the paths of incomplete journeys, which we will need to know for PRSD-1394

## Checklist

Delete any that are not applicable, and add explanation below for any that are applicable but haven't been done

- [X] Test suite has been run in full locally and is passing
- [X] Branch has been rebased onto main and run locally, with everything working as expected (both for your new feature
  and any related functionality)