### PR TITLE
PRSD-1504: Empty Registered Properties Tab

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/LandlordDetailsController.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/LandlordDetailsController.kt
@@ -53,6 +53,7 @@ class LandlordDetailsController(
         val registeredPropertiesList = propertyOwnershipService.getRegisteredPropertiesForLandlordUser(principal.name)
 
         model.addAttribute("registeredPropertiesList", registeredPropertiesList)
+        model.addAttribute("registerPropertyUrl", RegisterPropertyController.PROPERTY_REGISTRATION_ROUTE)
         model.addAttribute("backUrl", LANDLORD_DASHBOARD_URL)
         model.addAttribute("registeredPropertiesTabId", REGISTERED_PROPERTIES_FRAGMENT)
 

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -816,6 +816,8 @@ landlordDetails.registeredProperties.table.tenantedHeading=Tenanted
 landlordDetails.registeredProperties.table.registrationNumberHeading=Registration number
 landlordDetails.registeredProperties.table.licensingTypeHeading=Licensing type
 landlordDetails.registeredProperties.notLicensed.label=Not licensed
+landlordDetails.registeredProperties.none.beforeLink=No registered properties.
+landlordDetails.registeredProperties.none.link=Register a property
 landlordDetails.update.title=Update Landlord record
 
 propertyDetails.title=Property record

--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -767,8 +767,7 @@ landlordSearch.error.hint.link=search for a property
 landlordSearch.details.heading=Help find a landlord record
 landlordSearch.details.body=If you can\u2019t find a landlord record, they may not be registered. Local councils can request the landlord registers with the database.
 
-lastUpdated.afterName=updated these details on
-lastUpdated.afterDate=.
+lastUpdated=<strong>{0,,name}</strong> updated these details on <strong>{1,,date}</strong>.
 
 propertySearch.title=Search for a property
 propertySearch.heading=Search for a property

--- a/src/main/resources/templates/fragments/lastModifiedInsetText.html
+++ b/src/main/resources/templates/fragments/lastModifiedInsetText.html
@@ -1,11 +1,5 @@
-<th:block th:fragment="lastModifiedInsetText(lastModifiedBy, lastModifiedDate)"
-     th:if="${lastModifiedDate != null}" >
-    <div th:replace="~{fragments/warningInsetText :: warningInsetText(~{:: #last-updated-text})}">
-        <th:block id="last-updated-text">
-            <strong th:text="${lastModifiedBy}">name</strong>
-            <span th:text="' ' + #{lastUpdated.afterName} + ' '">landlordDetails.lastUpdated.afterName</span>
-            <strong th:text="${lastModifiedDate}">lastModifiedDate</strong>
-            <span th:text="#{lastUpdated.afterDate}">landlordDetails.lastUpdated.afterDate</span>
-        </th:block>
+<th:block th:fragment="lastModifiedInsetText(lastModifiedBy, lastModifiedDate)" th:if="${lastModifiedDate != null}">
+    <div id="last-modified-inset-text" th:replace="~{fragments/warningInsetText :: warningInsetText(~{::#last-modified-inset-text/content()})}">
+        <th:block th:utext="#{lastUpdated(${lastModifiedBy}, ${lastModifiedDate})}"></th:block>
     </div>
 </th:block>

--- a/src/main/resources/templates/landlordDetailsView.html
+++ b/src/main/resources/templates/landlordDetailsView.html
@@ -1,30 +1,27 @@
+<!--/*@thymesVar id="registerPropertyUrl" type="java.lang.String"*/-->
 <!DOCTYPE html>
-<html id="main-content" th:replace="~{fragments/layout :: layout(#{landlordDetails.title},~{::#main-content/content()}, false)}">
-    <a href="#" th:replace="~{fragments/forms/backLink :: backLink(${backUrl})}">Back link</a>
-    <main class="govuk-main-wrapper">
-        <div id="page-contents">
-            <h2 class="govuk-heading-m" th:text="#{landlordDetails.heading}">landlordDetails.heading</h2>
+<html id="page" th:replace="~{fragments/layout :: layout(#{landlordDetails.title},~{::#page/content()}, false)}">
+    <a th:replace="~{fragments/forms/backLink :: backLink(${backUrl})}">Back link</a>
+    <main class="govuk-main-wrapper" id="main-content">
+        <h2 class="govuk-heading-m" th:text="#{landlordDetails.heading}">landlordDetails.heading</h2>
 
-            <div id="delete-record-button" th:replace="~{fragments/buttons/pageHeaderActions :: pageHeaderActions(${name}, ~{::#delete-record-button/content()})}">
-                <a th:replace="~{fragments/buttons/primaryButtonLink :: primaryButtonLink(${deleteLandlordRecordUrl}, #{landlordDetails.removeRecord})}"></a>
+        <div id="delete-record-button" th:replace="~{fragments/buttons/pageHeaderActions :: pageHeaderActions(${name}, ~{::#delete-record-button/content()})}">
+            <a th:replace="~{fragments/buttons/primaryButtonLink :: primaryButtonLink(${deleteLandlordRecordUrl}, #{landlordDetails.removeRecord})}"></a>
+        </div>
+
+        <div id="tabs" th:replace="~{fragments/tabs/tabs :: tabs(~{::#tabs/content()})}">
+            <ul id="tab-headings" th:replace="~{fragments/tabs/tabsHeadingList :: tabsHeadingList(~{::#tab-headings/content()})}">
+                <li th:replace="~{fragments/tabs/tabsListItem :: tabsListItem('personal-details', #{landlordDetails.personalDetails.heading})}"></li>
+                <li th:replace="~{fragments/tabs/tabsListItem :: tabsListItem(${registeredPropertiesTabId}, #{landlordDetails.registeredProperties.heading})}"></li>
+            </ul>
+
+            <div id="personal-details-panel" th:replace="~{fragments/tabs/tabsPanel :: tabsPanel('personal-details', ~{::#personal-details-panel/content()})}">
+                <dl th:replace="~{fragments/summaryList :: summaryList(${landlord.personalDetails})}" ></dl>
             </div>
 
-            <div id="tabs-content" th:replace="~{fragments/tabs/tabs :: tabs(~{::#tabs-content/content()})}">
-                <ul id="tab-headings" th:replace="~{fragments/tabs/tabsHeadingList :: tabsHeadingList(~{::#tab-headings/content()})}">
-                    <li th:replace="~{fragments/tabs/tabsListItem :: tabsListItem('personal-details', #{landlordDetails.personalDetails.heading})}"></li>
-                    <li th:replace="~{fragments/tabs/tabsListItem :: tabsListItem(${registeredPropertiesTabId}, #{landlordDetails.registeredProperties.heading})}"></li>
-                </ul>
-
-                <div id="personal-details-panel-content" th:replace="~{fragments/tabs/tabsPanel :: tabsPanel('personal-details', ~{::#personal-details-panel-content/content()})}">
-                    <dl th:replace="~{fragments/summaryList :: summaryList(${landlord.personalDetails})}" ></dl>
-                </div>
-
-                <div id="registered-properties-panel-content" th:replace="~{fragments/tabs/tabsPanel :: tabsPanel(${registeredPropertiesTabId}, ~{::#registered-properties-panel-content/content()})}">
-                    <table th:replace="~{fragments/tables/table :: table(
-                        ${ { 'landlordDetails.registeredProperties.table.addressHeading', 'landlordDetails.registeredProperties.table.prnHeading' } },
-                        ~{::tbody},
-                        null
-                    )}">
+            <div id="registered-properties-panel" th:replace="~{fragments/tabs/tabsPanel :: tabsPanel(${registeredPropertiesTabId}, ~{::#registered-properties-panel/content()})}">
+                <th:block th:unless="${#lists.isEmpty(registeredPropertiesList)}">
+                    <table th:replace="~{fragments/tables/table :: table(${ { 'landlordDetails.registeredProperties.table.addressHeading', 'landlordDetails.registeredProperties.table.prnHeading' } }, ~{::tbody}, null)}">
                         <tbody class="govuk-table__body">
                             <tr class="govuk_table__row" th:each="property: ${registeredPropertiesList}">
                                 <td class="govuk-table__cell govuk-!-width-one-half">
