### PR TITLE
PRSD-1394: Hides compliant rows for completed records

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/summaryModels/ComplianceActionViewModelBuilder.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/summaryModels/ComplianceActionViewModelBuilder.kt
@@ -1,6 +1,7 @@
 package uk.gov.communities.prsdb.webapp.models.viewModels.summaryModels
 
 import uk.gov.communities.prsdb.webapp.config.interceptors.BackLinkInterceptor.Companion.overrideBackLinkForUrl
+import uk.gov.communities.prsdb.webapp.constants.enums.ComplianceCertStatus
 import uk.gov.communities.prsdb.webapp.controllers.PropertyComplianceController
 import uk.gov.communities.prsdb.webapp.controllers.PropertyDetailsController
 import uk.gov.communities.prsdb.webapp.helpers.converters.MessageKeyConverter
@@ -26,18 +27,24 @@ class ComplianceActionViewModelBuilder {
                         "complianceActions.summaryRow.registrationNumber",
                         dataModel.registrationNumber,
                     )
-                    addRow(
-                        "complianceActions.summaryRow.gasSafety",
-                        MessageKeyConverter.convert(dataModel.gasSafetyStatus),
-                    )
-                    addRow(
-                        "complianceActions.summaryRow.electricalSafety",
-                        MessageKeyConverter.convert(dataModel.eicrStatus),
-                    )
-                    addRow(
-                        "complianceActions.summaryRow.energyPerformance",
-                        MessageKeyConverter.convert(dataModel.epcStatus),
-                    )
+                    if (!dataModel.isComplete || dataModel.gasSafetyStatus != ComplianceCertStatus.ADDED) {
+                        addRow(
+                            "complianceActions.summaryRow.gasSafety",
+                            MessageKeyConverter.convert(dataModel.gasSafetyStatus),
+                        )
+                    }
+                    if (!dataModel.isComplete || dataModel.eicrStatus != ComplianceCertStatus.ADDED) {
+                        addRow(
+                            "complianceActions.summaryRow.electricalSafety",
+                            MessageKeyConverter.convert(dataModel.eicrStatus),
+                        )
+                    }
+                    if (!dataModel.isComplete || dataModel.epcStatus != ComplianceCertStatus.ADDED) {
+                        addRow(
+                            "complianceActions.summaryRow.energyPerformance",
+                            MessageKeyConverter.convert(dataModel.epcStatus),
+                        )
+                    }
                 }.toList()
 
         private fun getActions(

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/ComplianceActionsPageTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/ComplianceActionsPageTests.kt
@@ -53,7 +53,7 @@ class ComplianceActionsPageTests : IntegrationTest() {
             val completedComplianceCard = complianceActionsPage.getSummaryCard("4 Pretend Crescent")
             assertThat(completedComplianceCard.summaryList.registrationNumRow).containsText("P-CCCT-GRKC")
             assertThat(completedComplianceCard.summaryList.gasSafetyRow).containsText("Not added")
-            assertThat(completedComplianceCard.summaryList.electricalSafetyRow).containsText("Added")
+            assertThat(completedComplianceCard.summaryList.electricalSafetyRow).isHidden()
             assertThat(completedComplianceCard.summaryList.energyPerformanceRow).containsText("Expired")
 
             completedComplianceCard.getAction("Update expired or missing certificates").link.clickAndWait()

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/summaryModels/ComplianceActionViewModelBuilderTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/summaryModels/ComplianceActionViewModelBuilderTests.kt
@@ -1,18 +1,19 @@
 package uk.gov.communities.prsdb.webapp.models.viewModels.summaryModels
 
 import org.junit.jupiter.api.Named.named
-import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments.arguments
 import org.junit.jupiter.params.provider.MethodSource
+import org.junit.jupiter.params.provider.ValueSource
 import uk.gov.communities.prsdb.webapp.constants.enums.ComplianceCertStatus
 import uk.gov.communities.prsdb.webapp.helpers.converters.MessageKeyConverter
 import uk.gov.communities.prsdb.webapp.models.dataModels.ComplianceStatusDataModel
 import kotlin.test.assertEquals
 
 class ComplianceActionViewModelBuilderTests {
-    @Test
-    fun `fromDataModel returns a SummaryCardViewModel with the correct title and summary list`() {
+    @ParameterizedTest
+    @ValueSource(booleans = [true, false])
+    fun `fromDataModel returns a SummaryCardViewModel with the correct title and summary list when`(isComplete: Boolean) {
         // Arrange
         val dataModel =
             ComplianceStatusDataModel(
@@ -22,20 +23,24 @@ class ComplianceActionViewModelBuilderTests {
                 gasSafetyStatus = ComplianceCertStatus.ADDED,
                 eicrStatus = ComplianceCertStatus.NOT_ADDED,
                 epcStatus = ComplianceCertStatus.EXPIRED,
-                isComplete = true,
+                isComplete = isComplete,
             )
         val anyCurrentUrlKey = 1
 
         val expectedSummaryList =
-            listOf(
+            listOfNotNull(
                 SummaryListRowViewModel(
                     "complianceActions.summaryRow.registrationNumber",
                     dataModel.registrationNumber,
                 ),
-                SummaryListRowViewModel(
-                    "complianceActions.summaryRow.gasSafety",
-                    MessageKeyConverter.convert(dataModel.gasSafetyStatus),
-                ),
+                if (!isComplete) {
+                    SummaryListRowViewModel(
+                        "complianceActions.summaryRow.gasSafety",
+                        MessageKeyConverter.convert(dataModel.gasSafetyStatus),
+                    )
+                } else {
+                    null
+                },
                 SummaryListRowViewModel(
                     "complianceActions.summaryRow.electricalSafety",
                     MessageKeyConverter.convert(dataModel.eicrStatus),


### PR DESCRIPTION
## Ticket number

PRSD-1394

## Goal of change

Hides compliance action card summary list rows with 'Added' status for completed records

## Description of main change(s)

- Only adds compliance action card summary list rows for completed records if they don't have the 'Added' status

## Anything you'd like to highlight to the reviewer?

N/A

## Checklist

Delete any that are not applicable, and add explanation below for any that are applicable but haven't been done

- [X] Screenshots of any UI changes have been added
- [X] Unit tests for new logic (e.g. new service methods) have been added
- [X] Single page integration tests have been added for any unhappy-flow UI features, e.g. validation errors
- [X] Test suite has been run in full locally and is passing
- [X] Branch has been rebased onto main and run locally, with everything working as expected (both for your new feature
  and any related functionality)

## Screenshots
- All rows are shown for incomplete compliance forms; only 'Not added' and 'Expired' rows are shown for completed compliance records
<img width="901" height="797" alt="image" src="https://github.com/user-attachments/assets/652d43eb-f669-484d-9bf1-5757c8acc50a" />