### PR TITLE
PRSD-1587: Update gradle plugin to v3.5.6

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -92,6 +92,9 @@ dependencies {
 
     // Streaming upload without storing on local system
     implementation("org.apache.commons:commons-fileupload2-jakarta:2.0.0-M1")
+
+    // Gradle plugin
+    implementation("org.springframework.boot:spring-boot-gradle-plugin:3.5.6")
 }
 
 kotlin {


### PR DESCRIPTION
## Ticket number

PRSD-1587

## Goal of change

Update gradle plugin to v3.5.6

## Description of main change(s)

As above

## Anything you'd like to highlight to the reviewer?

In a previous [PR](https://github.com/communitiesuk/prsdb-webapp/pull/790) for this ticket I updated the "org.springframework.boot" instead of the individual gradle plugin as I have in this PR. It might turn out we need to upgrade more than just this plugin to remove the dependency but we'll find out after this PR is merged.

## Checklist

- [x] Test suite has been run in full locally and is passing
- [x] Branch has been rebased onto main and run locally, with everything working as expected (both for your new feature
  and any related functionality)
