### PR TITLE
PRSD-1361: identity not verified landlord registration page

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/LandlordRegistrationJourney.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/LandlordRegistrationJourney.kt
@@ -119,6 +119,7 @@ class LandlordRegistrationJourney(
             LandlordRegistrationStepId.VerifyIdentity,
             setOf(
                 verifyIdentityStep(),
+                identityNotVerifiedStep(),
                 nameStep(),
                 dateOfBirthStep(),
                 confirmIdentityStep(),
@@ -149,6 +150,26 @@ class LandlordRegistrationJourney(
             saveAfterSubmit = false,
         )
 
+    private fun identityNotVerifiedStep() =
+        Step(
+            id = LandlordRegistrationStepId.IdentityNotVerified,
+            page =
+                Page(
+                    formModel = NoInputFormModel::class,
+                    templateName = "forms/identityNotVerifiedForm",
+                    content =
+                        mapOf(
+                            "title" to "registerAsALandlord.title",
+                            "fieldSetHeading" to "forms.identityNotVerified.fieldSetHeading",
+                            "submitButtonText" to "forms.buttons.continue",
+                            BACK_URL_ATTR_NAME to RegisterLandlordController.LANDLORD_REGISTRATION_ROUTE,
+                        ),
+                    shouldDisplaySectionHeader = true,
+                ),
+            nextAction = { _, _ -> Pair(LandlordRegistrationStepId.Name, null) },
+            saveAfterSubmit = false,
+        )
+
     private fun nameStep() =
         Step(
             id = LandlordRegistrationStepId.Name,
@@ -163,7 +184,6 @@ class LandlordRegistrationJourney(
                             "fieldSetHint" to "forms.name.fieldSetHint",
                             "label" to "forms.name.label",
                             "submitButtonText" to "forms.buttons.continue",
-                            BACK_URL_ATTR_NAME to RegisterLandlordController.LANDLORD_REGISTRATION_ROUTE,
                         ),
                     shouldDisplaySectionHeader = true,
                 ),
@@ -546,7 +566,7 @@ class LandlordRegistrationJourney(
         if (LandlordRegistrationJourneyDataHelper.isIdentityVerified(filteredJourneyData)) {
             Pair(LandlordRegistrationStepId.ConfirmIdentity, null)
         } else {
-            Pair(LandlordRegistrationStepId.Name, null)
+            Pair(LandlordRegistrationStepId.IdentityNotVerified, null)
         }
 
     private fun countryOfResidenceNextAction(filteredJourneyData: JourneyData): Pair<LandlordRegistrationStepId, Int?> =

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/LandlordRegistrationJourney.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/LandlordRegistrationJourney.kt
@@ -164,7 +164,7 @@ class LandlordRegistrationJourney(
                             "submitButtonText" to "forms.buttons.continue",
                             BACK_URL_ATTR_NAME to RegisterLandlordController.LANDLORD_REGISTRATION_ROUTE,
                         ),
-                    shouldDisplaySectionHeader = true,
+                    shouldDisplaySectionHeader = false,
                 ),
             nextAction = { _, _ -> Pair(LandlordRegistrationStepId.Name, null) },
             saveAfterSubmit = false,

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/steps/LandlordRegistrationStepId.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/steps/LandlordRegistrationStepId.kt
@@ -7,6 +7,7 @@ enum class LandlordRegistrationStepId(
     override val groupIdentifier: LandlordRegistrationGroupIdentifier,
 ) : GroupedStepId<LandlordRegistrationGroupIdentifier> {
     VerifyIdentity(RegisterLandlordController.IDENTITY_VERIFICATION_PATH_SEGMENT, LandlordRegistrationGroupIdentifier.IdentityVerification),
+    IdentityNotVerified("identity-not-verified", LandlordRegistrationGroupIdentifier.IdentityVerification),
     Name("name", LandlordRegistrationGroupIdentifier.Name),
     DateOfBirth("date-of-birth", LandlordRegistrationGroupIdentifier.DateOfBirth),
     ConfirmIdentity("confirm-identity", LandlordRegistrationGroupIdentifier.IdentityVerification),

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -725,6 +725,11 @@ forms.name.error.missing=You must enter your full name
 
 forms.checkAnswers.heading=Check your answers
 
+forms.identityNotVerified.fieldSetHeading=You have not proven your identity using GOV.UK One Login
+forms.identityNotVerified.paragraph.one=You can return to GOV.UK One Login at any time to prove your identity. You only need to do this once.
+forms.identityNotVerified.paragraph.two=Proving your identity helps local councils understand who has registered on the database.
+forms.identityNotVerified.paragraph.three=You can continue using the database as normal.
+
 forms.confirmDetails.title=Confirm your details
 forms.confirmDetails.heading=Confirm your name and date of birth
 forms.confirmDetails.summary=These are your details from GOV.UK One Login. Check the information is correct.

--- a/src/main/resources/templates/forms/identityNotVerifiedForm.html
+++ b/src/main/resources/templates/forms/identityNotVerifiedForm.html
@@ -1,0 +1,18 @@
+<!--/*@thymesVar id="title" type="java.lang.String"*/-->
+<!--/*@thymesVar id="formModel" type="java.lang.Object"*/-->
+<!--/*@thymesVar id="formData" type="java.lang.Object"*/-->
+<!--/*@thymesVar id="submitButtonText" type="java.lang.String"*/-->
+<!--/*@thymesVar id="backUrl" type="java.lang.String"*/-->
+<!DOCTYPE html>
+<html th:replace="~{fragments/forms/questionPage :: questionPage(#{${title}},${formModel}, ~{::#form-content},${backUrl}, ${sectionHeaderInfo})}">
+
+<th:block id="form-content">
+    <th:block id="fieldset-content"
+              th:replace="~{fragments/forms/fieldSet :: fieldSet(~{::#fieldset-content/content()}, 'identityNotVerified', #{${fieldSetHeading}}, null)}">
+        <p class="govuk-body" th:text="#{forms.identityNotVerified.paragraph.one}">forms.identityNotVerified.paragraph.one</p>
+        <p class="govuk-body" th:text="#{forms.identityNotVerified.paragraph.two}">forms.identityNotVerified.paragraph.two</p>
+        <p class="govuk-body" th:text="#{forms.identityNotVerified.paragraph.three}">forms.identityNotVerified.paragraph.three</p>
+    </th:block>
+    <button th:replace="~{fragments/buttons/primaryButton :: primaryButton(#{${submitButtonText}})}"></button>
+</th:block>
+</html>

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/LandlordRegistrationJourneyTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/LandlordRegistrationJourneyTests.kt
@@ -24,6 +24,7 @@ import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.landlordReg
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.landlordRegistrationJourneyPages.LookupContactAddressFormPageLandlordRegistration
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.landlordRegistrationJourneyPages.ManualAddressFormPageLandlordRegistration
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.landlordRegistrationJourneyPages.ManualContactAddressFormPageLandlordRegistration
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.landlordRegistrationJourneyPages.NameFormPageLandlordRegistration
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.landlordRegistrationJourneyPages.NonEnglandOrWalesAddressFormPageLandlordRegistration
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.landlordRegistrationJourneyPages.PhoneNumberFormPageLandlordRegistration
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.landlordRegistrationJourneyPages.SelectAddressFormPageLandlordRegistration
@@ -161,7 +162,10 @@ class LandlordRegistrationJourneyTests : JourneyTestWithSeedData("data-mockuser-
     fun `User can navigate the whole journey if pages are correctly filled in (unverified, non England or Wales, selected address)`(
         page: Page,
     ) {
-        val namePage = navigator.skipToLandlordRegistrationNamePage()
+        val identityNotVerifiedPage = navigator.skipToLandlordRegistrationIdentityNotVerifiedPage()
+        identityNotVerifiedPage.clickContinue()
+
+        val namePage = assertPageIs(page, NameFormPageLandlordRegistration::class)
         namePage.submitName("landlord name")
 
         val dateOfBirthPage = assertPageIs(page, DateOfBirthFormPageLandlordRegistration::class)
@@ -214,7 +218,10 @@ class LandlordRegistrationJourneyTests : JourneyTestWithSeedData("data-mockuser-
     fun `User can navigate the whole journey if pages are correctly filled in (unverified, non England or Wales, manual address)`(
         page: Page,
     ) {
-        val namePage = navigator.skipToLandlordRegistrationNamePage()
+        val identityNotVerifiedPage = navigator.skipToLandlordRegistrationIdentityNotVerifiedPage()
+        identityNotVerifiedPage.clickContinue()
+
+        val namePage = assertPageIs(page, NameFormPageLandlordRegistration::class)
         namePage.submitName("landlord name")
 
         val dateOfBirthPage = assertPageIs(page, DateOfBirthFormPageLandlordRegistration::class)

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/Navigator.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/Navigator.kt
@@ -72,6 +72,7 @@ import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.landlordReg
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.landlordRegistrationJourneyPages.DateOfBirthFormPageLandlordRegistration
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.landlordRegistrationJourneyPages.DeclarationFormPageLandlordRegistration
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.landlordRegistrationJourneyPages.EmailFormPageLandlordRegistration
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.landlordRegistrationJourneyPages.IdentityNotVerifiedFormPageLandlordRegistration
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.landlordRegistrationJourneyPages.LookupAddressFormPageLandlordRegistration
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.landlordRegistrationJourneyPages.LookupContactAddressFormPageLandlordRegistration
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.landlordRegistrationJourneyPages.ManualAddressFormPageLandlordRegistration
@@ -193,6 +194,17 @@ class Navigator(
 
     fun navigateToLandlordRegistrationVerifyIdentityPage() {
         navigate("${RegisterLandlordController.LANDLORD_REGISTRATION_ROUTE}/${LandlordRegistrationStepId.VerifyIdentity.urlPathSegment}")
+    }
+
+    fun skipToLandlordRegistrationIdentityNotVerifiedPage(): IdentityNotVerifiedFormPageLandlordRegistration {
+        setJourneyDataInSession(
+            LandlordRegistrationJourneyFactory.JOURNEY_DATA_KEY,
+            JourneyPageDataBuilder.beforeLandlordRegistrationIdentityNotVerified().build(),
+        )
+        navigate(
+            "${RegisterLandlordController.LANDLORD_REGISTRATION_ROUTE}/${LandlordRegistrationStepId.IdentityNotVerified.urlPathSegment}",
+        )
+        return createValidPage(page, IdentityNotVerifiedFormPageLandlordRegistration::class)
     }
 
     fun skipToLandlordRegistrationNamePage(): NameFormPageLandlordRegistration {

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/landlordRegistrationJourneyPages/IdentityNotVerifiedFormPageLandlordRegistration.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/landlordRegistrationJourneyPages/IdentityNotVerifiedFormPageLandlordRegistration.kt
@@ -1,0 +1,18 @@
+package uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.landlordRegistrationJourneyPages
+
+import com.microsoft.playwright.Page
+import uk.gov.communities.prsdb.webapp.controllers.RegisterLandlordController
+import uk.gov.communities.prsdb.webapp.forms.steps.LandlordRegistrationStepId
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.FormWithSectionHeader
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages.BasePage
+
+class IdentityNotVerifiedFormPageLandlordRegistration(
+    page: Page,
+) : BasePage(
+        page,
+        "${RegisterLandlordController.LANDLORD_REGISTRATION_ROUTE}/${LandlordRegistrationStepId.IdentityNotVerified.urlPathSegment}",
+    ) {
+    val form = FormWithSectionHeader(page)
+
+    fun clickContinue() = form.submit()
+}

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/testHelpers/builders/JourneyPageDataBuilder.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/testHelpers/builders/JourneyPageDataBuilder.kt
@@ -13,6 +13,8 @@ class JourneyPageDataBuilder {
     companion object {
         fun beforeLandlordRegistrationConfirmIdentity() = JourneyDataBuilder().withVerifiedUser()
 
+        fun beforeLandlordRegistrationIdentityNotVerified() = JourneyDataBuilder().withUnverifiedUser(name = null, dob = null)
+
         fun beforeLandlordRegistrationName() = JourneyDataBuilder().withUnverifiedUser(name = null)
 
         fun beforeLandlordRegistrationDob() = JourneyDataBuilder().withUnverifiedUser(dob = null)


### PR DESCRIPTION
## Ticket number

PRSD-1361

## Goal of change

Add the Identity Not Verified page to the Landlord Registration Journey

## Description of main change(s)

Summary of the changes made. These should focus on the functionality that you've changed rather than the actual code
changes - those will be clear from the PR.
E.g. Prefer "Adds new endpoint for uploading gas safety certificates to s3" to "Adds new `UploadGasSafetyCertificate`
controller that accepts a `UploadFileRequest` and uses the `fileUploadService` to upload the file to s3"

## Screenshot

<img width="720" height="471" alt="image" src="https://github.com/user-attachments/assets/913f1a64-089a-43ce-bbf6-38ff8dcf8d71" />


## Checklist

- [X] Screenshots of any UI changes have been added
- [X] New journey steps have been added to the appropriate journey integration test(s)
- [ ] Test suite has been run in full locally and is passing
- [ ] Branch has been rebased onto main and run locally, with everything working as expected (both for your new feature
  and any related functionality)
