### PR TITLE
PRSD-NONE: Removes instances of unescaped user input

### DIFF
--- a/src/main/resources/messages.properties
+++ b/src/main/resources/messages.properties
@@ -1075,7 +1075,9 @@ forms.lookupAddress.houseNameOrNumber.error.missing=Enter a house name or number
 forms.lookupContactAddress.fieldSetHeading=What is your UK contact address?
 
 forms.selectAddress.fieldSetHeading=Select an address
-forms.selectAddress.fieldSetHint.beforeLink={0,,addressCount} addresses found for <strong>{1,,postcode}</strong> and <strong>{2,,houseNameOrNumber}</strong>.
+forms.selectAddress.fieldSetHint.beforePostcode={0,,addressCount} addresses found for
+forms.selectAddress.fieldSetHint.beforeHouseNameOrNumber=and
+forms.selectAddress.fieldSetHint.beforeLink=.
 forms.selectAddress.fieldSetHint.link=Search again
 forms.selectAddress.error.missing=Select an address
 forms.selectAddress.addAddressManually=I want to manually enter my address

--- a/src/main/resources/templates/forms/selectAddressForm.html
+++ b/src/main/resources/templates/forms/selectAddressForm.html
@@ -1,23 +1,26 @@
 <!--/*@thymesVar id="title" type="java.lang.String"*/-->
 <!--/*@thymesVar id="formModel" type="java.lang.Object"*/-->
-<!--/*@thymesVar id="fieldSetHeading" type="java.lang.String"*/-->
 <!--/*@thymesVar id="backUrl" type="java.lang.String"*/-->
+<!--/*@thymesVar id="sectionHeaderInfo" type="uk.gov.communities.prsdb.webapp.models.viewModels.SectionHeaderViewModel"*/-->
+<!--/*@thymesVar id="fieldSetHeading" type="java.lang.String"*/-->
+<!--/*@thymesVar id="addressCount" type="java.lang.Integer"*/-->
+<!--/*@thymesVar id="postcode" type="java.lang.String"*/-->
+<!--/*@thymesVar id="houseNameOrNumber" type="java.lang.String"*/-->
+<!--/*@thymesVar id="searchAgainUrl" type="java.lang.String"*/-->
 <!--/*@thymesVar id="options" type="java.lang.Object"*/-->
 <!--/*@thymesVar id="submitButtonText" type="java.lang.String"*/-->
 <!DOCTYPE html>
-<html th:replace="~{fragments/forms/questionPage :: questionPage(#{${title}}, ${formModel}, ~{::#form-content}, ${backUrl}, ${sectionHeaderInfo})}">
-<th:block id="form-content">
-    <th:block id="fieldset-content"
-              th:replace="~{fragments/forms/fieldSet :: fieldSet(~{::#fieldset-content/content()}, 'address', #{${fieldSetHeading}}, null)}">
+<html id="form" th:replace="~{fragments/forms/questionPage :: questionPage(#{${title}}, ${formModel}, ~{::#form/content()}, ${backUrl}, ${sectionHeaderInfo})}">
+    <th:block id="fieldset" th:replace="~{fragments/forms/fieldSet :: fieldSet(~{::#fieldset/content()}, 'address', #{${fieldSetHeading}}, null)}">
         <div id="address-hint" class="govuk-hint">
-            <span th:remove="tag"
-                  th:utext="#{forms.selectAddress.fieldSetHint.beforeLink(${addressCount},${postcode},${houseNameOrNumber})}">
-                forms.selectAddress.fieldSetHint.beforeLink
-            </span>
+            <span th:remove="tag" th:text="#{forms.selectAddress.fieldSetHint.beforePostcode(${addressCount})}">forms.selectAddress.fieldSetHint.beforePostcode</span>
+            <strong th:text="${postcode}"></strong>
+            <span th:remove="tag" th:text="#{forms.selectAddress.fieldSetHint.beforeHouseNameOrNumber}">forms.selectAddress.fieldSetHint.beforeHouseNameOrNumber</span>
+            <strong th:text="${houseNameOrNumber}">
+            </strong><span th:remove="tag" th:text="#{forms.selectAddress.fieldSetHint.beforeLink}">forms.selectAddress.fieldSetHint.beforeLink</span>
             <a class=govuk-link th:href="@{${searchAgainUrl}}" th:text="#{forms.selectAddress.fieldSetHint.link}"></a>
         </div>
         <th:block th:replace="~{fragments/forms/radios :: radios(null,'address',null, ${options})}"></th:block>
     </th:block>
     <button th:replace="~{fragments/buttons/primaryButton :: primaryButton(#{${submitButtonText}})}"></button>
-</th:block>
 </html>


### PR DESCRIPTION
## Ticket number

PRSD-NONE

## Goal of change

Removes instances of unescaped user input

## Description of main change(s)

- Removes instances where `th:utext` is used with user input variables

## Anything you'd like to highlight to the reviewer?

N/A

## Checklist

Delete any that are not applicable, and add explanation below for any that are applicable but haven't been done

- [X] Test suite has been run in full locally and is passing
- [X] Branch has been rebased onto main and run locally, with everything working as expected (both for your new feature
  and any related functionality)