### PR TITLE
PRSD-1166: Only display templates after complete processing

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -39,6 +39,8 @@ spring:
 
   thymeleaf:
     render-hidden-markers-before-checkboxes: true
+    servlet:
+      produce-partial-output-while-processing: false
 
   servlet:
     multipart:

--- a/src/main/resources/templates/fragments/layout.html
+++ b/src/main/resources/templates/fragments/layout.html
@@ -1,33 +1,28 @@
+<!--/*@thymesVar id="plausibleDomainId" type="String"*/-->
+<!--/*@thymesVar id="googleAnalyticsMeasurementId" type="String"*/-->
+<!--/*@thymesVar id="navLinks" type="java.util.List<String>"*/-->
 <!DOCTYPE html>
 <html th:fragment="layout(title, content, hasErrors)" lang="en" class="govuk-template govuk-template--rebranded">
 <head>
     <meta charset="utf-8">
-    <title th:text="((${hasErrors}) ? #{forms.errorMessage.prefix} : '' ) + ${title}">GOV.UK - The best place to find
-        government services and information</title>
+    <title th:text="((${hasErrors}) ? #{forms.errorMessage.prefix} : '' ) + ${title}">GOV.UK - The best place to find government services and information</title>
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
     <meta name="theme-color" content="#1d70b8">
-    <link rel="icon" sizes="48x48" href="/static/assets/rebrand/images/favicon.ico"
-          th:href="@{/assets/rebrand/images/favicon.ico}">
-    <link rel="icon" sizes="any" href="/static/assets/rebrand/images/favicon.svg"
-          th:href="@{/assets/rebrand/images/favicon.svg}" type="image/svg+xml">
-    <link rel="mask-icon" href="/static/assets/rebrand/images/govuk-icon-mask.svg"
-          th:href="@{/assets/rebrand/images/govuk-icon-mask.svg}" color="#1d70b8">
-    <link rel="apple-touch-icon" href="/static/assets/rebrand/images/govuk-icon-180.png">
-    <link rel="manifest" href="/static/assets/rebrand/manifest.json" th:href="@{/assets/rebrand/manifest.json}"
-          crossorigin="use-credentials">
-    <link rel="stylesheet" href="/static/assets/css/govuk-frontend.min.css"
-          th:href="@{/assets/css/govuk-frontend.min.css}">
-    <link rel="stylesheet" href="/static/assets/css/service-header.css" th:href="@{/assets/css/service-header.css}">
-    <link rel="stylesheet" href="/static/assets/css/accessible-autocomplete.min.css"
-          th:href="@{/assets/css/accessible-autocomplete.min.css}"/>
-    <link rel="stylesheet" href="/static/assets/css/moj-frontend.min.css" th:href="@{/assets/css/moj-frontend.min.css}">
-    <link rel="stylesheet" href="/static/assets/css/custom.css" th:href="@{/assets/css/custom.css}">
-    <!--/*@thymesVar id="plausibleDomainId" type="String"*/-->
+    <link rel="icon" sizes="48x48" th:href="@{/assets/rebrand/images/favicon.ico}">
+    <link rel="icon" sizes="any" th:href="@{/assets/rebrand/images/favicon.svg}" type="image/svg+xml">
+    <link rel="mask-icon" th:href="@{/assets/rebrand/images/govuk-icon-mask.svg}" color="#1d70b8">
+    <link rel="apple-touch-icon" th:href="@{/assets/rebrand/images/govuk-icon-180.png}">
+    <link rel="manifest" th:href="@{/assets/rebrand/manifest.json}" crossorigin="use-credentials">
+    <link rel="stylesheet" th:href="@{/assets/css/govuk-frontend.min.css}">
+    <link rel="stylesheet" th:href="@{/assets/css/service-header.css}">
+    <link rel="stylesheet" th:href="@{/assets/css/accessible-autocomplete.min.css}"/>
+    <link rel="stylesheet" th:href="@{/assets/css/moj-frontend.min.css}">
+    <link rel="stylesheet" th:href="@{/assets/css/custom.css}">
     <script defer th:attr="data-domain=${plausibleDomainId}" src="https://plausible.io/js/script.file-downloads.hash.outbound-links.js"></script>
     <script>window.plausible = window.plausible || function() { (window.plausible.q = window.plausible.q || []).push(arguments) }</script>
 </head>
 <script>
-    <!-- Set consent for google tag to denied by default -->
+    <!-- Set consent for Google tag to denied by default -->
     window.dataLayer = window.dataLayer || [];
     function gtag() { dataLayer.push(arguments); }
     gtag('consent', 'default', {
@@ -38,7 +33,6 @@
         'wait_for_update': 500,
     });
 </script>
-<!--/*@thymesVar id="googleAnalyticsMeasurementId" type="String"*/-->
 <script async th:src="'https://www.googletagmanager.com/gtag/js?id='+${googleAnalyticsMeasurementId}"></script>
 <script th:inline="javascript" th:with="measurementIdAsString=${googleAnalyticsMeasurementId}">
     <!-- Google tag (gtag.js) -->
@@ -60,11 +54,11 @@
 <a href="#main-content" class="govuk-skip-link" data-module="govuk-skip-link">Skip to main content</a>
 <header th:replace="~{fragments/header/header :: header(${navLinks})}"></header>
 <div class="govuk-width-container">
-    <div th:replace="~{ fragments/banners/betaBanner :: betaBanner }"></div>
+    <div th:replace="~{fragments/banners/betaBanner :: betaBanner}"></div>
     <div th:replace="${content}"></div>
 </div>
-<div th:replace="~{ fragments/footer :: footer }"></div>
-<script type="module" src="/static/assets/js/index.js" th:src="@{/assets/js/index.js}"></script>
-<script type="module" src="/static/assets/js/service-header.js" th:src="@{/assets/js/service-header.js}"></script>
+<div th:replace="~{fragments/footer :: footer}"></div>
+<script type="module" th:src="@{/assets/js/index.js}"></script>
+<script type="module" th:src="@{/assets/js/service-header.js}"></script>
 </body>
 </html>


### PR DESCRIPTION
## Ticket number

PRSD-1166

## Goal of change

Prevents Thymeleaf from producing output before templates have been fully processed

## Description of main change(s)

- Removes fallback static resources from layout fragment
- Configures Thymeleaf to not produce output while processing

## Anything you'd like to highlight to the reviewer?

- This PR is motivated by a QA on PRSD-1166, which revealed that the browser attempted to fetch a static asset before the template fully loaded

## Checklist

Delete any that are not applicable, and add explanation below for any that are applicable but haven't been done

- [X] Screenshots of any UI changes have been added
- [X] Test suite has been run in full locally and is passing
- [X] Branch has been rebased onto main and run locally, with everything working as expected (both for your new feature
  and any related functionality)