### PR TITLE
PRSD-NONE: Renames integration test base classes for clarity

### DIFF
--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/CancelLaUserInvitationTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/CancelLaUserInvitationTests.kt
@@ -1,10 +1,9 @@
 package uk.gov.communities.prsdb.webapp.integration
 
 import com.microsoft.playwright.Page
-import com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
-import uk.gov.communities.prsdb.webapp.integration.JourneyTestWithSeedData.NestedJourneyTestWithSeedData
+import uk.gov.communities.prsdb.webapp.integration.IntegrationTestWithMutableData.NestedIntegrationTestWithMutableData
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.BaseComponent.Companion.assertThat
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.CancelLaUserInvitationPage
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.CancelLaUserInvitationSuccessPage
@@ -16,7 +15,7 @@ import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages.B
 
 class CancelLaUserInvitationTests : IntegrationTest() {
     @Nested
-    inner class LaUserInvitation : NestedJourneyTestWithSeedData("data-la-users-and-invitations.sql") {
+    inner class LaUserInvitation : NestedIntegrationTestWithMutableData("data-la-users-and-invitations.sql") {
         @Test
         fun `an la user invitation can be cancelled`(page: Page) {
             // Changing the pending user takes you to the cancel invitation page
@@ -49,7 +48,7 @@ class CancelLaUserInvitationTests : IntegrationTest() {
     }
 
     @Nested
-    inner class LaAdminInvitation : NestedJourneyTestWithSeedData("data-la-invitations-user-is-system-operator.sql") {
+    inner class LaAdminInvitation : NestedIntegrationTestWithMutableData("data-la-invitations-user-is-system-operator.sql") {
         @Test
         fun `an la admin invitation can be cancelled by a system operator`(page: Page) {
             // Changing the pending user takes you to the cancel invitation page

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/ComplianceActionsPageTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/ComplianceActionsPageTests.kt
@@ -3,7 +3,7 @@ package uk.gov.communities.prsdb.webapp.integration
 import com.microsoft.playwright.Page
 import org.junit.jupiter.api.Nested
 import uk.gov.communities.prsdb.webapp.constants.COMPLIANCE_INFO_FRAGMENT
-import uk.gov.communities.prsdb.webapp.integration.SinglePageTestWithSeedData.NestedSinglePageTestWithSeedData
+import uk.gov.communities.prsdb.webapp.integration.IntegrationTestWithImmutableData.NestedIntegrationTestWithImmutableData
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.BaseComponent.Companion.assertThat
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.LandlordDetailsPage
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.PropertyDetailsPageLandlordView
@@ -15,7 +15,8 @@ import kotlin.test.assertEquals
 
 class ComplianceActionsPageTests : IntegrationTest() {
     @Nested
-    inner class LandlordsWithComplianceActions : NestedSinglePageTestWithSeedData("data-mockuser-landlord-with-compliance-actions.sql") {
+    inner class LandlordsWithComplianceActions :
+        NestedIntegrationTestWithImmutableData("data-mockuser-landlord-with-compliance-actions.sql") {
         @Test
         fun `the page loads with heading and subheading`() {
             val complianceActionsPage = navigator.goToComplianceActions()
@@ -62,7 +63,7 @@ class ComplianceActionsPageTests : IntegrationTest() {
     }
 
     @Nested
-    inner class LandlordsWithoutComplianceActions : NestedSinglePageTestWithSeedData("data-mockuser-landlord-with-properties.sql") {
+    inner class LandlordsWithoutComplianceActions : NestedIntegrationTestWithImmutableData("data-mockuser-landlord-with-properties.sql") {
         @Test
         fun `the page loads with heading and page text`() {
             val complianceActionsPage = navigator.goToComplianceActions()

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/CookieBannerTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/CookieBannerTests.kt
@@ -10,7 +10,7 @@ import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.CookiesPage
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages.BasePage.Companion.assertPageIs
 import kotlin.test.assertTrue
 
-class CookieBannerTests : SinglePageTestWithSeedData("data-local.sql") {
+class CookieBannerTests : IntegrationTestWithImmutableData("data-local.sql") {
     @Test
     fun `Cookie banner can be used to accept cookies, then confirmation can be hidden`(browserContext: BrowserContext) {
         // Load dashboard page

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/DeleteIncompletePropertyRegistrationAreYouSurePageTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/DeleteIncompletePropertyRegistrationAreYouSurePageTests.kt
@@ -8,7 +8,7 @@ import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.LandlordInc
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages.BasePage.Companion.assertPageIs
 
 class DeleteIncompletePropertyRegistrationAreYouSurePageTests :
-    SinglePageTestWithSeedData("data-mockuser-landlord-with-one-incomplete-property.sql") {
+    IntegrationTestWithImmutableData("data-mockuser-landlord-with-one-incomplete-property.sql") {
     val contextId = "1"
     val singleLineAddress = "1, SAVOY COURT, LONDON, WC2R 0EX"
 

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/EditLAUserTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/EditLAUserTests.kt
@@ -1,7 +1,6 @@
 package uk.gov.communities.prsdb.webapp.integration
 
 import com.microsoft.playwright.Page
-import com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat
 import org.junit.jupiter.api.Test
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.BaseComponent.Companion.assertThat
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.ConfirmDeleteLaUserPage
@@ -14,7 +13,7 @@ import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages.B
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
-class EditLAUserTests : JourneyTestWithSeedData("data-local.sql") {
+class EditLAUserTests : IntegrationTestWithMutableData("data-local.sql") {
     @Test
     fun `a user's access level can be updated`(page: Page) {
         // There is a basic user called Arthur Dent

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/ErrorPageTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/ErrorPageTests.kt
@@ -1,13 +1,12 @@
 package uk.gov.communities.prsdb.webapp.integration
 
 import com.microsoft.playwright.Page
-import com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat
 import org.junit.jupiter.api.Test
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.BaseComponent
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.ErrorPage
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages.BasePage.Companion.createValidPage
 
-class ErrorPageTests : SinglePageTestWithSeedData("data-local.sql") {
+class ErrorPageTests : IntegrationTestWithImmutableData("data-local.sql") {
     @Test
     fun `500 page renders when error controller path called`(page: Page) {
         navigator.navigate("/error")

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/GeneratePasscodeTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/GeneratePasscodeTests.kt
@@ -11,7 +11,7 @@ import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.LocalAuthor
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.PasscodeLimitExceededPage
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages.BasePage.Companion.assertPageIs
 
-class GeneratePasscodeTests : JourneyTestWithSeedData("data-local.sql") {
+class GeneratePasscodeTests : IntegrationTestWithMutableData("data-local.sql") {
     @MockitoSpyBean
     lateinit var passcodeRepository: PasscodeRepository
 

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/IntegrationTestWithImmutableData.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/IntegrationTestWithImmutableData.kt
@@ -6,8 +6,8 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.jdbc.core.JdbcTemplate
 import uk.gov.communities.prsdb.webapp.testHelpers.IntegrationTestHelper
 
-abstract class SinglePageTestWithSeedData(
-    private val scripts: List<String>,
+abstract class IntegrationTestWithImmutableData(
+    private val seedDataScripts: List<String>,
 ) : IntegrationTest() {
     constructor(script: String) : this(listOf(script))
 
@@ -16,11 +16,11 @@ abstract class SinglePageTestWithSeedData(
         @Autowired flyway: Flyway,
         @Autowired jdbcTemplate: JdbcTemplate,
     ) {
-        IntegrationTestHelper.resetAndSeedDatabase(flyway, scripts, jdbcTemplate)
+        IntegrationTestHelper.resetAndSeedDatabase(flyway, seedDataScripts, jdbcTemplate)
     }
 
-    abstract class NestedSinglePageTestWithSeedData(
-        private val scripts: List<String>,
+    abstract class NestedIntegrationTestWithImmutableData(
+        private val seedDataScripts: List<String>,
     ) : NestedIntegrationTest() {
         constructor(script: String) : this(listOf(script))
 
@@ -29,7 +29,7 @@ abstract class SinglePageTestWithSeedData(
             @Autowired flyway: Flyway,
             @Autowired jdbcTemplate: JdbcTemplate,
         ) {
-            IntegrationTestHelper.resetAndSeedDatabase(flyway, scripts, jdbcTemplate)
+            IntegrationTestHelper.resetAndSeedDatabase(flyway, seedDataScripts, jdbcTemplate)
         }
     }
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/IntegrationTestWithMutableData.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/IntegrationTestWithMutableData.kt
@@ -6,8 +6,8 @@ import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.jdbc.core.JdbcTemplate
 import uk.gov.communities.prsdb.webapp.testHelpers.IntegrationTestHelper
 
-abstract class JourneyTestWithSeedData(
-    private val scripts: List<String>,
+abstract class IntegrationTestWithMutableData(
+    private val seedDataScripts: List<String>,
 ) : IntegrationTest() {
     constructor(script: String) : this(listOf(script))
 
@@ -16,11 +16,11 @@ abstract class JourneyTestWithSeedData(
         @Autowired flyway: Flyway,
         @Autowired jdbcTemplate: JdbcTemplate,
     ) {
-        IntegrationTestHelper.resetAndSeedDatabase(flyway, scripts, jdbcTemplate)
+        IntegrationTestHelper.resetAndSeedDatabase(flyway, seedDataScripts, jdbcTemplate)
     }
 
-    abstract class NestedJourneyTestWithSeedData(
-        private val scripts: List<String>,
+    abstract class NestedIntegrationTestWithMutableData(
+        private val seedDataScripts: List<String>,
     ) : NestedIntegrationTest() {
         constructor(script: String) : this(listOf(script))
 
@@ -29,7 +29,7 @@ abstract class JourneyTestWithSeedData(
             @Autowired flyway: Flyway,
             @Autowired jdbcTemplate: JdbcTemplate,
         ) {
-            IntegrationTestHelper.resetAndSeedDatabase(flyway, scripts, jdbcTemplate)
+            IntegrationTestHelper.resetAndSeedDatabase(flyway, seedDataScripts, jdbcTemplate)
         }
     }
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/InviteLaAdminSinglePageTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/InviteLaAdminSinglePageTests.kt
@@ -4,7 +4,7 @@ import com.microsoft.playwright.Page
 import com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat
 import org.junit.jupiter.api.Test
 
-class InviteLaAdminSinglePageTests : SinglePageTestWithSeedData("data-local.sql") {
+class InviteLaAdminSinglePageTests : IntegrationTestWithImmutableData("data-local.sql") {
     @Test
     fun `inviting a new LA admin shows validation errors if the email is invalid or the email addresses don't match`(page: Page) {
         val invitePage = navigator.goToInviteLaAdmin()

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/InviteLaAdminTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/InviteLaAdminTests.kt
@@ -10,7 +10,7 @@ import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.InviteLaAdm
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages.BasePage.Companion.assertPageIs
 import java.net.URI
 
-class InviteLaAdminTests : JourneyTestWithSeedData("data-local.sql") {
+class InviteLaAdminTests : IntegrationTestWithMutableData("data-local.sql") {
     @Test
     fun `inviting a new LA admin ends with a confirmation page`(page: Page) {
         whenever(absoluteUrlProvider.buildInvitationUri(anyString()))

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/InviteLaUsersSinglePageTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/InviteLaUsersSinglePageTests.kt
@@ -3,7 +3,7 @@ package uk.gov.communities.prsdb.webapp.integration
 import com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat
 import org.junit.jupiter.api.Test
 
-class InviteLaUsersSinglePageTests : SinglePageTestWithSeedData("data-local.sql") {
+class InviteLaUsersSinglePageTests : IntegrationTestWithImmutableData("data-local.sql") {
     @Test
     fun `inviting a new LA user shows validation errors if the email addresses don't match`() {
         val invitePage = navigator.goToInviteNewLaUser(2)

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/InviteLaUsersTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/InviteLaUsersTests.kt
@@ -10,7 +10,7 @@ import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.LocalAuthor
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages.BasePage.Companion.assertPageIs
 import java.net.URI
 
-class InviteLaUsersTests : JourneyTestWithSeedData("data-local.sql") {
+class InviteLaUsersTests : IntegrationTestWithMutableData("data-local.sql") {
     @Test
     fun `inviting a new LA user ends with a success page with a button linking to the dashboard`(page: Page) {
         whenever(absoluteUrlProvider.buildInvitationUri(anyString()))

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/LaUserRegistrationJourneyTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/LaUserRegistrationJourneyTests.kt
@@ -26,7 +26,7 @@ import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.laUserRegis
 import uk.gov.communities.prsdb.webapp.services.LocalAuthorityInvitationService
 import uk.gov.communities.prsdb.webapp.services.LocalAuthorityService
 
-class LaUserRegistrationJourneyTests : JourneyTestWithSeedData("data-mockuser-not-lauser.sql") {
+class LaUserRegistrationJourneyTests : IntegrationTestWithMutableData("data-mockuser-not-lauser.sql") {
     @Autowired
     lateinit var localAuthorityService: LocalAuthorityService
 
@@ -102,7 +102,7 @@ class LaUserRegistrationJourneyTests : JourneyTestWithSeedData("data-mockuser-no
     }
 
     @Nested
-    inner class WithExpiredToken : NestedJourneyTestWithSeedData("data-mockuser-with-expired-invitation.sql") {
+    inner class WithExpiredToken : NestedIntegrationTestWithMutableData("data-mockuser-with-expired-invitation.sql") {
         @Test
         fun `User with an expired token is redirected to the invalid link page`(page: Page) {
             val expiredToken = "1234abcd-5678-abcd-1234-567abcd1111a"

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/LaUserRegistrationSinglePageTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/LaUserRegistrationSinglePageTests.kt
@@ -17,7 +17,7 @@ import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.laUserRegis
 import uk.gov.communities.prsdb.webapp.services.LocalAuthorityInvitationService
 import uk.gov.communities.prsdb.webapp.services.LocalAuthorityService
 
-class LaUserRegistrationSinglePageTests : SinglePageTestWithSeedData("data-mockuser-not-lauser.sql") {
+class LaUserRegistrationSinglePageTests : IntegrationTestWithImmutableData("data-mockuser-not-lauser.sql") {
     @Autowired
     lateinit var localAuthorityService: LocalAuthorityService
 
@@ -52,7 +52,7 @@ class LaUserRegistrationSinglePageTests : SinglePageTestWithSeedData("data-mocku
     }
 
     @Nested
-    inner class LaUserRegistrationStepLandingPage : NestedSinglePageTestWithSeedData("data-local.sql") {
+    inner class LaUserRegistrationStepLandingPage : NestedIntegrationTestWithImmutableData("data-local.sql") {
         @Test
         fun `Navigating here as a registered local authority user redirects to the LA dashboard page`(page: Page) {
             navigator.navigateToLaUserRegistrationLandingPage(invitation.token)

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/LandlordDashboardTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/LandlordDashboardTests.kt
@@ -12,7 +12,7 @@ import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyReg
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
-class LandlordDashboardTests : SinglePageTestWithSeedData("data-local.sql") {
+class LandlordDashboardTests : IntegrationTestWithImmutableData("data-local.sql") {
     @Test
     fun `the dashboard loads displaying the user's name and lrn`() {
         val dashboard = navigator.goToLandlordDashboard()
@@ -68,7 +68,7 @@ class LandlordDashboardTests : SinglePageTestWithSeedData("data-local.sql") {
     inner class NotificationBanner {
         @Nested
         inner class LandlordWithoutIncompletePropertiesOrIncompleteCompliance :
-            NestedSinglePageTestWithSeedData("data-mockuser-landlord-with-properties.sql") {
+            NestedIntegrationTestWithImmutableData("data-mockuser-landlord-with-properties.sql") {
             @Test
             fun `the dashboard loads without a notification banner`() {
                 val dashboard = navigator.goToLandlordDashboard()
@@ -80,7 +80,7 @@ class LandlordDashboardTests : SinglePageTestWithSeedData("data-local.sql") {
         inner class WithOnlyIncompleteProperties {
             @Nested
             inner class WithOne :
-                NestedSinglePageTestWithSeedData("data-mockuser-landlord-with-one-incomplete-property.sql") {
+                NestedIntegrationTestWithImmutableData("data-mockuser-landlord-with-one-incomplete-property.sql") {
                 @Test
                 fun `the notification banner loads with only correct message for one incomplete property`(page: Page) {
                     val dashboard = navigator.goToLandlordDashboard()
@@ -91,7 +91,7 @@ class LandlordDashboardTests : SinglePageTestWithSeedData("data-local.sql") {
             }
 
             @Nested
-            inner class WithMultiple : NestedSinglePageTestWithSeedData("data-mockuser-landlord-with-incomplete-properties.sql") {
+            inner class WithMultiple : NestedIntegrationTestWithImmutableData("data-mockuser-landlord-with-incomplete-properties.sql") {
                 @Test
                 fun `the notification banner loads with correct message for multiple incomplete properties`(page: Page) {
                     val dashboard = navigator.goToLandlordDashboard()
@@ -114,7 +114,7 @@ class LandlordDashboardTests : SinglePageTestWithSeedData("data-local.sql") {
         inner class WithOnlyIncompleteCompliances {
             @Nested
             inner class WithOne :
-                NestedSinglePageTestWithSeedData("data-mockuser-landlord-with-one-incomplete-compliance.sql") {
+                NestedIntegrationTestWithImmutableData("data-mockuser-landlord-with-one-incomplete-compliance.sql") {
                 @Test
                 fun `the notification banner loads with correct message for one incomplete compliance`(page: Page) {
                     val dashboard = navigator.goToLandlordDashboard()
@@ -124,7 +124,7 @@ class LandlordDashboardTests : SinglePageTestWithSeedData("data-local.sql") {
             }
 
             @Nested
-            inner class WithMultiple : NestedSinglePageTestWithSeedData("data-mockuser-landlord-with-compliance-actions.sql") {
+            inner class WithMultiple : NestedIntegrationTestWithImmutableData("data-mockuser-landlord-with-compliance-actions.sql") {
                 @Test
                 fun `the notification banner loads with correct message for multiple incomplete compliances`(page: Page) {
                     val dashboard = navigator.goToLandlordDashboard()
@@ -143,7 +143,7 @@ class LandlordDashboardTests : SinglePageTestWithSeedData("data-local.sql") {
 
         @Nested
         inner class WithIncompletePropertiesAndIncompleteCompliances :
-            NestedSinglePageTestWithSeedData("data-mockuser-landlord-with-incomplete-properties-and-incomplete-compliances.sql") {
+            NestedIntegrationTestWithImmutableData("data-mockuser-landlord-with-incomplete-properties-and-incomplete-compliances.sql") {
             @Test
             fun `the notification banner loads with correct heading and messages`(page: Page) {
                 val dashboard = navigator.goToLandlordDashboard()

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/LandlordDeregistrationJourneyTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/LandlordDeregistrationJourneyTests.kt
@@ -4,7 +4,7 @@ import com.microsoft.playwright.Page
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
-import uk.gov.communities.prsdb.webapp.integration.JourneyTestWithSeedData.NestedJourneyTestWithSeedData
+import uk.gov.communities.prsdb.webapp.integration.IntegrationTestWithMutableData.NestedIntegrationTestWithMutableData
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.BaseComponent.Companion.assertThat
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages.BasePage.Companion.assertPageIs
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.landlordDeregistrationJourneyPages.ConfirmationPageLandlordDeregistration
@@ -12,7 +12,7 @@ import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.landlordDer
 
 class LandlordDeregistrationJourneyTests : IntegrationTest() {
     @Nested
-    inner class LandlordWithProperties : NestedJourneyTestWithSeedData("data-mockuser-landlord-with-properties.sql") {
+    inner class LandlordWithProperties : NestedIntegrationTestWithMutableData("data-mockuser-landlord-with-properties.sql") {
         @Test
         fun `User with properties can navigate the whole journey`(page: Page) {
             val areYouSurePage = navigator.goToLandlordDeregistrationAreYouSurePage()
@@ -40,7 +40,7 @@ class LandlordDeregistrationJourneyTests : IntegrationTest() {
     }
 
     @Nested
-    inner class LandlordWithoutProperties : NestedJourneyTestWithSeedData("data-unverified-landlord.sql") {
+    inner class LandlordWithoutProperties : NestedIntegrationTestWithMutableData("data-unverified-landlord.sql") {
         @Test
         fun `User with no properties can navigate the whole journey`(page: Page) {
             val areYouSurePage = navigator.goToLandlordDeregistrationAreYouSurePage()

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/LandlordDeregistrationSinglePageTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/LandlordDeregistrationSinglePageTests.kt
@@ -4,13 +4,13 @@ import com.microsoft.playwright.Page
 import com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
-import uk.gov.communities.prsdb.webapp.integration.SinglePageTestWithSeedData.NestedSinglePageTestWithSeedData
+import uk.gov.communities.prsdb.webapp.integration.IntegrationTestWithImmutableData.NestedIntegrationTestWithImmutableData
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.LandlordDetailsPage
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages.BasePage
 
 class LandlordDeregistrationSinglePageTests : IntegrationTest() {
     @Nested
-    inner class LandlordWithProperties : NestedSinglePageTestWithSeedData("data-mockuser-landlord-with-properties.sql") {
+    inner class LandlordWithProperties : NestedIntegrationTestWithImmutableData("data-mockuser-landlord-with-properties.sql") {
         @Test
         fun `User is returned to the landlord details page if they submit No`(page: Page) {
             val areYouSurePage = navigator.goToLandlordDeregistrationAreYouSurePage()
@@ -36,7 +36,7 @@ class LandlordDeregistrationSinglePageTests : IntegrationTest() {
     }
 
     @Nested
-    inner class LandlordWithoutProperties : NestedSinglePageTestWithSeedData("data-unverified-landlord.sql") {
+    inner class LandlordWithoutProperties : NestedIntegrationTestWithImmutableData("data-unverified-landlord.sql") {
         @Test
         fun `Submitting with no option selected returns an error`() {
             val areYouSurePage = navigator.goToLandlordDeregistrationAreYouSurePage()

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/LandlordDetailTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/LandlordDetailTests.kt
@@ -1,7 +1,6 @@
 package uk.gov.communities.prsdb.webapp.integration
 
 import com.microsoft.playwright.Page
-import com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.BaseComponent.Companion.assertThat
@@ -12,7 +11,7 @@ import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.PropertyDet
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages.BasePage.Companion.assertPageIs
 import kotlin.test.assertEquals
 
-class LandlordDetailTests : SinglePageTestWithSeedData("data-local.sql") {
+class LandlordDetailTests : IntegrationTestWithImmutableData("data-local.sql") {
     @Nested
     inner class LandlordDetailsView {
         @Test

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/LandlordDetailsUpdateJourneyTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/LandlordDetailsUpdateJourneyTests.kt
@@ -26,7 +26,7 @@ import uk.gov.communities.prsdb.webapp.local.api.MockOSPlacesAPIResponses
 import uk.gov.communities.prsdb.webapp.models.dataModels.AddressDataModel
 import uk.gov.communities.prsdb.webapp.testHelpers.extensions.getFormattedUkPhoneNumber
 
-class LandlordDetailsUpdateJourneyTests : JourneyTestWithSeedData("data-local.sql") {
+class LandlordDetailsUpdateJourneyTests : IntegrationTestWithMutableData("data-local.sql") {
     private val phoneNumberUtil = PhoneNumberUtil.getInstance()
     val addressFound = "Entirely new test address"
 
@@ -42,7 +42,7 @@ class LandlordDetailsUpdateJourneyTests : JourneyTestWithSeedData("data-local.sq
     }
 
     @Nested
-    inner class NameUpdates : NestedJourneyTestWithSeedData("data-unverified-landlord.sql") {
+    inner class NameUpdates : NestedIntegrationTestWithMutableData("data-unverified-landlord.sql") {
         @Test
         fun `An unverified landlord can update their name`(page: Page) {
             // Details page
@@ -62,7 +62,7 @@ class LandlordDetailsUpdateJourneyTests : JourneyTestWithSeedData("data-local.sq
     }
 
     @Nested
-    inner class DateOfBirthUpdates : NestedJourneyTestWithSeedData("data-unverified-landlord.sql") {
+    inner class DateOfBirthUpdates : NestedIntegrationTestWithMutableData("data-unverified-landlord.sql") {
         @Test
         fun `An unverified landlord can update their date of birth`(page: Page) {
             // Details page

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/LandlordDetailsUpdateSinglePageTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/LandlordDetailsUpdateSinglePageTests.kt
@@ -13,7 +13,7 @@ import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages.B
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.updateLandlordDetailsPages.NoAddressFoundFormPageUpdateLandlordDetails
 import uk.gov.communities.prsdb.webapp.local.api.MockOSPlacesAPIResponses
 
-class LandlordDetailsUpdateSinglePageTests : SinglePageTestWithSeedData("data-local.sql") {
+class LandlordDetailsUpdateSinglePageTests : IntegrationTestWithImmutableData("data-local.sql") {
     @Nested
     inner class NameUpdates {
         @Test

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/LandlordIncompletePropertiesPageTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/LandlordIncompletePropertiesPageTests.kt
@@ -6,7 +6,7 @@ import kotlinx.datetime.DatePeriod
 import kotlinx.datetime.plus
 import org.junit.jupiter.api.Nested
 import uk.gov.communities.prsdb.webapp.helpers.DateTimeHelper
-import uk.gov.communities.prsdb.webapp.integration.SinglePageTestWithSeedData.NestedSinglePageTestWithSeedData
+import uk.gov.communities.prsdb.webapp.integration.IntegrationTestWithImmutableData.NestedIntegrationTestWithImmutableData
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.BaseComponent.Companion.assertThat
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.DeleteIncompletePropertyRegistrationAreYouSurePage
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.LandlordDetailsPage
@@ -20,7 +20,7 @@ import kotlin.test.assertEquals
 class LandlordIncompletePropertiesPageTests : IntegrationTest() {
     @Nested
     inner class LandlordsWithIncompleteProperties :
-        NestedSinglePageTestWithSeedData("data-mockuser-landlord-with-incomplete-properties.sql") {
+        NestedIntegrationTestWithImmutableData("data-mockuser-landlord-with-incomplete-properties.sql") {
         @Test
         fun `the page loads with heading and subheading`() {
             val incompletePropertiesPage = navigator.goToLandlordIncompleteProperties()
@@ -79,7 +79,7 @@ class LandlordIncompletePropertiesPageTests : IntegrationTest() {
     }
 
     @Nested
-    inner class LandlordsWithNoIncompleteProperties : NestedSinglePageTestWithSeedData("data-mockuser-landlord-with-properties.sql") {
+    inner class LandlordsWithNoIncompleteProperties : NestedIntegrationTestWithImmutableData("data-mockuser-landlord-with-properties.sql") {
         @Test
         fun `the page loads with heading and page text`() {
             val incompletePropertiesPage = navigator.goToLandlordIncompleteProperties()

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/LandlordRegistrationJourneyTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/LandlordRegistrationJourneyTests.kt
@@ -40,7 +40,7 @@ import uk.gov.communities.prsdb.webapp.testHelpers.extensions.getFormattedUkPhon
 import java.net.URI
 import kotlin.test.assertNotNull
 
-class LandlordRegistrationJourneyTests : JourneyTestWithSeedData("data-mockuser-not-landlord.sql") {
+class LandlordRegistrationJourneyTests : IntegrationTestWithMutableData("data-mockuser-not-landlord.sql") {
     private val phoneNumberUtil = PhoneNumberUtil.getInstance()
     private val absoluteLandlordUrl = "www.prsd.gov.uk/landlord"
 

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/LandlordRegistrationSinglePageTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/LandlordRegistrationSinglePageTests.kt
@@ -34,7 +34,7 @@ import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.VerifiedI
 import uk.gov.communities.prsdb.webapp.testHelpers.extensions.getFormattedInternationalPhoneNumber
 import java.time.LocalDate
 
-class LandlordRegistrationSinglePageTests : SinglePageTestWithSeedData("data-mockuser-not-landlord.sql") {
+class LandlordRegistrationSinglePageTests : IntegrationTestWithImmutableData("data-mockuser-not-landlord.sql") {
     private val phoneNumberUtil = PhoneNumberUtil.getInstance()
 
     @Nested
@@ -69,7 +69,7 @@ class LandlordRegistrationSinglePageTests : SinglePageTestWithSeedData("data-moc
     }
 
     @Nested
-    inner class AlreadyRegistered : NestedSinglePageTestWithSeedData("data-local.sql") {
+    inner class AlreadyRegistered : NestedIntegrationTestWithImmutableData("data-local.sql") {
         @Test
         fun `the 'Start Now' button directs a registered landlord to the landlord dashboard page`(page: Page) {
             val startPage = navigator.goToLandlordRegistrationStartPage()
@@ -80,7 +80,7 @@ class LandlordRegistrationSinglePageTests : SinglePageTestWithSeedData("data-moc
     }
 
     @Nested
-    inner class LandlordRegistrationStepVerifyIdentity : NestedSinglePageTestWithSeedData("data-local.sql") {
+    inner class LandlordRegistrationStepVerifyIdentity : NestedIntegrationTestWithImmutableData("data-local.sql") {
         @Test
         fun `Navigating here as a registered landlord redirects to the landlord dashboard page`(page: Page) {
             navigator.navigateToLandlordRegistrationVerifyIdentityPage()

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/LocalAuthorityDashboardTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/LocalAuthorityDashboardTests.kt
@@ -10,7 +10,7 @@ import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.SearchPrope
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages.BasePage.Companion.assertPageIs
 import kotlin.test.Test
 
-class LocalAuthorityDashboardTests : SinglePageTestWithSeedData("data-local.sql") {
+class LocalAuthorityDashboardTests : IntegrationTestWithImmutableData("data-local.sql") {
     @Test
     fun `the dashboard loads displaying the user's name and local authority`(page: Page) {
         val dashboard = navigator.goToLocalAuthorityDashboard()
@@ -40,7 +40,7 @@ class LocalAuthorityDashboardTests : SinglePageTestWithSeedData("data-local.sql"
     }
 
     @Nested
-    inner class LaUserNotAdmin : NestedSinglePageTestWithSeedData("data-mockuser-la-user-not-admin.sql") {
+    inner class LaUserNotAdmin : NestedIntegrationTestWithImmutableData("data-mockuser-la-user-not-admin.sql") {
         @Test
         fun `the manage users button is not visible`(page: Page) {
             val dashboard = navigator.goToLocalAuthorityDashboard()
@@ -49,7 +49,7 @@ class LocalAuthorityDashboardTests : SinglePageTestWithSeedData("data-local.sql"
     }
 
     @Nested
-    inner class LaAdminUser : NestedSinglePageTestWithSeedData("data-mockuser-la-admin-user.sql") {
+    inner class LaAdminUser : NestedIntegrationTestWithImmutableData("data-mockuser-la-admin-user.sql") {
         @Test
         fun `the manage users button is visible and when clicked redirects to the manage users page`(page: Page) {
             val dashboard = navigator.goToLocalAuthorityDashboard()

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/ManageLAUsersTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/ManageLAUsersTests.kt
@@ -1,7 +1,6 @@
 package uk.gov.communities.prsdb.webapp.integration
 
 import com.microsoft.playwright.Page
-import com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat
 import org.junit.jupiter.api.Nested
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.BaseComponent.Companion.assertThat
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.InviteNewLaUserPage
@@ -15,7 +14,7 @@ import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages.B
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
-class ManageLAUsersTests : SinglePageTestWithSeedData("data-local.sql") {
+class ManageLAUsersTests : IntegrationTestWithImmutableData("data-local.sql") {
     val localAuthorityId = 2
 
     @Test
@@ -27,14 +26,14 @@ class ManageLAUsersTests : SinglePageTestWithSeedData("data-local.sql") {
 
     @Test
     fun `pagination component renders with more than 10 table entries`(page: Page) {
-        var managePage = navigator.goToManageLaUsers(localAuthorityId)
+        val managePage = navigator.goToManageLaUsers(localAuthorityId)
         val pagination = managePage.getPaginationComponent()
         assertThat(pagination.nextLink).isVisible()
         assertEquals("1", pagination.currentPageNumberLinkText)
         assertThat(pagination.getPageNumberLink(2)).isVisible()
 
         pagination.getPageNumberLink(2).clickAndWait()
-        managePage = assertPageIs(page, ManageLaUsersPage::class)
+        assertPageIs(page, ManageLaUsersPage::class)
 
         assertThat(pagination.previousLink).isVisible()
         assertThat(pagination.getPageNumberLink(1)).isVisible()
@@ -42,7 +41,7 @@ class ManageLAUsersTests : SinglePageTestWithSeedData("data-local.sql") {
     }
 
     @Nested
-    inner class UserIsLaAdminButNotSystemOperator : NestedSinglePageTestWithSeedData("data-la-users-and-invitations.sql") {
+    inner class UserIsLaAdminButNotSystemOperator : NestedIntegrationTestWithImmutableData("data-la-users-and-invitations.sql") {
         @Test
         fun `table of users renders`() {
             val managePage = navigator.goToManageLaUsers(localAuthorityId)
@@ -80,7 +79,8 @@ class ManageLAUsersTests : SinglePageTestWithSeedData("data-local.sql") {
     }
 
     @Nested
-    inner class UserIsSystemOperatorButNotLaAdmin : NestedSinglePageTestWithSeedData("data-la-invitations-user-is-system-operator.sql") {
+    inner class UserIsSystemOperatorButNotLaAdmin :
+        NestedIntegrationTestWithImmutableData("data-la-invitations-user-is-system-operator.sql") {
         @Test
         fun `table renders all user types including la admin invitations`() {
             val managePage = navigator.goToManageLaUsers(localAuthorityId)

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/PasscodeEntrySinglePageTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/PasscodeEntrySinglePageTests.kt
@@ -13,7 +13,7 @@ import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages.B
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.landlordRegistrationJourneyPages.StartPageLandlordRegistration
 import uk.gov.communities.prsdb.webapp.services.PasscodeService
 
-class PasscodeEntrySinglePageTests : SinglePageTestWithSeedData("data-mockuser-not-landlord.sql") {
+class PasscodeEntrySinglePageTests : IntegrationTestWithImmutableData("data-mockuser-not-landlord.sql") {
     @MockitoBean
     lateinit var passcodeService: PasscodeService
 

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/PropertyComplianceJourneyTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/PropertyComplianceJourneyTests.kt
@@ -81,7 +81,7 @@ import kotlin.test.assertFalse
 import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 
-class PropertyComplianceJourneyTests : JourneyTestWithSeedData("data-local.sql") {
+class PropertyComplianceJourneyTests : IntegrationTestWithMutableData("data-local.sql") {
     @MockitoBean
     private lateinit var epcRegisterClient: EpcRegisterClient
 

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/PropertyComplianceSinglePageTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/PropertyComplianceSinglePageTests.kt
@@ -41,7 +41,7 @@ import uk.gov.communities.prsdb.webapp.services.UploadService
 import uk.gov.communities.prsdb.webapp.testHelpers.mockObjects.MockEpcData
 import kotlin.test.assertTrue
 
-class PropertyComplianceSinglePageTests : SinglePageTestWithSeedData("data-local.sql") {
+class PropertyComplianceSinglePageTests : IntegrationTestWithImmutableData("data-local.sql") {
     @MockitoBean
     private lateinit var fileUploader: UploadService
 

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/PropertyComplianceUpdateJourneyTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/PropertyComplianceUpdateJourneyTests.kt
@@ -71,7 +71,7 @@ import uk.gov.communities.prsdb.webapp.testHelpers.mockObjects.MockEpcData
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
-class PropertyComplianceUpdateJourneyTests : JourneyTestWithSeedData("data-local.sql") {
+class PropertyComplianceUpdateJourneyTests : IntegrationTestWithMutableData("data-local.sql") {
     @MockitoBean
     private lateinit var epcRegisterClient: EpcRegisterClient
 
@@ -689,7 +689,7 @@ class PropertyComplianceUpdateJourneyTests : JourneyTestWithSeedData("data-local
                 ),
             )
         updateEpcPage.submitHasNewCertificate()
-        var checkAutoMatchedEpcPage = assertPageIs(page, CheckAutoMatchedEpcPagePropertyComplianceUpdate::class, urlArguments)
+        val checkAutoMatchedEpcPage = assertPageIs(page, CheckAutoMatchedEpcPagePropertyComplianceUpdate::class, urlArguments)
 
         // Check Auto Matched EPC page
         checkAutoMatchedEpcPage.submitMatchedEpcDetailsCorrect()

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/PropertyComplianceUpdateSinglePageTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/PropertyComplianceUpdateSinglePageTests.kt
@@ -12,7 +12,7 @@ import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyCom
 import kotlin.test.assertContains
 import kotlin.test.assertEquals
 
-class PropertyComplianceUpdateSinglePageTests : SinglePageTestWithSeedData("data-local.sql") {
+class PropertyComplianceUpdateSinglePageTests : IntegrationTestWithImmutableData("data-local.sql") {
     @Test
     fun `Submitting UpdateGasSafetyStep with no option selected returns an error`() {
         val updateGasSafetyPage = navigator.goToPropertyComplianceUpdateUpdateGasSafetyPage(PROPERTY_OWNERSHIP_ID)

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/PropertyDeregistrationJourneyTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/PropertyDeregistrationJourneyTests.kt
@@ -9,7 +9,7 @@ import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages.B
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyDeregistrationJourneyPages.ConfirmationPagePropertyDeregistration
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyDeregistrationJourneyPages.ReasonPagePropertyDeregistration
 
-class PropertyDeregistrationJourneyTests : JourneyTestWithSeedData("data-local.sql") {
+class PropertyDeregistrationJourneyTests : IntegrationTestWithMutableData("data-local.sql") {
     @Test
     fun `User can navigate the whole journey if pages are correctly filled in`(page: Page) {
         val propertyOwnershipId = 1

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/PropertyDeregistrationSinglePageTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/PropertyDeregistrationSinglePageTests.kt
@@ -7,7 +7,7 @@ import org.junit.jupiter.api.Test
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.PropertyDetailsPageLandlordView
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages.BasePage
 
-class PropertyDeregistrationSinglePageTests : SinglePageTestWithSeedData("data-local.sql") {
+class PropertyDeregistrationSinglePageTests : IntegrationTestWithImmutableData("data-local.sql") {
     @Nested
     inner class AreYouSureStep {
         @Test

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/PropertyDetailsTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/PropertyDetailsTests.kt
@@ -18,7 +18,7 @@ import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyCom
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyDeregistrationJourneyPages.AreYouSureFormPagePropertyDeregistration
 import kotlin.test.assertEquals
 
-class PropertyDetailsTests : SinglePageTestWithSeedData("data-local.sql") {
+class PropertyDetailsTests : IntegrationTestWithImmutableData("data-local.sql") {
     @Nested
     inner class PropertyDetailsLandlordView {
         @Test

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/PropertyDetailsUpdateJourneyTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/PropertyDetailsUpdateJourneyTests.kt
@@ -27,7 +27,7 @@ import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyDet
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyDetailsUpdateJourneyPages.SelectiveLicenceFormPagePropertyDetailsUpdate
 import kotlin.test.assertContains
 
-class PropertyDetailsUpdateJourneyTests : JourneyTestWithSeedData("data-local.sql") {
+class PropertyDetailsUpdateJourneyTests : IntegrationTestWithMutableData("data-local.sql") {
     private val propertyOwnershipId = 1L
     private val urlArguments = mapOf("propertyOwnershipId" to propertyOwnershipId.toString())
 

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/PropertyDetailsUpdateSinglePageTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/PropertyDetailsUpdateSinglePageTests.kt
@@ -13,7 +13,7 @@ import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyDet
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyDetailsUpdateJourneyPages.PeopleOccupancyFormPagePropertyDetailsUpdate
 import kotlin.test.assertEquals
 
-class PropertyDetailsUpdateSinglePageTests : SinglePageTestWithSeedData("data-local.sql") {
+class PropertyDetailsUpdateSinglePageTests : IntegrationTestWithImmutableData("data-local.sql") {
     private val propertyOwnershipId = 1L
     private val urlArguments = mapOf("propertyOwnershipId" to propertyOwnershipId.toString())
 

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/PropertyRegistrationJourneyTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/PropertyRegistrationJourneyTests.kt
@@ -45,7 +45,7 @@ import uk.gov.communities.prsdb.webapp.services.EmailNotificationService
 import java.net.URI
 import kotlin.test.assertTrue
 
-class PropertyRegistrationJourneyTests : JourneyTestWithSeedData("data-local.sql") {
+class PropertyRegistrationJourneyTests : IntegrationTestWithMutableData("data-local.sql") {
     private val absoluteLandlordUrl = "www.prsd.gov.uk/landlord"
 
     @MockitoSpyBean

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/PropertyRegistrationSinglePageTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/PropertyRegistrationSinglePageTests.kt
@@ -24,7 +24,7 @@ import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyReg
 import uk.gov.communities.prsdb.webapp.local.api.MockOSPlacesAPIResponses
 import uk.gov.communities.prsdb.webapp.models.dataModels.AddressDataModel
 
-class PropertyRegistrationSinglePageTests : SinglePageTestWithSeedData("data-local.sql") {
+class PropertyRegistrationSinglePageTests : IntegrationTestWithImmutableData("data-local.sql") {
     @Nested
     inner class TaskListStep {
         @Test

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/ReadMe.md
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/ReadMe.md
@@ -6,12 +6,12 @@ We use Playwright to drive our web integration tests. This is configured in our 
 
 We set seed data by passing SQL script names into integration test class constructors. There are three base classes:
 
-* `JourneyTestWithSeedData` - resets and seeds the database before each test (use when tests affect the database)
-* `SinglePageTestWithSeedData` - resets and seeds the database before each test class (use when tests don't affect the database)
+* `IntegrationTestWithMutableData` - resets and seeds the database before each test (use when tests affect the database)
+* `IntegrationTestWithImmutableData` - resets and seeds the database before each test class (use when tests don't affect the database)
 * `IntegrationTest` - doesn't reset or seed the database (use when **all** tests get their seed data from nested classes)
 
 Tests that require different seed data to the rest of the class must be put in nested classes that inherit from 
-`NestedJourneyTestWithSeedData` or `NestedSinglePageTestWithSeedData` depending on the outer class.
+`NestedIntegrationTestWithMutableData` or `NestedIntegrationTestWithImmutableData` depending on the outer class.
 
 ## Page Objects (and Components)
 

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/SearchRegisterTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/SearchRegisterTests.kt
@@ -25,7 +25,7 @@ import kotlin.collections.mapOf
 import kotlin.test.assertContains
 import kotlin.test.assertTrue
 
-class SearchRegisterTests : SinglePageTestWithSeedData("data-search.sql") {
+class SearchRegisterTests : IntegrationTestWithImmutableData("data-search.sql") {
     @Nested
     inner class LandlordSearchTests {
         @Test


### PR DESCRIPTION
## Ticket number

PRSD-NONE

## Goal of change

Renames integration test base classes for clarity

## Description of main change(s)

- Renames integration test base classes to make it clear that we differentiate by whether tests write to the database or not, rather than whether they test a journey or a single page

## Anything you'd like to highlight to the reviewer?

N/A

## Checklist

Delete any that are not applicable, and add explanation below for any that are applicable but haven't been done

- [ ] Test suite has been run in full locally and is passing
- [X] Branch has been rebased onto main and run locally, with everything working as expected (both for your new feature
  and any related functionality)