### PR TITLE
PRSD-1508: Add declaration message to CYA page landlord registration

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/pages/LandlordRegistrationCheckAnswersPage.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/forms/pages/LandlordRegistrationCheckAnswersPage.kt
@@ -14,6 +14,7 @@ class LandlordRegistrationCheckAnswersPage(
             mapOf(
                 "title" to "registerAsALandlord.title",
                 "summaryName" to "registerAsALandlord.checkAnswers.summaryName",
+                "showWarning" to true,
                 "submitButtonText" to "forms.buttons.confirmAndContinue",
             ),
         journeyDataService = journeyDataService,

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -1290,7 +1290,7 @@ forms.update.checkLicensing.update.summaryName=You have updated the property lic
 forms.update.checkLicensing.remove.summaryName=You have removed this property\u2019s licence
 forms.update.checkOccupancy.summaryName=You have updated whether the property is occupied by tenants
 forms.update.warning=You must not provide any false or misleading information on the database. By submitting this information, you agree it\u2019s accurate to the best of your knowledge at the time of updating.
-forms.warning=Do not provide any false or misleading information on the database. By submitting this information, you agree it\u2019s accurate to the best of your knowledge.
+forms.warning=Do not provide any false or misleading information on the database. By submitting this information, you confirm it\u2019s accurate to the best of your knowledge.
 
 forms.update.gasSafetyType.fieldSetHeading=Do you want to add a new gas safety certificate or add an exemption?
 forms.update.gasSafetyType.certificate=Add a new gas safety certificate

--- a/src/main/resources/templates/forms/checkAnswersForm.html
+++ b/src/main/resources/templates/forms/checkAnswersForm.html
@@ -15,7 +15,7 @@
     <h2 class="govuk-heading-m" th:text="#{${summaryName}}"></h2>
     <dl th:replace="~{fragments/summaryList :: summaryList(${summaryListData})}"></dl>
     <th:block th:if="${showWarning}">
-        <div th:replace="~{fragments/warningText :: warningText(#{forms.update.warning})}">forms.update.warning</div>
+        <div th:replace="~{fragments/warningText :: warningText(#{forms.warning})}">forms.update.warning</div>
     </th:block>
     <input type="hidden" name="submittedFilteredJourneyData" th:value="${submittedFilteredJourneyData}"/>
     <button th:replace="~{fragments/buttons/primaryButton :: primaryButton(#{${submitButtonText}})}"></button>


### PR DESCRIPTION
## Ticket number

PRSD-1508

## Goal of change

Add declaration message to CYA page landlord registration

## Description of main change(s)

As Above

## Anything you'd like to highlight to the reviewer?

This should be merged before PR: https://github.com/communitiesuk/prsdb-webapp/pull/723

## Screenshots

### After
<img width="720" height="707" alt="image" src="https://github.com/user-attachments/assets/ef25af2b-906d-4731-86af-a260d920f86e" />


### Before
<img width="720" height="557" alt="image" src="https://github.com/user-attachments/assets/6c6aa12e-77c4-4c6e-a726-397260ca25a9" />


## Checklist

- [X] Screenshots of any UI changes have been added
- [x] Test suite has been run in full locally and is passing
- [X] Branch has been rebased onto main and run locally, with everything working as expected (both for your new feature
  and any related functionality)
