### PR TITLE
PRSD-NONE: Add a new manual Deploy pipeline 

### DIFF
--- a/.github/workflows/deploy-integration.yml
+++ b/.github/workflows/deploy-integration.yml
@@ -1,0 +1,14 @@
+name: Deploy - Integration
+on: workflow_dispatch
+
+jobs:
+  build-and-deploy-integration:
+    uses: ./.github/workflows/deploy.yml
+    with:
+      environment: "integration"
+      build-and-deploy-role: "arn:aws:iam::794038239680:role/integration-push-image"
+      update-ecs-role: "arn:aws:iam::794038239680:role/github-actions-terraform-admin"
+      ecr-repository: "integration-webapp"
+      account-id: "794038239680"
+      branch: "main"
+    secrets: inherit

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -1,0 +1,14 @@
+name: Deploy - Production
+on: workflow_dispatch
+
+jobs:
+  build-and-deploy-production:
+    uses: ./.github/workflows/deploy.yml
+    with:
+      environment: "production"
+      build-and-deploy-role: "arn:aws:iam::879161327637:role/production-push-image"
+      update-ecs-role: "arn:aws:iam::879161327637:role/github-actions-terraform-admin"
+      ecr-repository: "production-webapp"
+      account-id: "879161327637"
+      branch: "production"
+    secrets: inherit

--- a/.github/workflows/deploy-test.yml
+++ b/.github/workflows/deploy-test.yml
@@ -1,0 +1,14 @@
+name: Deploy - Test
+on: workflow_dispatch
+
+jobs:
+  build-and-deploy-integration:
+    uses: ./.github/workflows/deploy.yml
+    with:
+      environment: "test"
+      build-and-deploy-role: "arn:aws:iam::869935096717:role/test-push-image"
+      update-ecs-role: "arn:aws:iam::869935096717:role/github-actions-terraform-admin"
+      ecr-repository: "test-webapp"
+      account-id: "869935096717"
+      branch: "test"
+    secrets: inherit

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,128 @@
+name: Deploy
+description: Build and deploy the application to the specified environment without running tests or database migrations.
+on:
+  workflow_call:
+    inputs:
+      environment:
+        description: "Select deployment environment"
+        required: true
+        type: string
+      build-and-deploy-role:
+        description: "Developer role used to deploy the environment"
+        required: true
+        type: string
+      update-ecs-role:
+        description: "Developer role used to update the ecs task definition"
+        required: true
+        type: string
+      ecr-repository:
+        description: "Name of the ecr repository for the build image"
+        required: true
+        type: string
+      account-id:
+        description: "Id of the AWS account containing the target environment"
+        required: true
+        type: string
+      branch:
+        required: true
+        type: string
+    secrets:
+      ONE_LOGIN_PRIVATE_KEY:
+        required: true
+      ONE_LOGIN_PUBLIC_KEY:
+        required: true
+      NOTIFY_KEY:
+        required: true
+      SLACK_WEBHOOK:
+        required: true
+
+jobs:
+  build-and-deploy:
+    name: Build and Deploy
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    env:
+      AWS_REGION: "eu-west-2"
+    outputs:
+      image_name: ${{ steps.build-image.outputs.image_name }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'corretto'
+          java-version: 17
+          cache: 'gradle'
+
+      - name: Install node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+      - run: npm ci
+      - run: npm run build
+
+      - name: Get latest version tag for minor version
+        id: get-latest-tag
+        uses: oprypin/find-latest-tag@v1
+        with:
+          repository: communitiesuk/prsdb-webapp
+          prefix: 'v0.'
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ inputs.build-and-deploy-role }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Build, tag, and push image to Amazon ECR
+        id: build-image
+        env:
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          ECR_REPOSITORY: ${{ inputs.ecr-repository }}
+          IMAGE_TAG: "${{ steps.get-latest-tag.outputs.tag }}-${{ github.sha }}"
+        run: |
+          ./gradlew bootBuildImage
+          IMAGE=$ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG
+          docker tag prsdb-webapp:latest $IMAGE
+          docker push $IMAGE
+          echo "image_name=$IMAGE" >> $GITHUB_OUTPUT
+
+  update-task-definition:
+    name: Update task definition
+    needs: build-and-deploy
+    permissions:
+      id-token: write
+      contents: read
+    uses: communitiesuk/prsdb-infra/.github/workflows/update-task-definition.yml@main
+    with:
+      environment_name: ${{ inputs.environment }}
+      account_id: ${{ inputs.account-id }}
+      image_name: ${{ needs.build-and-deploy.outputs.image_name }}
+
+  update-ecs-service:
+    name: Update ECS service
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    env:
+      AWS_REGION: "eu-west-2"
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ inputs.update-ecs-role }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Redeploy ECS service
+        run: |
+          aws ecs update-service --cluster ${{ inputs.environment }}-app --service ${{ inputs.environment }}-app --task-definition prsdb-webapp-${{ inputs.environment }} --force-new-deployment


### PR DESCRIPTION
## Ticket number

PRSD-NONE

## Goal of change

Add new "Deploy" pipeline for quickly redeploying the webapp when we have change the infrastructure

## Description of main change(s)

Add "Deploy" pipelines with manual triggers.
These are the same as the existing "Build and Deploy" pipelines but without the (slow) testing and database migration jobs. I also took out the slack reporting job but that might not be sensible

## Anything you'd like to highlight to the reviewer?

I'm not 100% sure this is doing what we want, but the aim was to have a job we can trigger manually which will deploy a new task definition with the latest webapp image when we have made infrastructure changes.

## Checklist

Delete any that are not applicable, and add explanation below for any that are applicable but haven't been done

- [ ] Screenshots of any UI changes have been added
- [ ] Unit tests for new logic (e.g. new service methods) have been added
- [ ] Controller tests for any new endpoints, including testing the relevant permissions
- [ ] Single page integration tests have been added for any unhappy-flow UI features, e.g. validation errors
- [ ] New journey steps have been added to the appropriate journey integration test(s)
- [ ] A new journey integration test has been added for any new journeys
- [ ] New email templates have been added to `/src/main/kotlin/resources/emails/emailTemplates.json`
- [ ] Test suite has been run in full locally and is passing
- [ ] Branch has been rebased onto main and run locally, with everything working as expected (both for your new feature
  and any related functionality)
- [ ] TODO comments referencing this JIRA ticket have been searched for and removed - if a future PR will address them,
  mention that here
- [ ] Seed data has been updated as needed for your feature to be tested without having to e.g. register a new property
- [ ] Any special release instructions (e.g. the database will need resetting) have been added as checklist items to a draft PR (merging `main` into `test`) for the next release
