### PR TITLE
PRSD-934: Add ktLintFormat to pre-commit hook instructions and pipelines

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -74,6 +74,9 @@ jobs:
           EMAILNOTIFICATIONS_APIKEY: ${{ secrets.NOTIFY_KEY }}
         run: ./gradlew clean check --no-daemon
 
+      - name: Run ktlintFormat
+        run: ./gradlew ktlintFormat --no-daemon
+
       - name: Get latest version tag for minor version
         id: get-latest-tag
         uses: oprypin/find-latest-tag@v1

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -38,3 +38,6 @@ jobs:
           EMAILNOTIFICATIONS_APIKEY: ${{ secrets.NOTIFY_KEY }}
           EMAILNOTIFICATIONS_USE_PRODUCTION_NOTIFY: github.base_ref == 'production' || github.merge_group.base_ref == 'refs/head/production'
         run: ./gradlew clean check --no-daemon
+
+      - name: Run ktlintFormat
+        run: ./gradlew ktlintFormat --no-daemon

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -23,8 +23,8 @@ application locally.
 We are using Ktlint for linting, via the [ktlint-gradle plugin](https://github.com/jlleitschuh/ktlint-gradle) and the
 [ktlint Intellij plugin](https://plugins.jetbrains.com/plugin/15057-ktlint) which can be installed from within Intellij.
 
-To ensure that your code meets the linting and formatting rules (as well as checking that the tests pass), we recommend
-installing the pre-commit hook by running the `addKtlintCheckGitPreCommitHook` task from Gradle tab in Intellij.
+To ensure that your code meets the linting and formatting rules install these pre-commit hooks by running the
+`addKtlintCheckGitPreCommitHook` and `addKtlintFormatGitPreCommitHook` tasks from Gradle tab in Intellij.
 
 There are also some local secrets that will need to be set up if you need to test integrations with other services when
 running the project locally. Ask the team lead where these can be found.


### PR DESCRIPTION
## Ticket number

PRSD-934

## Goal of change

Add ktLintFormat to pre-commit hook instructions  and pipelines

## Description of main change(s)

As above

## Anything you'd like to highlight to the reviewer?

When this is merged it I will also send a message in dev slack asking everyone to add the ktLintFormat to their pre-commit hooks

## Checklist

N/A
