### PR TITLE
PDJB-241: Remove passcode local council dependency and move endpoint to system-operator

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/GeneratePasscodeController.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/GeneratePasscodeController.kt
@@ -8,31 +8,21 @@ import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import uk.gov.communities.prsdb.webapp.annotations.webAnnotations.PrsdbController
 import uk.gov.communities.prsdb.webapp.constants.GENERATE_PASSCODE_PATH_SEGMENT
-import uk.gov.communities.prsdb.webapp.constants.LOCAL_COUNCIL_PATH_SEGMENT
-import uk.gov.communities.prsdb.webapp.controllers.LocalCouncilDashboardController.Companion.LOCAL_COUNCIL_DASHBOARD_URL
+import uk.gov.communities.prsdb.webapp.constants.SYSTEM_OPERATOR_PATH_SEGMENT
 import uk.gov.communities.prsdb.webapp.exceptions.PasscodeLimitExceededException
-import uk.gov.communities.prsdb.webapp.services.LocalCouncilDataService
 import uk.gov.communities.prsdb.webapp.services.PasscodeService
-import java.security.Principal
 
-@PreAuthorize("hasRole('LOCAL_COUNCIL_ADMIN')")
+@PreAuthorize("hasRole('SYSTEM_OPERATOR')")
 @PrsdbController
 @RequestMapping(GeneratePasscodeController.GENERATE_PASSCODE_URL)
 @Profile("require-passcode")
 class GeneratePasscodeController(
     private val passcodeService: PasscodeService,
-    private val localCouncilDataService: LocalCouncilDataService,
 ) {
     @GetMapping
-    fun generatePasscodeGet(
-        model: Model,
-        principal: Principal,
-    ): String {
-        val localCouncilUser = localCouncilDataService.getLocalCouncilUser(principal.name)
-        model.addAttribute("dashboardUrl", LOCAL_COUNCIL_DASHBOARD_URL)
-
+    fun generatePasscodeGet(model: Model): String {
         return try {
-            val passcode = passcodeService.getOrGeneratePasscode(localCouncilUser.localCouncil.id.toLong())
+            val passcode = passcodeService.getOrGeneratePasscode()
             model.addAttribute("passcode", passcode)
             "generatePasscode"
         } catch (e: PasscodeLimitExceededException) {
@@ -41,18 +31,10 @@ class GeneratePasscodeController(
     }
 
     @PostMapping
-    fun generatePasscodePost(
-        model: Model,
-        principal: Principal,
-    ): String {
-        val localCouncilUser = localCouncilDataService.getLocalCouncilUser(principal.name)
-        model.addAttribute("dashboardUrl", LOCAL_COUNCIL_DASHBOARD_URL)
-
+    fun generatePasscodePost(model: Model): String {
         return try {
-            val passcode = passcodeService.generateAndStorePasscode(localCouncilUser.localCouncil.id.toLong())
+            val passcode = passcodeService.generateAndStorePasscode()
             model.addAttribute("passcode", passcode)
-            model.addAttribute("dashboardUrl", LOCAL_COUNCIL_DASHBOARD_URL)
-            model.addAttribute("backUrl", LOCAL_COUNCIL_DASHBOARD_URL)
             "generatePasscode"
         } catch (e: PasscodeLimitExceededException) {
             "error/passcodeLimit"
@@ -60,6 +42,6 @@ class GeneratePasscodeController(
     }
 
     companion object {
-        const val GENERATE_PASSCODE_URL = "/$LOCAL_COUNCIL_PATH_SEGMENT/$GENERATE_PASSCODE_PATH_SEGMENT"
+        const val GENERATE_PASSCODE_URL = "/$SYSTEM_OPERATOR_PATH_SEGMENT/$GENERATE_PASSCODE_PATH_SEGMENT"
     }
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/LocalCouncilDashboardController.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/LocalCouncilDashboardController.kt
@@ -39,11 +39,6 @@ class LocalCouncilDashboardController(
                 "navLinks",
                 listOf(
                     NavigationLinkViewModel(
-                        GeneratePasscodeController.GENERATE_PASSCODE_URL,
-                        "navLink.generatePasscode.title",
-                        false,
-                    ),
-                    NavigationLinkViewModel(
                         ManageLocalCouncilUsersController.getLocalCouncilManageUsersRoute(localCouncilUser.localCouncil.id),
                         "navLink.manageUsers.title",
                         false,

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/database/entity/Passcode.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/database/entity/Passcode.kt
@@ -3,7 +3,6 @@ package uk.gov.communities.prsdb.webapp.database.entity
 import jakarta.persistence.Entity
 import jakarta.persistence.Id
 import jakarta.persistence.JoinColumn
-import jakarta.persistence.ManyToOne
 import jakarta.persistence.OneToOne
 
 @Entity
@@ -12,19 +11,13 @@ class Passcode() : ModifiableAuditableEntity() {
     lateinit var passcode: String
         private set
 
-    @ManyToOne(optional = false)
-    @JoinColumn(name = "local_council_id", nullable = false)
-    lateinit var localCouncil: LocalCouncil
-        private set
-
     @OneToOne(optional = true)
     @JoinColumn(name = "subject_identifier", nullable = true, unique = true)
     var baseUser: PrsdbUser? = null
         private set
 
-    constructor(passcode: String, localCouncil: LocalCouncil, baseUser: PrsdbUser? = null) : this() {
+    constructor(passcode: String, baseUser: PrsdbUser? = null) : this() {
         this.passcode = passcode
-        this.localCouncil = localCouncil
         this.baseUser = baseUser
     }
 

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/PasscodeService.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/PasscodeService.kt
@@ -8,7 +8,6 @@ import uk.gov.communities.prsdb.webapp.constants.HAS_USER_CLAIMED_A_PASSCODE
 import uk.gov.communities.prsdb.webapp.constants.LAST_GENERATED_PASSCODE
 import uk.gov.communities.prsdb.webapp.constants.SAFE_CHARACTERS_CHARSET
 import uk.gov.communities.prsdb.webapp.database.entity.Passcode
-import uk.gov.communities.prsdb.webapp.database.repository.LocalCouncilRepository
 import uk.gov.communities.prsdb.webapp.database.repository.PasscodeRepository
 import uk.gov.communities.prsdb.webapp.exceptions.PasscodeLimitExceededException
 
@@ -16,7 +15,6 @@ import uk.gov.communities.prsdb.webapp.exceptions.PasscodeLimitExceededException
 @Profile("require-passcode")
 class PasscodeService(
     private val passcodeRepository: PasscodeRepository,
-    private val localCouncilRepository: LocalCouncilRepository,
     private val prsdbUserService: PrsdbUserService,
     private val session: HttpSession,
 ) {
@@ -26,28 +24,18 @@ class PasscodeService(
     }
 
     @Transactional
-    fun generatePasscode(localCouncilId: Long): Passcode {
-        // Check if passcode limit has been reached
+    fun generatePasscode(): Passcode {
         val currentPasscodeCount = passcodeRepository.count()
         if (currentPasscodeCount >= MAX_PASSCODES) {
             throw PasscodeLimitExceededException("Maximum number of passcodes ($MAX_PASSCODES) has been reached")
         }
-
-        val localCouncil =
-            localCouncilRepository
-                .findById(localCouncilId.toInt())
-                .orElseThrow { IllegalArgumentException("LocalCouncil with id $localCouncilId not found") }
 
         var passcodeString: String
         do {
             passcodeString = generateRandomPasscodeString()
         } while (passcodeRepository.existsByPasscode(passcodeString))
 
-        val passcode =
-            Passcode(
-                passcode = passcodeString,
-                localCouncil = localCouncil,
-            )
+        val passcode = Passcode(passcode = passcodeString)
 
         return passcodeRepository.save(passcode)
     }
@@ -58,13 +46,13 @@ class PasscodeService(
         session.setAttribute(LAST_GENERATED_PASSCODE, passcode)
     }
 
-    fun generateAndStorePasscode(localCouncilId: Long): String {
-        val generatedPasscode = generatePasscode(localCouncilId)
+    fun generateAndStorePasscode(): String {
+        val generatedPasscode = generatePasscode()
         setLastGeneratedPasscode(generatedPasscode.passcode)
         return generatedPasscode.passcode
     }
 
-    fun getOrGeneratePasscode(localCouncilId: Long): String = getLastGeneratedPasscode() ?: generateAndStorePasscode(localCouncilId)
+    fun getOrGeneratePasscode(): String = getLastGeneratedPasscode() ?: generateAndStorePasscode()
 
     fun isValidPasscode(passcode: String): Boolean {
         val normalizedPasscode = normalizePasscode(passcode)
@@ -92,7 +80,6 @@ class PasscodeService(
         val passcode = findPasscode(passcodeString) ?: return false
 
         if (passcode.baseUser != null) {
-            // Already claimed
             return false
         }
 

--- a/src/main/resources/data-integration.sql
+++ b/src/main/resources/data-integration.sql
@@ -230,12 +230,12 @@ VALUES (1, 5, '01/01/25', '01/01/25',
 
 SELECT setval(pg_get_serial_sequence('property_compliance', 'id'), (SELECT MAX(id) FROM property_compliance));
 
-INSERT INTO passcode (passcode, local_council_id, created_date, last_modified_date, subject_identifier)
-VALUES ('PRSD22', 2, current_date, null, 'urn:fdc:gov.uk:2022:mGHDySEVfCsvfvc6lVWf6Qt9Dv0ZxPQWKoEzcjnBlUo'),
-       ('PRSD23', 2, current_date, null, 'urn:fdc:gov.uk:2022:_RNZomOzEjxF4o2NzxWskS062b7hTVWLFI8TYsmoWAk'),
-       ('PRSD24', 2, current_date, null, 'urn:fdc:gov.uk:2022:A9B5GpzhlOrNoGQM65oUESHL5i3O9fp0wjizEFVcCrU'),
-       ('PRSD25', 2, current_date, null, 'urn:fdc:gov.uk:2022:ListhqO1Hu6G90tyF_Rozj4F0YkLHreBnCQZ3JQSiEU'),
-       ('PRSD26', 2, current_date, null, 'urn:fdc:gov.uk:2022:07lXHJeQwE0k5PZO7w_PQF425vT8T7e63MrvyPYNSoI'),
-       ('PRSD27', 2, current_date, null, 'urn:fdc:gov.uk:2022:sgO5-g7fThIp2MhXMcvFo5N6ObnstGFVNSYFkghMd24'),
-       ('PRSD29', 2, current_date, null, 'urn:fdc:gov.uk:2022:La9gwI6zvuzT3yvKjsKEH2cDbtL88wNbiqAeXQ0plEM'),
-       ('PRSD32', 2, current_date, null, 'urn:fdc:gov.uk:2022:mwfvbb5GgiDh0acjz9EDDQ7zwskWZzUSnWfavL70f6s') ON CONFLICT DO NOTHING;
+INSERT INTO passcode (passcode, created_date, last_modified_date, subject_identifier)
+VALUES ('PRSD22', current_date, null, 'urn:fdc:gov.uk:2022:mGHDySEVfCsvfvc6lVWf6Qt9Dv0ZxPQWKoEzcjnBlUo'),
+       ('PRSD23', current_date, null, 'urn:fdc:gov.uk:2022:_RNZomOzEjxF4o2NzxWskS062b7hTVWLFI8TYsmoWAk'),
+       ('PRSD24', current_date, null, 'urn:fdc:gov.uk:2022:A9B5GpzhlOrNoGQM65oUESHL5i3O9fp0wjizEFVcCrU'),
+       ('PRSD25', current_date, null, 'urn:fdc:gov.uk:2022:ListhqO1Hu6G90tyF_Rozj4F0YkLHreBnCQZ3JQSiEU'),
+       ('PRSD26', current_date, null, 'urn:fdc:gov.uk:2022:07lXHJeQwE0k5PZO7w_PQF425vT8T7e63MrvyPYNSoI'),
+       ('PRSD27', current_date, null, 'urn:fdc:gov.uk:2022:sgO5-g7fThIp2MhXMcvFo5N6ObnstGFVNSYFkghMd24'),
+       ('PRSD29', current_date, null, 'urn:fdc:gov.uk:2022:La9gwI6zvuzT3yvKjsKEH2cDbtL88wNbiqAeXQ0plEM'),
+       ('PRSD32', current_date, null, 'urn:fdc:gov.uk:2022:mwfvbb5GgiDh0acjz9EDDQ7zwskWZzUSnWfavL70f6s') ON CONFLICT DO NOTHING;

--- a/src/main/resources/data-test.sql
+++ b/src/main/resources/data-test.sql
@@ -224,25 +224,25 @@ ON CONFLICT DO NOTHING;
 
 SELECT setval(pg_get_serial_sequence('system_operator', 'id'), (SELECT MAX(id) FROM system_operator));
 
-INSERT INTO passcode (passcode, local_council_id, created_date, last_modified_date, subject_identifier)
-VALUES ('PRSD22', 1, current_date, null, 'urn:fdc:gov.uk:2022:mGHDySEVfCsvfvc6lVWf6Qt9Dv0ZxPQWKoEzcjnBlUo'), -- Team-PRSDB+landlord@softwire.com
-       ('PRSD23', 1, current_date, null, 'urn:fdc:gov.uk:2022:_RNZomOzEjxF4o2NzxWskS062b7hTVWLFI8TYsmoWAk'), -- travis.woodward@communities.gov.uk
-       ('PRSD24', 1, current_date, null, 'urn:fdc:gov.uk:2022:A9B5GpzhlOrNoGQM65oUESHL5i3O9fp0wjizEFVcCrU'), -- alexander.read@softwire.com
-       ('PRSD25', 1, current_date, null, 'urn:fdc:gov.uk:2022:ListhqO1Hu6G90tyF_Rozj4F0YkLHreBnCQZ3JQSiEU'), -- kiran.randhawakukar@softwire.com
-       ('PRSD26', 1, current_date, null, 'urn:fdc:gov.uk:2022:07lXHJeQwE0k5PZO7w_PQF425vT8T7e63MrvyPYNSoI'), -- jasmin.conterio@softwire.com
-       ('PRSD27', 1, current_date, null, 'urn:fdc:gov.uk:2022:sgO5-g7fThIp2MhXMcvFo5N6ObnstGFVNSYFkghMd24'), -- Team-PRSDB+Unverified@softwire.com
-       ('PRSD29', 1, current_date, null, 'urn:fdc:gov.uk:2022:La9gwI6zvuzT3yvKjsKEH2cDbtL88wNbiqAeXQ0plEM'), -- team-prsdb+verified@softwire.com
-       ('PRSD34', 1, current_date, null, 'urn:fdc:gov.uk:2022:ea8XwChQkjezm4MgGJIzI_HRm7l8IPPTIMT705UQXjI'), -- geetika.kejriwal@communities.gov.uk
-       ('PRSD35', 1, current_date, null, 'urn:fdc:gov.uk:2022:kob7zYIuzdrUxKTYq7160l_6Tj2ScXTPJ876jZVvAFA'), -- catherine.graham2@communities.gov.uk
-       ('PRSD37', 1, current_date, null, 'urn:fdc:gov.uk:2022:DXI5RSmCmbPQQhBAPCbw1nkL-Dauufg6VOWdR9TuYlk'), -- norris.orighoye@communities.gov.uk
-       ('PRSD39', 1, current_date, null, 'urn:fdc:gov.uk:2022:vgKfvjYRO1LnJkmBr7CkEV62g9WoDeD-sZZNt9GCiVU'), -- sharan.flora@communities.gov.uk
-       ('PRSD42', 1, current_date, null, 'urn:fdc:gov.uk:2022:pciqch9dYbtBx2rAhxvaCIEu00cQv3NFeIk5f4BesLo'), -- rowan.hill@softwire.com
-       ('PRSD52', 1, current_date, null, 'urn:fdc:gov.uk:2022:Q2BSE6pweSpQF8oSBhjHAIjEuLlkRJZzJQ4TO0c7wgI'), -- sandra.lila@communities.gov.uk
-       ('PRSD53', 1, current_date, null, 'urn:fdc:gov.uk:2022:T0PqJH7B2o8y3t8-cCEsAk1tL8iSf-svJy-O5HvsynE'), -- chris.lightfoot@communities.gov.uk
-       ('PRSD54', 1, current_date, null, 'urn:fdc:gov.uk:2022:BqdyyKzMzY6miLk0NSjJZ8j4GHtmuLgL45KisrXMxMg'), -- Ned.FrederickCalas-Hathaway@softwire.com
-       ('PRSD55', 1, current_date, null, 'urn:fdc:gov.uk:2022:po6yDD8EFb0c0UfVVoEZHKQyN_mvBG81mcZPz1r83Ss'), -- Dani
-       ('PRSD56', 1, current_date, null, 'urn:fdc:gov.uk:2022:nzYcgBUq3Exgd00RvATgx6_nIUpEq5vO0mMeeNGoLI8'), -- Shannon
-       ('PRSD57', 1, current_date, null, 'urn:fdc:gov.uk:2022:zLxuwilkLOLLpD3tTmOcG_lE8BNj0NFyqjU17lzn6cI'), -- Rebecca
-       ('PRSD58', 1, current_date, null, 'urn:fdc:gov.uk:2022:mCqrvLgjky23tcKQNo4C4GjDn13sZNcVhdhfqqvimTc'), -- Lewis
-       ('PRSD59', 1, current_date, null, 'urn:fdc:gov.uk:2022:V7SiTu5znvhYuTqkLgN0cOzaGrzkKpGBnrWj8BRQ34Y')  -- Adam
+INSERT INTO passcode (passcode, created_date, last_modified_date, subject_identifier)
+VALUES ('PRSD22', current_date, null, 'urn:fdc:gov.uk:2022:mGHDySEVfCsvfvc6lVWf6Qt9Dv0ZxPQWKoEzcjnBlUo'), -- Team-PRSDB+landlord@softwire.com
+       ('PRSD23', current_date, null, 'urn:fdc:gov.uk:2022:_RNZomOzEjxF4o2NzxWskS062b7hTVWLFI8TYsmoWAk'), -- travis.woodward@communities.gov.uk
+       ('PRSD24', current_date, null, 'urn:fdc:gov.uk:2022:A9B5GpzhlOrNoGQM65oUESHL5i3O9fp0wjizEFVcCrU'), -- alexander.read@softwire.com
+       ('PRSD25', current_date, null, 'urn:fdc:gov.uk:2022:ListhqO1Hu6G90tyF_Rozj4F0YkLHreBnCQZ3JQSiEU'), -- kiran.randhawakukar@softwire.com
+       ('PRSD26', current_date, null, 'urn:fdc:gov.uk:2022:07lXHJeQwE0k5PZO7w_PQF425vT8T7e63MrvyPYNSoI'), -- jasmin.conterio@softwire.com
+       ('PRSD27', current_date, null, 'urn:fdc:gov.uk:2022:sgO5-g7fThIp2MhXMcvFo5N6ObnstGFVNSYFkghMd24'), -- Team-PRSDB+Unverified@softwire.com
+       ('PRSD29', current_date, null, 'urn:fdc:gov.uk:2022:La9gwI6zvuzT3yvKjsKEH2cDbtL88wNbiqAeXQ0plEM'), -- team-prsdb+verified@softwire.com
+       ('PRSD34', current_date, null, 'urn:fdc:gov.uk:2022:ea8XwChQkjezm4MgGJIzI_HRm7l8IPPTIMT705UQXjI'), -- geetika.kejriwal@communities.gov.uk
+       ('PRSD35', current_date, null, 'urn:fdc:gov.uk:2022:kob7zYIuzdrUxKTYq7160l_6Tj2ScXTPJ876jZVvAFA'), -- catherine.graham2@communities.gov.uk
+       ('PRSD37', current_date, null, 'urn:fdc:gov.uk:2022:DXI5RSmCmbPQQhBAPCbw1nkL-Dauufg6VOWdR9TuYlk'), -- norris.orighoye@communities.gov.uk
+       ('PRSD39', current_date, null, 'urn:fdc:gov.uk:2022:vgKfvjYRO1LnJkmBr7CkEV62g9WoDeD-sZZNt9GCiVU'), -- sharan.flora@communities.gov.uk
+       ('PRSD42', current_date, null, 'urn:fdc:gov.uk:2022:pciqch9dYbtBx2rAhxvaCIEu00cQv3NFeIk5f4BesLo'), -- rowan.hill@softwire.com
+       ('PRSD52', current_date, null, 'urn:fdc:gov.uk:2022:Q2BSE6pweSpQF8oSBhjHAIjEuLlkRJZzJQ4TO0c7wgI'), -- sandra.lila@communities.gov.uk
+       ('PRSD53', current_date, null, 'urn:fdc:gov.uk:2022:T0PqJH7B2o8y3t8-cCEsAk1tL8iSf-svJy-O5HvsynE'), -- chris.lightfoot@communities.gov.uk
+       ('PRSD54', current_date, null, 'urn:fdc:gov.uk:2022:BqdyyKzMzY6miLk0NSjJZ8j4GHtmuLgL45KisrXMxMg'), -- Ned.FrederickCalas-Hathaway@softwire.com
+       ('PRSD55', current_date, null, 'urn:fdc:gov.uk:2022:po6yDD8EFb0c0UfVVoEZHKQyN_mvBG81mcZPz1r83Ss'), -- Dani
+       ('PRSD56', current_date, null, 'urn:fdc:gov.uk:2022:nzYcgBUq3Exgd00RvATgx6_nIUpEq5vO0mMeeNGoLI8'), -- Shannon
+       ('PRSD57', current_date, null, 'urn:fdc:gov.uk:2022:zLxuwilkLOLLpD3tTmOcG_lE8BNj0NFyqjU17lzn6cI'), -- Rebecca
+       ('PRSD58', current_date, null, 'urn:fdc:gov.uk:2022:mCqrvLgjky23tcKQNo4C4GjDn13sZNcVhdhfqqvimTc'), -- Lewis
+       ('PRSD59', current_date, null, 'urn:fdc:gov.uk:2022:V7SiTu5znvhYuTqkLgN0cOzaGrzkKpGBnrWj8BRQ34Y')  -- Adam
 ON CONFLICT DO NOTHING;

--- a/src/main/resources/db/migrations/V1_21_0__remove_local_council_from_passcode.sql
+++ b/src/main/resources/db/migrations/V1_21_0__remove_local_council_from_passcode.sql
@@ -1,0 +1,1 @@
+ALTER TABLE passcode DROP COLUMN local_council_id;

--- a/src/main/resources/db/migrations/V1_21_0__remove_local_council_from_passcode.sql
+++ b/src/main/resources/db/migrations/V1_21_0__remove_local_council_from_passcode.sql
@@ -1,1 +1,2 @@
+ALTER TABLE passcode DROP CONSTRAINT passcode_local_authority_id_fkey;
 ALTER TABLE passcode DROP COLUMN local_council_id;

--- a/src/main/resources/templates/error/passcodeLimit.html
+++ b/src/main/resources/templates/error/passcodeLimit.html
@@ -6,9 +6,6 @@
             <h1 class="govuk-heading-l" th:text="#{error.passcodeLimit.header}">error.passcodeLimit.header</h1>
             <p class="govuk-body" th:text="#{error.passcodeLimit.body.one}">error.passcodeLimit.body.one</p>
             <p class="govuk-body" th:text="#{error.passcodeLimit.body.two}">error.passcodeLimit.body.two</p>
-            <button th:replace="~{fragments/buttons/primaryButtonLink :: primaryButtonLink(${dashboardUrl}, #{error.passcodeLimit.cta})}">
-                error.passcodeLimit.cta
-            </button>
         </div>
     </div>
 </main>

--- a/src/main/resources/templates/generatePasscode.html
+++ b/src/main/resources/templates/generatePasscode.html
@@ -15,7 +15,6 @@
         <form method="POST" th:action="@{''}">
             <div class="govuk-button-group">
                 <button th:replace="~{fragments/buttons/primaryButton :: primaryButton(#{generatePasscode.generateAnother})}">generatePasscode.generateAnother</button>
-                <a th:replace="~{fragments/buttons/secondaryButtonLink :: secondaryButtonLink(${dashboardUrl}, #{generatePasscode.returnToDashboard})}">generatePasscode.returnToDashboard</a>
             </div>
         </form>
     </main>

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/controllers/GeneratePasscodeControllerTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/controllers/GeneratePasscodeControllerTests.kt
@@ -12,11 +12,8 @@ import org.springframework.test.web.servlet.get
 import org.springframework.test.web.servlet.post
 import org.springframework.web.context.WebApplicationContext
 import uk.gov.communities.prsdb.webapp.controllers.GeneratePasscodeController.Companion.GENERATE_PASSCODE_URL
-import uk.gov.communities.prsdb.webapp.controllers.LocalCouncilDashboardController.Companion.LOCAL_COUNCIL_DASHBOARD_URL
 import uk.gov.communities.prsdb.webapp.exceptions.PasscodeLimitExceededException
-import uk.gov.communities.prsdb.webapp.services.LocalCouncilDataService
 import uk.gov.communities.prsdb.webapp.services.PasscodeService
-import uk.gov.communities.prsdb.webapp.testHelpers.mockObjects.MockLocalCouncilData.Companion.createLocalCouncilUser
 import kotlin.test.Test
 
 @WebMvcTest(GeneratePasscodeController::class)
@@ -26,9 +23,6 @@ class GeneratePasscodeControllerTests(
 ) : ControllerTest(webContext) {
     @MockitoBean
     private lateinit var passcodeService: PasscodeService
-
-    @MockitoBean
-    private lateinit var localCouncilDataService: LocalCouncilDataService
 
     @Test
     fun `generatePasscodeGet returns a redirect for unauthenticated user`() {
@@ -50,13 +44,11 @@ class GeneratePasscodeControllerTests(
     }
 
     @Test
-    @WithMockUser(roles = ["LOCAL_COUNCIL_ADMIN"])
-    fun `generatePasscodeGet returns 200 and generates passcode for authorized LC admin`() {
-        val localCouncilUser = createLocalCouncilUser()
+    @WithMockUser(roles = ["SYSTEM_OPERATOR"])
+    fun `generatePasscodeGet returns 200 and generates passcode for authorized system operator`() {
         val testPasscode = "ABC123"
 
-        whenever(localCouncilDataService.getLocalCouncilUser("user")).thenReturn(localCouncilUser)
-        whenever(passcodeService.getOrGeneratePasscode(localCouncilUser.localCouncil.id.toLong()))
+        whenever(passcodeService.getOrGeneratePasscode())
             .thenReturn(testPasscode)
 
         mvc
@@ -66,18 +58,14 @@ class GeneratePasscodeControllerTests(
                 view { name("generatePasscode") }
                 model {
                     attribute("passcode", testPasscode)
-                    attribute("dashboardUrl", LOCAL_COUNCIL_DASHBOARD_URL)
                 }
             }
     }
 
     @Test
-    @WithMockUser(roles = ["LOCAL_COUNCIL_ADMIN"])
+    @WithMockUser(roles = ["SYSTEM_OPERATOR"])
     fun `generatePasscodeGet returns passcode limit error when limit exceeded`() {
-        val localCouncilUser = createLocalCouncilUser()
-
-        whenever(localCouncilDataService.getLocalCouncilUser("user")).thenReturn(localCouncilUser)
-        whenever(passcodeService.getOrGeneratePasscode(localCouncilUser.localCouncil.id.toLong()))
+        whenever(passcodeService.getOrGeneratePasscode())
             .thenThrow(PasscodeLimitExceededException("Passcode limit exceeded"))
 
         mvc
@@ -112,13 +100,11 @@ class GeneratePasscodeControllerTests(
     }
 
     @Test
-    @WithMockUser(roles = ["LOCAL_COUNCIL_ADMIN"])
-    fun `generatePasscodePost returns 200 and generates new passcode for authorized Local Council admin`() {
-        val localCouncilUser = createLocalCouncilUser()
+    @WithMockUser(roles = ["SYSTEM_OPERATOR"])
+    fun `generatePasscodePost returns 200 and generates new passcode for authorized system operator`() {
         val testPasscode = "DEF456"
 
-        whenever(localCouncilDataService.getLocalCouncilUser("user")).thenReturn(localCouncilUser)
-        whenever(passcodeService.generateAndStorePasscode(localCouncilUser.localCouncil.id.toLong()))
+        whenever(passcodeService.generateAndStorePasscode())
             .thenReturn(testPasscode)
 
         mvc
@@ -130,19 +116,14 @@ class GeneratePasscodeControllerTests(
                 view { name("generatePasscode") }
                 model {
                     attribute("passcode", testPasscode)
-                    attribute("dashboardUrl", LOCAL_COUNCIL_DASHBOARD_URL)
-                    attribute("backUrl", LOCAL_COUNCIL_DASHBOARD_URL)
                 }
             }
     }
 
     @Test
-    @WithMockUser(roles = ["LOCAL_COUNCIL_ADMIN"])
+    @WithMockUser(roles = ["SYSTEM_OPERATOR"])
     fun `generatePasscodePost returns passcode limit error when limit exceeded`() {
-        val localCouncilUser = createLocalCouncilUser()
-
-        whenever(localCouncilDataService.getLocalCouncilUser("user")).thenReturn(localCouncilUser)
-        whenever(passcodeService.generateAndStorePasscode(localCouncilUser.localCouncil.id.toLong()))
+        whenever(passcodeService.generateAndStorePasscode())
             .thenThrow(PasscodeLimitExceededException("Passcode limit exceeded"))
 
         mvc
@@ -157,7 +138,7 @@ class GeneratePasscodeControllerTests(
 
     @Test
     @WithMockUser(roles = ["LOCAL_COUNCIL_USER"])
-    fun `generatePasscodeGet returns 403 for LOCAL_COUNCIL_USER role (should only allow LOCAL_COUNCIL_ADMIN)`() {
+    fun `generatePasscodeGet returns 403 for LOCAL_COUNCIL_USER role`() {
         mvc
             .get(GENERATE_PASSCODE_URL)
             .andExpect {
@@ -167,7 +148,29 @@ class GeneratePasscodeControllerTests(
 
     @Test
     @WithMockUser(roles = ["LOCAL_COUNCIL_USER"])
-    fun `generatePasscodePost returns 403 for LOCAL_COUNCIL_USER role (should only allow LOCAL_COUNCIL_ADMIN)`() {
+    fun `generatePasscodePost returns 403 for LOCAL_COUNCIL_USER role`() {
+        mvc
+            .post(GENERATE_PASSCODE_URL) {
+                contentType = MediaType.APPLICATION_FORM_URLENCODED
+                with(csrf())
+            }.andExpect {
+                status { isForbidden() }
+            }
+    }
+
+    @Test
+    @WithMockUser(roles = ["LOCAL_COUNCIL_ADMIN"])
+    fun `generatePasscodeGet returns 403 for LOCAL_COUNCIL_ADMIN role`() {
+        mvc
+            .get(GENERATE_PASSCODE_URL)
+            .andExpect {
+                status { isForbidden() }
+            }
+    }
+
+    @Test
+    @WithMockUser(roles = ["LOCAL_COUNCIL_ADMIN"])
+    fun `generatePasscodePost returns 403 for LOCAL_COUNCIL_ADMIN role`() {
         mvc
             .post(GENERATE_PASSCODE_URL) {
                 contentType = MediaType.APPLICATION_FORM_URLENCODED

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/GeneratePasscodeTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/GeneratePasscodeTests.kt
@@ -5,10 +5,10 @@ import org.junit.jupiter.api.Test
 import org.mockito.kotlin.whenever
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.bean.override.mockito.MockitoSpyBean
+import uk.gov.communities.prsdb.webapp.controllers.GeneratePasscodeController.Companion.GENERATE_PASSCODE_URL
 import uk.gov.communities.prsdb.webapp.database.repository.PasscodeRepository
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.BaseComponent.Companion.assertThat
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.GeneratePasscodePage
-import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.LocalCouncilDashboardPage
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.PasscodeLimitExceededPage
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages.BasePage.Companion.assertPageIs
 import kotlin.test.assertEquals
@@ -20,19 +20,11 @@ class GeneratePasscodeTests : IntegrationTestWithMutableData("data-local.sql") {
     lateinit var passcodeRepository: PasscodeRepository
 
     @Test
-    fun `local council admin can access generate passcode page from dashboard and navigate back`(page: Page) {
-        // Navigate to generate passcode page from LA dashboard
-        val dashboardPage = navigator.goToLocalCouncilDashboard()
-        dashboardPage.generatePasscodeLink.clickAndWait()
-        val generatePasscodePage = assertPageIs(page, GeneratePasscodePage::class)
+    fun `system operator can access generate passcode page`(page: Page) {
+        val generatePasscodePage = navigator.goToGeneratePasscodePage()
 
-        // Verify passcode is displayed
         assertThat(generatePasscodePage.banner.title).containsText("New passcode")
         assert(generatePasscodePage.banner.passcode.isNotEmpty()) { "Passcode should be generated and displayed" }
-
-        // Test return to dashboard link
-        generatePasscodePage.returnToDashboardButton.clickAndWait()
-        assertPageIs(page, LocalCouncilDashboardPage::class)
     }
 
     @Test
@@ -76,35 +68,21 @@ class GeneratePasscodeTests : IntegrationTestWithMutableData("data-local.sql") {
 
     @Test
     fun `exceeding maximum passcode limit redirects to error page`(page: Page) {
-        // Mock the repository to return a count >= 1000 to trigger the limit exceeded condition
         whenever(passcodeRepository.count()).thenReturn(1000L)
+        navigator.navigate(GENERATE_PASSCODE_URL)
 
-        // Try to reach the generate passcode page from the LA dashboard
-        val dashboardPage = navigator.goToLocalCouncilDashboard()
-        dashboardPage.generatePasscodeLink.clickAndWait()
-
-        // Verify we're redirected to the passcode limit error page
         val errorPage = assertPageIs(page, PasscodeLimitExceededPage::class)
         assertThat(errorPage.heading).containsText("Maximum number of passcodes reached")
     }
 
     @Test
     fun `exceeding maximum passcode limit when generating new passcode redirects to error page`(page: Page) {
-        // Navigate to generate passcode page first (this should work normally)
-        val dashboardPage = navigator.goToLocalCouncilDashboard()
-        dashboardPage.generatePasscodeLink.clickAndWait()
-        val generatePasscodePage = assertPageIs(page, GeneratePasscodePage::class)
-
-        // Verify initial passcode is generated
+        val generatePasscodePage = navigator.goToGeneratePasscodePage()
         assert(generatePasscodePage.banner.passcode.isNotEmpty()) { "Initial passcode should be generated" }
 
-        // Now mock the repository to return a count >= 1000 to trigger the limit for the next generation
         whenever(passcodeRepository.count()).thenReturn(1000L)
-
-        // Click generate another passcode button
         generatePasscodePage.generateAnotherButton.clickAndWait()
 
-        // Verify we're redirected to the passcode limit error page
         val errorPage = assertPageIs(page, PasscodeLimitExceededPage::class)
         assertThat(errorPage.heading).containsText("Maximum number of passcodes reached")
     }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/GeneratePasscodePage.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/GeneratePasscodePage.kt
@@ -3,7 +3,6 @@ package uk.gov.communities.prsdb.webapp.integration.pageObjects.pages
 import com.microsoft.playwright.Page
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.Button
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.ConfirmationBanner
-import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.Link
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages.BasePage
 
 class GeneratePasscodePage(
@@ -11,7 +10,6 @@ class GeneratePasscodePage(
 ) : BasePage(page, "generate-passcode") {
     val banner = GeneratePasscodeBanner(page)
     val generateAnotherButton = Button.byText(page, "Generate another passcode")
-    val returnToDashboardButton = Link.byText(page, "Return to dashboard", selectorOrLocator = "a")
 
     class GeneratePasscodeBanner(
         private val page: Page,

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/LocalCouncilDashboardPage.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/LocalCouncilDashboardPage.kt
@@ -14,7 +14,6 @@ class LocalCouncilDashboardPage(
     val betaBanner = BetaBanner(page)
     val bannerHeading = Heading(page.locator("div.prsd-dashboard-panel h1.govuk-heading-xl"))
     val bannerSubHeading = Heading(page.locator("div.prsd-dashboard-panel div.govuk-body-l"))
-    val generatePasscodeLink = Link.byText(page, "Generate a passcode", selectorOrLocator = "li.govuk-service-navigation__item")
     val manageUsersLink = Link.byText(page, "Manage users", selectorOrLocator = "li.govuk-service-navigation__item")
 
     val searchPropertyButton = Button.byText(page, "Search for a property")

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/PasscodeLimitExceededPage.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/PasscodeLimitExceededPage.kt
@@ -1,7 +1,6 @@
 package uk.gov.communities.prsdb.webapp.integration.pageObjects.pages
 
 import com.microsoft.playwright.Page
-import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.Button
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.Heading
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages.BasePage
 
@@ -11,10 +10,4 @@ class PasscodeLimitExceededPage(
     val heading = Heading(page.locator("main h1"))
     val bodyTextOne = page.locator("p.govuk-body").first()
     val bodyTextTwo = page.locator("p.govuk-body").nth(1)
-    val returnToDashboardButton = Button.byText(page, "Return to dashboard")
-
-    fun clickReturnToDashboard(): LocalCouncilDashboardPage {
-        returnToDashboardButton.clickAndWait()
-        return createValidPage(page, LocalCouncilDashboardPage::class)
-    }
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/PasscodeServiceTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/PasscodeServiceTests.kt
@@ -10,7 +10,6 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.mockito.ArgumentCaptor.captor
 import org.mockito.ArgumentMatchers.any
-import org.mockito.ArgumentMatchers.anyInt
 import org.mockito.ArgumentMatchers.anyString
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.never
@@ -20,46 +19,37 @@ import org.mockito.kotlin.whenever
 import uk.gov.communities.prsdb.webapp.constants.HAS_USER_CLAIMED_A_PASSCODE
 import uk.gov.communities.prsdb.webapp.constants.LAST_GENERATED_PASSCODE
 import uk.gov.communities.prsdb.webapp.constants.SAFE_CHARACTERS_CHARSET
-import uk.gov.communities.prsdb.webapp.database.entity.LocalCouncil
 import uk.gov.communities.prsdb.webapp.database.entity.Passcode
-import uk.gov.communities.prsdb.webapp.database.repository.LocalCouncilRepository
 import uk.gov.communities.prsdb.webapp.database.repository.PasscodeRepository
 import uk.gov.communities.prsdb.webapp.exceptions.PasscodeLimitExceededException
 import uk.gov.communities.prsdb.webapp.testHelpers.mockObjects.MockLandlordData
-import java.util.Optional
 
 class PasscodeServiceTests {
     private lateinit var mockPasscodeRepository: PasscodeRepository
-    private lateinit var mockLocalCouncilRepository: LocalCouncilRepository
     private lateinit var mockPrsdbUserService: PrsdbUserService
     private lateinit var mockSession: HttpSession
     private lateinit var passcodeService: PasscodeService
 
-    private val mockLocalCouncil = LocalCouncil()
     private val mockPasscode = Passcode()
 
     @BeforeEach
     fun setup() {
         mockPasscodeRepository = mock()
-        mockLocalCouncilRepository = mock()
         mockPrsdbUserService = mock()
         mockSession = mock()
-        passcodeService = PasscodeService(mockPasscodeRepository, mockLocalCouncilRepository, mockPrsdbUserService, mockSession)
+        passcodeService = PasscodeService(mockPasscodeRepository, mockPrsdbUserService, mockSession)
     }
 
     @Test
-    fun `generatePasscode creates a valid passcode for the given local council`() {
-        val localCouncilId = 123L
+    fun `generatePasscode creates a valid passcode`() {
         whenever(mockPasscodeRepository.count()).thenReturn(500L)
-        whenever(mockLocalCouncilRepository.findById(anyInt())).thenReturn(Optional.of(mockLocalCouncil))
         whenever(mockPasscodeRepository.existsByPasscode(anyString())).thenReturn(false)
         whenever(mockPasscodeRepository.save(any(Passcode::class.java))).thenReturn(mockPasscode)
 
-        val result = passcodeService.generatePasscode(localCouncilId)
+        val result = passcodeService.generatePasscode()
 
         assertEquals(mockPasscode, result)
         verify(mockPasscodeRepository).count()
-        verify(mockLocalCouncilRepository).findById(localCouncilId.toInt())
 
         val passcodeCaptor = captor<Passcode>()
         verify(mockPasscodeRepository).save(passcodeCaptor.capture())
@@ -72,18 +62,15 @@ class PasscodeServiceTests {
             "Generated passcode '${savedPasscode.passcode}' contains unsafe characters",
         )
         assertNotNull(savedPasscode.passcode)
-        assertEquals(mockLocalCouncil, savedPasscode.localCouncil)
     }
 
     @Test
     fun `generatePasscode handles collisions and creates unique passcode`() {
-        val localCouncilId = 123L
         whenever(mockPasscodeRepository.count()).thenReturn(500L)
-        whenever(mockLocalCouncilRepository.findById(anyInt())).thenReturn(Optional.of(mockLocalCouncil))
         whenever(mockPasscodeRepository.existsByPasscode(anyString())).thenReturn(true, true, false)
         whenever(mockPasscodeRepository.save(any(Passcode::class.java))).thenReturn(mockPasscode)
 
-        passcodeService.generatePasscode(localCouncilId)
+        passcodeService.generatePasscode()
 
         verify(mockPasscodeRepository).count()
         verify(mockPasscodeRepository, times(3)).existsByPasscode(anyString())
@@ -91,83 +78,58 @@ class PasscodeServiceTests {
     }
 
     @Test
-    fun `generatePasscode throws exception when local council not found`() {
-        val localCouncilId = 999L
-        whenever(mockPasscodeRepository.count()).thenReturn(500L)
-        whenever(mockLocalCouncilRepository.findById(anyInt())).thenReturn(Optional.empty())
-
-        val exception =
-            assertThrows(IllegalArgumentException::class.java) {
-                passcodeService.generatePasscode(localCouncilId)
-            }
-
-        assertEquals("LocalCouncil with id $localCouncilId not found", exception.message)
-        verify(mockPasscodeRepository).count()
-    }
-
-    @Test
     fun `generatePasscode throws PasscodeLimitExceededException when limit is reached`() {
-        val localCouncilId = 123L
         whenever(mockPasscodeRepository.count()).thenReturn(1000L)
 
         val exception =
             assertThrows(PasscodeLimitExceededException::class.java) {
-                passcodeService.generatePasscode(localCouncilId)
+                passcodeService.generatePasscode()
             }
 
         assertEquals("Maximum number of passcodes (1000) has been reached", exception.message)
         verify(mockPasscodeRepository).count()
-        verify(mockLocalCouncilRepository, never()).findById(anyInt())
         verify(mockPasscodeRepository, never()).save(any(Passcode::class.java))
     }
 
     @Test
     fun `generatePasscode throws PasscodeLimitExceededException when limit is exceeded`() {
-        val localCouncilId = 123L
         whenever(mockPasscodeRepository.count()).thenReturn(1001L)
 
         val exception =
             assertThrows(PasscodeLimitExceededException::class.java) {
-                passcodeService.generatePasscode(localCouncilId)
+                passcodeService.generatePasscode()
             }
 
         assertEquals("Maximum number of passcodes (1000) has been reached", exception.message)
         verify(mockPasscodeRepository).count()
-        verify(mockLocalCouncilRepository, never()).findById(anyInt())
         verify(mockPasscodeRepository, never()).save(any(Passcode::class.java))
     }
 
     @Test
     fun `generatePasscode succeeds when count is just below limit`() {
-        val localCouncilId = 123L
         whenever(mockPasscodeRepository.count()).thenReturn(999L)
-        whenever(mockLocalCouncilRepository.findById(anyInt())).thenReturn(Optional.of(mockLocalCouncil))
         whenever(mockPasscodeRepository.existsByPasscode(anyString())).thenReturn(false)
         whenever(mockPasscodeRepository.save(any(Passcode::class.java))).thenReturn(mockPasscode)
 
-        val result = passcodeService.generatePasscode(localCouncilId)
+        val result = passcodeService.generatePasscode()
 
         assertEquals(mockPasscode, result)
         verify(mockPasscodeRepository).count()
-        verify(mockLocalCouncilRepository).findById(localCouncilId.toInt())
         verify(mockPasscodeRepository).save(any(Passcode::class.java))
     }
 
     @Test
-    fun `generateAndStorePasscode creates and stores a valid passcode for the given local council`() {
-        val localCouncilId = 123L
+    fun `generateAndStorePasscode creates and stores a valid passcode`() {
         val mockPasscodeValue = "ABC123"
-        val mockPasscodeWithValue = Passcode(mockPasscodeValue, mockLocalCouncil)
+        val mockPasscodeWithValue = Passcode(mockPasscodeValue)
         whenever(mockPasscodeRepository.count()).thenReturn(500L)
-        whenever(mockLocalCouncilRepository.findById(anyInt())).thenReturn(Optional.of(mockLocalCouncil))
         whenever(mockPasscodeRepository.existsByPasscode(anyString())).thenReturn(false)
         whenever(mockPasscodeRepository.save(any(Passcode::class.java))).thenReturn(mockPasscodeWithValue)
 
-        val result = passcodeService.generateAndStorePasscode(localCouncilId)
+        val result = passcodeService.generateAndStorePasscode()
 
         assertEquals(mockPasscodeValue, result)
         verify(mockPasscodeRepository).count()
-        verify(mockLocalCouncilRepository).findById(localCouncilId.toInt())
 
         val passcodeCaptor = captor<Passcode>()
         verify(mockPasscodeRepository).save(passcodeCaptor.capture())
@@ -180,17 +142,15 @@ class PasscodeServiceTests {
             "Generated passcode '${savedPasscode.passcode}' contains unsafe characters",
         )
         assertNotNull(savedPasscode.passcode)
-        assertEquals(mockLocalCouncil, savedPasscode.localCouncil)
     }
 
     @Test
     fun `generateAndStorePasscode throws PasscodeLimitExceededException when limit is reached`() {
-        val localCouncilId = 123L
         whenever(mockPasscodeRepository.count()).thenReturn(1000L)
 
         val exception =
             assertThrows(PasscodeLimitExceededException::class.java) {
-                passcodeService.generateAndStorePasscode(localCouncilId)
+                passcodeService.generateAndStorePasscode()
             }
 
         assertEquals("Maximum number of passcodes (1000) has been reached", exception.message)
@@ -200,13 +160,12 @@ class PasscodeServiceTests {
 
     @Test
     fun `getOrGeneratePasscode throws PasscodeLimitExceededException when limit is reached and no cached passcode exists`() {
-        val localCouncilId = 123L
         whenever(mockSession.getAttribute(LAST_GENERATED_PASSCODE)).thenReturn(null)
         whenever(mockPasscodeRepository.count()).thenReturn(1000L)
 
         val exception =
             assertThrows(PasscodeLimitExceededException::class.java) {
-                passcodeService.getOrGeneratePasscode(localCouncilId)
+                passcodeService.getOrGeneratePasscode()
             }
 
         assertEquals("Maximum number of passcodes (1000) has been reached", exception.message)
@@ -215,38 +174,33 @@ class PasscodeServiceTests {
 
     @Test
     fun `getOrGeneratePasscode returns cached passcode when limit is reached but passcode exists in session`() {
-        val localCouncilId = 123L
         val cachedPasscode = "ABC123"
         whenever(mockSession.getAttribute(LAST_GENERATED_PASSCODE)).thenReturn(cachedPasscode)
         whenever(mockPasscodeRepository.count()).thenReturn(1000L)
 
-        val result = passcodeService.getOrGeneratePasscode(localCouncilId)
+        val result = passcodeService.getOrGeneratePasscode()
 
         assertEquals(cachedPasscode, result)
         verify(mockSession).getAttribute(LAST_GENERATED_PASSCODE)
         verify(mockPasscodeRepository, never()).count()
-        verify(mockLocalCouncilRepository, never()).findById(anyInt())
         verify(mockPasscodeRepository, never()).save(any(Passcode::class.java))
     }
 
     @Test
     fun `getOrGeneratePasscode generates new passcode when no cached passcode exists`() {
-        val localCouncilId = 123L
         val mockPasscodeValue = "XYZ789"
-        val mockPasscodeWithValue = Passcode(mockPasscodeValue, mockLocalCouncil)
+        val mockPasscodeWithValue = Passcode(mockPasscodeValue)
         whenever(mockSession.getAttribute(LAST_GENERATED_PASSCODE)).thenReturn(null)
         whenever(mockPasscodeRepository.count()).thenReturn(500L)
-        whenever(mockLocalCouncilRepository.findById(anyInt())).thenReturn(Optional.of(mockLocalCouncil))
         whenever(mockPasscodeRepository.existsByPasscode(anyString())).thenReturn(false)
         whenever(mockPasscodeRepository.save(any(Passcode::class.java))).thenReturn(mockPasscodeWithValue)
 
-        val result = passcodeService.getOrGeneratePasscode(localCouncilId)
+        val result = passcodeService.getOrGeneratePasscode()
 
         assertEquals(mockPasscodeValue, result)
         verify(mockSession).getAttribute(LAST_GENERATED_PASSCODE)
         verify(mockSession).setAttribute(LAST_GENERATED_PASSCODE, mockPasscodeValue)
         verify(mockPasscodeRepository).count()
-        verify(mockLocalCouncilRepository).findById(localCouncilId.toInt())
         verify(mockPasscodeRepository).save(any(Passcode::class.java))
     }
 

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/testHelpers/mockObjects/MockLandlordData.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/testHelpers/mockObjects/MockLandlordData.kt
@@ -183,9 +183,8 @@ class MockLandlordData {
 
         fun createPasscode(
             code: String = "ABCDEF",
-            localCouncil: LocalCouncil = createLocalCouncil(),
             baseUser: PrsdbUser? = createPrsdbUser(),
-        ) = Passcode(code, localCouncil, baseUser)
+        ) = Passcode(code, baseUser)
 
         fun createLandlordSearchResultDataModel(
             id: Long = 1,

--- a/src/test/resources/data-mockuser-landlord-with-properties-and-incomplete-property.sql
+++ b/src/test/resources/data-mockuser-landlord-with-properties-and-incomplete-property.sql
@@ -1,8 +1,8 @@
 INSERT INTO prsdb_user (id, created_date)
 VALUES ('urn:fdc:gov.uk:2022:UVWXY', '10/14/24');
 
-INSERT INTO passcode (passcode, local_council_id, subject_identifier)
-VALUES ('PRS23', 2, 'urn:fdc:gov.uk:2022:UVWXY');
+INSERT INTO passcode (passcode, subject_identifier)
+VALUES ('PRS23', 'urn:fdc:gov.uk:2022:UVWXY');
 
 INSERT INTO registration_number (id, created_date, number, type)
 VALUES (1, '09/13/24', 2001001001, 1),

--- a/src/test/resources/data-mockuser-landlord-with-properties.sql
+++ b/src/test/resources/data-mockuser-landlord-with-properties.sql
@@ -1,8 +1,8 @@
 INSERT INTO prsdb_user (id, created_date)
 VALUES ('urn:fdc:gov.uk:2022:UVWXY', '10/14/24');
 
-INSERT INTO passcode (passcode, local_council_id, subject_identifier)
-VALUES ('PRS23', 2, 'urn:fdc:gov.uk:2022:UVWXY');
+INSERT INTO passcode (passcode, subject_identifier)
+VALUES ('PRS23', 'urn:fdc:gov.uk:2022:UVWXY');
 
 INSERT INTO registration_number (id, created_date, number, type)
 VALUES (1, '09/13/24', 2001001001, 1),

--- a/src/test/resources/data-passcode.sql
+++ b/src/test/resources/data-passcode.sql
@@ -2,6 +2,6 @@ INSERT INTO prsdb_user (id, created_date)
 VALUES ('urn:fdc:gov.uk:2022:UVWXY', '10/14/24'),
        ('urn:fdc:gov.uk:2022:ABCDE', '10/14/24');
 
-INSERT INTO passcode (passcode, local_council_id, created_date, last_modified_date, subject_identifier)
-VALUES ('FREE01', 2, current_date, null, null),
-       ('TAKEN1', 2, current_date, null, 'urn:fdc:gov.uk:2022:ABCDE');
+INSERT INTO passcode (passcode, created_date, last_modified_date, subject_identifier)
+VALUES ('FREE01', current_date, null, null),
+       ('TAKEN1', current_date, null, 'urn:fdc:gov.uk:2022:ABCDE');


### PR DESCRIPTION
## Ticket number

PDJB-241

## Goal of change

Decouple passcodes from local councils and move the generate-passcode page under the system-operator URL path.

## Description of main change(s)

- Removed the local council foreign key from the `Passcode` entity and dropped the `local_council_id` column via a Flyway migration
- Removed the `LocalCouncilDataService` dependency and `Principal` parameter from `GeneratePasscodeController` — passcode generation no longer needs a council context
- Changed access from `LOCAL_COUNCIL_ADMIN` to `SYSTEM_OPERATOR` role
- Moved the endpoint from `/local-council/generate-passcode` to `/system-operator/generate-passcode`
- Removed the 'Generate passcode' navigation link from the local council dashboard
- Removed the 'Return to dashboard' links from both the generate passcode page and the passcode limit error page
- Simplified `PasscodeService` by removing the `localCouncilId` parameter from all generation methods
- Updated seed data, unit tests, controller tests, integration tests, and page objects to match

## Anything you'd like to highlight to the reviewer?

The endpoint now falls under the `DefaultSecurityConfig` filter chain (instead of `LocalCouncilSecurityConfig`) which is consistent with other system-operator routes like `ManageLocalCouncilAdminsController`.

## Checklist

- [x] Unit tests for new logic (e.g. new service methods) have been added
- [x] Controller tests for any new endpoints, including testing the relevant permissions
- [x] Branch has been rebased onto main and run locally, with everything working as expected (both for your new feature and any related functionality)
- [x] Seed data has been updated as needed for your feature to be tested without having to e.g. register a new property
