### PR TITLE
PDJB-665: tenancy start before expiry page

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/states/EpcState.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/states/EpcState.kt
@@ -1,5 +1,6 @@
 package uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states
 
+import uk.gov.communities.prsdb.webapp.exceptions.PrsdbWebException
 import uk.gov.communities.prsdb.webapp.journeys.JourneyState
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.CheckEpcAnswersStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.ConfirmEpcDetailsRetrievedByCertificateNumberStep
@@ -48,4 +49,6 @@ interface EpcState : JourneyState {
     val epcMissingStep: EpcMissingStep
     val provideEpcLaterStep: ProvideEpcLaterStep
     val checkEpcAnswersStep: CheckEpcAnswersStep
+
+    fun getNotNullAcceptedEpc() = acceptedEpc ?: throw PrsdbWebException("Attempting to access accepted EPC when it is null in state")
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/EpcInDateAtStartOfTenancyCheckStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/EpcInDateAtStartOfTenancyCheckStepConfig.kt
@@ -1,28 +1,57 @@
 package uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps
 
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.context.MessageSource
 import uk.gov.communities.prsdb.webapp.annotations.webAnnotations.JourneyFrameworkComponent
+import uk.gov.communities.prsdb.webapp.helpers.extensions.MessageSourceExtensions.Companion.getMessageForKey
 import uk.gov.communities.prsdb.webapp.journeys.AbstractRequestableStepConfig
-import uk.gov.communities.prsdb.webapp.journeys.JourneyState
 import uk.gov.communities.prsdb.webapp.journeys.JourneyStep.RequestableStep
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.EpcState
 import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.EpcExpiryCheckFormModel
-import uk.gov.communities.prsdb.webapp.models.viewModels.formModels.RadiosViewModel.Companion.yesOrNoRadios
+import uk.gov.communities.prsdb.webapp.models.viewModels.formModels.RadiosButtonViewModel
+import java.time.format.DateTimeFormatter
+import java.util.Locale
 
-// TODO PDJB-665: Implement step - this was the EpcExpiryCheckStep so might need some renaming
 @JourneyFrameworkComponent("propertyRegistrationEpcExpiryCheckStepConfig")
 class EpcInDateAtStartOfTenancyCheckStepConfig :
-    AbstractRequestableStepConfig<EpcInDateAtStartOfTenancyCheckMode, EpcExpiryCheckFormModel, JourneyState>() {
+    AbstractRequestableStepConfig<EpcInDateAtStartOfTenancyCheckMode, EpcExpiryCheckFormModel, EpcState>() {
     override val formModelClass = EpcExpiryCheckFormModel::class
 
-    override fun getStepSpecificContent(state: JourneyState) =
-        mapOf(
-            "fieldSetHeading" to "propertyCompliance.epcTask.epcInDateAtStartOfTenancy.fieldSetHeading",
-            "fieldName" to "tenancyStartedBeforeExpiry",
-            "radioOptions" to yesOrNoRadios(),
+    @Autowired
+    lateinit var messageSource: MessageSource
+
+    override fun getStepSpecificContent(state: EpcState): Map<String, Any?> {
+        val expiryDate = state.acceptedEpc?.expiryDateAsJavaLocalDate
+        val formattedDate = expiryDate?.format(DateTimeFormatter.ofPattern("d MMMM yyyy", Locale.ENGLISH))
+        val yesHintValue =
+            formattedDate?.let {
+                messageSource.getMessageForKey(
+                    "forms.epcInDateAtStartOfTenancyCheck.yes.hint",
+                    arrayOf(it),
+                )
+            }
+        return mapOf(
+            "expiryDate" to expiryDate,
+            "radioOptions" to
+                listOf(
+                    RadiosButtonViewModel(
+                        value = true,
+                        valueStr = "yes",
+                        labelMsgKey = "forms.radios.option.yes.label",
+                        hintValue = yesHintValue,
+                    ),
+                    RadiosButtonViewModel(
+                        value = false,
+                        valueStr = "no",
+                        labelMsgKey = "forms.radios.option.no.label",
+                    ),
+                ),
         )
+    }
 
-    override fun chooseTemplate(state: JourneyState) = "forms/todoWithRadios"
+    override fun chooseTemplate(state: EpcState) = "forms/epcInDateAtStartOfTenancyCheckForm"
 
-    override fun mode(state: JourneyState) =
+    override fun mode(state: EpcState) =
         getFormModelFromStateOrNull(state)?.let {
             when (it.tenancyStartedBeforeExpiry) {
                 true -> EpcInDateAtStartOfTenancyCheckMode.IN_DATE
@@ -35,7 +64,7 @@ class EpcInDateAtStartOfTenancyCheckStepConfig :
 @JourneyFrameworkComponent("propertyRegistrationEpcExpiryCheckStep")
 final class EpcInDateAtStartOfTenancyCheckStep(
     stepConfig: EpcInDateAtStartOfTenancyCheckStepConfig,
-) : RequestableStep<EpcInDateAtStartOfTenancyCheckMode, EpcExpiryCheckFormModel, JourneyState>(stepConfig) {
+) : RequestableStep<EpcInDateAtStartOfTenancyCheckMode, EpcExpiryCheckFormModel, EpcState>(stepConfig) {
     companion object {
         const val ROUTE_SEGMENT = "epc-in-date-at-start-of-tenancy-check"
     }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/EpcInDateAtStartOfTenancyCheckStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/EpcInDateAtStartOfTenancyCheckStepConfig.kt
@@ -1,35 +1,19 @@
 package uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps
 
-import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.context.MessageSource
 import uk.gov.communities.prsdb.webapp.annotations.webAnnotations.JourneyFrameworkComponent
-import uk.gov.communities.prsdb.webapp.helpers.extensions.MessageSourceExtensions.Companion.getMessageForKey
 import uk.gov.communities.prsdb.webapp.journeys.AbstractRequestableStepConfig
 import uk.gov.communities.prsdb.webapp.journeys.JourneyStep.RequestableStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.EpcState
 import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.EpcInDateAtStartOfTenancyCheckFormModel
 import uk.gov.communities.prsdb.webapp.models.viewModels.formModels.RadiosButtonViewModel
-import java.time.format.DateTimeFormatter
-import java.util.Locale
 
 @JourneyFrameworkComponent("propertyRegistrationEpcInDateAtStartOfTenancyCheckStepConfig")
 class EpcInDateAtStartOfTenancyCheckStepConfig :
     AbstractRequestableStepConfig<EpcInDateAtStartOfTenancyCheckMode, EpcInDateAtStartOfTenancyCheckFormModel, EpcState>() {
     override val formModelClass = EpcInDateAtStartOfTenancyCheckFormModel::class
 
-    @Autowired
-    lateinit var messageSource: MessageSource
-
     override fun getStepSpecificContent(state: EpcState): Map<String, Any?> {
-        val expiryDate = state.acceptedEpc?.expiryDateAsJavaLocalDate
-        val formattedDate = expiryDate?.format(DateTimeFormatter.ofPattern("d MMMM yyyy", Locale.ENGLISH))
-        val yesHintValue =
-            formattedDate?.let {
-                messageSource.getMessageForKey(
-                    "propertyCompliance.epcTask.epcInDateAtStartOfTenancy.yes.hint",
-                    arrayOf(it),
-                )
-            }
+        val expiryDate = state.getNotNullAcceptedEpc().expiryDateAsJavaLocalDate
         return mapOf(
             "expiryDate" to expiryDate,
             "radioOptions" to
@@ -38,7 +22,8 @@ class EpcInDateAtStartOfTenancyCheckStepConfig :
                         value = true,
                         valueStr = "yes",
                         labelMsgKey = "forms.radios.option.yes.label",
-                        hintValue = yesHintValue,
+                        hintMsgKey = "propertyCompliance.epcTask.epcInDateAtStartOfTenancy.yes.hint",
+                        hintMsgArg = expiryDate,
                     ),
                     RadiosButtonViewModel(
                         value = false,

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/EpcInDateAtStartOfTenancyCheckStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/EpcInDateAtStartOfTenancyCheckStepConfig.kt
@@ -26,7 +26,7 @@ class EpcInDateAtStartOfTenancyCheckStepConfig :
         val yesHintValue =
             formattedDate?.let {
                 messageSource.getMessageForKey(
-                    "forms.epcInDateAtStartOfTenancyCheck.yes.hint",
+                    "propertyCompliance.epcTask.epcInDateAtStartOfTenancy.yes.hint",
                     arrayOf(it),
                 )
             }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/EpcInDateAtStartOfTenancyCheckStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/EpcInDateAtStartOfTenancyCheckStepConfig.kt
@@ -12,7 +12,7 @@ import uk.gov.communities.prsdb.webapp.models.viewModels.formModels.RadiosButton
 import java.time.format.DateTimeFormatter
 import java.util.Locale
 
-@JourneyFrameworkComponent("propertyRegistrationEpcExpiryCheckStepConfig")
+@JourneyFrameworkComponent("propertyRegistrationEpcInDateAtStartOfTenancyCheckStepConfig")
 class EpcInDateAtStartOfTenancyCheckStepConfig :
     AbstractRequestableStepConfig<EpcInDateAtStartOfTenancyCheckMode, EpcInDateAtStartOfTenancyCheckFormModel, EpcState>() {
     override val formModelClass = EpcInDateAtStartOfTenancyCheckFormModel::class
@@ -61,7 +61,7 @@ class EpcInDateAtStartOfTenancyCheckStepConfig :
         }
 }
 
-@JourneyFrameworkComponent("propertyRegistrationEpcExpiryCheckStep")
+@JourneyFrameworkComponent("propertyRegistrationEpcInDateAtStartOfTenancyCheckStep")
 final class EpcInDateAtStartOfTenancyCheckStep(
     stepConfig: EpcInDateAtStartOfTenancyCheckStepConfig,
 ) : RequestableStep<EpcInDateAtStartOfTenancyCheckMode, EpcInDateAtStartOfTenancyCheckFormModel, EpcState>(stepConfig) {

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/EpcInDateAtStartOfTenancyCheckStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/EpcInDateAtStartOfTenancyCheckStepConfig.kt
@@ -7,15 +7,15 @@ import uk.gov.communities.prsdb.webapp.helpers.extensions.MessageSourceExtension
 import uk.gov.communities.prsdb.webapp.journeys.AbstractRequestableStepConfig
 import uk.gov.communities.prsdb.webapp.journeys.JourneyStep.RequestableStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.EpcState
-import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.EpcExpiryCheckFormModel
+import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.EpcInDateAtStartOfTenancyCheckFormModel
 import uk.gov.communities.prsdb.webapp.models.viewModels.formModels.RadiosButtonViewModel
 import java.time.format.DateTimeFormatter
 import java.util.Locale
 
 @JourneyFrameworkComponent("propertyRegistrationEpcExpiryCheckStepConfig")
 class EpcInDateAtStartOfTenancyCheckStepConfig :
-    AbstractRequestableStepConfig<EpcInDateAtStartOfTenancyCheckMode, EpcExpiryCheckFormModel, EpcState>() {
-    override val formModelClass = EpcExpiryCheckFormModel::class
+    AbstractRequestableStepConfig<EpcInDateAtStartOfTenancyCheckMode, EpcInDateAtStartOfTenancyCheckFormModel, EpcState>() {
+    override val formModelClass = EpcInDateAtStartOfTenancyCheckFormModel::class
 
     @Autowired
     lateinit var messageSource: MessageSource
@@ -64,7 +64,7 @@ class EpcInDateAtStartOfTenancyCheckStepConfig :
 @JourneyFrameworkComponent("propertyRegistrationEpcExpiryCheckStep")
 final class EpcInDateAtStartOfTenancyCheckStep(
     stepConfig: EpcInDateAtStartOfTenancyCheckStepConfig,
-) : RequestableStep<EpcInDateAtStartOfTenancyCheckMode, EpcExpiryCheckFormModel, EpcState>(stepConfig) {
+) : RequestableStep<EpcInDateAtStartOfTenancyCheckMode, EpcInDateAtStartOfTenancyCheckFormModel, EpcState>(stepConfig) {
     companion object {
         const val ROUTE_SEGMENT = "epc-in-date-at-start-of-tenancy-check"
     }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/requestModels/formModels/EpcInDateAtStartOfTenancyCheckFormModel.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/requestModels/formModels/EpcInDateAtStartOfTenancyCheckFormModel.kt
@@ -1,0 +1,8 @@
+package uk.gov.communities.prsdb.webapp.models.requestModels.formModels
+
+import jakarta.validation.constraints.NotNull
+
+class EpcInDateAtStartOfTenancyCheckFormModel : FormModel {
+    @NotNull(message = "propertyCompliance.epcTask.epcInDateAtStartOfTenancy.missing")
+    var tenancyStartedBeforeExpiry: Boolean? = null
+}

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/formModels/RadiosViewModel.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/formModels/RadiosViewModel.kt
@@ -31,6 +31,7 @@ data class RadiosButtonViewModel<T>(
     val valueStr: String = value.toString(),
     override val labelMsgKey: String? = null,
     val hintMsgKey: String? = null,
+    val hintMsgArg: Any? = null,
     val hintValue: String? = null,
     val conditionalFragment: String? = null,
 ) : RadiosViewModel(labelMsgKey)

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/formModels/RadiosViewModel.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/formModels/RadiosViewModel.kt
@@ -31,6 +31,7 @@ data class RadiosButtonViewModel<T>(
     val valueStr: String = value.toString(),
     override val labelMsgKey: String? = null,
     val hintMsgKey: String? = null,
+    val hintValue: String? = null,
     val conditionalFragment: String? = null,
 ) : RadiosViewModel(labelMsgKey)
 

--- a/src/main/resources/messages/forms.yml
+++ b/src/main/resources/messages/forms.yml
@@ -1026,6 +1026,15 @@ epcExpiryCheck:
     one: 'An EPC is valid for 10 years. After 10 years, you only need a new EPC for the property if new tenants move in after the EPC expires.'
     two: 'If the same tenants remain, the EPC is stays valid even after 10 years.'
     three: 'To check if you need a new EPC, did the current tenancy start before {0,,expiryDate}?'
+epcInDateAtStartOfTenancyCheck:
+  missing: Select if the EPC was still in date when the current tenancy began
+  heading: Confirm when the current tenancy began
+  paragraph:
+    one: 'This EPC expired on <strong>{0,,expiryDate}</strong>.'
+    two: You can continue a tenancy with an expired EPC. It only matters that the EPC was valid when the current tenancy began.
+  fieldSetHeading: Was the EPC still in date when the current tenancy began?
+  'yes':
+    hint: 'The current tenancy started on or before {0,,expiryDate}'
 invalidEpc:
   whatNext:
     heading: What you need to do next

--- a/src/main/resources/messages/forms.yml
+++ b/src/main/resources/messages/forms.yml
@@ -1026,15 +1026,6 @@ epcExpiryCheck:
     one: 'An EPC is valid for 10 years. After 10 years, you only need a new EPC for the property if new tenants move in after the EPC expires.'
     two: 'If the same tenants remain, the EPC is stays valid even after 10 years.'
     three: 'To check if you need a new EPC, did the current tenancy start before {0,,expiryDate}?'
-epcInDateAtStartOfTenancyCheck:
-  missing: Select if the EPC was still in date when the current tenancy began
-  heading: Confirm when the current tenancy began
-  paragraph:
-    one: 'This EPC expired on <strong>{0,,expiryDate}</strong>.'
-    two: You can continue a tenancy with an expired EPC. It only matters that the EPC was valid when the current tenancy began.
-  fieldSetHeading: Was the EPC still in date when the current tenancy began?
-  'yes':
-    hint: 'The current tenancy started on or before {0,,expiryDate}'
 invalidEpc:
   whatNext:
     heading: What you need to do next

--- a/src/main/resources/messages/propertyCompliance.yml
+++ b/src/main/resources/messages/propertyCompliance.yml
@@ -435,7 +435,14 @@ epcTask:
       continueWithLatest: Continue with most recent EPC
       searchAgain: Search by certificate number again
   epcInDateAtStartOfTenancy:
+    missing: Select if the EPC was still in date when the current tenancy began
+    heading: Confirm when the current tenancy began
+    paragraph:
+      one: 'This EPC expired on <strong>{0,,expiryDate}</strong>.'
+      two: You can continue a tenancy with an expired EPC. It only matters that the EPC was valid when the current tenancy began.
     fieldSetHeading: Was the EPC still in date when the current tenancy began?
+    'yes':
+      hint: 'The current tenancy started on or before {0,,expiryDate}'
   hasEpc:
     error:
       missing: Select whether you have an EPC for this property

--- a/src/main/resources/templates/forms/epcInDateAtStartOfTenancyCheckForm.html
+++ b/src/main/resources/templates/forms/epcInDateAtStartOfTenancyCheckForm.html
@@ -7,14 +7,14 @@
 <!DOCTYPE html>
 <html id="form-content" th:replace="~{fragments/forms/questionPage :: questionPage(#{${title}}, ${formModel}, ~{::#form-content/content()}, ${backUrl}, ${sectionHeaderInfo})}">
     <th:block id="question-content">
-        <h1 class="govuk-heading-l" th:text="#{forms.epcInDateAtStartOfTenancyCheck.heading}">
+        <h1 class="govuk-heading-l" th:text="#{propertyCompliance.epcTask.epcInDateAtStartOfTenancy.heading}">
             heading
         </h1>
-        <p class="govuk-body" th:utext="#{forms.epcInDateAtStartOfTenancyCheck.paragraph.one(${{expiryDate}})}">forms.epcInDateAtStartOfTenancyCheck.paragraph.one</p>
-        <p class="govuk-body" th:text="#{forms.epcInDateAtStartOfTenancyCheck.paragraph.two}">forms.epcInDateAtStartOfTenancyCheck.paragraph.two</p>
+        <p class="govuk-body" th:utext="#{propertyCompliance.epcTask.epcInDateAtStartOfTenancy.paragraph.one(${{expiryDate}})}">propertyCompliance.epcTask.epcInDateAtStartOfTenancy.paragraph.one</p>
+        <p class="govuk-body" th:text="#{propertyCompliance.epcTask.epcInDateAtStartOfTenancy.paragraph.two}">propertyCompliance.epcTask.epcInDateAtStartOfTenancy.paragraph.two</p>
     </th:block>
     <th:block id="form-content">
-        <th:block id="fieldset-content" th:replace="~{fragments/forms/minorFieldSet :: minorFieldSet(~{::#fieldset-content/content()}, 'tenancyStartedBeforeExpiry', #{forms.epcInDateAtStartOfTenancyCheck.fieldSetHeading}, null)}">
+        <th:block id="fieldset-content" th:replace="~{fragments/forms/minorFieldSet :: minorFieldSet(~{::#fieldset-content/content()}, 'tenancyStartedBeforeExpiry', #{propertyCompliance.epcTask.epcInDateAtStartOfTenancy.fieldSetHeading}, null)}">
             <th:block th:replace="~{fragments/forms/radios :: radios(null, 'tenancyStartedBeforeExpiry', null, ${radioOptions})}"></th:block>
         </th:block>
         <button th:replace="~{fragments/buttons/primaryButton :: primaryButton(#{forms.buttons.saveAndContinue})}"></button>

--- a/src/main/resources/templates/forms/epcInDateAtStartOfTenancyCheckForm.html
+++ b/src/main/resources/templates/forms/epcInDateAtStartOfTenancyCheckForm.html
@@ -1,0 +1,22 @@
+<!--/*@thymesVar id="title" type="java.lang.String"*/-->
+<!--/*@thymesVar id="formModel" type="java.lang.Object"*/-->
+<!--/*@thymesVar id="backUrl" type="java.lang.String"*/-->
+<!--/*@thymesVar id="sectionHeaderInfo" type="uk.gov.communities.prsdb.webapp.models.viewModels.SectionHeaderViewModel"*/-->
+<!--/*@thymesVar id="expiryDate" type="java.time.LocalDate"*/-->
+<!--/*@thymesVar id="radioOptions" type="uk.gov.communities.prsdb.webapp.models.viewModels.formModels.RadiosViewModel"*/-->
+<!DOCTYPE html>
+<html id="form-content" th:replace="~{fragments/forms/questionPage :: questionPage(#{${title}}, ${formModel}, ~{::#form-content/content()}, ${backUrl}, ${sectionHeaderInfo})}">
+    <th:block id="question-content">
+        <h1 class="govuk-heading-l" th:text="#{forms.epcInDateAtStartOfTenancyCheck.heading}">
+            heading
+        </h1>
+        <p class="govuk-body" th:utext="#{forms.epcInDateAtStartOfTenancyCheck.paragraph.one(${{expiryDate}})}">forms.epcInDateAtStartOfTenancyCheck.paragraph.one</p>
+        <p class="govuk-body" th:text="#{forms.epcInDateAtStartOfTenancyCheck.paragraph.two}">forms.epcInDateAtStartOfTenancyCheck.paragraph.two</p>
+    </th:block>
+    <th:block id="form-content">
+        <th:block id="fieldset-content" th:replace="~{fragments/forms/minorFieldSet :: minorFieldSet(~{::#fieldset-content/content()}, 'tenancyStartedBeforeExpiry', #{forms.epcInDateAtStartOfTenancyCheck.fieldSetHeading}, null)}">
+            <th:block th:replace="~{fragments/forms/radios :: radios(null, 'tenancyStartedBeforeExpiry', null, ${radioOptions})}"></th:block>
+        </th:block>
+        <button th:replace="~{fragments/buttons/primaryButton :: primaryButton(#{forms.buttons.saveAndContinue})}"></button>
+    </th:block>
+</html>

--- a/src/main/resources/templates/fragments/forms/radios.html
+++ b/src/main/resources/templates/fragments/forms/radios.html
@@ -12,7 +12,7 @@
                            th:id="${radioItemID}"
                            th:attr="aria-describedby=${option.hintMsgKey != null or option.hintValue != null} ? ${hintID}, data-aria-controls=${option.conditionalFragment != null} ? ${conditionalFragmentID}">
                     <label class="govuk-label govuk-radios__label" th:for="${radioItemID}" th:text="${option.labelMsgKey != null ? #messages.msg(option.labelMsgKey) : option.value}">option.labelMsgKey</label>
-                    <div class="govuk-hint govuk-radios__hint" th:if="${option.hintMsgKey != null or option.hintValue != null}" th:id="${hintID}" th:text="${option.hintValue != null ? option.hintValue : #messages.msg(option.hintMsgKey)}">option.hintMsgKey</div>
+                    <div class="govuk-hint govuk-radios__hint" th:if="${option.hintMsgKey != null or option.hintValue != null}" th:id="${hintID}" th:with="hintArg=${{option.hintMsgArg}}" th:text="${option.hintValue != null ? option.hintValue : (option.hintMsgArg != null ? #messages.msg(option.hintMsgKey, hintArg) : #messages.msg(option.hintMsgKey))}">option.hintMsgKey</div>
                 </div>
                 <div th:if="${option.conditionalFragment}" class="govuk-radios__conditional govuk-radios__conditional--hidden" th:id="${conditionalFragmentID}" th:with="fragmentCall=|fragments/conditional/${option.conditionalFragment}|">
                     <th:block th:replace="~{__${fragmentCall}__ :: ${option.conditionalFragment}}"></th:block>

--- a/src/main/resources/templates/fragments/forms/radios.html
+++ b/src/main/resources/templates/fragments/forms/radios.html
@@ -10,9 +10,9 @@
                            type="radio"
                            th:field="*{__${fieldName}__}" th:value="${option.value}"
                            th:id="${radioItemID}"
-                           th:attr="aria-describedby=${option.hintMsgKey != null} ? ${hintID}, data-aria-controls=${option.conditionalFragment != null} ? ${conditionalFragmentID}">
+                           th:attr="aria-describedby=${option.hintMsgKey != null or option.hintValue != null} ? ${hintID}, data-aria-controls=${option.conditionalFragment != null} ? ${conditionalFragmentID}">
                     <label class="govuk-label govuk-radios__label" th:for="${radioItemID}" th:text="${option.labelMsgKey != null ? #messages.msg(option.labelMsgKey) : option.value}">option.labelMsgKey</label>
-                    <div class="govuk-hint govuk-radios__hint" th:if="${option.hintMsgKey != null}" th:id="${hintID}" th:text="#{${option.hintMsgKey}}">option.hintMsgKey</div>
+                    <div class="govuk-hint govuk-radios__hint" th:if="${option.hintMsgKey != null or option.hintValue != null}" th:id="${hintID}" th:text="${option.hintValue != null ? option.hintValue : #messages.msg(option.hintMsgKey)}">option.hintMsgKey</div>
                 </div>
                 <div th:if="${option.conditionalFragment}" class="govuk-radios__conditional govuk-radios__conditional--hidden" th:id="${conditionalFragmentID}" th:with="fragmentCall=|fragments/conditional/${option.conditionalFragment}|">
                     <th:block th:replace="~{__${fragmentCall}__ :: ${option.conditionalFragment}}"></th:block>

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/PropertyRegistrationJourneyTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/PropertyRegistrationJourneyTests.kt
@@ -932,7 +932,6 @@ class PropertyRegistrationJourneyTests : IntegrationTestWithMutableData("data-lo
         confirmUprnMatchedEpcDetailsPage.submitYes()
         val epcExpiryCheckPage = assertPageIs(page, EpcInDateAtStartOfTenancyCheckPagePropertyRegistration::class)
 
-        // TODO PDJB-665 - tenants in place when epc expired - NO
         epcExpiryCheckPage.submitEpcExpired()
         val epcExpiredPage = assertPageIs(page, EpcExpiredFormPagePropertyRegistration::class)
 

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/PropertyRegistrationSinglePageTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/PropertyRegistrationSinglePageTests.kt
@@ -1070,6 +1070,17 @@ class PropertyRegistrationSinglePageTests : IntegrationTestWithImmutableData("da
     }
 
     @Nested
+    inner class EpcInDateAtStartOfTenancyCheckStep {
+        @Test
+        fun `Submitting with no option selected returns an error`() {
+            val epcInDateAtStartOfTenancyCheckPage = navigator.skipToPropertyRegistrationEpcInDateAtStartOfTenancyCheckPage()
+            epcInDateAtStartOfTenancyCheckPage.form.submit()
+            assertThat(epcInDateAtStartOfTenancyCheckPage.form.getErrorMessage())
+                .containsText("Select if the EPC was still in date when the current tenancy began")
+        }
+    }
+
+    @Nested
     inner class HasMeesExemptionStep {
         @Test
         fun `Submitting with no option selected returns an error`() {

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/PropertyRegistrationSinglePageTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/PropertyRegistrationSinglePageTests.kt
@@ -1078,6 +1078,13 @@ class PropertyRegistrationSinglePageTests : IntegrationTestWithImmutableData("da
             assertThat(epcInDateAtStartOfTenancyCheckPage.form.getErrorMessage())
                 .containsText("Select if the EPC was still in date when the current tenancy began")
         }
+
+        @Test
+        fun `Page displays the EPC expiry date in the body text and Yes radio hint`() {
+            val epcInDateAtStartOfTenancyCheckPage = navigator.skipToPropertyRegistrationEpcInDateAtStartOfTenancyCheckPage()
+            assertThat(epcInDateAtStartOfTenancyCheckPage.bodyParagraph).containsText("5 January 2022")
+            assertThat(epcInDateAtStartOfTenancyCheckPage.form.yesHint).containsText("5 January 2022")
+        }
     }
 
     @Nested

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/Navigator.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/Navigator.kt
@@ -131,6 +131,7 @@ import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyReg
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyRegistrationJourneyPages.ConfirmEpcDetailsRetrievedByUprnFormPagePropertyRegistration
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyRegistrationJourneyPages.ElectricalCertExpiryDateFormPagePropertyRegistration
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyRegistrationJourneyPages.EpcExemptionFormPagePropertyRegistration
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyRegistrationJourneyPages.EpcInDateAtStartOfTenancyCheckPagePropertyRegistration
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyRegistrationJourneyPages.EpcMissingFormPagePropertyRegistration
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyRegistrationJourneyPages.FindYourEpcFormPagePropertyRegistration
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyRegistrationJourneyPages.FurnishedStatusFormPagePropertyRegistration
@@ -204,6 +205,7 @@ import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.Confi
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.ConfirmEpcRetrievedByUprnStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.ElectricalCertExpiryDateStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.EpcExemptionStep
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.EpcInDateAtStartOfTenancyCheckStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.FindYourEpcStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.FurnishedStatusStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.GasCertIssueDateStep
@@ -692,6 +694,14 @@ class Navigator(
         )
         navigateToPropertyRegistrationJourneyStep(ConfirmEpcRetrievedByUprnStep.ROUTE_SEGMENT)
         return createValidPage(page, ConfirmEpcDetailsRetrievedByUprnFormPagePropertyRegistration::class)
+    }
+
+    fun skipToPropertyRegistrationEpcInDateAtStartOfTenancyCheckPage(): EpcInDateAtStartOfTenancyCheckPagePropertyRegistration {
+        setJourneyStateInSession(
+            PropertyStateSessionBuilder.beforePropertyRegistrationEpcInDateAtStartOfTenancyCheck().build(),
+        )
+        navigateToPropertyRegistrationJourneyStep(EpcInDateAtStartOfTenancyCheckStep.ROUTE_SEGMENT)
+        return createValidPage(page, EpcInDateAtStartOfTenancyCheckPagePropertyRegistration::class)
     }
 
     fun skipToPropertyRegistrationHasMeesExemptionPage(): HasMeesExemptionFormPagePropertyRegistration {

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/propertyRegistrationJourneyPages/EpcInDateAtStartOfTenancyCheckPagePropertyRegistration.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/propertyRegistrationJourneyPages/EpcInDateAtStartOfTenancyCheckPagePropertyRegistration.kt
@@ -12,6 +12,7 @@ class EpcInDateAtStartOfTenancyCheckPagePropertyRegistration(
     page: Page,
 ) : BasePage(page, "${RegisterPropertyController.PROPERTY_REGISTRATION_ROUTE}/${EpcInDateAtStartOfTenancyCheckStep.ROUTE_SEGMENT}") {
     val heading = Heading(page.locator("h1"))
+    val bodyParagraph = page.locator("p.govuk-body").first()
     val form = EpcInDateAtStartOfTenancyCheckForm(page)
 
     fun submitEpcInDate() {
@@ -28,5 +29,6 @@ class EpcInDateAtStartOfTenancyCheckPagePropertyRegistration(
         page: Page,
     ) : Form(page) {
         val epcInDateAtStartOfTenancyRadios = Radios(locator)
+        val yesHint = locator.locator(".govuk-radios__hint")
     }
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/propertyRegistrationJourneyPages/EpcInDateAtStartOfTenancyCheckPagePropertyRegistration.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/propertyRegistrationJourneyPages/EpcInDateAtStartOfTenancyCheckPagePropertyRegistration.kt
@@ -8,7 +8,6 @@ import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.Radios
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages.BasePage
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.EpcInDateAtStartOfTenancyCheckStep
 
-// TODO PDJB-665: Implement EPC Expiry Check page object
 class EpcInDateAtStartOfTenancyCheckPagePropertyRegistration(
     page: Page,
 ) : BasePage(page, "${RegisterPropertyController.PROPERTY_REGISTRATION_ROUTE}/${EpcInDateAtStartOfTenancyCheckStep.ROUTE_SEGMENT}") {

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/EpcInDateAtStartOfTenancyCheckStepConfigTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/EpcInDateAtStartOfTenancyCheckStepConfigTests.kt
@@ -1,0 +1,65 @@
+package uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.whenever
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.EpcState
+import uk.gov.communities.prsdb.webapp.testHelpers.mockObjects.AlwaysTrueValidator
+
+@ExtendWith(MockitoExtension::class)
+class EpcInDateAtStartOfTenancyCheckStepConfigTests {
+    @Mock
+    lateinit var mockState: EpcState
+
+    private val routeSegment = EpcInDateAtStartOfTenancyCheckStep.ROUTE_SEGMENT
+
+    @Test
+    fun `mode returns null when form model is not present`() {
+        val stepConfig = setupStepConfig()
+
+        val result = stepConfig.mode(mockState)
+
+        assertNull(result)
+    }
+
+    @Test
+    fun `mode returns null when tenancyStartedBeforeExpiry is null`() {
+        val stepConfig = setupStepConfig()
+        whenever(mockState.getStepData(routeSegment)).thenReturn(emptyMap())
+
+        val result = stepConfig.mode(mockState)
+
+        assertNull(result)
+    }
+
+    @Test
+    fun `mode returns IN_DATE when tenancyStartedBeforeExpiry is true`() {
+        val stepConfig = setupStepConfig()
+        whenever(mockState.getStepData(routeSegment)).thenReturn(mapOf("tenancyStartedBeforeExpiry" to true))
+
+        val result = stepConfig.mode(mockState)
+
+        assertEquals(EpcInDateAtStartOfTenancyCheckMode.IN_DATE, result)
+    }
+
+    @Test
+    fun `mode returns NOT_IN_DATE when tenancyStartedBeforeExpiry is false`() {
+        val stepConfig = setupStepConfig()
+        whenever(mockState.getStepData(routeSegment)).thenReturn(mapOf("tenancyStartedBeforeExpiry" to false))
+
+        val result = stepConfig.mode(mockState)
+
+        assertEquals(EpcInDateAtStartOfTenancyCheckMode.NOT_IN_DATE, result)
+    }
+
+    private fun setupStepConfig(): EpcInDateAtStartOfTenancyCheckStepConfig {
+        val stepConfig = EpcInDateAtStartOfTenancyCheckStepConfig()
+        stepConfig.routeSegment = routeSegment
+        stepConfig.validator = AlwaysTrueValidator()
+        return stepConfig
+    }
+}

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/testHelpers/builders/PropertyStateSessionBuilder.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/testHelpers/builders/PropertyStateSessionBuilder.kt
@@ -169,6 +169,12 @@ class PropertyStateSessionBuilder(
                 .withEpcProvideLater()
                 .withOccupancyStatus(propertyIsOccupied)
 
+        fun beforePropertyRegistrationEpcInDateAtStartOfTenancyCheck() =
+            beforePropertyRegistrationHasElectricalCert()
+                .withElectricalSafetyCertificateMissing()
+                .withAcceptedEpcFoundByUprn(MockEpcData.createEpcDataModel(expiryDate = MockEpcData.expiryDateInThePast))
+                .withOccupancyStatus(true)
+
         fun beforePropertyRegistrationHasMeesExemption() =
             beforePropertyRegistrationHasElectricalCert()
                 .withElectricalSafetyCertificateMissing()


### PR DESCRIPTION
## Ticket number

PDJB-665

## Goal of change

Adds the tenancy started before expiry page

## Description of main change(s)

Adds a page for if the tenancy (when occupied) started before the certificate expired.
Adds tests
<img width="984" height="761" alt="image" src="https://github.com/user-attachments/assets/92122727-f7dd-40c6-b613-66b3a5920f78" />

## Checklist

Delete any that are not applicable, and add explanation below for any that are applicable but haven't been done

- [x] Screenshots of any UI changes have been added
- [x] Unit tests for new logic (e.g. new service methods) have been added
- [x] Single page integration tests have been added for any unhappy-flow UI features, e.g. validation errors
- [x] New journey steps have been added to the appropriate journey integration test(s)
- [x] Test suite has been run in full locally and is passing
- [x] Branch has been rebased onto main and run locally, with everything working as expected (both for your new feature
  and any related functionality)
- [x] TODO comments referencing this JIRA ticket have been searched for and removed - if a future PR will address them,
  mention that here
- [x] QA instructions have been added to the ticket (particularly if this is the last PR required to complete the ticket)
