### PR TITLE
feat(PDJB-320): Update PropertyUpdateConfirmation email content

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/emailModels/PropertyUpdateConfirmation.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/emailModels/PropertyUpdateConfirmation.kt
@@ -3,23 +3,23 @@ package uk.gov.communities.prsdb.webapp.models.viewModels.emailModels
 import java.net.URI
 
 data class PropertyUpdateConfirmation(
-    val singleLineAddress: String,
-    val registrationNumber: String,
-    val dashboardUrl: URI,
-    val updatedBullets: EmailBulletPointList,
+    val name: String,
+    val multiLineAddress: String,
+    val updatedItems: String,
+    val propertyRecordUrl: URI,
 ) : EmailTemplateModel {
-    private val singleLineAddressKey = "single line address"
-    private val registrationNumberKey = "registration number"
-    private val dashboardUrlKey = "dashboard url"
-    private val updatedBulletsKey = "updated bullets"
+    private val nameKey = "name"
+    private val multiLineAddressKey = "multi line address"
+    private val updatedItemsKey = "updated items"
+    private val propertyRecordUrlKey = "property record url"
 
     override val template = EmailTemplate.PROPERTY_UPDATE_CONFIRMATION
 
     override fun toHashMap(): HashMap<String, String> =
         hashMapOf(
-            singleLineAddressKey to singleLineAddress,
-            registrationNumberKey to registrationNumber,
-            dashboardUrlKey to dashboardUrl.toASCIIString(),
-            updatedBulletsKey to updatedBullets.toString(),
+            nameKey to name,
+            multiLineAddressKey to multiLineAddress,
+            updatedItemsKey to updatedItems,
+            propertyRecordUrlKey to propertyRecordUrl.toASCIIString(),
         )
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/PropertyOwnershipService.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/PropertyOwnershipService.kt
@@ -25,7 +25,6 @@ import uk.gov.communities.prsdb.webapp.helpers.AddressHelper
 import uk.gov.communities.prsdb.webapp.models.dataModels.ComplianceStatusDataModel
 import uk.gov.communities.prsdb.webapp.models.dataModels.RegistrationNumberDataModel
 import uk.gov.communities.prsdb.webapp.models.dataModels.updateModels.PropertyOwnershipUpdateModel
-import uk.gov.communities.prsdb.webapp.models.viewModels.emailModels.EmailBulletPointList
 import uk.gov.communities.prsdb.webapp.models.viewModels.emailModels.PropertyUpdateConfirmation
 import uk.gov.communities.prsdb.webapp.models.viewModels.searchResultModels.PropertySearchResultViewModel
 import uk.gov.communities.prsdb.webapp.models.viewModels.summaryModels.RegisteredPropertyLandlordViewModel
@@ -358,26 +357,23 @@ class PropertyOwnershipService(
         val hasNumberOfHouseholdsChanged = update.numberOfHouseholds?.let { wasPropertyOccupied && it > 0 } ?: false
         val isUpdatingOccupationStatus = update.numberOfPeople != null && !isUpdatingFromOccupiedToOccupied
 
-        val updatedBullets =
+        val updatedItems =
             listOfNotNull(
-                if (update.ownershipType != null) "ownership type" else null,
-                if (update.isLicenceUpdatable()) "licensing information" else null,
-                if (isUpdatingOccupationStatus) "whether the property is occupied by tenants" else null,
-                if (hasNumberOfHouseholdsChanged) "the number of households living in this property" else null,
-                if (isUpdatingFromOccupiedToOccupied) "the number of people living in this property" else null,
+                if (update.ownershipType != null) "The ownership type" else null,
+                if (update.isLicenceUpdatable()) "The licensing information" else null,
+                if (isUpdatingOccupationStatus) "Whether the property is occupied by tenants" else null,
+                if (hasNumberOfHouseholdsChanged) "The number of households living in this property" else null,
+                if (isUpdatingFromOccupiedToOccupied) "The number of people living in this property" else null,
             )
 
-        if (!updatedBullets.isEmpty()) {
+        if (updatedItems.isNotEmpty()) {
             updateConfirmationEmailService.sendEmail(
                 propertyOwnership.primaryLandlord.email,
                 PropertyUpdateConfirmation(
-                    singleLineAddress = propertyOwnership.address.singleLineAddress,
-                    registrationNumber =
-                        RegistrationNumberDataModel
-                            .fromRegistrationNumber(propertyOwnership.registrationNumber)
-                            .toString(),
-                    dashboardUrl = absoluteUrlProvider.buildLandlordDashboardUri(),
-                    updatedBullets = EmailBulletPointList(updatedBullets),
+                    name = propertyOwnership.primaryLandlord.name,
+                    multiLineAddress = propertyOwnership.address.toMultiLineAddress(),
+                    updatedItems = updatedItems.joinToString("\n"),
+                    propertyRecordUrl = absoluteUrlProvider.buildComplianceInformationUri(propertyOwnership.id),
                 ),
             )
         }

--- a/src/main/resources/emails/PropertyUpdateConfirmation.md
+++ b/src/main/resources/emails/PropertyUpdateConfirmation.md
@@ -1,17 +1,16 @@
-# You have updated a property on the database
-## You have updated the property details for:
-^ ((single line address))
+Hello ((name)),
 
-This properties registration number is:
+You have updated a property record.
 
-((registration number))
+## Property
 
-You have updated this information for the property:
-((updated bullets))
+((multi line address))
 
-If you made a mistake, you can update the property again.
+## What was updated
 
-[Sign in to the database](((dashboard url))) to view this property.
+((updated items))
+
+[View property record](((property record url)))
 
 ---
 This is an automated email – do not reply.

--- a/src/main/resources/emails/emailTemplates.json
+++ b/src/main/resources/emails/emailTemplates.json
@@ -77,8 +77,8 @@
     "bodyLocation": "/emails/VirusScanUnsuccessful.md"
   },
   {
-    "test_id": "0ec8d025-1c06-4265-9b5d-37427b4acfc8",
-    "prod_id": "b1a64644-f233-44e3-a148-2932269a2313",
+    "test_id": "ac8ba0ba-a11e-41b0-a610-45d6a52a8bd6",
+    "prod_id": "ea8b2c49-148d-413b-87a1-dafbc5a161c5",
     "enumName": "PROPERTY_UPDATE_CONFIRMATION",
     "subject": "You updated a property record",
     "bodyLocation": "/emails/PropertyUpdateConfirmation.md"

--- a/src/main/resources/emails/emailTemplates.json
+++ b/src/main/resources/emails/emailTemplates.json
@@ -80,7 +80,7 @@
     "test_id": "0ec8d025-1c06-4265-9b5d-37427b4acfc8",
     "prod_id": "b1a64644-f233-44e3-a148-2932269a2313",
     "enumName": "PROPERTY_UPDATE_CONFIRMATION",
-    "subject": "GOV.UK - You have updated a property on the PRS database",
+    "subject": "You updated a property record",
     "bodyLocation": "/emails/PropertyUpdateConfirmation.md"
   },
   {

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/emailModels/EmailTemplateModelsTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/emailModels/EmailTemplateModelsTests.kt
@@ -94,10 +94,10 @@ class EmailTemplateModelsTests {
                 ),
                 EmailTemplateTestData(
                     PropertyUpdateConfirmation(
-                        "1 Street Name, Town, Country, AB1 2CD",
-                        "P-XXX-YYY",
-                        URI("prsdUrl"),
-                        EmailBulletPointList("Thing you changed"),
+                        "Test Name",
+                        "1 Street Name\nTown\nAB1 2CD",
+                        "Thing you changed",
+                        URI("propertyRecordUrl"),
                     ),
                     "/emails/PropertyUpdateConfirmation.md",
                 ),

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/PropertyOwnershipServiceTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/PropertyOwnershipServiceTests.kt
@@ -748,7 +748,7 @@ class PropertyOwnershipServiceTests {
             mockLicenseService.updateLicence(propertyOwnership.license, updateModel.licensingType, updateModel.licenceNumber),
         ).thenReturn(updateLicence)
 
-        whenever(absoluteUrlProvider.buildLandlordDashboardUri()).thenReturn(URI("http://example.com"))
+        whenever(absoluteUrlProvider.buildComplianceInformationUri(any())).thenReturn(URI("http://example.com"))
 
         // Act
         propertyOwnershipService.updatePropertyOwnership(propertyOwnership.id, updateModel) {}
@@ -778,20 +778,19 @@ class PropertyOwnershipServiceTests {
         whenever(mockPropertyOwnershipRepository.findByIdAndIsActiveTrue(propertyOwnership.id))
             .thenReturn(propertyOwnership)
 
-        whenever(absoluteUrlProvider.buildLandlordDashboardUri()).thenReturn(URI("http://example.com"))
+        whenever(absoluteUrlProvider.buildComplianceInformationUri(any())).thenReturn(URI("http://example.com"))
 
         // Act
         propertyOwnershipService.updatePropertyOwnership(propertyOwnership.id, update) {}
 
         // Assert
-        val expectedRegistrationNumber = RegistrationNumberDataModel.fromRegistrationNumber(propertyOwnership.registrationNumber)
         verify(emailNotificationService).sendEmail(
             eq(propertyOwnership.primaryLandlord.email),
             argThat { email ->
-                email.updatedBullets.bulletPoints.containsAll(expectedEmailBullets) &&
-                    email.updatedBullets.bulletPoints.size == expectedEmailBullets.size &&
-                    email.singleLineAddress == propertyOwnership.address.singleLineAddress &&
-                    email.registrationNumber == expectedRegistrationNumber.toString()
+                email.updatedItems.split("\n").containsAll(expectedEmailBullets) &&
+                    email.updatedItems.split("\n").size == expectedEmailBullets.size &&
+                    email.multiLineAddress == propertyOwnership.address.toMultiLineAddress() &&
+                    email.name == propertyOwnership.primaryLandlord.name
             },
         )
     }
@@ -862,7 +861,7 @@ class PropertyOwnershipServiceTests {
             mockLicenseService.updateLicence(propertyOwnership.license, updateModel.licensingType, updateModel.licenceNumber),
         ).thenReturn(null)
 
-        whenever(absoluteUrlProvider.buildLandlordDashboardUri()).thenReturn(URI("http://example.com"))
+        whenever(absoluteUrlProvider.buildComplianceInformationUri(any())).thenReturn(URI("http://example.com"))
 
         // Act
         propertyOwnershipService.updatePropertyOwnership(propertyOwnership.id, updateModel) {}
@@ -1424,10 +1423,10 @@ class PropertyOwnershipServiceTests {
                     Named.of(
                         "all fields changed except occupancy",
                         listOf(
-                            "ownership type",
-                            "licensing information",
-                            "the number of households living in this property",
-                            "the number of people living in this property",
+                            "The ownership type",
+                            "The licensing information",
+                            "The number of households living in this property",
+                            "The number of people living in this property",
                         ),
                     ),
                 ),
@@ -1445,7 +1444,7 @@ class PropertyOwnershipServiceTests {
                     ),
                     Named.of(
                         "an occupancy change",
-                        listOf("whether the property is occupied by tenants"),
+                        listOf("Whether the property is occupied by tenants"),
                     ),
                 ),
                 Arguments.of(
@@ -1462,7 +1461,7 @@ class PropertyOwnershipServiceTests {
                     ),
                     Named.of(
                         "an occupancy change",
-                        listOf("whether the property is occupied by tenants"),
+                        listOf("Whether the property is occupied by tenants"),
                     ),
                 ),
                 Arguments.of(
@@ -1480,8 +1479,8 @@ class PropertyOwnershipServiceTests {
                     Named.of(
                         "all non-occupancy fields changed",
                         listOf(
-                            "ownership type",
-                            "licensing information",
+                            "The ownership type",
+                            "The licensing information",
                         ),
                     ),
                 ),
@@ -1500,7 +1499,7 @@ class PropertyOwnershipServiceTests {
                     Named.of(
                         "an occupancy change",
                         listOf(
-                            "whether the property is occupied by tenants",
+                            "Whether the property is occupied by tenants",
                         ),
                     ),
                 ),
@@ -1519,8 +1518,8 @@ class PropertyOwnershipServiceTests {
                     Named.of(
                         "a change to the number of households and people",
                         listOf(
-                            "the number of households living in this property",
-                            "the number of people living in this property",
+                            "The number of households living in this property",
+                            "The number of people living in this property",
                         ),
                     ),
                 ),


### PR DESCRIPTION
## Ticket number

PDJB-320

## Goal of change

Update the PropertyUpdateConfirmation email to match the new Figma designs.

## Description of main change(s)

- Adds personalised greeting with landlord name (`Dear ((name))`)
- Replaces single-line address with multi-line address format
- Replaces bullet point list with plain-text updated items (joined by newlines)
- Links to specific property record page instead of the landlord dashboard
- Updates email subject line to "You updated a property record"
- Removes registration number from email content

## Anything you'd like to highlight to the reviewer?

- The GOV.UK Notify template will also need to be updated to match the new markdown template before this is deployed
- Reuses the existing `buildComplianceInformationUri` method for the property record URL (both resolve to the same PropertyDetailsController endpoint)
- `EmailBulletPointList` is no longer used by this email but is still used by compliance confirmation emails — it has not been removed

## Checklist

- [x] Unit tests for new logic (e.g. new service methods) have been added
- [x] Test suite has been run in full locally and is passing
- [x] Branch has been rebased onto main and run locally, with everything working as expected (both for your new feature and any related functionality)
- [x] TODO comments referencing this JIRA ticket have been searched for and removed - if a future PR will address them, mention that here