### PR TITLE
PRSD-1422: Adds LA and LL routes for cookies page

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/config/security/DefaultSecurityConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/config/security/DefaultSecurityConfig.kt
@@ -47,7 +47,7 @@ class DefaultSecurityConfig(
                     .permitAll()
                     .requestMatchers("/local/**")
                     .permitAll()
-                    .requestMatchers("$COOKIES_ROUTE/**")
+                    .requestMatchers(COOKIES_ROUTE)
                     .permitAll()
                     .anyRequest()
                     .authenticated()

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/config/security/LandlordSecurityConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/config/security/LandlordSecurityConfig.kt
@@ -23,6 +23,7 @@ import uk.gov.communities.prsdb.webapp.config.filters.MultipartFormDataFilter
 import uk.gov.communities.prsdb.webapp.config.filters.OauthTokenSecondaryValidatingFilter
 import uk.gov.communities.prsdb.webapp.config.resolvers.AdditionalParameterAddingOAuth2RequestResolver
 import uk.gov.communities.prsdb.webapp.constants.OneLoginClaimKeys
+import uk.gov.communities.prsdb.webapp.controllers.CookiesController
 import uk.gov.communities.prsdb.webapp.controllers.PasscodeEntryController
 import uk.gov.communities.prsdb.webapp.controllers.RegisterLandlordController
 import uk.gov.communities.prsdb.webapp.services.UserRolesService
@@ -46,6 +47,8 @@ class LandlordSecurityConfig(
                     .requestMatchers(RegisterLandlordController.LANDLORD_REGISTRATION_ROUTE)
                     .permitAll()
                     .requestMatchers(PasscodeEntryController.PASSCODE_ENTRY_ROUTE)
+                    .permitAll()
+                    .requestMatchers(CookiesController.LL_COOKIES_ROUTE)
                     .permitAll()
                     .anyRequest()
                     .authenticated()

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/config/security/LocalAuthoritySecurityConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/config/security/LocalAuthoritySecurityConfig.kt
@@ -10,6 +10,7 @@ import org.springframework.security.oauth2.core.oidc.user.OidcUser
 import org.springframework.security.web.SecurityFilterChain
 import uk.gov.communities.prsdb.webapp.annotations.PrsdbWebConfiguration
 import uk.gov.communities.prsdb.webapp.constants.LOCAL_AUTHORITY_PATH_SEGMENT
+import uk.gov.communities.prsdb.webapp.controllers.CookiesController
 import uk.gov.communities.prsdb.webapp.services.UserRolesService
 
 @PrsdbWebConfiguration
@@ -24,6 +25,8 @@ class LocalAuthoritySecurityConfig(
             .securityMatcher("/$LOCAL_AUTHORITY_PATH_SEGMENT/**")
             .authorizeHttpRequests { requests ->
                 requests
+                    .requestMatchers(CookiesController.LA_COOKIES_ROUTE)
+                    .permitAll()
                     .anyRequest()
                     .authenticated()
             }.oauth2Login { oauth ->

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/CookiesController.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/CookiesController.kt
@@ -4,15 +4,21 @@ import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import uk.gov.communities.prsdb.webapp.annotations.PrsdbController
 import uk.gov.communities.prsdb.webapp.constants.COOKIES_PATH_SEGMENT
+import uk.gov.communities.prsdb.webapp.constants.LANDLORD_PATH_SEGMENT
+import uk.gov.communities.prsdb.webapp.constants.LOCAL_AUTHORITY_PATH_SEGMENT
 import uk.gov.communities.prsdb.webapp.controllers.CookiesController.Companion.COOKIES_ROUTE
+import uk.gov.communities.prsdb.webapp.controllers.CookiesController.Companion.LA_COOKIES_ROUTE
+import uk.gov.communities.prsdb.webapp.controllers.CookiesController.Companion.LL_COOKIES_ROUTE
 
 @PrsdbController
-@RequestMapping(COOKIES_ROUTE)
+@RequestMapping(COOKIES_ROUTE, LL_COOKIES_ROUTE, LA_COOKIES_ROUTE)
 class CookiesController {
     @GetMapping
     fun getCookiesPage(): String = "cookies"
 
     companion object {
         const val COOKIES_ROUTE = "/$COOKIES_PATH_SEGMENT"
+        const val LL_COOKIES_ROUTE = "/$LANDLORD_PATH_SEGMENT$COOKIES_ROUTE"
+        const val LA_COOKIES_ROUTE = "/$LOCAL_AUTHORITY_PATH_SEGMENT$COOKIES_ROUTE"
     }
 }


### PR DESCRIPTION
## Ticket number

PRSD-1422

## Goal of change

Adds LA and LL routes for cookies page to remove reliance on URL-rewriter's excluded list

## Description of main change(s)

- Adds LA and LL prefixed routes for cookies page

## Anything you'd like to highlight to the reviewer?

- This PR is accompanied by an [infra](https://github.com/communitiesuk/prsdb-infra/pull/138) one that removes the cookies page endpoint from the URL-rewriter's excluded list

## Checklist

Delete any that are not applicable, and add explanation below for any that are applicable but haven't been done

- [X] Test suite has been run in full locally and is passing
- [X] Branch has been rebased onto main and run locally, with everything working as expected (both for your new feature
  and any related functionality)