### PR TITLE
PDJB-654: Delete uploaded files from S3 when removed from journey

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/RemoveElectricalCertUploadStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/RemoveElectricalCertUploadStepConfig.kt
@@ -9,12 +9,14 @@ import uk.gov.communities.prsdb.webapp.journeys.shared.AnyMembers
 import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.RemoveFileFormModel
 import uk.gov.communities.prsdb.webapp.models.viewModels.formModels.RadiosViewModel
 import uk.gov.communities.prsdb.webapp.services.CollectionKeyParameterService
+import uk.gov.communities.prsdb.webapp.services.UploadService
 import kotlin.collections.get
 import kotlin.collections.remove
 
 @JourneyFrameworkComponent
 class RemoveElectricalCertUploadStepConfig(
     private val collectionKeyParameterService: CollectionKeyParameterService,
+    private val uploadService: UploadService,
 ) : AbstractRequestableStepConfig<AnyMembers, RemoveFileFormModel, ElectricalSafetyState>() {
     override val formModelClass = RemoveFileFormModel::class
 
@@ -50,9 +52,11 @@ class RemoveElectricalCertUploadStepConfig(
         if (getFormModelFromStateOrNull(state)?.wantsToProceed == false) {
             return
         }
+        val keyToRemove = collectionKeyParameterService.getParameterOrNull()
         val currentMap = state.electricalUploadMap.toMutableMap()
 
-        currentMap.remove(collectionKeyParameterService.getParameterOrNull())
+        currentMap[keyToRemove]?.let { uploadService.deleteUploadedFile(it.fileUploadId) }
+        currentMap.remove(keyToRemove)
         state.electricalUploadMap = currentMap
     }
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/RemoveGasCertUploadStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/RemoveGasCertUploadStepConfig.kt
@@ -9,12 +9,14 @@ import uk.gov.communities.prsdb.webapp.journeys.shared.AnyMembers
 import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.RemoveFileFormModel
 import uk.gov.communities.prsdb.webapp.models.viewModels.formModels.RadiosViewModel
 import uk.gov.communities.prsdb.webapp.services.CollectionKeyParameterService
+import uk.gov.communities.prsdb.webapp.services.UploadService
 import kotlin.collections.get
 import kotlin.collections.remove
 
 @JourneyFrameworkComponent
 class RemoveGasCertUploadStepConfig(
     private val collectionKeyParameterService: CollectionKeyParameterService,
+    private val uploadService: UploadService,
 ) : AbstractRequestableStepConfig<AnyMembers, RemoveFileFormModel, GasSafetyState>() {
     override val formModelClass = RemoveFileFormModel::class
 
@@ -50,9 +52,11 @@ class RemoveGasCertUploadStepConfig(
         if (getFormModelFromStateOrNull(state)?.wantsToProceed == false) {
             return
         }
+        val keyToRemove = collectionKeyParameterService.getParameterOrNull()
         val currentMap = state.gasUploadMap.toMutableMap()
 
-        currentMap.remove(collectionKeyParameterService.getParameterOrNull())
+        currentMap[keyToRemove]?.let { uploadService.deleteUploadedFile(it.fileUploadId) }
+        currentMap.remove(keyToRemove)
         state.gasUploadMap = currentMap
     }
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/local/services/LocalSafeFileDeleter.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/local/services/LocalSafeFileDeleter.kt
@@ -1,0 +1,18 @@
+package uk.gov.communities.prsdb.webapp.local.services
+
+import org.springframework.context.annotation.Primary
+import org.springframework.context.annotation.Profile
+import uk.gov.communities.prsdb.webapp.annotations.webAnnotations.PrsdbWebService
+import uk.gov.communities.prsdb.webapp.database.entity.FileUpload
+import uk.gov.communities.prsdb.webapp.services.SafeFileDeleter
+import java.io.File
+
+@PrsdbWebService
+@Primary
+@Profile("local")
+class LocalSafeFileDeleter : SafeFileDeleter {
+    override fun deleteFile(fileUpload: FileUpload): Boolean {
+        val localFile = File(".local-uploads/${fileUpload.objectKey}")
+        return localFile.exists() && localFile.delete()
+    }
+}

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/AwsS3SafeFileDeleter.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/AwsS3SafeFileDeleter.kt
@@ -1,0 +1,23 @@
+package uk.gov.communities.prsdb.webapp.services
+
+import org.springframework.beans.factory.annotation.Value
+import software.amazon.awssdk.services.s3.S3Client
+import uk.gov.communities.prsdb.webapp.annotations.webAnnotations.PrsdbWebService
+import uk.gov.communities.prsdb.webapp.database.entity.FileUpload
+
+@PrsdbWebService
+class AwsS3SafeFileDeleter(
+    private val s3Client: S3Client,
+    @Value("\${aws.s3.safeBucket}")
+    val safeBucketName: String,
+) : SafeFileDeleter {
+    override fun deleteFile(fileUpload: FileUpload): Boolean {
+        val deleteResponse =
+            s3Client
+                .deleteObject { request ->
+                    request.bucket(safeBucketName).key(fileUpload.objectKey)
+                }
+
+        return deleteResponse.sdkHttpResponse().isSuccessful
+    }
+}

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/SafeFileDeleter.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/SafeFileDeleter.kt
@@ -1,0 +1,7 @@
+package uk.gov.communities.prsdb.webapp.services
+
+import uk.gov.communities.prsdb.webapp.database.entity.FileUpload
+
+interface SafeFileDeleter {
+    fun deleteFile(fileUpload: FileUpload): Boolean
+}

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/UploadService.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/UploadService.kt
@@ -1,5 +1,6 @@
 package uk.gov.communities.prsdb.webapp.services
 
+import jakarta.transaction.Transactional
 import uk.gov.communities.prsdb.webapp.annotations.webAnnotations.PrsdbWebService
 import uk.gov.communities.prsdb.webapp.constants.enums.FileUploadStatus
 import uk.gov.communities.prsdb.webapp.database.entity.FileUpload
@@ -54,6 +55,7 @@ class UploadService(
             null
         }
 
+    @Transactional
     fun deleteUploadedFile(fileUploadId: Long) {
         val fileUpload = getFileUploadById(fileUploadId)
 

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/UploadService.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/UploadService.kt
@@ -10,6 +10,7 @@ import java.io.InputStream
 class UploadService(
     private val uploader: FileUploader,
     private val downloader: FileDownloader,
+    private val safeFileDeleter: SafeFileDeleter,
     private val uploadRepository: FileUploadRepository,
 ) {
     fun uploadFile(
@@ -52,4 +53,18 @@ class UploadService(
         } else {
             null
         }
+
+    fun deleteUploadedFile(fileUploadId: Long) {
+        val fileUpload = getFileUploadById(fileUploadId)
+
+        if (fileUpload.status == FileUploadStatus.DELETED) return
+
+        val previousStatus = fileUpload.status
+        fileUpload.status = FileUploadStatus.DELETED
+        uploadRepository.save(fileUpload)
+
+        if (previousStatus == FileUploadStatus.SCANNED) {
+            safeFileDeleter.deleteFile(fileUpload)
+        }
+    }
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/VirusScanProcessingService.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/VirusScanProcessingService.kt
@@ -2,6 +2,7 @@ package uk.gov.communities.prsdb.webapp.services
 
 import jakarta.transaction.Transactional
 import uk.gov.communities.prsdb.webapp.annotations.taskAnnotations.PrsdbTaskService
+import uk.gov.communities.prsdb.webapp.constants.enums.FileUploadStatus
 import uk.gov.communities.prsdb.webapp.database.entity.VirusScanCallback
 import uk.gov.communities.prsdb.webapp.database.entity.VirusScanCallback.Companion.extractFileUpload
 import uk.gov.communities.prsdb.webapp.database.repository.FileUploadRepository
@@ -36,6 +37,12 @@ class VirusScanProcessingService(
         scanResultStatus: ScanResult,
     ) {
         val fileUpload = callbackDetails.extractFileUpload()
+
+        if (fileUpload.status == FileUploadStatus.DELETED) {
+            dequarantiner.deleteQuarantinedFile(fileUpload)
+            callbackDetails.forEach { virusScanCallbackRepository.delete(it) }
+            return
+        }
 
         when (scanResultStatus) {
             ScanResult.NoThreats -> {

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/UploadServiceTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/UploadServiceTests.kt
@@ -6,7 +6,6 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.InjectMocks
 import org.mockito.Mock
-import org.mockito.Mockito.mock
 import org.mockito.Mockito.never
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.any
@@ -18,6 +17,7 @@ import uk.gov.communities.prsdb.webapp.database.entity.FileUpload
 import uk.gov.communities.prsdb.webapp.database.repository.FileUploadRepository
 import uk.gov.communities.prsdb.webapp.models.dataModels.UploadedFileLocator
 import java.io.InputStream
+import java.util.Optional
 
 @ExtendWith(MockitoExtension::class)
 class UploadServiceTests {
@@ -29,6 +29,9 @@ class UploadServiceTests {
 
     @Mock
     private lateinit var mockDownloader: FileDownloader
+
+    @Mock
+    private lateinit var mockSafeFileDeleter: SafeFileDeleter
 
     @InjectMocks
     private lateinit var uploadService: UploadService
@@ -59,11 +62,6 @@ class UploadServiceTests {
     @Test
     fun `when uploading fails, uploadFile does not save a result and returns null`() {
         // Given
-        val mockUploader = mock<FileUploader>()
-        val mockRepository = mock<FileUploadRepository>()
-        val mockDownloader = mock<FileDownloader>()
-        val uploadService = UploadService(mockUploader, mockDownloader, mockRepository)
-
         val proposedObjectKey = "testObjectKey"
         whenever(mockUploader.uploadFile(any(), any()))
             .thenReturn(null)
@@ -74,5 +72,41 @@ class UploadServiceTests {
         // Then
         verify(mockRepository, never()).save(any())
         assertNull(result)
+    }
+
+    @Test
+    fun `deleteUploadedFile sets status to DELETED and deletes from safe bucket for scanned files`() {
+        val fileUpload = FileUpload(FileUploadStatus.SCANNED, "key", "txt", "eTag", "versionId")
+        whenever(mockRepository.findById(1L)).thenReturn(Optional.of(fileUpload))
+        whenever(mockSafeFileDeleter.deleteFile(any())).thenReturn(true)
+
+        uploadService.deleteUploadedFile(1L)
+
+        assertEquals(FileUploadStatus.DELETED, fileUpload.status)
+        verify(mockRepository).save(fileUpload)
+        verify(mockSafeFileDeleter).deleteFile(fileUpload)
+    }
+
+    @Test
+    fun `deleteUploadedFile sets status to DELETED without S3 deletion for quarantined files`() {
+        val fileUpload = FileUpload(FileUploadStatus.QUARANTINED, "key", "txt", "eTag", "versionId")
+        whenever(mockRepository.findById(1L)).thenReturn(Optional.of(fileUpload))
+
+        uploadService.deleteUploadedFile(1L)
+
+        assertEquals(FileUploadStatus.DELETED, fileUpload.status)
+        verify(mockRepository).save(fileUpload)
+        verify(mockSafeFileDeleter, never()).deleteFile(any())
+    }
+
+    @Test
+    fun `deleteUploadedFile is a no-op for already deleted files`() {
+        val fileUpload = FileUpload(FileUploadStatus.DELETED, "key", "txt", "eTag", "versionId")
+        whenever(mockRepository.findById(1L)).thenReturn(Optional.of(fileUpload))
+
+        uploadService.deleteUploadedFile(1L)
+
+        verify(mockRepository, never()).save(any())
+        verify(mockSafeFileDeleter, never()).deleteFile(any())
     }
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/VirusScanProcessingServiceTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/VirusScanProcessingServiceTests.kt
@@ -9,6 +9,7 @@ import org.mockito.InjectMocks
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.any
+import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import uk.gov.communities.prsdb.webapp.constants.enums.FileUploadStatus
@@ -129,5 +130,32 @@ class VirusScanProcessingServiceTests {
         val scanResultStatus = ScanResult.AccessDenied
 
         assertThrows<PrsdbWebException> { virusScanProcessingService.processScan(locator, scanResultStatus) }
+    }
+
+    @Test
+    fun `processScan cleans up quarantine file and callbacks for already deleted file`() {
+        // Arrange
+        val fileUpload =
+            FileUpload(
+                FileUploadStatus.DELETED,
+                "s3Key",
+                "txt",
+                "eTag",
+                "versionId",
+            )
+        val locator = UploadedFileLocator(fileUpload.objectKey, fileUpload.eTag, fileUpload.versionId)
+        val callback = VirusScanCallback(fileUpload, "")
+
+        whenever(virusScanCallbackRepository.findAllByFileUpload_ObjectKeyAndFileUpload_VersionId(any(), any()))
+            .thenReturn(listOf(callback))
+        whenever(dequarantiner.deleteQuarantinedFile(any())).thenReturn(true)
+
+        // Act
+        virusScanProcessingService.processScan(locator, ScanResult.NoThreats)
+
+        // Assert
+        verify(dequarantiner).deleteQuarantinedFile(fileUpload)
+        verify(dequarantiner, never()).dequarantineFile(any())
+        verify(virusScanCallbackRepository).delete(callback)
     }
 }


### PR DESCRIPTION
## Ticket number

PDJB-654

## Goal of change

Ensure uploaded certificate files are deleted from S3 when a user removes them during property registration, rather than being orphaned.

## Description of main change(s)

- Adds a `SafeFileDeleter` interface (with AWS and local implementations) for deleting files from the safe S3 bucket in web server mode
- Adds `deleteUploadedFile` method to `UploadService` that sets the file status to DELETED then deletes the safe bucket copy for scanned files
- Updates both the gas and electrical remove certificate step configs to call `deleteUploadedFile` when a user confirms removal
- Updates `VirusScanProcessingService` to handle the DELETED status — if a file was marked DELETED while still quarantined, the scan processor cleans up the quarantine copy instead of dequarantining it

## Anything you'd like to highlight to the reviewer?

The design deliberately avoids deleting from the quarantine bucket in web server mode. The `QuarantinedFileDeleter` implementations are `@PrsdbTaskService` beans (not available in web context), and there is a potential race condition with the scan processor. Instead, the scan processor is updated to recognise the DELETED status and handle quarantine cleanup itself.

## Checklist

- [x] Unit tests for new logic (e.g. new service methods) have been added
- [x] Test suite has been run in full locally and is passing