### PR TITLE
PDJB-NONE: Fix performance issue causing flaky integration tests

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/JourneyStep.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/JourneyStep.kt
@@ -154,8 +154,7 @@ sealed class JourneyStep<out TEnum : Enum<out TEnum>, TFormModel : FormModel, in
     val lifecycleOrchestrator: StepLifecycleOrchestrator
         get() = stepConfig.getStepLifecycleOrchestrator(this)
 
-    val isStepReachable: Boolean
-        get() = parentage.allowsChild()
+    val isStepReachable: Boolean by lazy(LazyThreadSafetyMode.NONE) { parentage.allowsChild() }
 
     val formModelOrNull: TFormModel?
         get() = stepConfig.getFormModelFromStateOrNull(state)
@@ -170,7 +169,7 @@ sealed class JourneyStep<out TEnum : Enum<out TEnum>, TFormModel : FormModel, in
 
     private lateinit var state: TState
 
-    val outcome: TEnum? get() = if (isStepReachable) stepConfig.mode(state) else null
+    val outcome: TEnum? by lazy(LazyThreadSafetyMode.NONE) { if (isStepReachable) stepConfig.mode(state) else null }
 
     private lateinit var nextDestination: (mode: TEnum) -> Destination
 


### PR DESCRIPTION
## Ticket number

PDJB-725

## Goal of change

Fix performance issue causing flaky integration tests

## Description of main change(s)

The journey tests in [this PR ](https://github.com/communitiesuk/prsdb-webapp/pull/1132) were getting flaky (2 failed when run all together, one of those passed when run separately, the other passed when run in debug so it paused at the failure point before continuing successfully).

Claude has been digging into it for me, this is the copilot summary:

Root Cause

The checkEpcAnswersStep has 10 OrParents conditions. When computing backUrl, allowingParentSteps evaluates all 10
parents via filter. Each parent's allowsChild() recursively evaluates isStepReachable and outcome on ancestor steps,
traversing the entire journey tree. Without memoization, the same steps were re-evaluated exponentially — 178,000+
evaluations before the 60s timeout killed the request.

Fix

Changed isStepReachable and outcome from computed properties (re-evaluated on every access) to lazy vals (computed
once, cached per step instance). Since step beans are prototype-scoped (fresh per request), the cache is naturally
request-scoped:

 val isStepReachable: Boolean by lazy(LazyThreadSafetyMode.NONE) { parentage.allowsChild() }
 val outcome: TEnum? by lazy(LazyThreadSafetyMode.NONE) { if (isStepReachable) stepConfig.mode(state) else null }

This reduces evaluation from exponential to linear — each step's reachability and outcome are computed at most once
per request.

## Anything you'd like to highlight to the reviewer?

This came up when developing this PR https://github.com/communitiesuk/prsdb-webapp/pull/1132.
Originally this branch came off that one, I've run the tests and am happy they pass locally.
Now rebased back onto main for PR

## Checklist

Delete any that are not applicable, and add explanation below for any that are applicable but haven't been done

- [x] Test suite has been run in full locally and is passing