@@ -34,7 +31,12 @@
                             </tr>
                         </tbody>
                     </table>
-                </div>
+                </th:block>
+
+                <p th:if="${#lists.isEmpty(registeredPropertiesList)}" class="govuk-body">
+                    <span th:remove="tag" th:text="#{landlordDetails.registeredProperties.none.beforeLink}">landlordDetails.registeredProperties.none.beforeLink</span>
+                    <a class="govuk-link" th:href="@{${registerPropertyUrl}}" th:text="#{landlordDetails.registeredProperties.none.link}">landlordDetails.registeredProperties.none.link</a>
+                </p>
             </div>
         </div>
     </main>

--- a/src/main/resources/templates/landlordDetailsView.html
+++ b/src/main/resources/templates/landlordDetailsView.html
@@ -33,7 +33,7 @@
                     </table>
                 </th:block>
 
-                <p th:if="${#lists.isEmpty(registeredPropertiesList)}" class="govuk-body">
+                <p th:if="${#lists.isEmpty(registeredPropertiesList)}" class="govuk-body" data-testid="no-registered-properties-msg">
                     <span th:remove="tag" th:text="#{landlordDetails.registeredProperties.none.beforeLink}">landlordDetails.registeredProperties.none.beforeLink</span>
                     <a class="govuk-link" th:href="@{${registerPropertyUrl}}" th:text="#{landlordDetails.registeredProperties.none.link}">landlordDetails.registeredProperties.none.link</a>
                 </p>

