### PR TITLE
PRSD-1516: QA fixes: 's to \u2019s; add missing space

### DIFF
--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -299,7 +299,7 @@ registerAsALandlord.whoCanAccess.onBehalf.bullet.two=a landlord can assign you p
 
 registerAsALandlord.access.heading=Access the PRS Database
 registerAsALandlord.access.paragraph.one=This is a private beta for the Private Rented Sector (PRS) Database. The service is being developed and tested with a small group of users.
-registerAsALandlord.access.paragraph.two.beforeLink=You'll need a
+registerAsALandlord.access.paragraph.two.beforeLink=You\u2019ll need a
 registerAsALandlord.access.paragraph.two.link=GOV.UK One Login
 registerAsALandlord.access.paragraph.two.afterLink=to use this service. You can create a GOV.UK One Login if you do not already have one.
 registerAsALandlord.access.paragraph.three.beforeLink=When you sign in, you may be asked to
@@ -308,7 +308,7 @@ registerAsALandlord.access.paragraph.three.afterLink=using photo ID like a passp
 
 registerAsALandlord.about.heading=About this service
 registerAsALandlord.about.paragraph.one.beforeLink=When the
-registerAsALandlord.about.paragraph.one.link=Renters' Rights Bill
+registerAsALandlord.about.paragraph.one.link=Renters\u2019 Rights Bill
 registerAsALandlord.about.paragraph.one.afterLink=becomes law, the Private Rented Sector (PRS) Database will collect information about private landlords and their rented properties in England.
 registerAsALandlord.about.paragraph.two=The database aims to give:
 registerAsALandlord.about.paragraph.two.bullet.one=local councils accurate data about rental properties in England
@@ -327,7 +327,7 @@ registerAsALandlord.about.paragraph.four.bullet.four=give feedback to help make 
 
 registerAsALandlord.howItWorks.heading=How this private beta works
 registerAsALandlord.howItWorks.paragraph.one=This private beta gives you an early look at parts of the database. The information is presented as if it\u2019s the live service so you can test and give feedback about how it might work in the future.
-registerAsALandlord.howItWorks.paragraph.two=The bill for this database has not become law yet, so there's no legal requirement for anyone to use or take part in this beta.
+registerAsALandlord.howItWorks.paragraph.two=The bill for this database has not become law yet, so there\u2019s no legal requirement for anyone to use or take part in this beta.
 registerAsALandlord.howItWorks.paragraph.three=This means:
 registerAsALandlord.howItWorks.paragraph.three.bullet.one=local councils cannot use any information you add to take enforcement action
 registerAsALandlord.howItWorks.paragraph.three.bullet.two=there are no penalties if the information is wrong or incomplete
@@ -337,10 +337,10 @@ registerAsALandlord.howItWorks.paragraph.four.bullet.two=use real data or test d
 registerAsALandlord.howItWorks.paragraph.four.bullet.three=delete your account at any time
 registerAsALandlord.howItWorks.paragraph.five=When this private beta ends:
 registerAsALandlord.howItWorks.paragraph.five.bullet.one=Your account will be deleted
-registerAsALandlord.howItWorks.paragraph.five.bullet.two=All information you've added will be permanently removed from the system
+registerAsALandlord.howItWorks.paragraph.five.bullet.two=All information you\u2019ve added will be permanently removed from the system
 
 registerAsALandlord.futureRequirements.heading=Future requirements for landlords
-registerAsALandlord.futureRequirements.paragraph.one=The Renters' Rights Bill will introduce changes to how private properties are let out.
+registerAsALandlord.futureRequirements.paragraph.one=The Renters\u2019 Rights Bill will introduce changes to how private properties are let out.
 registerAsALandlord.futureRequirements.paragraph.two.beforeLink=Once the bill becomes law, all landlords of assured and regulated tenancies must register on the
 registerAsALandlord.futureRequirements.paragraph.two.link=Private Rented Sector (PRS) Database (opens in new tab)
 registerAsALandlord.futureRequirements.paragraph.two.afterLink=.
@@ -358,10 +358,10 @@ registerAsALandlord.howYouCanHelp.paragraph.two=Only selected local councils and
 registerAsALandlord.howYouCanHelp.paragraph.three=This service will change. Your feedback will be used to test and shape new features as it develops.
 
 registerAsALandlord.informationManagement.heading=How information is used and managed
-registerAsALandlord.informationManagement.paragraph.one=If you choose to register for this private beta, you'll be asked for:
+registerAsALandlord.informationManagement.paragraph.one=If you choose to register for this private beta, you\u2019ll be asked for:
 registerAsALandlord.informationManagement.paragraph.one.bullet.one=your personal details
 registerAsALandlord.informationManagement.paragraph.one.bullet.two=details about your rental properties
-registerAsALandlord.informationManagement.paragraph.one.bullet.three=compliance information for your rental properties (for example,gas safety certificates)
+registerAsALandlord.informationManagement.paragraph.one.bullet.three=compliance information for your rental properties (for example, gas safety certificates)
 registerAsALandlord.informationManagement.heading.two=How local councils can use your information
 registerAsALandlord.informationManagement.paragraph.two=Local councils taking part in this private beta can view information you\u2019ve added. This helps them understand how the database might work.
 registerAsALandlord.informationManagement.paragraph.three=They cannot use this information to take enforcement action against you, like issuing you a fine.
@@ -371,7 +371,7 @@ registerAsALandlord.informationManagement.paragraph.five.beforeLink=Read the
 registerAsALandlord.informationManagement.paragraph.five.link=privacy notice (opens in a new tab)
 registerAsALandlord.informationManagement.paragraph.five.afterLink=to understand how your data will be used and managed in more detail.
 registerAsALandlord.informationManagement.paragraph.six=You must agree to the privacy notice before registering. You\u2019ll be asked to confirm this during the registration process.
-registerAsALandlord.informationManagement.paragraph.seven=You'll get an email if the privacy notice changes.
+registerAsALandlord.informationManagement.paragraph.seven=You\u2019ll get an email if the privacy notice changes.
 
 registerAsALandlord.checkAnswers.summaryName=Your details
 registerAsALandlord.checkAnswers.rowHeading.name=Name


### PR DESCRIPTION
## Ticket number

PRSD-1516

## Goal of change

Resolve minor copy tweaks suggested in QA

## Description of main change(s)

* Turned `'`s into `\u2018`s
* Added a missing space

(These were both pre-existing issues, not introduced in PRSD-1516, but we'll fix while we're here)

## Anything you'd like to highlight to the reviewer?

N/A

## Checklist

Delete any that are not applicable, and add explanation below for any that are applicable but haven't been done

- [x] Screenshots of any UI changes have been added
- [x] Test suite has been run in full locally and is passing
- [x] Branch has been rebased onto main and run locally, with everything working as expected (both for your new feature
  and any related functionality)
