### PR TITLE
PRSD-1423: Sets passcode entry form's field width

### DIFF
--- a/src/main/resources/templates/fragments/forms/fixedWidthTextInput.html
+++ b/src/main/resources/templates/fragments/forms/fixedWidthTextInput.html
@@ -1,6 +1,6 @@
 <!--The fieldWidth input can be 2, 3, 4, 5, 10, 20, 30-->
 <!--See https://design-system.service.gov.uk/components/text-input/#fixed-width-inputs -->
-<th:block th:fragment="fixedWidthTextInput(label, fieldName, hint, fieldWidth)"
+<th:block th:fragment="fixedWidthTextInput(label, fieldName, hint, fieldWidth)" th:with="labelSize=${labelSize}"
           th:assert="${fieldWidth == 2 || fieldWidth == 3 || fieldWidth == 4 || fieldWidth ==  5 || fieldWidth ==  10 || fieldWidth ==  20 || fieldWidth ==  30}">
     <th:block th:replace="~{fragments/forms/innerTextInput :: innerTextInput(${label}, ${fieldName}, ${hint}, ${fieldWidth})}"></th:block>
 </th:block>

--- a/src/main/resources/templates/passcodeEntry.html
+++ b/src/main/resources/templates/passcodeEntry.html
@@ -12,7 +12,7 @@
         <p class="govuk-body" th:text="#{passcodeEntry.paragraph.three}">passcodeEntry.paragraph.three</p>
 
         <form th:action="@{''}" id="passcode-form" method="post" th:object="${passcodeRequestModel}" novalidate>
-            <input th:replace="~{fragments/forms/basicTextInput :: textInput(label=#{passcodeEntry.passcodeLabel}, fieldName='passcode', hint=null, labelSize='m')}">
+            <input th:replace="~{fragments/forms/fixedWidthTextInput :: fixedWidthTextInput(label=#{passcodeEntry.passcodeLabel}, fieldName='passcode', hint=null, fieldWidth=10, labelSize='m')}">
             <button th:replace="~{fragments/buttons/primaryButton :: primaryButton(#{forms.buttons.submit})}"></button>
         </form>
     </main>


### PR DESCRIPTION
## Ticket number

PRSD-1423

## Goal of change

Sets passcode entry form's field width

## Description of main change(s)

As above

## Anything you'd like to highlight to the reviewer?

N/A

## Checklist

Delete any that are not applicable, and add explanation below for any that are applicable but haven't been done

- [X] Screenshots of any UI changes have been added
- [X] Test suite has been run in full locally and is passing
- [X] Branch has been rebased onto main and run locally, with everything working as expected (both for your new feature
  and any related functionality)

##Screenshots
<img width="991" height="827" alt="image" src="https://github.com/user-attachments/assets/30782991-87f4-4bee-bf03-8b9c3085d2e0" />