### PR TITLE
PRSD-1021: Renames OS API key

### DIFF
--- a/.run/local.run.xml
+++ b/.run/local.run.xml
@@ -1,6 +1,6 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="local" type="SpringBootApplicationConfigurationType" factoryName="Spring Boot">
-    <option name="ACTIVE_PROFILES" value="local, local-no-auth, local-mock-os-places" />
+    <option name="ACTIVE_PROFILES" value="local, local-no-auth, local-mock-os-api" />
     <option name="envFilePaths">
       <option value="$PROJECT_DIR$/.env" />
     </option>

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/config/OSPlacesConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/config/OSPlacesConfig.kt
@@ -8,10 +8,10 @@ import java.net.http.HttpClient
 
 @PrsdbWebConfiguration
 class OSPlacesConfig {
-    @Value("\${os-places.base-url}")
+    @Value("\${os.places.base-url}")
     lateinit var baseURL: String
 
-    @Value("\${os-places.api-key}")
+    @Value("\${os.api-key}")
     lateinit var apiKey: String
 
     val httpClient: HttpClient = HttpClient.newHttpClient()

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/local/api/controllers/OSPlacesAPIStubController.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/local/api/controllers/OSPlacesAPIStubController.kt
@@ -7,7 +7,7 @@ import org.springframework.web.bind.annotation.RequestParam
 import uk.gov.communities.prsdb.webapp.annotations.PrsdbRestController
 import uk.gov.communities.prsdb.webapp.local.api.MockOSPlacesAPIResponses
 
-@Profile("local-mock-os-places")
+@Profile("local-mock-os-api")
 @PrsdbRestController
 @RequestMapping("/local/os-places")
 class OSPlacesAPIStubController {

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -153,6 +153,7 @@ spring:
     activate:
       on-profile: local-mock-os-places
 
-os-places:
-  base-url: http://localhost:8080/local/os-places
+os:
   api-key: fake-key
+  places:
+    base-url: http://localhost:8080/local/os-places

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -151,7 +151,7 @@ spring:
 spring:
   config:
     activate:
-      on-profile: local-mock-os-places
+      on-profile: local-mock-os-api
 
 os:
   api-key: fake-key

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -57,9 +57,10 @@ notify:
   support-email: ${EMAILNOTIFICATIONS_SUPPORTEMAIL:Team-PRSDB+virus-notification@softwire.com}
   use-production-notify: ${EMAILNOTIFICATIONS_USE_PRODUCTION_NOTIFY}
 
-os-places:
-  api-key: ${OS_PLACES_API_KEY}
-  base-url: https://api.os.uk/search/places/v1
+os:
+  api-key: ${OS_API_KEY}
+  places:
+    base-url: https://api.os.uk/search/places/v1
 
 epc:
   base-url: ${EPC_REGISTER_BASE_URL}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -13,9 +13,6 @@ notify:
   support-email: support@example.com
   use-production-notify: false
 
-os-places:
-  api-key: ${OS_PLACES_API_KEY}
-
 base-url:
   landlord: example.com
   local-authority: example.com


### PR DESCRIPTION
## Ticket number

PRSD-1021

## Goal of change

Renames OS API key to be more general

## Description of main change(s)

- Renames OS API key and mock profile to be more general
- Updates dev `.env` file in Keeper

## Anything you'd like to highlight to the reviewer?

- This ticket prompted the renaming as we'll be using another OS API (with the same key)
- This PR shouldn't be merged until the [corresponding infra one](https://github.com/communitiesuk/prsdb-infra/pull/182) is

## Checklist

Delete any that are not applicable, and add explanation below for any that are applicable but haven't been done

- [X] Test suite has been run in full locally and is passing
- [X] Branch has been rebased onto main and run locally, with everything working as expected (both for your new feature
  and any related functionality)