### PR TITLE
PRSD-1418: Revisit cert. upload page without re-uploading

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/PropertyComplianceJourney.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/PropertyComplianceJourney.kt
@@ -112,7 +112,6 @@ class PropertyComplianceJourney(
         }
     }
 
-    private val isCheckingAnswers = checkingAnswersForStep != null
     private val checkingAnswersFor = PropertyComplianceStepId.entries.find { it.urlPathSegment == checkingAnswersForStep }
 
     override val stepRouter = GroupedStepRouter(this)
@@ -122,7 +121,7 @@ class PropertyComplianceJourney(
         PropertyComplianceSharedStepFactory(
             defaultSaveAfterSubmit = true,
             isUpdateJourney = false,
-            isCheckingAnswers = isCheckingAnswers,
+            checkingAnswersFor = checkingAnswersFor,
             journeyDataService = journeyDataService,
             epcCertificateUrlProvider = epcCertificateUrlProvider,
             certificateUploadService = certificateUploadService,

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/PropertyComplianceUpdateJourney.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/journeys/PropertyComplianceUpdateJourney.kt
@@ -84,14 +84,12 @@ class PropertyComplianceUpdateJourney(
 
     private val checkingAnswersFor = PropertyComplianceStepId.entries.find { it.urlPathSegment == checkingAnswersForStep }
 
-    private val isCheckingAnswers = checkingAnswersForStep != null
-
     private val stepFactory
         get() =
             PropertyComplianceSharedStepFactory(
                 defaultSaveAfterSubmit = false,
                 isUpdateJourney = true,
-                isCheckingAnswers = isCheckingAnswers,
+                checkingAnswersFor = checkingAnswersFor,
                 journeyDataService = journeyDataService,
                 epcCertificateUrlProvider = epcCertificateUrlProvider,
                 certificateUploadService = certificateUploadService,

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -985,6 +985,7 @@ forms.buttons.continueToCheckEpc=Continue to check EPC
 forms.buttons.continueToSearch=Continue to search
 forms.buttons.confirmAndSubmitCompliance=Confirm and submit compliance information
 forms.buttons.returnToPropertyRecord=Return to property record
+forms.buttons.uploadAndContinue=Upload and continue
 
 forms.links.change=Change
 forms.links.view=View
@@ -1434,6 +1435,13 @@ forms.uploadCertificate.eicr.error.missing=Select an EICR
 forms.uploadCertificate.error.wrongType=The selected file must be a PDF, PNG or JPG
 forms.uploadCertificate.error.tooBig=The selected file must be smaller than 15MB
 forms.uploadCertificate.error.unsuccessfulUpload=The selected file could not be uploaded - try again
+forms.uploadCertificate.noScript=You do not have JavaScript enabled.
+forms.uploadCertificate.insetText=You have already uploaded a file. If you upload a new file, you will replace the existing one.
+forms.uploadCertificate.continueLink=Continue with existing file
+forms.uploadCertificate.details.heading=If your file is too big
+forms.uploadCertificate.details.bullet.heading=To make the file smaller, try these steps:
+forms.uploadCertificate.details.bullet.one=Use an image editing tool or online file compressor to make the file smaller
+forms.uploadCertificate.details.bullet.two=Save the file as a PDF with a smaller resolution size
 
 forms.uploadCertificateConfirmation.heading=Your file is being scanned
 forms.uploadCertificateConfirmation.paragraph=Your file will be scanned for viruses. It will upload automatically if there are no issues found.

--- a/src/main/resources/templates/forms/uploadCertificateForm.html
+++ b/src/main/resources/templates/forms/uploadCertificateForm.html
@@ -4,13 +4,26 @@
 <!--/*@thymesVar id="sectionHeaderInfo" type="uk.gov.communities.prsdb.webapp.models.viewModels.SectionHeaderViewModel"*/-->
 <!--/*@thymesVar id="fieldSetHeading" type="java.lang.String"*/-->
 <!--/*@thymesVar id="fieldSetHint" type="java.lang.String"*/-->
+<!--/*@thymesVar id="alreadyUploaded" type="java.lang.Boolean"*/-->
+<!--/*@thymesVar id="nextStepUrl" type="java.lang.String"*/-->
 <!DOCTYPE html>
-<html id="form-content" th:replace="~{fragments/forms/questionPage :: questionPage(title=#{${title}}, formModel=${formModel}, formContent=~{::#form-content/content()}, backUrl=${backUrl}, sectionHeaderInfo=${sectionHeaderInfo}, enctype='multipart/form-data', formId='single-file-upload-form')}">
-    <th:block id="fieldset-content" th:replace="~{fragments/forms/fieldSet :: fieldSet(~{::#fieldset-content/content()}, 'certificate', #{${fieldSetHeading}}, #{${fieldSetHint}})}">
+<html id="form" th:replace="~{fragments/forms/questionPage :: questionPage(title=#{${title}}, formModel=${formModel}, formContent=~{::#form/content()}, backUrl=${backUrl}, sectionHeaderInfo=${sectionHeaderInfo}, enctype='multipart/form-data', formId='single-file-upload-form')}">
+    <th:block id="fieldset" th:replace="~{fragments/forms/fieldSet :: fieldSet(~{::#fieldset/content()}, 'certificate', #{${fieldSetHeading}}, #{${fieldSetHint}})}">
         <div th:replace="~{fragments/forms/fileUpload :: fileUpload(#{forms.uploadCertificate.label}, 'certificate', null)}"></div>
     </th:block>
-    <noscript>
-        <div th:replace="~{fragments/warningText :: warningText('You do not have JavaScript enabled.')}">warning</div>
-    </noscript>
-    <button th:replace="~{fragments/buttons/primaryButton :: primaryButton(#{forms.buttons.saveAndContinue})}"></button>
+    <noscript th:insert="~{fragments/warningText :: warningText(#{forms.uploadCertificate.noScript})}"></noscript>
+    <div th:if="${alreadyUploaded}" class="govuk-inset-text" th:text="#{forms.uploadCertificate.insetText}">forms.uploadCertificate.insetText</div>
+    <div class="govuk-button-group">
+        <button th:replace="~{fragments/buttons/primaryButton :: primaryButton(#{forms.buttons.uploadAndContinue})}">forms.buttons.uploadAndContinue</button>
+        <a th:if="${alreadyUploaded}" class="govuk-link" th:text="#{forms.uploadCertificate.continueLink}" th:href="${nextStepUrl}">forms.uploadCertificate.continueLink</a>
+    </div>
+    <div id="details" th:replace="~{fragments/details :: details(#{forms.uploadCertificate.details.heading}, ~{::#details/content()})}">
+        <div class="govuk-details__text">
+            <p th:text="#{forms.uploadCertificate.details.bullet.heading}">forms.uploadCertificate.details.bullet.heading</p>
+            <ul class="govuk-list govuk-list--bullet">
+                <li th:text="#{forms.uploadCertificate.details.bullet.one}">forms.uploadCertificate.details.bullet.one</li>
+                <li th:text="#{forms.uploadCertificate.details.bullet.two}">forms.uploadCertificate.details.bullet.two</li>
+            </ul>
+        </div>
+    </div>
 </html>

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/PropertyComplianceJourneyTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/PropertyComplianceJourneyTests.kt
@@ -701,6 +701,74 @@ class PropertyComplianceJourneyTests : IntegrationTestWithMutableData("data-loca
     }
 
     @Test
+    fun `User does not have to re-upload their certs when they re-visit upload pages`(page: Page) {
+        // Prefill journey answers
+        var checkAndSubmitPage = navigator.skipToPropertyComplianceCheckAnswersPage(PROPERTY_OWNERSHIP_ID)
+
+        // Upload initial Gas Safety Cert.
+        checkAndSubmitPage.form.gasSummaryList.statusRow
+            .clickActionLinkAndWait()
+        val gasSafetyPage = assertPageIs(page, GasSafetyPagePropertyCompliance::class, urlArguments)
+        gasSafetyPage.submitHasCert()
+
+        val gasSafetyIssueDatePage = assertPageIs(page, GasSafetyIssueDatePagePropertyCompliance::class, urlArguments)
+        gasSafetyIssueDatePage.submitDate(currentDate)
+
+        var gasSafeEngineerNumPage = assertPageIs(page, GasSafeEngineerNumPagePropertyCompliance::class, urlArguments)
+        gasSafeEngineerNumPage.submitEngineerNum("1234567")
+
+        whenever(fileUploader.uploadFile(any(), any())).thenReturn(UploadedFileLocator("validGasSafety", "mockETag", "mockVersionId"))
+        var gasSafetyUploadPage = assertPageIs(page, GasSafetyUploadPagePropertyCompliance::class, urlArguments)
+        BaseComponent.assertThat(gasSafetyUploadPage.continueLink).isHidden()
+        gasSafetyUploadPage.uploadCertificate("validFile.png")
+
+        var gasSafetyUploadConfirmationPage = assertPageIs(page, GasSafetyUploadConfirmationPagePropertyCompliance::class, urlArguments)
+        gasSafetyUploadConfirmationPage.saveAndContinueButton.clickAndWait()
+        checkAndSubmitPage = assertPageIs(page, CheckAndSubmitPagePropertyCompliance::class, urlArguments)
+
+        // Upload initial EICR
+        checkAndSubmitPage.form.eicrSummaryList.statusRow
+            .clickActionLinkAndWait()
+        val eicrPage = assertPageIs(page, EicrPagePropertyCompliance::class, urlArguments)
+        eicrPage.submitHasCert()
+
+        var eicrIssueDatePage = assertPageIs(page, EicrIssueDatePagePropertyCompliance::class, urlArguments)
+        eicrIssueDatePage.submitDate(currentDate)
+
+        whenever(fileUploader.uploadFile(any(), any())).thenReturn(UploadedFileLocator("validEicr", "mockETag", "mockVersionId"))
+        var eicrUploadPage = assertPageIs(page, EicrUploadPagePropertyCompliance::class, urlArguments)
+        BaseComponent.assertThat(eicrUploadPage.continueLink).isHidden()
+        eicrUploadPage.uploadCertificate("validFile.png")
+
+        val eicrUploadConfirmationPage = assertPageIs(page, EicrUploadConfirmationPagePropertyCompliance::class, urlArguments)
+        eicrUploadConfirmationPage.saveAndContinueButton.clickAndWait()
+        checkAndSubmitPage = assertPageIs(page, CheckAndSubmitPagePropertyCompliance::class, urlArguments)
+
+        // Revisit Gas Safety Cert. Upload page without re-uploading
+        checkAndSubmitPage.form.gasSummaryList.engineerNumRow
+            .clickActionLinkAndWait()
+        gasSafeEngineerNumPage = assertPageIs(page, GasSafeEngineerNumPagePropertyCompliance::class, urlArguments)
+        gasSafeEngineerNumPage.form.submit()
+
+        gasSafetyUploadPage = assertPageIs(page, GasSafetyUploadPagePropertyCompliance::class, urlArguments)
+        gasSafetyUploadPage.continueLink.clickAndWait()
+
+        gasSafetyUploadConfirmationPage = assertPageIs(page, GasSafetyUploadConfirmationPagePropertyCompliance::class, urlArguments)
+        gasSafetyUploadConfirmationPage.saveAndContinueButton.clickAndWait()
+        checkAndSubmitPage = assertPageIs(page, CheckAndSubmitPagePropertyCompliance::class, urlArguments)
+
+        // Revisit EICR Upload page without re-uploading
+        checkAndSubmitPage.form.eicrSummaryList.issueDateRow
+            .clickActionLinkAndWait()
+        eicrIssueDatePage = assertPageIs(page, EicrIssueDatePagePropertyCompliance::class, urlArguments)
+        eicrIssueDatePage.form.submit()
+
+        eicrUploadPage = assertPageIs(page, EicrUploadPagePropertyCompliance::class, urlArguments)
+        eicrUploadPage.continueLink.clickAndWait()
+        assertPageIs(page, EicrUploadConfirmationPagePropertyCompliance::class, urlArguments)
+    }
+
+    @Test
     fun `User is not shown feedback page again if they choose give feedback later`(page: Page) {
         val checkAndSubmitPage = navigator.skipToPropertyComplianceCheckAnswersPage(PROPERTY_OWNERSHIP_ID)
         checkAndSubmitPage.form.submit()

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/components/SummaryList.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/components/SummaryList.kt
@@ -5,9 +5,9 @@ import com.microsoft.playwright.Page
 
 open class SummaryList(
     parentLocator: Locator,
-    index: Int = 0,
-) : BaseComponent(parentLocator.locator(".govuk-summary-list").nth(index)) {
-    constructor(page: Page, index: Int = 0) : this(page.locator("html"), index)
+    index: Int? = null,
+) : BaseComponent(if (index != null) parentLocator.locator(DEFAULT_SELECCTOR).nth(index) else parentLocator.locator(DEFAULT_SELECCTOR)) {
+    constructor(page: Page, index: Int? = null) : this(page.locator("html"), index)
 
     protected fun getRow(key: String) = SummaryListRow.byKey(locator, key)
 
@@ -43,5 +43,9 @@ open class SummaryList(
         parentLocator: Locator,
     ) : BaseComponent(parentLocator.locator(".govuk-summary-list__actions")) {
         val actionLink = Link.default(locator)
+    }
+
+    companion object {
+        private const val DEFAULT_SELECCTOR = ".govuk-summary-list"
     }
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/components/SummaryList.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/components/SummaryList.kt
@@ -5,8 +5,9 @@ import com.microsoft.playwright.Page
 
 open class SummaryList(
     parentLocator: Locator,
-) : BaseComponent(parentLocator.locator(".govuk-summary-list")) {
-    constructor(page: Page) : this(page.locator("html"))
+    index: Int = 0,
+) : BaseComponent(parentLocator.locator(".govuk-summary-list").nth(index)) {
+    constructor(page: Page, index: Int = 0) : this(page.locator("html"), index)
 
     protected fun getRow(key: String) = SummaryListRow.byKey(locator, key)
 

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/basePages/UploadCertificateFormPage.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/basePages/UploadCertificateFormPage.kt
@@ -6,6 +6,7 @@ import com.microsoft.playwright.options.FormData
 import com.microsoft.playwright.options.RequestOptions
 import org.springframework.util.ResourceUtils
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.FileUpload
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.Link
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.PostForm
 
 abstract class UploadCertificateFormPage(
@@ -13,6 +14,7 @@ abstract class UploadCertificateFormPage(
     urlSegment: String,
 ) : BasePage(page, urlSegment) {
     val form = UploadCertificateForm(page)
+    val continueLink = Link.byText(page, "Continue with existing file")
 
     fun uploadCertificate(fileName: String) {
         val filePath = ResourceUtils.getFile("classpath:data/certificates/$fileName").path

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/propertyComplianceJourneyPages/CheckAndSubmitPagePropertyCompliance.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/propertyComplianceJourneyPages/CheckAndSubmitPagePropertyCompliance.kt
@@ -4,6 +4,7 @@ import com.microsoft.playwright.Page
 import uk.gov.communities.prsdb.webapp.controllers.PropertyComplianceController
 import uk.gov.communities.prsdb.webapp.forms.steps.PropertyComplianceStepId
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.PostForm
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.SummaryList
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages.BasePage
 
 class CheckAndSubmitPagePropertyCompliance(
@@ -14,5 +15,26 @@ class CheckAndSubmitPagePropertyCompliance(
         PropertyComplianceController.getPropertyCompliancePath(urlArguments["propertyOwnershipId"]!!.toLong()) +
             "/${PropertyComplianceStepId.CheckAndSubmit.urlPathSegment}",
     ) {
-    val form = PostForm(page)
+    val form = CheckAndSubmitPagePropertyComplianceForm(page)
+
+    class CheckAndSubmitPagePropertyComplianceForm(
+        page: Page,
+    ) : PostForm(page) {
+        val gasSummaryList = GasSummaryList(page)
+        val eicrSummaryList = EicrSummaryList(page)
+    }
+
+    class GasSummaryList(
+        page: Page,
+    ) : SummaryList(page, index = 0) {
+        val statusRow = SummaryListRow.byKey(locator, "Gas safety certificate")
+        val engineerNumRow = SummaryListRow.byKey(locator, "Gas Safe engineer number")
+    }
+
+    class EicrSummaryList(
+        page: Page,
+    ) : SummaryList(page, index = 1) {
+        val statusRow = SummaryListRow.byKey(locator, "Electrical installation condition report (EICR)")
+        val issueDateRow = SummaryListRow.byKey(locator, "Issue date")
+    }
 }


### PR DESCRIPTION
## Ticket number

PRSD-1418

## Goal of change

Updates certificate upload page to match new designs

## Description of main change(s)

- Updates certificate form's content to match new designs
- Adds logic for conditionally showing content to users who've already uploaded a certificate

## Anything you'd like to highlight to the reviewer?

- This PR doesn't complete the ticket

## Checklist

Delete any that are not applicable, and add explanation below for any that are applicable but haven't been done

- [X] Screenshots of any UI changes have been added
- [X] New journey steps have been added to the appropriate journey integration test(s)
- [X] Test suite has been run in full locally and is passing
- [X] Branch has been rebased onto main and run locally, with everything working as expected (both for your new feature
  and any related functionality)

## Screenshots
- First visit to cert upload page
<img width="967" height="939" alt="image" src="https://github.com/user-attachments/assets/f722f259-27bd-448c-95b1-a426d028e45f" />

- Subsequent visits to cert upload page (if file uploaded)
<img width="976" height="1004" alt="image" src="https://github.com/user-attachments/assets/6e56252b-b1a0-4745-bc40-b11fd6a9195c" />