### PR TITLE
PRSD-1357: fix styling on delete LC user page

### DIFF
--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -317,7 +317,7 @@ deleteLAUser.heading=Before you remove this account
 deleteLAUser.emailLabel=Email
 deleteLAUser.para.one=Once removed, the user cannot access this local council on the database.
 deleteLAUser.para.two=You will need to invite this user again to give them access.
-deleteLAUser.warning=Make sure you are removing the correct user before you continue.
+deleteLAUser.para.three=Make sure you are removing the correct user before you continue.
 deleteLAUser.deleteAccountButton=Remove this account
 
 deleteLAUserSuccess.title=User removed

--- a/src/main/resources/templates/deleteLAUser.html
+++ b/src/main/resources/templates/deleteLAUser.html
@@ -19,7 +19,7 @@
             <section>
                 <p class="govuk-body" th:text="#{deleteLAUser.para.one}">deleteLAUser.para.one</p>
                 <p class="govuk-body" th:text="#{deleteLAUser.para.two}">deleteLAUser.para.two</p>
-                <div th:replace="~{fragments/warningText :: warningText(#{deleteLAUser.warning})}">deleteLAUser.warning</div>
+                <p class="govuk-body" th:text="#{deleteLAUser.para.three}">deleteLAUser.para.three</p>
             </section>
             <form method="post" th:action="@{''}">
                 <button th:replace="~{fragments/buttons/warningButton :: warningButton(buttonText=#{deleteLAUser.deleteAccountButton})}"></button>


### PR DESCRIPTION
## Ticket number

PRSD-1357

## Goal of change

Stop using warning styled text on delete LC user page

## Description of main change(s)

As above

## Screenshots

### After
<img width="720" height="487" alt="image" src="https://github.com/user-attachments/assets/8bb88f54-10f3-492b-923f-3ffeed7d2d28" />


### Before 
<img width="720" height="517" alt="image" src="https://github.com/user-attachments/assets/4730a43a-0858-455e-b5b0-316835b27f74" />


## Checklist

- [X] Screenshots of any UI changes have been added
- [x] Test suite has been run in full locally and is passing
- [X] Branch has been rebased onto main and run locally, with everything working as expected (both for your new feature
  and any related functionality)
