### PR TITLE
PRSD-1166: Prevent Multiple Passcode Claims

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/config/interceptors/PasscodeInterceptor.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/config/interceptors/PasscodeInterceptor.kt
@@ -6,11 +6,11 @@ import org.springframework.web.servlet.HandlerInterceptor
 import uk.gov.communities.prsdb.webapp.constants.LANDLORD_PATH_SEGMENT
 import uk.gov.communities.prsdb.webapp.constants.PASSCODE_REDIRECT_URL
 import uk.gov.communities.prsdb.webapp.constants.SUBMITTED_PASSCODE
+import uk.gov.communities.prsdb.webapp.controllers.LandlordController.Companion.LANDLORD_DASHBOARD_URL
 import uk.gov.communities.prsdb.webapp.controllers.PasscodeEntryController.Companion.PASSCODE_ALREADY_USED_ROUTE
 import uk.gov.communities.prsdb.webapp.controllers.PasscodeEntryController.Companion.PASSCODE_ENTRY_ROUTE
 import uk.gov.communities.prsdb.webapp.helpers.URIQueryBuilder
 import uk.gov.communities.prsdb.webapp.services.PasscodeService
-import java.security.Principal
 
 class PasscodeInterceptor(
     private val passcodeService: PasscodeService,
@@ -20,62 +20,60 @@ class PasscodeInterceptor(
         response: HttpServletResponse,
         handler: Any,
     ): Boolean {
-        val currentPath = request.requestURI
+        // Don't allow users who have claimed a passcode to access passcode pages
+        val principal = request.userPrincipal
+        if (principal != null && passcodeService.hasUserClaimedAPasscode(principal.name)) {
+            return handleAuthenticatedUserWithClaimedPasscode(request, response)
+        }
 
         // Only apply interceptor to non-passcode landlord routes
-        val passcodeRoutes = listOf(PASSCODE_ENTRY_ROUTE, PASSCODE_ALREADY_USED_ROUTE)
+        val currentPath = request.requestURI
         if (!currentPath.startsWith("/$LANDLORD_PATH_SEGMENT/") || currentPath in passcodeRoutes) {
             return true
         }
 
-        val principal = request.userPrincipal
-        val submittedPasscode = request.session.getAttribute(SUBMITTED_PASSCODE) as? String
-
         return if (principal == null) {
-            handleUnauthenticatedUser(request, response, submittedPasscode)
+            handleUnauthenticatedUser(request, response)
         } else {
-            handleAuthenticatedUser(request, response, principal, submittedPasscode)
+            handleAuthenticatedUserWithoutClaimedPasscode(request, response, principal.name)
         }
     }
+
+    private fun handleAuthenticatedUserWithClaimedPasscode(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+    ): Boolean =
+        if (request.requestURI in passcodeRoutes) {
+            redirectToDashboardAndReturnFalse(response)
+        } else {
+            true
+        }
 
     private fun handleUnauthenticatedUser(
         request: HttpServletRequest,
         response: HttpServletResponse,
-        submittedPasscode: String?,
     ): Boolean =
-        if (submittedPasscode != null) {
+        if (request.session.getAttribute(SUBMITTED_PASSCODE) != null) {
             true
         } else {
             redirectToPasscodeEntryAndReturnFalse(request, response)
         }
 
-    private fun handleAuthenticatedUser(
-        request: HttpServletRequest,
-        response: HttpServletResponse,
-        principal: Principal,
-        submittedPasscode: String?,
-    ): Boolean {
-        val userId = principal.name
-
-        return if (submittedPasscode == null) {
-            handleUserWithoutSessionPasscode(request, response, userId)
-        } else {
-            handleUserWithSessionPasscode(request, response, userId, submittedPasscode)
-        }
-    }
-
-    private fun handleUserWithoutSessionPasscode(
+    private fun handleAuthenticatedUserWithoutClaimedPasscode(
         request: HttpServletRequest,
         response: HttpServletResponse,
         userId: String,
-    ): Boolean =
-        if (passcodeService.hasUserClaimedPasscode(userId)) {
-            true
+    ): Boolean {
+        val submittedPasscode = request.session.getAttribute(SUBMITTED_PASSCODE) as String?
+
+        return if (submittedPasscode != null) {
+            handleAuthenticatedUserWithSessionPasscode(request, response, userId, submittedPasscode)
         } else {
             redirectToPasscodeEntryAndReturnFalse(request, response)
         }
+    }
 
-    private fun handleUserWithSessionPasscode(
+    private fun handleAuthenticatedUserWithSessionPasscode(
         request: HttpServletRequest,
         response: HttpServletResponse,
         userId: String,
@@ -85,10 +83,10 @@ class PasscodeInterceptor(
             passcodeService.findPasscode(submittedPasscode)
                 ?: return redirectToPasscodeEntryAndReturnFalse(request, response)
 
-        return when {
-            passcode.baseUser == null -> handleUnclaimedPasscode(request, response, userId, submittedPasscode)
-            passcodeService.isPasscodeClaimedByUser(submittedPasscode, userId) -> true
-            else -> redirectToPasscodeAlreadyUsedAndReturnFalse(response)
+        return if (passcode.baseUser == null) {
+            handleUnclaimedPasscode(request, response, userId, submittedPasscode)
+        } else {
+            redirectToPasscodeAlreadyUsedAndReturnFalse(response)
         }
     }
 
@@ -104,6 +102,11 @@ class PasscodeInterceptor(
             redirectToPasscodeEntryAndReturnFalse(request, response)
         }
 
+    private fun redirectToDashboardAndReturnFalse(response: HttpServletResponse): Boolean {
+        response.sendRedirect(LANDLORD_DASHBOARD_URL)
+        return false
+    }
+
     private fun redirectToPasscodeEntryAndReturnFalse(
         request: HttpServletRequest,
         response: HttpServletResponse,
@@ -118,5 +121,9 @@ class PasscodeInterceptor(
     private fun redirectToPasscodeAlreadyUsedAndReturnFalse(response: HttpServletResponse): Boolean {
         response.sendRedirect(PASSCODE_ALREADY_USED_ROUTE)
         return false
+    }
+
+    companion object {
+        private val passcodeRoutes = listOf(PASSCODE_ENTRY_ROUTE, PASSCODE_ALREADY_USED_ROUTE)
     }
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/constants/SessionAttributes.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/constants/SessionAttributes.kt
@@ -23,3 +23,5 @@ const val LAST_GENERATED_PASSCODE = "lastGeneratedPasscode"
 const val SUBMITTED_PASSCODE = "submittedPasscode"
 
 const val PASSCODE_REDIRECT_URL = "passcodeRedirectUrl"
+
+const val HAS_USER_CLAIMED_A_PASSCODE = "hasUserClaimedAPasscode"

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/PasscodeService.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/PasscodeService.kt
@@ -4,6 +4,7 @@ import jakarta.servlet.http.HttpSession
 import jakarta.transaction.Transactional
 import org.springframework.context.annotation.Profile
 import uk.gov.communities.prsdb.webapp.annotations.PrsdbWebService
+import uk.gov.communities.prsdb.webapp.constants.HAS_USER_CLAIMED_A_PASSCODE
 import uk.gov.communities.prsdb.webapp.constants.LAST_GENERATED_PASSCODE
 import uk.gov.communities.prsdb.webapp.constants.SAFE_CHARACTERS_CHARSET
 import uk.gov.communities.prsdb.webapp.database.entity.Passcode
@@ -70,7 +71,8 @@ class PasscodeService(
         return passcodeRepository.existsByPasscode(normalizedPasscode)
     }
 
-    fun hasUserClaimedPasscode(userId: String) = passcodeRepository.existsByBaseUser_Id(userId)
+    fun hasUserClaimedAPasscode(userId: String) =
+        session.getAttribute(HAS_USER_CLAIMED_A_PASSCODE) as Boolean? == true || passcodeRepository.existsByBaseUser_Id(userId)
 
     fun findPasscode(passcodeString: String): Passcode? = passcodeRepository.findByPasscode(normalizePasscode(passcodeString))
 
@@ -88,6 +90,7 @@ class PasscodeService(
 
         val user = oneLoginUserService.findOrCreate1LUser(userId)
         passcode.claimByUser(user)
+        session.setAttribute(HAS_USER_CLAIMED_A_PASSCODE, true)
         return true
     }
 

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/PasscodeService.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/PasscodeService.kt
@@ -94,14 +94,6 @@ class PasscodeService(
         return true
     }
 
-    fun isPasscodeClaimedByUser(
-        passcodeString: String,
-        userId: String,
-    ): Boolean {
-        val passcode = findPasscode(passcodeString) ?: return false
-        return passcode.baseUser?.id == userId
-    }
-
     private fun generateRandomPasscodeString(): String =
         (1..PASSCODE_LENGTH)
             .map { SAFE_CHARACTERS_CHARSET.random() }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/config/interceptors/PasscodeInterceptorTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/config/interceptors/PasscodeInterceptorTests.kt
@@ -1,15 +1,18 @@
 package uk.gov.communities.prsdb.webapp.config.interceptors
 
-import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
 import jakarta.servlet.http.HttpSession
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.ArgumentMatchers.anyString
-import org.mockito.Mockito.mock
+import org.mockito.InjectMocks
+import org.mockito.Mock
 import org.mockito.Mockito.never
 import org.mockito.Mockito.verify
+import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.whenever
+import org.springframework.mock.web.MockHttpServletRequest
 import uk.gov.communities.prsdb.webapp.constants.PASSCODE_REDIRECT_URL
 import uk.gov.communities.prsdb.webapp.constants.SUBMITTED_PASSCODE
 import uk.gov.communities.prsdb.webapp.controllers.LandlordController.Companion.LANDLORD_DASHBOARD_URL
@@ -18,192 +21,166 @@ import uk.gov.communities.prsdb.webapp.controllers.PasscodeEntryController.Compa
 import uk.gov.communities.prsdb.webapp.controllers.PasscodeEntryController.Companion.PASSCODE_ENTRY_ROUTE
 import uk.gov.communities.prsdb.webapp.services.PasscodeService
 import uk.gov.communities.prsdb.webapp.testHelpers.mockObjects.MockLandlordData
-import java.security.Principal
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
+@ExtendWith(MockitoExtension::class)
 class PasscodeInterceptorTests {
-    private lateinit var passcodeService: PasscodeService
+    private val userId = "userId"
+
+    private val mockRequest = MockHttpServletRequest()
+
+    @Mock
+    private lateinit var mockSession: HttpSession
+
+    @Mock
+    private lateinit var mockResponse: HttpServletResponse
+
+    @Mock
+    private lateinit var mockPasscodeService: PasscodeService
+
+    @InjectMocks
     private lateinit var passcodeInterceptor: PasscodeInterceptor
-    private lateinit var request: HttpServletRequest
-    private lateinit var response: HttpServletResponse
-    private lateinit var session: HttpSession
-    private lateinit var principal: Principal
-    private val handler = Any()
 
     @BeforeEach
     fun setup() {
-        passcodeService = mock(PasscodeService::class.java)
-        passcodeInterceptor = PasscodeInterceptor(passcodeService)
-        request = mock(HttpServletRequest::class.java)
-        response = mock(HttpServletResponse::class.java)
-        session = mock(HttpSession::class.java)
-        principal = mock(Principal::class.java)
+        mockRequest.setSession(mockSession)
+    }
 
-        whenever(request.session).thenReturn(session)
+    private fun callPreHandle() = passcodeInterceptor.preHandle(mockRequest, mockResponse, handler = Any())
+
+    @Test
+    fun `preHandle allows authenticated users with a claimed passcode who aren't trying to access passcode routes`() {
+        mockRequest.requestURI = LANDLORD_DASHBOARD_URL
+        mockRequest.setUserPrincipal { userId }
+        whenever(mockPasscodeService.hasUserClaimedAPasscode(userId)).thenReturn(true)
+
+        assertTrue(callPreHandle())
+        verify(mockResponse, never()).sendRedirect(anyString())
+    }
+
+    @Test
+    fun `preHandle redirects authenticated users with a claimed passcode who are trying to access passcode routes`() {
+        mockRequest.requestURI = PASSCODE_ENTRY_ROUTE
+        mockRequest.setUserPrincipal { userId }
+        whenever(mockPasscodeService.hasUserClaimedAPasscode(userId)).thenReturn(true)
+
+        assertFalse(callPreHandle())
+        verify(mockResponse).sendRedirect(LANDLORD_DASHBOARD_URL)
     }
 
     @Test
     fun `preHandle allows non-landlord paths`() {
-        whenever(request.requestURI).thenReturn(LOCAL_AUTHORITY_DASHBOARD_URL)
+        mockRequest.requestURI = LOCAL_AUTHORITY_DASHBOARD_URL
 
-        val result = passcodeInterceptor.preHandle(request, response, handler)
-
-        assertTrue(result)
-        verify(response, never()).sendRedirect(anyString())
+        assertTrue(callPreHandle())
+        verify(mockResponse, never()).sendRedirect(anyString())
     }
 
     @Test
-    fun `preHandle allows passcode entry route`() {
-        whenever(request.requestURI).thenReturn(PASSCODE_ENTRY_ROUTE)
+    fun `preHandle allows passcode entry route when user has not claimed a passcode`() {
+        mockRequest.requestURI = PASSCODE_ENTRY_ROUTE
 
-        val result = passcodeInterceptor.preHandle(request, response, handler)
-
-        assertTrue(result)
-        verify(response, never()).sendRedirect(anyString())
+        assertTrue(callPreHandle())
+        verify(mockResponse, never()).sendRedirect(anyString())
     }
 
     @Test
-    fun `preHandle allows passcode already used route`() {
-        whenever(request.requestURI).thenReturn(PASSCODE_ALREADY_USED_ROUTE)
+    fun `preHandle allows passcode already used route when user has not claimed a passcode`() {
+        mockRequest.requestURI = PASSCODE_ENTRY_ROUTE
 
-        val result = passcodeInterceptor.preHandle(request, response, handler)
-
-        assertTrue(result)
-        verify(response, never()).sendRedirect(anyString())
+        assertTrue(callPreHandle())
+        verify(mockResponse, never()).sendRedirect(anyString())
     }
 
     @Test
-    fun `preHandle redirects unauthenticated user without passcode to entry page`() {
-        whenever(request.requestURI).thenReturn(LANDLORD_DASHBOARD_URL)
-        whenever(request.queryString).thenReturn("param=value")
-        whenever(request.userPrincipal).thenReturn(null)
-        whenever(session.getAttribute(SUBMITTED_PASSCODE)).thenReturn(null)
+    fun `preHandle redirects unauthenticated users without a session passcode to entry page`() {
+        mockRequest.requestURI = LANDLORD_DASHBOARD_URL
+        mockRequest.queryString = "param=value"
+        mockRequest.userPrincipal = null
+        whenever(mockSession.getAttribute(SUBMITTED_PASSCODE)).thenReturn(null)
 
-        val result = passcodeInterceptor.preHandle(request, response, handler)
-
-        assertFalse(result)
-        verify(session).setAttribute(PASSCODE_REDIRECT_URL, "$LANDLORD_DASHBOARD_URL?param=value")
-        verify(response).sendRedirect(PASSCODE_ENTRY_ROUTE)
+        assertFalse(callPreHandle())
+        verify(mockSession).setAttribute(PASSCODE_REDIRECT_URL, "$LANDLORD_DASHBOARD_URL?param=value")
+        verify(mockResponse).sendRedirect(PASSCODE_ENTRY_ROUTE)
     }
 
     @Test
-    fun `preHandle allows unauthenticated user with valid passcode in session`() {
-        whenever(request.requestURI).thenReturn(LANDLORD_DASHBOARD_URL)
-        whenever(request.userPrincipal).thenReturn(null)
-        whenever(session.getAttribute(SUBMITTED_PASSCODE)).thenReturn("ABCDEF")
+    fun `preHandle allows unauthenticated users with a session passcode`() {
+        mockRequest.requestURI = LANDLORD_DASHBOARD_URL
+        mockRequest.userPrincipal = null
+        whenever(mockSession.getAttribute(SUBMITTED_PASSCODE)).thenReturn("ABCDEF")
 
-        val result = passcodeInterceptor.preHandle(request, response, handler)
-
-        assertTrue(result)
-        verify(response, never()).sendRedirect(anyString())
+        assertTrue(callPreHandle())
+        verify(mockResponse, never()).sendRedirect(anyString())
     }
 
     @Test
-    fun `preHandle allows authenticated user who has claimed a passcode`() {
-        whenever(request.requestURI).thenReturn(LANDLORD_DASHBOARD_URL)
-        whenever(request.userPrincipal).thenReturn(principal)
-        whenever(principal.name).thenReturn("userID")
-        whenever(session.getAttribute(SUBMITTED_PASSCODE)).thenReturn(null)
-        whenever(passcodeService.hasUserClaimedPasscode("userID")).thenReturn(true)
+    fun `preHandle redirects authenticated users without a claimed or session passcode to entry page`() {
+        mockRequest.requestURI = LANDLORD_DASHBOARD_URL
+        mockRequest.setUserPrincipal { userId }
+        whenever(mockPasscodeService.hasUserClaimedAPasscode(userId)).thenReturn(false)
+        whenever(mockSession.getAttribute(SUBMITTED_PASSCODE)).thenReturn(null)
 
-        val result = passcodeInterceptor.preHandle(request, response, handler)
-
-        assertTrue(result)
-        verify(response, never()).sendRedirect(anyString())
+        assertFalse(callPreHandle())
+        verify(mockSession).setAttribute(PASSCODE_REDIRECT_URL, LANDLORD_DASHBOARD_URL)
+        verify(mockResponse).sendRedirect(PASSCODE_ENTRY_ROUTE)
     }
 
     @Test
-    fun `preHandle redirects authenticated user without claimed passcode to entry page`() {
-        whenever(request.requestURI).thenReturn(LANDLORD_DASHBOARD_URL)
-        whenever(request.userPrincipal).thenReturn(principal)
-        whenever(principal.name).thenReturn("userID")
-        whenever(session.getAttribute(SUBMITTED_PASSCODE)).thenReturn(null)
-        whenever(passcodeService.hasUserClaimedPasscode("userID")).thenReturn(false)
+    fun `preHandle redirects authenticated users without a claimed or valid session passcode to entry page`() {
+        mockRequest.requestURI = LANDLORD_DASHBOARD_URL
+        mockRequest.setUserPrincipal { userId }
+        whenever(mockPasscodeService.hasUserClaimedAPasscode(userId)).thenReturn(false)
+        val sessionPasscode = "INVALID"
+        whenever(mockSession.getAttribute(SUBMITTED_PASSCODE)).thenReturn(sessionPasscode)
+        whenever(mockPasscodeService.findPasscode(sessionPasscode)).thenReturn(null)
 
-        val result = passcodeInterceptor.preHandle(request, response, handler)
-
-        assertFalse(result)
-        verify(response).sendRedirect(PASSCODE_ENTRY_ROUTE)
+        assertFalse(callPreHandle())
+        verify(mockSession).setAttribute(PASSCODE_REDIRECT_URL, LANDLORD_DASHBOARD_URL)
+        verify(mockResponse).sendRedirect(PASSCODE_ENTRY_ROUTE)
     }
 
     @Test
-    fun `preHandle allows authenticated user with valid passcode claimed by same user`() {
-        whenever(request.requestURI).thenReturn(LANDLORD_DASHBOARD_URL)
-        whenever(request.userPrincipal).thenReturn(principal)
-        whenever(principal.name).thenReturn("userID")
-        whenever(session.getAttribute(SUBMITTED_PASSCODE)).thenReturn("ABCDEF")
-        val passcode = MockLandlordData.createPasscode(code = "ABCDEF", baseUser = MockLandlordData.createOneLoginUser("userID"))
-        whenever(passcodeService.findPasscode("ABCDEF")).thenReturn(passcode)
-        whenever(passcodeService.isPasscodeClaimedByUser("ABCDEF", "userID")).thenReturn(true)
-
-        val result = passcodeInterceptor.preHandle(request, response, handler)
-
-        assertTrue(result)
-        verify(response, never()).sendRedirect(anyString())
-    }
-
-    @Test
-    fun `preHandle redirects to already used page when passcode claimed by different user`() {
-        whenever(request.requestURI).thenReturn(LANDLORD_DASHBOARD_URL)
-        whenever(request.userPrincipal).thenReturn(principal)
-        whenever(principal.name).thenReturn("userID")
-        whenever(session.getAttribute(SUBMITTED_PASSCODE)).thenReturn("ABCDEF")
-        val passcode = MockLandlordData.createPasscode(code = "ABCDEF", baseUser = MockLandlordData.createOneLoginUser("otherUserID"))
-        whenever(passcodeService.findPasscode("ABCDEF")).thenReturn(passcode)
-        whenever(passcodeService.isPasscodeClaimedByUser("ABCDEF", "userID")).thenReturn(false)
-
-        val result = passcodeInterceptor.preHandle(request, response, handler)
-
-        assertFalse(result)
-        verify(response).sendRedirect(PASSCODE_ALREADY_USED_ROUTE)
-    }
-
-    @Test
-    fun `preHandle claims unclaimed passcode for authenticated user`() {
-        whenever(request.requestURI).thenReturn(LANDLORD_DASHBOARD_URL)
-        whenever(request.userPrincipal).thenReturn(principal)
-        whenever(principal.name).thenReturn("userID")
-        whenever(session.getAttribute(SUBMITTED_PASSCODE)).thenReturn("ABCDEF")
+    fun `preHandle allows authenticated users with a valid unclaimed session passcode to claim it`() {
+        mockRequest.requestURI = LANDLORD_DASHBOARD_URL
+        mockRequest.setUserPrincipal { userId }
         val passcode = MockLandlordData.createPasscode(code = "ABCDEF", baseUser = null)
-        whenever(passcodeService.findPasscode("ABCDEF")).thenReturn(passcode)
-        whenever(passcodeService.claimPasscodeForUser("ABCDEF", "userID")).thenReturn(true)
+        whenever(mockSession.getAttribute(SUBMITTED_PASSCODE)).thenReturn(passcode.passcode)
+        whenever(mockPasscodeService.findPasscode(passcode.passcode)).thenReturn(passcode)
+        whenever(mockPasscodeService.claimPasscodeForUser(passcode.passcode, userId)).thenReturn(true)
 
-        val result = passcodeInterceptor.preHandle(request, response, handler)
-
-        assertTrue(result)
-        verify(passcodeService).claimPasscodeForUser("ABCDEF", "userID")
-        verify(response, never()).sendRedirect(anyString())
+        assertTrue(callPreHandle())
+        verify(mockPasscodeService).claimPasscodeForUser(passcode.passcode, userId)
+        verify(mockResponse, never()).sendRedirect(anyString())
     }
 
     @Test
-    fun `preHandle redirects to entry page if claiming an unclaimed passcode for authenticated user fails`() {
-        whenever(request.requestURI).thenReturn(LANDLORD_DASHBOARD_URL)
-        whenever(request.userPrincipal).thenReturn(principal)
-        whenever(principal.name).thenReturn("userID")
-        whenever(session.getAttribute(SUBMITTED_PASSCODE)).thenReturn("ABCDEF")
+    fun `preHandle redirects authenticated users with a valid unclaimed session passcode to entry page if claiming it fails`() {
+        mockRequest.requestURI = LANDLORD_DASHBOARD_URL
+        mockRequest.setUserPrincipal { userId }
+        whenever(mockPasscodeService.hasUserClaimedAPasscode(userId)).thenReturn(false)
         val passcode = MockLandlordData.createPasscode(code = "ABCDEF", baseUser = null)
-        whenever(passcodeService.findPasscode("ABCDEF")).thenReturn(passcode)
-        whenever(passcodeService.claimPasscodeForUser("ABCDEF", "userID")).thenReturn(false)
+        whenever(mockSession.getAttribute(SUBMITTED_PASSCODE)).thenReturn(passcode.passcode)
+        whenever(mockPasscodeService.findPasscode(passcode.passcode)).thenReturn(passcode)
+        whenever(mockPasscodeService.claimPasscodeForUser(passcode.passcode, userId)).thenReturn(false)
 
-        val result = passcodeInterceptor.preHandle(request, response, handler)
-
-        assertFalse(result)
-        verify(passcodeService).claimPasscodeForUser("ABCDEF", "userID")
-        verify(response).sendRedirect(PASSCODE_ENTRY_ROUTE)
+        assertFalse(callPreHandle())
+        verify(mockPasscodeService).claimPasscodeForUser(passcode.passcode, userId)
+        verify(mockSession).setAttribute(PASSCODE_REDIRECT_URL, LANDLORD_DASHBOARD_URL)
+        verify(mockResponse).sendRedirect(PASSCODE_ENTRY_ROUTE)
     }
 
     @Test
-    fun `preHandle redirects to entry page when passcode not found`() {
-        whenever(request.requestURI).thenReturn(LANDLORD_DASHBOARD_URL)
-        whenever(request.userPrincipal).thenReturn(principal)
-        whenever(principal.name).thenReturn("userID")
-        whenever(session.getAttribute(SUBMITTED_PASSCODE)).thenReturn("INVALID")
-        whenever(passcodeService.findPasscode("INVALID")).thenReturn(null)
+    fun `preHandle redirects authenticated users who try to claim already-used passcodes to already used page`() {
+        mockRequest.requestURI = LANDLORD_DASHBOARD_URL
+        mockRequest.setUserPrincipal { userId }
+        whenever(mockPasscodeService.hasUserClaimedAPasscode(userId)).thenReturn(false)
+        val passcode = MockLandlordData.createPasscode(code = "ABCDEF", baseUser = MockLandlordData.createOneLoginUser())
+        whenever(mockSession.getAttribute(SUBMITTED_PASSCODE)).thenReturn(passcode.passcode)
+        whenever(mockPasscodeService.findPasscode(passcode.passcode)).thenReturn(passcode)
 
-        val result = passcodeInterceptor.preHandle(request, response, handler)
-
-        assertFalse(result)
-        verify(response).sendRedirect(PASSCODE_ENTRY_ROUTE)
+        assertFalse(callPreHandle())
+        verify(mockResponse).sendRedirect(PASSCODE_ALREADY_USED_ROUTE)
     }
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/PasscodeEntryFlowTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/PasscodeEntryFlowTests.kt
@@ -114,4 +114,20 @@ class PasscodeEntryFlowTests : IntegrationTestWithMutableData("data-passcode.sql
         navigator.navigateToLandlordRegistrationStartPage()
         assertPageIs(page, PasscodeEntryPage::class)
     }
+
+    @Test
+    fun `Users who have claimed a passcode can't access passcode pages`(page: Page) {
+        // Claim a passcode and redirect to previous page
+        navigator.navigateToLandlordDashboard()
+        val passcodeEntryPage = assertPageIs(page, PasscodeEntryPage::class)
+        passcodeEntryPage.submitPasscode("FREE01")
+        assertPageIs(page, LandlordDashboardPage::class)
+
+        // Try to access passcode pages
+        navigator.navigateToPasscodeEntryPage()
+        assertPageIs(page, LandlordDashboardPage::class)
+
+        navigator.navigateToPasscodeUsedPage()
+        assertPageIs(page, LandlordDashboardPage::class)
+    }
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/Navigator.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/Navigator.kt
@@ -23,6 +23,8 @@ import uk.gov.communities.prsdb.webapp.controllers.LocalAuthorityDashboardContro
 import uk.gov.communities.prsdb.webapp.controllers.ManageLocalAuthorityUsersController.Companion.getLaInviteNewUserRoute
 import uk.gov.communities.prsdb.webapp.controllers.ManageLocalAuthorityUsersController.Companion.getLaManageUsersRoute
 import uk.gov.communities.prsdb.webapp.controllers.PasscodeEntryController
+import uk.gov.communities.prsdb.webapp.controllers.PasscodeEntryController.Companion.PASSCODE_ALREADY_USED_ROUTE
+import uk.gov.communities.prsdb.webapp.controllers.PasscodeEntryController.Companion.PASSCODE_ENTRY_ROUTE
 import uk.gov.communities.prsdb.webapp.controllers.PropertyComplianceController
 import uk.gov.communities.prsdb.webapp.controllers.PropertyDetailsController
 import uk.gov.communities.prsdb.webapp.controllers.RegisterLAUserController
@@ -1243,6 +1245,14 @@ class Navigator(
     fun goToGeneratePasscodePage(): GeneratePasscodePage {
         navigate(GENERATE_PASSCODE_URL)
         return createValidPage(page, GeneratePasscodePage::class)
+    }
+
+    fun navigateToPasscodeEntryPage() {
+        navigate(PASSCODE_ENTRY_ROUTE)
+    }
+
+    fun navigateToPasscodeUsedPage() {
+        navigate(PASSCODE_ALREADY_USED_ROUTE)
     }
 
     fun navigateToLandlordDashboard() {

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/PasscodeServiceTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/PasscodeServiceTests.kt
@@ -327,25 +327,4 @@ class PasscodeServiceTests {
         verify(mockOneLoginUserService).findOrCreate1LUser(user.id)
         assertEquals(user, availablePasscode.baseUser)
     }
-
-    @Test
-    fun `isPasscodeClaimedByUser returns false if the passcode does not exist`() {
-        val passcode = "NON_EXISTENT"
-        whenever(mockPasscodeRepository.findByPasscode(passcode)).thenReturn(null)
-        assertFalse(passcodeService.isPasscodeClaimedByUser(passcode, "userId"))
-    }
-
-    @Test
-    fun `isPasscodeClaimedByUser returns false if the passcode is not claimed by the user`() {
-        val passcode = MockLandlordData.createPasscode(code = "TAKEN", baseUser = MockLandlordData.createOneLoginUser(id = "otherUserId"))
-        whenever(mockPasscodeRepository.findByPasscode(passcode.passcode)).thenReturn(passcode)
-        assertFalse(passcodeService.isPasscodeClaimedByUser(passcode.passcode, "userId"))
-    }
-
-    @Test
-    fun `isPasscodeClaimedByUser returns true if the passcode is claimed by the user`() {
-        val passcode = MockLandlordData.createPasscode(code = "CLAIMED", baseUser = MockLandlordData.createOneLoginUser(id = "userId"))
-        whenever(mockPasscodeRepository.findByPasscode(passcode.passcode)).thenReturn(passcode)
-        assertTrue(passcodeService.isPasscodeClaimedByUser(passcode.passcode, passcode.baseUser!!.id))
-    }
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/PasscodeServiceTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/PasscodeServiceTests.kt
@@ -17,6 +17,7 @@ import org.mockito.Mockito.never
 import org.mockito.Mockito.times
 import org.mockito.Mockito.verify
 import org.mockito.kotlin.whenever
+import uk.gov.communities.prsdb.webapp.constants.HAS_USER_CLAIMED_A_PASSCODE
 import uk.gov.communities.prsdb.webapp.constants.LAST_GENERATED_PASSCODE
 import uk.gov.communities.prsdb.webapp.constants.SAFE_CHARACTERS_CHARSET
 import uk.gov.communities.prsdb.webapp.database.entity.LocalAuthority
@@ -281,6 +282,22 @@ class PasscodeServiceTests {
 
         assertTrue(result)
         verify(mockPasscodeRepository).existsByPasscode(normalizedPasscode)
+    }
+
+    @Test
+    fun `hasUserClaimedAPasscode returns true if the HAS_USER_CLAIMED_A_PASSCODE flag is set in session`() {
+        whenever(mockSession.getAttribute(HAS_USER_CLAIMED_A_PASSCODE)).thenReturn(true)
+        assertTrue(passcodeService.hasUserClaimedAPasscode("userId"))
+    }
+
+    @Test
+    fun `hasUserClaimedAPasscode checks the database if the HAS_USER_CLAIMED_A_PASSCODE flag is not set in session`() {
+        val userId = "userId"
+        whenever(mockSession.getAttribute(HAS_USER_CLAIMED_A_PASSCODE)).thenReturn(null)
+        whenever(mockPasscodeRepository.existsByBaseUser_Id(userId)).thenReturn(true)
+
+        assertTrue(passcodeService.hasUserClaimedAPasscode(userId))
+        verify(mockPasscodeRepository).existsByBaseUser_Id(userId)
     }
 
     @Test


### PR DESCRIPTION
## Ticket number

PRSD-1166

## Goal of change

Prevent landlords from claiming more than one passcode

## Description of main change(s)

- Caches whether user has claimed a passcode
- Redirects landlords to the dashboard if they try to access passcode pages after claiming a passcode

## Anything you'd like to highlight to the reviewer?

N/A

## Checklist

Delete any that are not applicable, and add explanation below for any that are applicable but haven't been done

- [X] Unit tests for new logic (e.g. new service methods) have been added
- [X] New journey steps have been added to the appropriate journey integration test(s)
- [X] Test suite has been run in full locally and is passing
- [X] Branch has been rebased onto main and run locally, with everything working as expected (both for your new feature
  and any related functionality)