### PR TITLE
PDJB-654: Implement remove electrical cert upload page

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/RemoveElectricalCertUploadStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/RemoveElectricalCertUploadStepConfig.kt
@@ -3,19 +3,29 @@ package uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps
 import uk.gov.communities.prsdb.webapp.annotations.webAnnotations.JourneyFrameworkComponent
 import uk.gov.communities.prsdb.webapp.journeys.AbstractRequestableStepConfig
 import uk.gov.communities.prsdb.webapp.journeys.JourneyStep.RequestableStep
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.CertificateUpload
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.ElectricalSafetyState
 import uk.gov.communities.prsdb.webapp.journeys.shared.AnyMembers
-import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.NoInputFormModel
+import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.RemoveFileFormModel
+import uk.gov.communities.prsdb.webapp.models.viewModels.formModels.RadiosViewModel
+import uk.gov.communities.prsdb.webapp.services.CollectionKeyParameterService
+import kotlin.collections.get
+import kotlin.collections.remove
 
-// TODO PDJB-654: Implement Remove Electrical Cert Upload page
 @JourneyFrameworkComponent
-class RemoveElectricalCertUploadStepConfig : AbstractRequestableStepConfig<AnyMembers, NoInputFormModel, ElectricalSafetyState>() {
-    override val formModelClass = NoInputFormModel::class
+class RemoveElectricalCertUploadStepConfig(
+    private val collectionKeyParameterService: CollectionKeyParameterService,
+) : AbstractRequestableStepConfig<AnyMembers, RemoveFileFormModel, ElectricalSafetyState>() {
+    override val formModelClass = RemoveFileFormModel::class
 
     override fun getStepSpecificContent(state: ElectricalSafetyState) =
-        mapOf("todoComment" to "TODO PDJB-654: Implement Remove Electrical Cert Upload page")
+        mapOf(
+            "fieldSetHeading" to "uploads.removeUploads.fieldSetHeading",
+            "radioOptions" to RadiosViewModel.yesOrNoRadios(),
+            "optionalFieldSetHeadingParam" to getFileToRemove(state)?.fileName,
+        )
 
-    override fun chooseTemplate(state: ElectricalSafetyState) = "forms/todo"
+    override fun chooseTemplate(state: ElectricalSafetyState): String = "forms/areYouSureForm"
 
     override fun mode(state: ElectricalSafetyState) =
         if (state.electricalUploadMap.isNotEmpty()) {
@@ -23,12 +33,34 @@ class RemoveElectricalCertUploadStepConfig : AbstractRequestableStepConfig<AnyMe
         } else {
             AnyMembers.NO_MEMBERS
         }
+
+    private fun getFileToRemove(state: ElectricalSafetyState): CertificateUpload? {
+        val keyToRemove = collectionKeyParameterService.getParameterOrNull()
+        return state.electricalUploadMap[keyToRemove]
+    }
+
+    override fun beforeAttemptingToReachStep(state: ElectricalSafetyState): Boolean {
+        val keyToRemove = collectionKeyParameterService.getParameterOrNull()
+        val currentMap = state.electricalUploadMap
+
+        return keyToRemove != null && keyToRemove in currentMap.keys
+    }
+
+    override fun afterStepDataIsAdded(state: ElectricalSafetyState) {
+        if (getFormModelFromStateOrNull(state)?.wantsToProceed == false) {
+            return
+        }
+        val currentMap = state.electricalUploadMap.toMutableMap()
+
+        currentMap.remove(collectionKeyParameterService.getParameterOrNull())
+        state.electricalUploadMap = currentMap
+    }
 }
 
 @JourneyFrameworkComponent
 final class RemoveElectricalCertUploadStep(
     stepConfig: RemoveElectricalCertUploadStepConfig,
-) : RequestableStep<AnyMembers, NoInputFormModel, ElectricalSafetyState>(stepConfig) {
+) : RequestableStep<AnyMembers, RemoveFileFormModel, ElectricalSafetyState>(stepConfig) {
     companion object {
         const val ROUTE_SEGMENT = "remove-electrical-safety-certificate-upload"
     }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/tasks/ElectricalSafetyTask.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/tasks/ElectricalSafetyTask.kt
@@ -80,7 +80,6 @@ class ElectricalSafetyTask : Task<ElectricalSafetyState>() {
                 backStep { journey.electricalCertExpiryDateStep }
                 savable()
             }
-            // TODO PDJB-654: Implement Remove Electrical Cert Upload step logic
             step(journey.removeElectricalCertUploadStep) {
                 routeSegment(RemoveElectricalCertUploadStep.ROUTE_SEGMENT)
                 parents {

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/PropertyRegistrationJourneyTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/PropertyRegistrationJourneyTests.kt
@@ -83,6 +83,7 @@ import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyReg
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyRegistrationJourneyPages.ProvideElectricalCertLaterFormPagePropertyRegistration
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyRegistrationJourneyPages.ProvideEpcLaterFormPagePropertyRegistration
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyRegistrationJourneyPages.ProvideGasCertLaterFormPagePropertyRegistration
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyRegistrationJourneyPages.RemoveElectricalCertUploadFormPagePropertyRegistration
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyRegistrationJourneyPages.RemoveGasCertUploadFormPagePropertyRegistration
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyRegistrationJourneyPages.RemoveJointLandlordAreYouSureFormPagePropertyRegistration
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyRegistrationJourneyPages.RentAmountFormPagePropertyRegistration
@@ -361,14 +362,37 @@ class PropertyRegistrationJourneyTests : IntegrationTestWithMutableData("data-lo
         // Electrical Cert Expiry Date - render page
         assertThat(electricalCertExpiryDatePage.heading).containsText("What’s the expiry date on the Electrical Installation Certificate?")
         electricalCertExpiryDatePage.submitDate(validExpiryDate)
-        val uploadElectricalCertPage = assertPageIs(page, UploadElectricalCertFormPagePropertyRegistration::class)
+        var uploadElectricalCertPage = assertPageIs(page, UploadElectricalCertFormPagePropertyRegistration::class)
 
         // Upload Electrical Cert - render page
         uploadElectricalCertPage.uploadElectricalCertificate(Path.of("src/test/resources/test-files/blank.png"))
-        val checkElectricalCertUploadsPage = assertPageIs(page, CheckElectricalCertUploadsFormPagePropertyRegistration::class)
+        var checkElectricalCertUploadsPage = assertPageIs(page, CheckElectricalCertUploadsFormPagePropertyRegistration::class)
 
         // Check Electrical Cert Uploads - render page
         assertThat(checkElectricalCertUploadsPage.table.getCell(0, 0)).containsText("blank.png")
+        assertEquals(checkElectricalCertUploadsPage.table.rows.count(), 1)
+        checkElectricalCertUploadsPage.form.addAnotherButton.clickAndWait()
+        uploadElectricalCertPage = assertPageIs(page, UploadElectricalCertFormPagePropertyRegistration::class)
+
+        uploadElectricalCertPage.uploadElectricalCertificate(Path.of("src/test/resources/test-files/blank.png"))
+        checkElectricalCertUploadsPage = assertPageIs(page, CheckElectricalCertUploadsFormPagePropertyRegistration::class)
+        assertThat(checkElectricalCertUploadsPage.table.getCell(0, 0)).containsText("blank.png")
+        assertThat(checkElectricalCertUploadsPage.table.getCell(1, 0)).containsText("blank.png")
+        assertEquals(checkElectricalCertUploadsPage.table.rows.count(), 2)
+
+        checkElectricalCertUploadsPage.table
+            .getClickableCell(0, 2)
+            .link
+            .clickAndWait()
+
+        val removeElectricalCertUploadPage = assertPageIs(page, RemoveElectricalCertUploadFormPagePropertyRegistration::class)
+
+        removeElectricalCertUploadPage.form.radios.selectValue("true")
+        removeElectricalCertUploadPage.form.submit()
+
+        checkElectricalCertUploadsPage = assertPageIs(page, CheckElectricalCertUploadsFormPagePropertyRegistration::class)
+        assertThat(checkElectricalCertUploadsPage.table.getCell(0, 0)).containsText("blank.png")
+
         assertEquals(checkElectricalCertUploadsPage.table.rows.count(), 1)
         checkElectricalCertUploadsPage.form.submit()
         val checkElectricalSafetyAnswersPage = assertPageIs(page, CheckElectricalSafetyAnswersFormPagePropertyRegistration::class)

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/propertyRegistrationJourneyPages/RemoveElectricalCertUploadFormPagePropertyRegistration.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/propertyRegistrationJourneyPages/RemoveElectricalCertUploadFormPagePropertyRegistration.kt
@@ -2,15 +2,16 @@ package uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyRe
 
 import com.microsoft.playwright.Page
 import uk.gov.communities.prsdb.webapp.controllers.RegisterPropertyController
-import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.Form
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.BackLink
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.FormWithRadios
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.Heading
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages.BasePage
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.RemoveElectricalCertUploadStep
 
-// TODO PDJB-654: Implement Remove Electrical Cert Upload page object
 class RemoveElectricalCertUploadFormPagePropertyRegistration(
     page: Page,
 ) : BasePage(page, "${RegisterPropertyController.PROPERTY_REGISTRATION_ROUTE}/${RemoveElectricalCertUploadStep.ROUTE_SEGMENT}") {
     val heading = Heading(page.locator("h1"))
-    val form = Form(page)
+    val form = FormWithRadios(page)
+    val backLink = BackLink.default(page)
 }


### PR DESCRIPTION
## Ticket number

PDJB-654

## Goal of change

Allow users to remove uploaded electrical safety certificates from the property registration journey.

## Description of main change(s)

- Implements the `RemoveElectricalCertUploadStepConfig` following the established gas safety remove pattern, using the `areYouSureForm` template with yes/no radios
- Updates the integration test page object to use `FormWithRadios` and `BackLink`
- Adds integration test coverage: uploads two certificates, removes one via the remove page, and verifies only one remains

## Anything you'd like to highlight to the reviewer?

Neither the gas nor electrical remove steps currently delete the uploaded files from S3 — they only remove the entry from journey state. S3 cleanup for both certificate types is covered in a follow-up PR: #1200.

## Checklist

- [x] New journey steps have been added to the appropriate journey integration test(s)
- [x] TODO comments referencing this JIRA ticket have been searched for and removed