### PR TITLE
PRSD-976: Make the signature duration configurable

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/AwsS3FileDownloader.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/AwsS3FileDownloader.kt
@@ -13,6 +13,8 @@ import java.time.Duration
 class AwsS3FileDownloader(
     @Value("\${aws.s3.safeBucket}")
     val safeBucketName: String,
+    @Value("\${aws.s3.signatureDuration}")
+    val signatureDuration: Duration,
 ) : FileDownloader {
     override fun getDownloadUrl(
         fileUpload: FileUpload,
@@ -41,7 +43,7 @@ class AwsS3FileDownloader(
         val presignRequest =
             GetObjectPresignRequest
                 .builder()
-                .signatureDuration(Duration.ofMinutes(10))
+                .signatureDuration(signatureDuration)
                 .getObjectRequest(objectRequestBuilder.build())
                 .build()
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -71,6 +71,7 @@ server:
 
 aws:
   s3:
+    signatureDuration: ${AWS_S3_SIGNATURE_DURATION:1h}
     quarantineBucket: ${AWS_QUARANTINE_BUCKET}
     safeBucket: ${S3_SAFE_BUCKET_KEY}
 

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -23,3 +23,4 @@ aws:
   s3:
     quarantineBucket: 'quarantine-bucket'
     safeBucket: 'safe-bucket'
+    signatureDuration: '1h'


### PR DESCRIPTION
## Ticket number
PRSD-976

## Goal of change
Make the duration of the signed urls for document download configurable. I'm defaulting it to 1 hour.

## Checklist

Delete any that are not applicable, and add explanation below for any that are applicable but haven't been done

- [X] Test suite has been run in full locally and is passing
- [X] Branch has been rebased onto main and run locally, with everything working as expected (both for your new feature
  and any related functionality)
