### PR TITLE
PRSD-1553: Remove gas safety engineer row from property record when empty

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/summaryModels/propertyComplianceViewModels/GasSafetyViewModelFactory.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/summaryModels/propertyComplianceViewModels/GasSafetyViewModelFactory.kt
@@ -45,10 +45,12 @@ class GasSafetyViewModelFactory(
                         key = "propertyDetails.complianceInformation.validUntil",
                         value = propertyCompliance.gasSafetyCertExpiryDate,
                     )
-                    addRow(
-                        key = "propertyDetails.complianceInformation.gasSafety.gasSafeEngineerNumber",
-                        value = propertyCompliance.gasSafetyCertEngineerNum,
-                    )
+                    if (propertyCompliance.gasSafetyCertEngineerNum != null) {
+                        addRow(
+                            key = "propertyDetails.complianceInformation.gasSafety.gasSafeEngineerNumber",
+                            value = propertyCompliance.gasSafetyCertEngineerNum,
+                        )
+                    }
                 } else {
                     addRow(
                         key = "propertyDetails.complianceInformation.exemption",

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/summaryModels/propertyComplianceViewModels/GasSafetyViewModelBuilderTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/summaryModels/propertyComplianceViewModels/GasSafetyViewModelBuilderTests.kt
@@ -137,10 +137,6 @@ class GasSafetyViewModelBuilderTests {
                             "propertyDetails.complianceInformation.validUntil",
                             expiredBeforeUpload.gasSafetyCertExpiryDate,
                         ),
-                        SummaryListRowViewModel(
-                            "propertyDetails.complianceInformation.gasSafety.gasSafeEngineerNumber",
-                            expiredBeforeUpload.gasSafetyCertEngineerNum,
-                        ),
                     ),
                 ),
                 arguments(


### PR DESCRIPTION
## Ticket number

PRSD-1553

## Goal of change

Remove gas safety engineer row from property record when empty

## Description of main change(s)

As above and updated test

## Screenshots

### After
<img width="720" height="236" alt="image" src="https://github.com/user-attachments/assets/3f7bd581-295b-4ade-a982-8d4feb1d9105" />


### Before
<img width="720" height="236" alt="image" src="https://github.com/user-attachments/assets/5e3ed52c-2202-4e50-a806-f6d288f98902" />


## Checklist

- [x] Screenshots of any UI changes have been added
- [x] Test suite has been run in full locally and is passing
- [x] Branch has been rebased onto main and run locally, with everything working as expected (both for your new feature
  and any related functionality)
