### PR TITLE
PDJB-NONE: Profile-gate NftDataSeeder to fix scheduled task startup

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/application/NftDataSeedingTaskApplicationRunner.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/application/NftDataSeedingTaskApplicationRunner.kt
@@ -4,13 +4,11 @@ import org.springframework.boot.ApplicationArguments
 import org.springframework.boot.ApplicationRunner
 import org.springframework.boot.SpringApplication
 import org.springframework.context.ApplicationContext
-import org.springframework.context.annotation.Profile
 import uk.gov.communities.prsdb.webapp.annotations.taskAnnotations.PrsdbTask
 import uk.gov.communities.prsdb.webapp.services.NftDataSeeder
 import kotlin.system.exitProcess
 
 @PrsdbTask("nft-data-seeder")
-@Profile("local", "nft")
 class NftDataSeedingTaskApplicationRunner(
     private val context: ApplicationContext,
     private val nftDataSeeder: NftDataSeeder,

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/NftDataSeeder.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/NftDataSeeder.kt
@@ -2,6 +2,7 @@ package uk.gov.communities.prsdb.webapp.services
 
 import org.hibernate.SessionFactory
 import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.annotation.Profile
 import uk.gov.communities.prsdb.webapp.annotations.taskAnnotations.PrsdbTaskService
 import uk.gov.communities.prsdb.webapp.constants.enums.CertificateType
 import uk.gov.communities.prsdb.webapp.constants.enums.RegistrationNumberType
@@ -27,12 +28,12 @@ import kotlin.math.ceil
 import kotlin.math.min
 
 @PrsdbTaskService
+@Profile("nft-data-seeder")
 class NftDataSeeder(
     private val sessionFactory: SessionFactory,
     private val localCouncilRepository: LocalCouncilRepository,
     private val addressRepository: AddressRepository,
-    // TODO PDJB-239: Ensure EPC_CERTIFICATE_BASE_URL is available when running the seeder
-    @Value("\${epc.certificate-base-url:}")
+    @Value("\${epc.certificate-base-url}")
     private val epcCertificateBaseUrl: String,
 ) {
     private lateinit var nftDataSeederDao: NftDataSeederDao

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/applications/PrsdbTaskApplicationTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/applications/PrsdbTaskApplicationTests.kt
@@ -28,7 +28,6 @@ import uk.gov.communities.prsdb.webapp.services.AbsoluteUrlProvider
 import uk.gov.communities.prsdb.webapp.services.AwsS3DequarantiningFileCopier
 import uk.gov.communities.prsdb.webapp.services.AwsS3QuarantinedFileDeleter
 import uk.gov.communities.prsdb.webapp.services.IncompletePropertiesService
-import uk.gov.communities.prsdb.webapp.services.NftDataSeeder
 import uk.gov.communities.prsdb.webapp.services.NgdAddressLoader
 import uk.gov.communities.prsdb.webapp.services.NotifyEmailNotificationService
 import uk.gov.communities.prsdb.webapp.services.NotifyIdService
@@ -82,7 +81,6 @@ class PrsdbTaskApplicationTests {
                 PropertyOwnershipSearchRepositoryImpl::class.simpleBeanName,
                 LandlordSearchRepositoryImpl::class.simpleBeanName,
                 IncompletePropertiesService::class.simpleBeanName,
-                NftDataSeeder::class.simpleBeanName,
             ).map { it.lowercase() }.toSet()
 
         val beanNames = ApplicationTestHelper.getAvailableBeanNames(context!!)

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/applications/PrsdbWebappApplicationTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/applications/PrsdbWebappApplicationTests.kt
@@ -26,7 +26,6 @@ import uk.gov.communities.prsdb.webapp.local.services.LocalQuarantinedFileDelete
 import uk.gov.communities.prsdb.webapp.services.AwsS3DequarantiningFileCopier
 import uk.gov.communities.prsdb.webapp.services.AwsS3QuarantinedFileDeleter
 import uk.gov.communities.prsdb.webapp.services.EpcCertificateUrlProvider
-import uk.gov.communities.prsdb.webapp.services.NftDataSeeder
 import uk.gov.communities.prsdb.webapp.services.NgdAddressLoader
 import uk.gov.communities.prsdb.webapp.services.OneLoginIdentityService
 import uk.gov.communities.prsdb.webapp.services.UploadDequarantiner
@@ -98,7 +97,6 @@ class PrsdbWebappApplicationTests {
                 VirusNotificationEmailHandler::class.simpleBeanName,
                 OsDownloadsConfig::class.simpleBeanName,
                 NgdAddressLoader::class.simpleBeanName,
-                NftDataSeeder::class.simpleBeanName,
             ).map { it.lowercase() }.toSet()
 
         val beanNames = ApplicationTestHelper.getAvailableBeanNames(context!!)


### PR DESCRIPTION
## Ticket number

PDJB-NONE

## Goal of change

Fix scheduled tasks failing to start due to unresolvable `EPC_CERTIFICATE_BASE_URL` placeholder in `NftDataSeeder`.

## Description of main change(s)

- Adds `@Profile("nft-data-seeder")` to `NftDataSeeder` so it only loads when that profile is explicitly activated, preventing the `epc.certificate-base-url` property from being resolved during other tasks
- Removes the redundant `@Profile` annotation from `NftDataSeedingTaskApplicationRunner` since `@PrsdbTask("nft-data-seeder")` already gates on the profile via `TaskHasName`
- Removes the blank default from the `@Value` annotation to avoid silent failures when the seeder is actually used
- Updates application tests to remove `NftDataSeeder` from expected bean lists

## Anything you'd like to highlight to the reviewer?

The previous fix (PR #1194) added a blank default to the `@Value` annotation, but this did not work because Spring resolves the nested `$`{EPC_CERTIFICATE_BASE_URL}` placeholder from `application.yml` first, before the outer default applies.

## Checklist

- [x] Test suite has been run in full locally and is passing