### PR TITLE
PRSD-1532: Make string urls in tests use constants

### DIFF
--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/LandlordDashboardTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/LandlordDashboardTests.kt
@@ -2,6 +2,7 @@ package uk.gov.communities.prsdb.webapp.integration
 
 import com.microsoft.playwright.Page
 import org.junit.jupiter.api.Nested
+import uk.gov.communities.prsdb.webapp.constants.RENTERS_RIGHTS_BILL_URL
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.BaseComponent.Companion.assertThat
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.ComplianceActionsPage
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.LandlordDetailsPage
@@ -60,8 +61,7 @@ class LandlordDashboardTests : IntegrationTestWithImmutableData("data-local.sql"
     @Test
     fun `the renters rights bill link goes to an external page`(page: Page) {
         val dashboard = navigator.goToLandlordDashboard()
-        assertThat(dashboard.rentersRightsBillLink)
-            .hasAttribute("href", "https://bills.parliament.uk/bills/3764")
+        assertThat(dashboard.rentersRightsBillLink).hasAttribute("href", RENTERS_RIGHTS_BILL_URL)
     }
 
     @Test

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/LandlordPrivacyNoticeTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/LandlordPrivacyNoticeTests.kt
@@ -3,6 +3,8 @@ package uk.gov.communities.prsdb.webapp.integration
 import com.microsoft.playwright.BrowserContext
 import com.microsoft.playwright.Page
 import org.junit.jupiter.api.Test
+import uk.gov.communities.prsdb.webapp.constants.COMPLAINTS_PROCEDURE_URL
+import uk.gov.communities.prsdb.webapp.constants.INFORMATION_COMMISSIONERS_OFFICE_URL
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.BaseComponent.Companion.assertThat
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.LandlordPrivacyNoticePage
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages.BasePage.Companion.assertPageIs
@@ -21,11 +23,7 @@ class LandlordPrivacyNoticeTests : IntegrationTestWithImmutableData("data-local.
         page: Page,
     ) {
         val privacyNoticePage = navigator.goToLandlordPrivacyNoticePage()
-        assertThat(privacyNoticePage.mhclgComplaintsLink)
-            .hasAttribute(
-                "href",
-                "https://www.gov.uk/government/organisations/ministry-of-housing-communities-local-government/about/complaints-procedure",
-            )
+        assertThat(privacyNoticePage.mhclgComplaintsLink).hasAttribute("href", COMPLAINTS_PROCEDURE_URL)
         assertThat(privacyNoticePage.mhclgComplaintsLink).hasAttribute("rel", "noreferrer noopener")
         assertThat(privacyNoticePage.mhclgComplaintsLink).hasAttribute("target", "_blank")
     }
@@ -43,7 +41,7 @@ class LandlordPrivacyNoticeTests : IntegrationTestWithImmutableData("data-local.
         page: Page,
     ) {
         val privacyNoticePage = navigator.goToLandlordPrivacyNoticePage()
-        assertThat(privacyNoticePage.icoLink).hasAttribute("href", "https://ico.org.uk/")
+        assertThat(privacyNoticePage.icoLink).hasAttribute("href", INFORMATION_COMMISSIONERS_OFFICE_URL)
         assertThat(privacyNoticePage.icoLink).hasAttribute("rel", "noreferrer noopener")
         assertThat(privacyNoticePage.icoLink).hasAttribute("target", "_blank")
     }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/LocalAuthorityDashboardTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/LocalAuthorityDashboardTests.kt
@@ -2,6 +2,7 @@ package uk.gov.communities.prsdb.webapp.integration
 
 import com.microsoft.playwright.Page
 import org.junit.jupiter.api.Nested
+import uk.gov.communities.prsdb.webapp.constants.RENTERS_RIGHTS_BILL_PRSD
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.BaseComponent.Companion.assertThat
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.ManageLaUsersPage
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.SearchLandlordRegisterPage
@@ -34,12 +35,7 @@ class LocalAuthorityDashboardTests : IntegrationTestWithImmutableData("data-loca
     @Test
     fun `the renters rights bill link goes to an external page`(page: Page) {
         val dashboard = navigator.goToLocalAuthorityDashboard()
-        assertThat(dashboard.rentersRightsBillLink)
-            .hasAttribute(
-                "href",
-                "https://www.gov.uk/government/publications/guide-to-the-renters-rights-bill" +
-                    "/guide-to-the-renters-rights-bill#private-rented-sector-database",
-            )
+        assertThat(dashboard.rentersRightsBillLink).hasAttribute("href", RENTERS_RIGHTS_BILL_PRSD)
     }
 
     @Nested


### PR DESCRIPTION
## Ticket number

PRSD-1532

## Goal of change

Make string urls in tests use constants

## Description of main change(s)

As above

## Anything you'd like to highlight to the reviewer?

N/A

## Checklist

- [ ] Test suite has been run in full locally and is passing
