### PR TITLE
PRSD-1510: Remove back link from give feedback page

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/BetaFeedbackController.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/BetaFeedbackController.kt
@@ -92,7 +92,6 @@ class BetaFeedbackController(
         model.addAttribute("formModel", formModel)
         val referrer = request.getHeader("referer")
         model.addAttribute("referrerHeader", referrer)
-        model.addAttribute("backUrl", referrer)
         return "betaBannerFeedback"
     }
 
@@ -114,7 +113,6 @@ class BetaFeedbackController(
         if (bindingResult.hasErrors()) {
             val referrer = request.getHeader("referer")
             model.addAttribute("referrerHeader", referrer)
-            model.addAttribute("backUrl", referrer)
             model.addAttribute("formModel", betaFeedbackModel)
             return "betaBannerFeedback"
         }

--- a/src/main/resources/templates/betaBannerFeedback.html
+++ b/src/main/resources/templates/betaBannerFeedback.html
@@ -1,10 +1,9 @@
 <!--/*@thymesVar id="title" type="java.lang.String"*/-->
 <!--/*@thymesVar id="betaFeedbackModel" type="java.lang.Object"*/-->
-<!--/*@thymesVar id="backUrl" type="java.lang.String"*/-->
 <!--/*@thymesVar id="feedbackUrl" type="java.lang.String"*/-->
 <!--/*@thymesVar id="referrerHeader" type="java.lang.String"*/-->
 <!DOCTYPE html>
-<html id="form-content" th:replace="~{fragments/forms/questionPage :: questionPage(#{betaBannerFeedback.heading}, ${formModel}, ~{::#form-content/content()}, ${backUrl}, null)}">
+<html id="form-content" th:replace="~{fragments/forms/questionPage :: questionPage(#{betaBannerFeedback.heading}, ${formModel}, ~{::#form-content/content()}, null, null)}">
     <th:block th:replace="~{forms/betaBannerFeedbackForm :: betaBannerFeedbackForm}"></th:block>
     <section>
         <h2 class="govuk-heading-m" th:text="#{betaBannerFeedback.heading.two}">betaBannerFeedback.heading.two</h2>


### PR DESCRIPTION
## Ticket number

PRSD-1510

## Goal of change

Remove back link from give feedback page

## Description of main change(s)

As above

## Screenshots

### After
<img width="718" height="160" alt="image" src="https://github.com/user-attachments/assets/2e54b81c-4020-45d9-9058-699166897033" />


### Before
<img width="718" height="160" alt="image" src="https://github.com/user-attachments/assets/76b0dcaa-4c99-4096-a84d-46ac9866e1fd" />


## Checklist

- [X] Screenshots of any UI changes have been added
- [X] Test suite has been run in full locally and is passing
- [X] Branch has been rebased onto main and run locally, with everything working as expected (both for your new feature
  and any related functionality)