### PR TITLE
PRSD-1311: Refactor property registration email confirmation to come from service

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/RegisterPropertyController.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/RegisterPropertyController.kt
@@ -78,11 +78,9 @@ class RegisterPropertyController(
         @PathVariable("stepName") stepName: String,
         @RequestParam(value = "subpage", required = false) subpage: Int?,
         @RequestParam(value = CHECKING_ANSWERS_FOR_PARAMETER_NAME, required = false) checkingAnswersForStep: String? = null,
-        model: Model,
-        principal: Principal,
     ): ModelAndView =
         propertyRegistrationJourneyFactory
-            .create(principal.name)
+            .create()
             .getModelAndViewForStep(
                 stepName,
                 subpage,
@@ -90,9 +88,9 @@ class RegisterPropertyController(
             )
 
     @GetMapping("/$TASK_LIST_PATH_SEGMENT")
-    fun getTaskList(principal: Principal): ModelAndView =
+    fun getTaskList(): ModelAndView =
         propertyRegistrationJourneyFactory
-            .create(principal.name)
+            .create()
             .getModelAndViewForTaskList()
 
     @PostMapping("/{stepName}")
@@ -101,11 +99,10 @@ class RegisterPropertyController(
         @RequestParam(value = "subpage", required = false) subpage: Int?,
         @RequestParam(value = CHECKING_ANSWERS_FOR_PARAMETER_NAME, required = false) checkingAnswersForStep: String? = null,
         @RequestParam formData: PageData,
-        model: Model,
         principal: Principal,
     ): ModelAndView =
         propertyRegistrationJourneyFactory
-            .create(principal.name)
+            .create()
             .completeStep(
                 stepName,
                 formData,
@@ -115,10 +112,7 @@ class RegisterPropertyController(
             )
 
     @GetMapping("/$CONFIRMATION_PATH_SEGMENT")
-    fun getConfirmation(
-        model: Model,
-        principal: Principal,
-    ): String {
+    fun getConfirmation(model: Model): String {
         val propertyRegistrationNumber =
             propertyRegistrationService.getLastPrnRegisteredThisSession()
                 ?: throw ResponseStatusException(

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/PropertyRegistrationJourney.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/PropertyRegistrationJourney.kt
@@ -26,7 +26,6 @@ import uk.gov.communities.prsdb.webapp.forms.tasks.JourneySection
 import uk.gov.communities.prsdb.webapp.forms.tasks.JourneyTask
 import uk.gov.communities.prsdb.webapp.helpers.JourneyDataHelper
 import uk.gov.communities.prsdb.webapp.helpers.PropertyRegistrationJourneyDataHelper
-import uk.gov.communities.prsdb.webapp.models.dataModels.RegistrationNumberDataModel
 import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.DeclarationFormModel
 import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.HmoAdditionalLicenceFormModel
 import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.HmoMandatoryLicenceFormModel
@@ -41,15 +40,11 @@ import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.Ownership
 import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.PropertyTypeFormModel
 import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.SelectAddressFormModel
 import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.SelectiveLicenceFormModel
-import uk.gov.communities.prsdb.webapp.models.viewModels.emailModels.PropertyRegistrationConfirmationEmail
 import uk.gov.communities.prsdb.webapp.models.viewModels.formModels.CheckboxViewModel
 import uk.gov.communities.prsdb.webapp.models.viewModels.formModels.RadiosButtonViewModel
 import uk.gov.communities.prsdb.webapp.models.viewModels.formModels.RadiosDividerViewModel
-import uk.gov.communities.prsdb.webapp.services.AbsoluteUrlProvider
 import uk.gov.communities.prsdb.webapp.services.AddressLookupService
-import uk.gov.communities.prsdb.webapp.services.EmailNotificationService
 import uk.gov.communities.prsdb.webapp.services.JourneyDataService
-import uk.gov.communities.prsdb.webapp.services.LandlordService
 import uk.gov.communities.prsdb.webapp.services.LocalAuthorityService
 import uk.gov.communities.prsdb.webapp.services.PropertyRegistrationService
 
@@ -59,9 +54,6 @@ class PropertyRegistrationJourney(
     private val addressLookupService: AddressLookupService,
     private val propertyRegistrationService: PropertyRegistrationService,
     private val localAuthorityService: LocalAuthorityService,
-    private val landlordService: LandlordService,
-    private val absoluteUrlProvider: AbsoluteUrlProvider,
-    private val confirmationEmailSender: EmailNotificationService<PropertyRegistrationConfirmationEmail>,
 ) : JourneyWithTaskList<RegisterPropertyStepId>(
         journeyType = JourneyType.PROPERTY_REGISTRATION,
         initialStepId = RegisterPropertyStepId.LookupAddress,
@@ -614,27 +606,15 @@ class PropertyRegistrationJourney(
         try {
             val address = PropertyRegistrationJourneyDataHelper.getAddress(filteredJourneyData)!!
             val baseUserId = SecurityContextHolder.getContext().authentication.name
-            val propertyRegistrationNumber =
-                propertyRegistrationService.registerPropertyAndReturnPropertyRegistrationNumber(
-                    address = address,
-                    propertyType = PropertyRegistrationJourneyDataHelper.getPropertyType(filteredJourneyData)!!,
-                    licenseType = PropertyRegistrationJourneyDataHelper.getLicensingType(filteredJourneyData)!!,
-                    licenceNumber = PropertyRegistrationJourneyDataHelper.getLicenseNumber(filteredJourneyData)!!,
-                    ownershipType = PropertyRegistrationJourneyDataHelper.getOwnershipType(filteredJourneyData)!!,
-                    numberOfHouseholds = PropertyRegistrationJourneyDataHelper.getNumberOfHouseholds(filteredJourneyData),
-                    numberOfPeople = PropertyRegistrationJourneyDataHelper.getNumberOfTenants(filteredJourneyData),
-                    baseUserId = baseUserId,
-                )
-
-            propertyRegistrationService.setLastPrnRegisteredThisSession(propertyRegistrationNumber.number)
-
-            confirmationEmailSender.sendEmail(
-                landlordService.retrieveLandlordByBaseUserId(baseUserId)!!.email,
-                PropertyRegistrationConfirmationEmail(
-                    RegistrationNumberDataModel.fromRegistrationNumber(propertyRegistrationNumber).toString(),
-                    address.singleLineAddress,
-                    absoluteUrlProvider.buildLandlordDashboardUri().toString(),
-                ),
+            propertyRegistrationService.registerProperty(
+                address = address,
+                propertyType = PropertyRegistrationJourneyDataHelper.getPropertyType(filteredJourneyData)!!,
+                licenseType = PropertyRegistrationJourneyDataHelper.getLicensingType(filteredJourneyData)!!,
+                licenceNumber = PropertyRegistrationJourneyDataHelper.getLicenseNumber(filteredJourneyData)!!,
+                ownershipType = PropertyRegistrationJourneyDataHelper.getOwnershipType(filteredJourneyData)!!,
+                numberOfHouseholds = PropertyRegistrationJourneyDataHelper.getNumberOfHouseholds(filteredJourneyData),
+                numberOfPeople = PropertyRegistrationJourneyDataHelper.getNumberOfTenants(filteredJourneyData),
+                baseUserId = baseUserId,
             )
 
             journeyDataService.deleteJourneyData()

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/factories/PropertyRegistrationJourneyFactory.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/factories/PropertyRegistrationJourneyFactory.kt
@@ -4,11 +4,7 @@ import org.springframework.validation.Validator
 import uk.gov.communities.prsdb.webapp.annotations.PrsdbWebComponent
 import uk.gov.communities.prsdb.webapp.controllers.RegisterPropertyController
 import uk.gov.communities.prsdb.webapp.forms.journeys.PropertyRegistrationJourney
-import uk.gov.communities.prsdb.webapp.models.viewModels.emailModels.PropertyRegistrationConfirmationEmail
-import uk.gov.communities.prsdb.webapp.services.AbsoluteUrlProvider
 import uk.gov.communities.prsdb.webapp.services.AddressLookupService
-import uk.gov.communities.prsdb.webapp.services.EmailNotificationService
-import uk.gov.communities.prsdb.webapp.services.LandlordService
 import uk.gov.communities.prsdb.webapp.services.LocalAuthorityService
 import uk.gov.communities.prsdb.webapp.services.PropertyRegistrationService
 import uk.gov.communities.prsdb.webapp.services.factories.JourneyDataServiceFactory
@@ -20,20 +16,14 @@ class PropertyRegistrationJourneyFactory(
     private val addressLookupService: AddressLookupService,
     private val propertyRegistrationService: PropertyRegistrationService,
     private val localAuthorityService: LocalAuthorityService,
-    private val landlordService: LandlordService,
-    private val absoluteUrlProvider: AbsoluteUrlProvider,
-    private val confirmationEmailSender: EmailNotificationService<PropertyRegistrationConfirmationEmail>,
 ) {
-    fun create(principalName: String) =
+    fun create() =
         PropertyRegistrationJourney(
             validator,
             journeyDataServiceFactory.create(JOURNEY_DATA_KEY),
             addressLookupService,
             propertyRegistrationService,
             localAuthorityService,
-            landlordService,
-            absoluteUrlProvider,
-            confirmationEmailSender,
         )
 
     companion object {

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/controllers/RegisterPropertyControllerTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/controllers/RegisterPropertyControllerTests.kt
@@ -55,7 +55,7 @@ class RegisterPropertyControllerTests(
 
     @BeforeEach
     fun setupMocks() {
-        whenever(propertyRegistrationJourneyFactory.create(any())).thenReturn(propertyRegistrationJourney)
+        whenever(propertyRegistrationJourneyFactory.create()).thenReturn(propertyRegistrationJourney)
         whenever(propertyRegistrationJourney.initialStepId).thenReturn(RegisterPropertyStepId.PlaceholderPage)
         whenever(journeyDataServiceFactory.create(any())).thenReturn(journeyDataService)
         whenever(journeyDataService.journeyDataKey).thenReturn(PropertyRegistrationJourneyFactory.JOURNEY_DATA_KEY)

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/PropertyRegistrationJourneyTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/PropertyRegistrationJourneyTests.kt
@@ -15,19 +15,13 @@ import uk.gov.communities.prsdb.webapp.constants.enums.RegistrationNumberType
 import uk.gov.communities.prsdb.webapp.database.entity.RegistrationNumber
 import uk.gov.communities.prsdb.webapp.forms.PageData
 import uk.gov.communities.prsdb.webapp.forms.steps.RegisterPropertyStepId
-import uk.gov.communities.prsdb.webapp.models.viewModels.emailModels.PropertyRegistrationConfirmationEmail
-import uk.gov.communities.prsdb.webapp.services.AbsoluteUrlProvider
 import uk.gov.communities.prsdb.webapp.services.AddressLookupService
-import uk.gov.communities.prsdb.webapp.services.EmailNotificationService
 import uk.gov.communities.prsdb.webapp.services.JourneyDataService
-import uk.gov.communities.prsdb.webapp.services.LandlordService
 import uk.gov.communities.prsdb.webapp.services.LocalAuthorityService
 import uk.gov.communities.prsdb.webapp.services.PropertyRegistrationService
 import uk.gov.communities.prsdb.webapp.testHelpers.JourneyTestHelper
 import uk.gov.communities.prsdb.webapp.testHelpers.builders.JourneyDataBuilder
 import uk.gov.communities.prsdb.webapp.testHelpers.mockObjects.AlwaysTrueValidator
-import uk.gov.communities.prsdb.webapp.testHelpers.mockObjects.MockLandlordData
-import java.net.URI
 
 class PropertyRegistrationJourneyTests {
     @Mock
@@ -40,16 +34,7 @@ class PropertyRegistrationJourneyTests {
     lateinit var localAuthorityService: LocalAuthorityService
 
     @Mock
-    lateinit var landlordService: LandlordService
-
-    @Mock
     lateinit var addressLookupService: AddressLookupService
-
-    @Mock
-    lateinit var confirmationEmailSender: EmailNotificationService<PropertyRegistrationConfirmationEmail>
-
-    @Mock
-    lateinit var urlProvider: AbsoluteUrlProvider
 
     val alwaysTrueValidator: AlwaysTrueValidator = AlwaysTrueValidator()
 
@@ -58,10 +43,7 @@ class PropertyRegistrationJourneyTests {
         mockJourneyDataService = mock()
         mockPropertyRegistrationService = mock()
         localAuthorityService = mock()
-        landlordService = mock()
         addressLookupService = mock()
-        confirmationEmailSender = mock()
-        urlProvider = mock()
     }
 
     @Nested
@@ -72,11 +54,8 @@ class PropertyRegistrationJourneyTests {
 
         @BeforeEach
         fun beforeEach() {
-            whenever(landlordService.retrieveLandlordByBaseUserId(any())).thenReturn(MockLandlordData.createLandlord())
-            whenever(urlProvider.buildLandlordDashboardUri()).thenReturn(URI("https:gov.uk"))
-
             whenever(
-                mockPropertyRegistrationService.registerPropertyAndReturnPropertyRegistrationNumber(
+                mockPropertyRegistrationService.registerProperty(
                     any(),
                     any(),
                     any(),
@@ -95,9 +74,6 @@ class PropertyRegistrationJourneyTests {
                     addressLookupService = addressLookupService,
                     propertyRegistrationService = mockPropertyRegistrationService,
                     localAuthorityService = localAuthorityService,
-                    landlordService = landlordService,
-                    confirmationEmailSender = confirmationEmailSender,
-                    absoluteUrlProvider = urlProvider,
                 )
             JourneyTestHelper.setMockUser(principalName)
         }
@@ -118,7 +94,7 @@ class PropertyRegistrationJourneyTests {
             completeStep(RegisterPropertyStepId.Declaration)
 
             // Assert
-            verify(mockPropertyRegistrationService).registerPropertyAndReturnPropertyRegistrationNumber(
+            verify(mockPropertyRegistrationService).registerProperty(
                 any(),
                 any(),
                 any(),
@@ -146,7 +122,7 @@ class PropertyRegistrationJourneyTests {
             completeStep(RegisterPropertyStepId.Declaration)
 
             // Assert
-            verify(mockPropertyRegistrationService).registerPropertyAndReturnPropertyRegistrationNumber(
+            verify(mockPropertyRegistrationService).registerProperty(
                 any(),
                 argThat { type -> type == PropertyType.FLAT },
                 any(),
@@ -176,7 +152,7 @@ class PropertyRegistrationJourneyTests {
             completeStep(RegisterPropertyStepId.Declaration)
 
             // Assert
-            verify(mockPropertyRegistrationService).registerPropertyAndReturnPropertyRegistrationNumber(
+            verify(mockPropertyRegistrationService).registerProperty(
                 any(),
                 any(),
                 argThat { type -> type == LicensingType.HMO_MANDATORY_LICENCE },
@@ -204,7 +180,7 @@ class PropertyRegistrationJourneyTests {
             completeStep(RegisterPropertyStepId.Declaration)
 
             // Assert
-            verify(mockPropertyRegistrationService).registerPropertyAndReturnPropertyRegistrationNumber(
+            verify(mockPropertyRegistrationService).registerProperty(
                 any(),
                 any(),
                 argThat { type -> type == LicensingType.NO_LICENSING },


### PR DESCRIPTION

## Ticket number
PRSD-1311

## Goal of change
Refactor - currently the journey separately calls the registration service then sends emails - that should be part of registration

## Anything you'd like to highlight to the reviewer?
I've also deleted some unused method parameters e.g. in the factory for the journey!

## Checklist
- [x] Test suite has been run in full locally and is passing
- [x] Branch has been rebased onto main and run locally, with everything working as expected (both for your new feature
  and any related functionality)