--- a/src/main/resources/templates/localAuthorityLandlordDetailsView.html
+++ b/src/main/resources/templates/localAuthorityLandlordDetailsView.html
@@ -35,7 +35,7 @@
                     </table>
                 </th:block>
 
-                <p th:if="${#lists.isEmpty(registeredPropertiesList)}" class="govuk-body" th:text="#{landlordDetails.registeredProperties.none.beforeLink}">landlordDetails.registeredProperties.none.beforeLink</p>
+                <p th:if="${#lists.isEmpty(registeredPropertiesList)}" class="govuk-body" data-testid="no-registered-properties-msg" th:text="#{landlordDetails.registeredProperties.none.beforeLink}">landlordDetails.registeredProperties.none.beforeLink</p>
             </div>
         </div>
     </main>

--- a/src/main/resources/templates/localAuthorityLandlordDetailsView.html
+++ b/src/main/resources/templates/localAuthorityLandlordDetailsView.html
@@ -1,59 +1,42 @@
 <!DOCTYPE html>
-<html id="main-content"
-      th:replace="~{fragments/layout :: layout(#{landlordDetails.title}, ~{::#main-content/content()}, false)}">
-<a href="#" th:replace="~{fragments/forms/backLink :: backLink(${backUrl})}">Back link</a>
-<main class="govuk-main-wrapper">
-    <div id="page-contents">
+<html id="page" th:replace="~{fragments/layout :: layout(#{landlordDetails.title}, ~{::#page/content()}, false)}">
+    <a th:replace="~{fragments/forms/backLink :: backLink(${backUrl})}">Back link</a>
+    <main class="govuk-main-wrapper" id="main-content">
         <h2 class="govuk-heading-m" th:text="#{landlordDetails.heading}">landlordDetails.heading</h2>
 
         <h1 class="govuk-heading-l" th:text="${name}">name</h1>
 
