### PR TITLE
Down-merging Hotfix: PRSD-NONE: Uses env variable for OL DID URL & adds prod notify Ids

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -48,7 +48,7 @@ one-login:
   jwt:
     public.key: ${ONE_LOGIN_PUBLIC_KEY}
     private.key: ${ONE_LOGIN_PRIVATE_KEY}
-  did.uri: https://identity.integration.account.gov.uk/.well-known/did.json
+  did.uri: ${ONE_LOGIN_DID_URL}
 
 notify:
   api-key: ${EMAILNOTIFICATIONS_APIKEY}

--- a/src/main/resources/emails/emailTemplates.json
+++ b/src/main/resources/emails/emailTemplates.json
@@ -1,91 +1,91 @@
 [
   {
     "test_id": "d0a5908e-240b-4951-8b88-908f0082960b",
-    "prod_id": null,
+    "prod_id": "511d1529-981e-48d8-b86a-fd0abc607ad3",
     "enumName": "LOCAL_AUTHORITY_INVITATION_EMAIL",
     "subject": "GOV.UK - You’ve been invited by a local council to register on the PRS Database",
     "bodyLocation": "/emails/LocalAuthorityInvitation.md"
   },
   {
     "test_id": "72b0d2ac-3684-48c6-8ece-d27c2d89047d",
-    "prod_id": null,
+    "prod_id": "ada7d8fc-a5d7-44d7-9e13-f0bd187d4ed0",
     "enumName": "LOCAL_AUTHORITY_INVITATION_CANCELLATION_EMAIL",
     "subject": "GOV.UK - Your invite to register on the PRS Database has been cancelled",
     "bodyLocation": "/emails/LocalAuthorityInvitationCancellation.md"
   },
   {
     "test_id": "767e3b8e-8977-4107-8a3a-11cb40300113",
-    "prod_id": null,
+    "prod_id": "a70690a0-2822-4bf7-a53b-0839f46f7d9b",
     "enumName": "LOCAL_AUTHORITY_ADMIN_INVITATION_EMAIL",
     "subject": "PRD – You’ve been invited to register as a local council admin on the Privately Rented Database",
     "bodyLocation": "/emails/LocalAuthorityAdminInvitation.md"
   },
   {
     "test_id": "1bd9e020-d6f8-494f-ae6a-904e642d3f55",
-    "prod_id": null,
+    "prod_id": "fa26bdf8-8983-4d52-bdb7-2b531c9960ad",
     "enumName": "LANDLORD_REGISTRATION_CONFIRMATION_EMAIL",
     "subject": "GOV.UK - Your landlord registration number",
     "bodyLocation": "/emails/LandlordRegistrationConfirmation.md"
   },
   {
     "test_id": "90bf3bc0-5269-4a44-8ed2-147c9308196f",
-    "prod_id": null,
+    "prod_id": "f7d90928-1f27-492b-a7b4-18fff9cc2e6a",
     "enumName": "PROPERTY_REGISTRATION_CONFIRMATION",
     "subject": "GOV.UK - Your registered property on the PRS Database",
     "bodyLocation": "/emails/PropertyRegistrationConfirmation.md"
   },
   {
     "test_id": "96a2f7a8-26b2-4377-944c-6f68c96d7ebe",
-    "prod_id": null,
+    "prod_id": "464eb0a4-20b8-4ae8-874d-32ad06997329",
     "enumName": "PROPERTY_DEREGISTRATION_CONFIRMATION",
     "subject": "GOV.UK - You have deleted a property from the PRS database",
     "bodyLocation": "/emails/PropertyDeregistrationConfirmation.md"
   },
   {
     "test_id": "bd70c902-7ecd-4033-83e0-80613501928a",
-    "prod_id": null,
+    "prod_id": "343b177e-ed76-4798-82a9-b60307f4428e",
     "enumName": "LANDLORD_NO_PROPERTIES_DEREGISTRATION_CONFIRMATION",
     "subject": "GOV.UK - You have deleted your record from the PRS database",
     "bodyLocation": "/emails/LandlordNoPropertiesDeregistrationConfirmation.md"
   },
   {
     "test_id": "72829802-ee1a-4ab8-8003-61165d0bb489",
-    "prod_id": null,
+    "prod_id": "64008bea-5a6f-4dd4-84cc-9539718f770c",
     "enumName": "LANDLORD_WITH_PROPERTIES_DEREGISTRATION_CONFIRMATION",
     "subject": "GOV.UK - You have deleted your landlord record and properties from the PRS database",
     "bodyLocation": "/emails/LandlordWithPropertiesDeregistrationConfirmation.md"
   },
   {
     "test_id": "2782faf2-6123-4352-9d36-03df1bb45a3d",
-    "prod_id": null,
+    "prod_id": "a15f099e-47f0-4c47-ad11-c88c6fe9d78f",
     "enumName": "FULL_PROPERTY_COMPLIANCE_CONFIRMATION",
     "subject": "GOV.UK – You have added compliance information for a property",
     "bodyLocation": "/emails/FullPropertyComplianceConfirmation.md"
   },
   {
     "test_id": "2b686d25-1a07-4b4b-bf5d-52455c9392ad",
-    "prod_id": null,
+    "prod_id": "98382708-1636-4457-8efa-0a154c68775f",
     "enumName": "PARTIAL_PROPERTY_COMPLIANCE_CONFIRMATION",
     "subject": "GOV.UK – You need to take action to provide compliance for a property",
     "bodyLocation": "/emails/PartialPropertyComplianceConfirmation.md"
   },
   {
     "test_id": "7bed4d38-1551-4049-8c06-2b42594b5a73",
-    "prod_id": null,
+    "prod_id": "2e73e6b5-6bdc-42af-ad94-021108c6f166",
     "enumName": "VIRUS_SCAN_UNSUCCESSFUL",
     "subject": "((subject certificate type)) for a property failed our virus scan",
     "bodyLocation": "/emails/VirusScanUnsuccessful.md"
   },
   {
     "test_id": "0ec8d025-1c06-4265-9b5d-37427b4acfc8",
-    "prod_id": null,
+    "prod_id": "b1a64644-f233-44e3-a148-2932269a2313",
     "enumName": "PROPERTY_UPDATE_CONFIRMATION",
     "subject": "GOV.UK - You have updated a property on the PRS database",
     "bodyLocation": "/emails/PropertyUpdateConfirmation.md"
   },
   {
     "test_id": "03e610ae-7ea7-4b32-86e9-77b54f2211cc",
-    "prod_id": null,
+    "prod_id": "780de476-5a00-4f8a-b2c1-580f38c087cd",
     "enumName": "LANDLORD_UPDATE_CONFIRMATION",
     "subject": "GOV.UK - You have updated your landlord details on the PRS database",
     "bodyLocation": "/emails/LandlordUpdateConfirmation.md"


### PR DESCRIPTION
## Ticket number

PRSD-NONE

## Goal of change

Down-merges hofitx for using env variable for One Login DID URL and adding production notify ids

## Anything you'd like to highlight to the reviewer?

This should not be merged until the related infra PR (https://github.com/communitiesuk/prsdb-infra/pull/148) has been merged and the environment variable has been set on AWS
