### PR TITLE
PRSD-NONE: Explicitly determines certificate expiry status

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/pages/cya/EicrSummaryRowsFactory.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/pages/cya/EicrSummaryRowsFactory.kt
@@ -12,8 +12,8 @@ import uk.gov.communities.prsdb.webapp.helpers.extensions.journeyExtensions.Prop
 import uk.gov.communities.prsdb.webapp.helpers.extensions.journeyExtensions.PropertyComplianceJourneyDataExtensions.Companion.getEicrIssueDate
 import uk.gov.communities.prsdb.webapp.helpers.extensions.journeyExtensions.PropertyComplianceJourneyDataExtensions.Companion.getHasCompletedEicrExemptionConfirmation
 import uk.gov.communities.prsdb.webapp.helpers.extensions.journeyExtensions.PropertyComplianceJourneyDataExtensions.Companion.getHasCompletedEicrExemptionMissing
-import uk.gov.communities.prsdb.webapp.helpers.extensions.journeyExtensions.PropertyComplianceJourneyDataExtensions.Companion.getHasCompletedEicrOutdated
 import uk.gov.communities.prsdb.webapp.helpers.extensions.journeyExtensions.PropertyComplianceJourneyDataExtensions.Companion.getHasCompletedEicrUploadConfirmation
+import uk.gov.communities.prsdb.webapp.helpers.extensions.journeyExtensions.PropertyComplianceJourneyDataExtensions.Companion.getIsEicrOutdated
 import uk.gov.communities.prsdb.webapp.models.viewModels.summaryModels.SummaryListRowViewModel
 
 class EicrSummaryRowsFactory(
@@ -34,15 +34,15 @@ class EicrSummaryRowsFactory(
 
     private fun getEicrStatusRow(filteredJourneyData: JourneyData): SummaryListRowViewModel {
         val fieldValue =
-            // TODO PRSD-976: Add link to gas safety cert (or appropriate message if virus scan failed)
-            if (filteredJourneyData.getHasCompletedEicrUploadConfirmation()) {
-                "forms.checkComplianceAnswers.eicr.download"
-            } else if (filteredJourneyData.getHasCompletedEicrOutdated()) {
-                "forms.checkComplianceAnswers.certificate.expired"
+            if (filteredJourneyData.getHasCompletedEicrExemptionMissing()) {
+                "forms.checkComplianceAnswers.certificate.notAdded"
             } else if (filteredJourneyData.getHasCompletedEicrExemptionConfirmation()) {
                 "forms.checkComplianceAnswers.certificate.notRequired"
-            } else if (filteredJourneyData.getHasCompletedEicrExemptionMissing()) {
-                "forms.checkComplianceAnswers.certificate.notAdded"
+            } else if (filteredJourneyData.getIsEicrOutdated() == true) {
+                "forms.checkComplianceAnswers.certificate.expired"
+            } else if (filteredJourneyData.getHasCompletedEicrUploadConfirmation()) {
+                // TODO PRSD-976: Add link to gas safety cert (or appropriate message if virus scan failed)
+                "forms.checkComplianceAnswers.eicr.download"
             } else {
                 throw PrsdbWebException("Unexpected EICR status in journey data.")
             }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/forms/pages/PropertyComplianceCheckAnswersPageTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/forms/pages/PropertyComplianceCheckAnswersPageTests.kt
@@ -260,6 +260,7 @@ class PropertyComplianceCheckAnswersPageTests {
             JourneyDataBuilder()
                 .withGasSafetyCertStatus(true)
                 .withGasSafetyIssueDate(gasCertIssueDate)
+                .withGasSafetyOutdatedConfirmation()
                 .withEicrStatus(true)
                 .withEicrIssueDate(eicrIssueDate)
                 .withEicrOutdatedConfirmation()
@@ -323,6 +324,97 @@ class PropertyComplianceCheckAnswersPageTests {
                     "forms.checkComplianceAnswers.epc.expiryCheck",
                     tenancyStartedBeforeExpiry,
                     PropertyComplianceStepId.EpcExpiryCheck.urlPathSegment,
+                ),
+                SummaryListRowViewModel.forCheckYourAnswersPage(
+                    "forms.checkComplianceAnswers.epc.energyRating",
+                    epcDetails.energyRating.uppercase(),
+                    null,
+                ),
+            )
+
+        whenever(mockStepFactory.checkAutoMatchedEpcStepId).thenReturn(PropertyComplianceStepId.CheckAutoMatchedEpc)
+        whenever(mockStepFactory.epcExpiryCheckStepId).thenReturn(PropertyComplianceStepId.EpcExpiryCheck)
+
+        // Act
+        val summaryData = getSummaryData(filteredJourneyData, expectEpcUrl = true)
+        val returnedGasSafetyData = summaryData["gasSafetyData"] as List<SummaryListRowViewModel>
+        val returnedEicrData = summaryData["eicrData"] as List<SummaryListRowViewModel>
+        val returnedEpcData = summaryData["epcData"] as List<SummaryListRowViewModel>
+
+        // Assert
+        assertIterableEquals(expectedGasSafetyData, returnedGasSafetyData)
+        assertIterableEquals(expectedEicrData, returnedEicrData)
+        assertIterableEquals(expectedEpcData, returnedEpcData)
+    }
+
+    @Test
+    fun `the correct summary rows appear when certificate expiry dates have passed since being provided`() {
+        // Arrange
+        val gasCertIssueDate = LocalDate.now().minusYears(GAS_SAFETY_CERT_VALIDITY_YEARS.toLong())
+        val eicrIssueDate = LocalDate.now().minusYears(EICR_VALIDITY_YEARS.toLong())
+        val epcDetails = MockEpcData.createEpcDataModel(expiryDate = LocalDate.now().minusDays(1).toKotlinLocalDate())
+        val filteredJourneyData =
+            JourneyDataBuilder()
+                .withGasSafetyCertStatus(true)
+                .withGasSafetyIssueDate(gasCertIssueDate)
+                .withGasSafeEngineerNum()
+                .withGasSafetyCertUploadConfirmation()
+                .withEicrStatus(true)
+                .withEicrIssueDate(eicrIssueDate)
+                .withEicrUploadConfirmation()
+                .withAutoMatchedEpcDetails(epcDetails)
+                .withCheckAutoMatchedEpcResult(true)
+                .build()
+
+        val expectedGasSafetyData =
+            listOf(
+                SummaryListRowViewModel.forCheckYourAnswersPage(
+                    "forms.checkComplianceAnswers.gasSafety.certificate",
+                    "forms.checkComplianceAnswers.certificate.expired",
+                    PropertyComplianceStepId.GasSafety.urlPathSegment,
+                ),
+                SummaryListRowViewModel.forCheckYourAnswersPage(
+                    "forms.checkComplianceAnswers.certificate.issueDate",
+                    gasCertIssueDate.toKotlinLocalDate(),
+                    PropertyComplianceStepId.GasSafetyIssueDate.urlPathSegment,
+                ),
+                SummaryListRowViewModel.forCheckYourAnswersPage(
+                    "forms.checkComplianceAnswers.certificate.validUntil",
+                    gasCertIssueDate.plusYears(GAS_SAFETY_CERT_VALIDITY_YEARS.toLong()).toKotlinLocalDate(),
+                    null,
+                ),
+            )
+        val expectedEicrData =
+            listOf(
+                SummaryListRowViewModel.forCheckYourAnswersPage(
+                    "forms.checkComplianceAnswers.eicr.certificate",
+                    "forms.checkComplianceAnswers.certificate.expired",
+                    PropertyComplianceStepId.EICR.urlPathSegment,
+                ),
+                SummaryListRowViewModel.forCheckYourAnswersPage(
+                    "forms.checkComplianceAnswers.certificate.issueDate",
+                    eicrIssueDate.toKotlinLocalDate(),
+                    PropertyComplianceStepId.EicrIssueDate.urlPathSegment,
+                ),
+                SummaryListRowViewModel.forCheckYourAnswersPage(
+                    "forms.checkComplianceAnswers.certificate.validUntil",
+                    eicrIssueDate.plusYears(EICR_VALIDITY_YEARS.toLong()).toKotlinLocalDate(),
+                    null,
+                ),
+            )
+        val expectedEpcData =
+            listOf(
+                SummaryListRowViewModel.forCheckYourAnswersPage(
+                    "forms.checkComplianceAnswers.epc.certificate",
+                    "forms.checkComplianceAnswers.epc.view",
+                    PropertyComplianceStepId.EPC.urlPathSegment,
+                    certificateUrl,
+                    valueUrlOpensNewTab = true,
+                ),
+                SummaryListRowViewModel.forCheckYourAnswersPage(
+                    "forms.checkComplianceAnswers.epc.expiryDate",
+                    epcDetails.expiryDate,
+                    null,
                 ),
                 SummaryListRowViewModel.forCheckYourAnswersPage(
                     "forms.checkComplianceAnswers.epc.energyRating",

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/testHelpers/builders/JourneyDataBuilder.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/testHelpers/builders/JourneyDataBuilder.kt
@@ -545,6 +545,11 @@ class JourneyDataBuilder(
         return this
     }
 
+    fun withGasSafetyOutdatedConfirmation(): JourneyDataBuilder {
+        journeyData[PropertyComplianceStepId.GasSafetyOutdated.urlPathSegment] = emptyMap<String, Any>()
+        return this
+    }
+
     fun withGasSafeEngineerNum(engineerNum: String = "1234567"): JourneyDataBuilder {
         journeyData[PropertyComplianceStepId.GasSafetyEngineerNum.urlPathSegment] =
             mapOf(GasSafeEngineerNumFormModel::engineerNumber.name to engineerNum)


### PR DESCRIPTION
## Ticket number

PRSD-NONE

## Goal of change

Determines certificate expiry status more explicitly 

## Description of main change(s)

- Determines cert expiry by checking dates rather than whether expiry confirmation pages have been visited

## Anything you'd like to highlight to the reviewer?

- This PR only affects the property compliance CYA pages. Something similar will be applied to the incomplete compliance page as part of PRSD-1394

## Checklist

Delete any that are not applicable, and add explanation below for any that are applicable but haven't been done

- [X] Unit tests for new logic (e.g. new service methods) have been added
- [X] Test suite has been run in full locally and is passing
- [X] Branch has been rebased onto main and run locally, with everything working as expected (both for your new feature
  and any related functionality)