-        <div th:replace="~{fragments/lastModifiedInsetText :: lastModifiedInsetText(${name}, ${lastModifiedDate})}">
+        <div th:replace="~{fragments/lastModifiedInsetText :: lastModifiedInsetText(${name}, ${lastModifiedDate})}"></div>
+
+        <div id="tabs" th:replace="~{fragments/tabs/tabs :: tabs(~{::#tabs/content()})}">
+            <ul id="tab-headings" th:replace="~{fragments/tabs/tabsHeadingList :: tabsHeadingList(~{::#tab-headings/content()})}">
+                <li th:replace="~{fragments/tabs/tabsListItem :: tabsListItem('personal-details', #{landlordDetails.personalDetails.heading})}"></li>
+                <li th:replace="~{fragments/tabs/tabsListItem :: tabsListItem(${registeredPropertiesTabId}, #{landlordDetails.registeredProperties.heading})}"></li>
+            </ul>
+
+            <div id="personal-details-panel" th:replace="~{fragments/tabs/tabsPanel :: tabsPanel('personal-details', ~{::#personal-details-panel/content()})}">
+                <dl th:replace="~{fragments/summaryList :: summaryList(${landlord.personalDetails})}"></dl>
+            </div>
+
+            <div id="registered-properties-panel" th:replace="~{fragments/tabs/tabsPanel :: tabsPanel(${registeredPropertiesTabId}, ~{::#registered-properties-panel/content()})}">
+                <th:block th:unless="${#lists.isEmpty(registeredPropertiesList)}">
+                    <table th:replace="~{fragments/tables/table :: table(${ { 'landlordDetails.registeredProperties.table.addressHeading', 'landlordDetails.registeredProperties.table.registrationNumberHeading', 'landlordDetails.registeredProperties.table.localAuthorityHeading', 'landlordDetails.registeredProperties.table.licensingTypeHeading', 'landlordDetails.registeredProperties.table.tenantedHeading' } }, ~{::tbody}, null)}">
+                        <tbody class="govuk-table__body">
+                        <tr class="govuk_table__row" th:each="property: ${registeredPropertiesList}">
+                            <td class="govuk-table__cell">
+                                <a class="govuk-link" th:text="${property.address}" th:href="@{${property.recordLink}}">${property.address}</a>
+                            </td>
+                            <td class="govuk-table__cell" th:text="${property.registrationNumber}"></td>
+                            <td class="govuk-table__cell" th:text="${property.localAuthorityName}"></td>
+                            <td class="govuk-table__cell" th:text="#{${property.licenseTypeMessageKey}}"></td>
+                            <td class="govuk-table__cell" th:text="#{${property.isTenantedMessageKey}}"></td>
+                        </tr>
+                        </tbody>
+                    </table>
+                </th:block>
+
+                <p th:if="${#lists.isEmpty(registeredPropertiesList)}" class="govuk-body" th:text="#{landlordDetails.registeredProperties.none.beforeLink}">landlordDetails.registeredProperties.none.beforeLink</p>
+            </div>
         </div>
-
-        <div th:replace="~{fragments/tabs/tabs :: tabs(~{:: #tabs-content})}">
-            <th:block id="tabs-content">
-                <ul th:replace="~{fragments/tabs/tabsHeadingList :: tabsHeadingList(~{:: #tab-headings})}">
-                    <th:block id="tab-headings">
-                        <li th:replace="~{fragments/tabs/tabsListItem :: tabsListItem('personal-details', #{landlordDetails.personalDetails.heading})}">
-                        </li>
-                        <li th:replace="~{fragments/tabs/tabsListItem :: tabsListItem(${registeredPropertiesTabId}, #{landlordDetails.registeredProperties.heading})}">
-                        </li>
-                    </th:block>
-                </ul>
-
-                <div id="personal-details-panel-content" th:replace="~{fragments/tabs/tabsPanel :: tabsPanel('personal-details', ~{:: #personal-details-panel-content/content()})}">
-                    <dl th:replace="~{fragments/summaryList :: summaryList(${landlord.personalDetails})}"></dl>
-                </div>
-
-                <div th:replace="~{fragments/tabs/tabsPanel :: tabsPanel(${registeredPropertiesTabId}, ~{:: #registered-properties-panel-content})}">
-                    <th:block id="registered-properties-panel-content">
-                        <table th:replace="~{fragments/tables/table :: table(
-                                ${ { 'landlordDetails.registeredProperties.table.addressHeading', 'landlordDetails.registeredProperties.table.registrationNumberHeading', 'landlordDetails.registeredProperties.table.localAuthorityHeading', 'landlordDetails.registeredProperties.table.licensingTypeHeading', 'landlordDetails.registeredProperties.table.tenantedHeading' } },
-                                ~{::tbody},
-                                null
-                            )}
-                        ">
-                            <tbody class="govuk-table__body">
-                            <tr class="govuk_table__row" th:each="property: ${registeredPropertiesList}">
-                                <td class="govuk-table__cell">
-                                    <a class="govuk-link" th:text="${property.address}"
-                                       th:href="@{${property.recordLink}}">
-                                        ${property.address}
-                                    </a>
-                                </td>
-                                <td class="govuk-table__cell" th:text="${property.registrationNumber}"></td>
-                                <td class="govuk-table__cell" th:text="${property.localAuthorityName}"></td>
-                                <td class="govuk-table__cell" th:text="#{${property.licenseTypeMessageKey}}"></td>
-                                <td class="govuk-table__cell" th:text="#{${property.isTenantedMessageKey}}"></td>
-                            </tr>
-                            </tbody>
-                        </table>
-                    </th:block>
-                </div>
-            </th:block>
-        </div>
-
-    </div>
-</main>
+    </main>
 </html>

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/LandlordDetailTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/LandlordDetailTests.kt
@@ -9,6 +9,7 @@ import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.LocalAuthor
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.PropertyDetailsPageLandlordView
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.PropertyDetailsPageLocalAuthorityView
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages.BasePage.Companion.assertPageIs
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyRegistrationJourneyPages.RegisterPropertyStartPage
 import kotlin.test.assertEquals
 
 class LandlordDetailTests : IntegrationTestWithImmutableData("data-local.sql") {
@@ -22,7 +23,7 @@ class LandlordDetailTests : IntegrationTestWithImmutableData("data-local.sql") {
         }
 
         @Test
-        fun `loading the landlord details page and selecting properties shows the registered properties table`(page: Page) {
+        fun `the registered properties tab contains the registered properties table when the landlord has properties`(page: Page) {
             val detailsPage = navigator.goToLandlordDetails()
 
             detailsPage.tabs.goToRegisteredProperties()
@@ -30,6 +31,7 @@ class LandlordDetailTests : IntegrationTestWithImmutableData("data-local.sql") {
             assertEquals(detailsPage.tabs.activeTabPanelId, "registered-properties")
             assertThat(detailsPage.registeredPropertiesTable.headerRow.getCell(0)).containsText("Property address")
             assertThat(detailsPage.registeredPropertiesTable.headerRow.getCell(1)).containsText("Property Registration Number")
+            assertThat(detailsPage.noRegisteredPropertiesMessage).isHidden()
         }
 
         @Test
@@ -50,6 +52,23 @@ class LandlordDetailTests : IntegrationTestWithImmutableData("data-local.sql") {
             propertyDetailsView.backLink.clickAndWait()
             assertPageIs(page, LandlordDetailsPage::class)
         }
+
+        @Nested
+        inner class LandlordWithoutProperties : NestedIntegrationTestWithImmutableData("data-unverified-landlord.sql") {
+            @Test
+            fun `the registered properties table doesn't appear if the landlord has no properties`(page: Page) {
+                val detailsPage = navigator.goToLandlordDetails()
+
+                detailsPage.tabs.goToRegisteredProperties()
+
+                assertEquals(detailsPage.tabs.activeTabPanelId, "registered-properties")
+                assertThat(detailsPage.registeredPropertiesTable).isHidden()
+                assertThat(detailsPage.noRegisteredPropertiesMessage).containsText("No registered properties.")
+
+                detailsPage.noRegisteredPropertiesLink.clickAndWait()
+                assertPageIs(page, RegisterPropertyStartPage::class)
+            }
+        }
     }
 
     @Nested
@@ -62,7 +81,7 @@ class LandlordDetailTests : IntegrationTestWithImmutableData("data-local.sql") {
         }
 
         @Test
-        fun `loading the landlord details page and selecting properties shows landlord's registered properties table`(page: Page) {
+        fun `the registered properties tab shows the landlord's registered properties table if they have properties`(page: Page) {
             val detailsPage = navigator.goToLandlordDetailsAsALocalAuthorityUser(1)
 
             detailsPage.tabs.goToRegisteredProperties()
@@ -73,6 +92,19 @@ class LandlordDetailTests : IntegrationTestWithImmutableData("data-local.sql") {
             assertThat(detailsPage.registeredPropertiesTable.headerRow.getCell(2)).containsText("Local council")
             assertThat(detailsPage.registeredPropertiesTable.headerRow.getCell(3)).containsText("Licensing type")
             assertThat(detailsPage.registeredPropertiesTable.headerRow.getCell(4)).containsText("Tenanted")
+            assertThat(detailsPage.noRegisteredPropertiesMessage).isHidden()
+        }
+
+        @Test
+        fun `the registered properties table doesn't appear if the landlord has no properties`(page: Page) {
+            val detailsPage = navigator.goToLandlordDetailsAsALocalAuthorityUser(3)
+
+            detailsPage.tabs.goToRegisteredProperties()
+
+            assertEquals(detailsPage.tabs.activeTabPanelId, "registered-properties")
+            assertThat(detailsPage.registeredPropertiesTable).isHidden()
+            assertThat(detailsPage.noRegisteredPropertiesMessage).containsText("No registered properties.")
+            assertThat(detailsPage.noRegisteredPropertiesLink).isHidden()
         }
 
         @Test

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/components/Paragraph.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/components/Paragraph.kt
@@ -1,0 +1,15 @@
+package uk.gov.communities.prsdb.webapp.integration.pageObjects.components
+
+import com.microsoft.playwright.Locator
+import com.microsoft.playwright.Page
+
+class Paragraph(
+    locator: Locator,
+) : BaseComponent(locator) {
+    companion object {
+        fun byTestId(
+            page: Page,
+            testId: String,
+        ) = Paragraph(page.locator("p[data-testid=\"$testId\"]"))
+    }
+}

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/basePages/LandlordDetailsBasePage.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/basePages/LandlordDetailsBasePage.kt
@@ -3,6 +3,7 @@ package uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages
 import com.microsoft.playwright.Page
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.BackLink
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.Link
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.Paragraph
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.SummaryList
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.Table
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.Tabs
@@ -15,6 +16,8 @@ abstract class LandlordDetailsBasePage(
     val backLink = BackLink.default(page)
     val personalDetailsSummaryList = LandlordPersonalDetailsSummaryList(page)
     val registeredPropertiesTable = Table(page)
+    val noRegisteredPropertiesMessage = Paragraph.byTestId(page, "no-registered-properties-msg")
+    val noRegisteredPropertiesLink = Link.byText(page, "Register a property")
 
     fun getPropertyAddressLink(address: String) = Link.byText(page, address)
 


### PR DESCRIPTION
## Ticket number

PRSD-1504

## Goal of change

Adds content for the registered properties tab of landlords without properties

## Description of main change(s)

As above

## Anything you'd like to highlight to the reviewer?

N/A

## Checklist

Delete any that are not applicable, and add explanation below for any that are applicable but haven't been done

- [X] Screenshots of any UI changes have been added
- [X] Single page integration tests have been added for any unhappy-flow UI features, e.g. validation errors
- [X] Test suite has been run in full locally and is passing
- [X] Branch has been rebased onto main and run locally, with everything working as expected (both for your new feature
  and any related functionality)

## Screenshots
- Landlord view
<img width="1007" height="543" alt="image" src="https://github.com/user-attachments/assets/d3b64969-2679-4540-af19-e3c07c3dcd28" />
- LC user view
<img width="988" height="632" alt="image" src="https://github.com/user-attachments/assets/a0158d50-1b0a-4b3a-b095-0118f68108c4" />