### PR TITLE
PDJB-NONE: unify bold text method

### DIFF
--- a/src/main/resources/messages/forms.yml
+++ b/src/main/resources/messages/forms.yml
@@ -1130,9 +1130,7 @@ lowEnergyRating:
 epcRequirements:
   heading: Requirements for letting a property
   paragraph:
-    one:
-      normalText: 'You need a valid EPC with a rating of'
-      boldText: E or higher.
+    one: 'You need a valid EPC with a rating of <strong>E or higher</strong>.'
     two: 'This means you may need to:'
     three:
       beforeLink: Some rental properties can have a rating lower than E if they have

--- a/src/main/resources/messages/propertyCompliance.yml
+++ b/src/main/resources/messages/propertyCompliance.yml
@@ -393,10 +393,7 @@ epcTask:
         paragraph: You need a valid EPC (unless your property is exempt from needing an EPC, for example, listed and work would unacceptably alter the character of the building).
       toLet:
         heading: To let a property (new tenancy)
-        paragraph:
-          beforeBold: 'You need a '
-          bold: valid EPC of E or higher
-          afterBold: ', unless:'
+        paragraph: 'You need a <strong>valid EPC of E or higher</strong>, unless:'
         bullets:
           one: your property is exempt from needing an EPC, for example, listed and work would unacceptably alter the character of the building
           two: you have a registered energy efficiency exemption on the PRS exemptions register (but you still need a valid EPC)
@@ -455,10 +452,7 @@ epcTask:
       toLet:
         heading: To let a property (new tenancy)
         paragraph:
-          one:
-            beforeBold: 'You need a '
-            bold: valid EPC of E or higher
-            afterBold: ', unless:'
+          one: 'You need a <strong>valid EPC of E or higher</strong>, unless:'
           two: If the EPC expires while the property’s occupied, you do not need to get a new EPC
             immediately. You only need a new EPC when you advertise the property or start a new tenancy.
         bullet:
@@ -540,9 +534,7 @@ epcTask:
       missing: Select if you have registered an energy efficiency exemption for this property
     heading: You need a registered energy efficiency exemption to let this property
     paragraph:
-      one:
-        normalText: This is because the property has an energy efficiency rating
-        boldText: below E.
+      one: 'This is because the property has an energy efficiency rating <strong>below E</strong>.'
       two:
         beforeLink: Learn how to register an exemption by reading
         link: guidance for landlords about minimum energy efficiency standards (opens in new tab)
@@ -556,9 +548,7 @@ epcTask:
     error:
       missing: Select which exemption applies to this property
     heading: Which energy efficiency exemption did you register for this property?
-    hint:
-      beforeBold: Select the exemption you registered on the
-      bold: PRS exemptions register
+    hint: 'Select the exemption you registered on the <strong>PRS exemptions register</strong>'
     radios:
       allImprovementsMade:
         label: ‘All relevant improvements made’ exemption
@@ -575,10 +565,7 @@ epcTask:
   lowEnergyRatingOccupied:
     heading: This property does not meet energy efficiency requirements for letting
     paragraph:
-      one:
-        normalText: This property has an EPC with an energy efficiency rating
-        boldText: lower than E.
-        afterBold: You’ve also told us there’s no registered energy efficiency exemption.
+      one: 'This property has an EPC with an energy efficiency rating <strong>lower than E</strong>. You’ve also told us there’s no registered energy efficiency exemption.'
     breakingLaw:
       heading: You’re breaking the law if tenants are living in this property
     warning: You can be fined for letting a property that does not meet energy efficiency requirements.
@@ -588,9 +575,7 @@ epcTask:
     reasonList:
       intro: 'This is because this property has:'
       bullet:
-        one:
-          beforeBold: an EPC with an energy efficiency rating
-          bold: lower than E
+        one: 'an EPC with an energy efficiency rating <strong>lower than E</strong>'
         two: no registered energy efficiency exemption.
     whatHappensNext:
       heading: What happens next
@@ -620,9 +605,7 @@ epcTask:
       one: Based on what you've told us, you need an EPC to let this property.
     requirements:
       paragraph:
-        one:
-          boldText: E or higher
-          afterBold: 'to let a property. This means you may need to:'
+        one: 'You need a valid EPC with a rating of <strong>E or higher</strong> to let a property. This means you may need to:'
   epcMissingOccupied:
     breakingLaw:
       heading: You’re breaking the law if tenants are living in this property
@@ -636,10 +619,7 @@ epcTask:
         link: Get a new energy certificate (opens in new tab)
       forLetting:
         heading: For letting a property
-        paragraph:
-          normalText: 'You must get a valid EPC with a rating of'
-          boldText: E or higher
-          afterBold: before letting this property.
+        paragraph: 'You must get a valid EPC with a rating of <strong>E or higher</strong> before letting this property.'
     whatYouNeedToDo:
       heading: What you need to do
       paragraph:

--- a/src/main/resources/templates/forms/confirmEpcDetailsByUprnForm.html
+++ b/src/main/resources/templates/forms/confirmEpcDetailsByUprnForm.html
@@ -33,9 +33,8 @@
                     <h2 class="govuk-heading-m" th:text="#{propertyCompliance.epcTask.confirmEpcDetailsFromUprn.details.toLet.heading}">
                         propertyCompliance.epcTask.confirmEpcDetailsFromUprn.details.toLet.heading
                     </h2>
-                    <p class="govuk-body">
-                        <span th:remove="tag" th:text="#{propertyCompliance.epcTask.confirmEpcDetailsFromUprn.details.toLet.paragraph.beforeBold}">propertyCompliance.epcTask.confirmEpcDetailsFromUprn.details.toLet.paragraph.beforeBold</span>
-                        <span class="govuk-!-font-weight-bold" th:text="#{propertyCompliance.epcTask.confirmEpcDetailsFromUprn.details.toLet.paragraph.bold}">propertyCompliance.epcTask.confirmEpcDetailsFromUprn.details.toLet.paragraph.bold</span><span th:remove="tag" th:text="#{propertyCompliance.epcTask.confirmEpcDetailsFromUprn.details.toLet.paragraph.afterBold}">propertyCompliance.epcTask.confirmEpcDetailsFromUprn.details.toLet.paragraph.afterBold</span>
+                    <p class="govuk-body" th:utext="#{propertyCompliance.epcTask.confirmEpcDetailsFromUprn.details.toLet.paragraph}">
+                        propertyCompliance.epcTask.confirmEpcDetailsFromUprn.details.toLet.paragraph
                     </p>
                     <ul class="govuk-list govuk-list--bullet">
                         <li th:text="#{propertyCompliance.epcTask.confirmEpcDetailsFromUprn.details.toLet.bullets.one}">

--- a/src/main/resources/templates/forms/epcMissingForOccupiedProperty.html
+++ b/src/main/resources/templates/forms/epcMissingForOccupiedProperty.html
@@ -11,11 +11,7 @@
         <th:block th:replace="~{fragments/content/epcMissingIntroContent :: epcMissingIntro}"></th:block>
         <section>
             <h2 class="govuk-heading-m" th:text="#{forms.epcRequirements.heading}">forms.epcRequirements.heading</h2>
-            <p class="govuk-body">
-                <span th:remove="tag" th:text="#{forms.epcRequirements.paragraph.one.normalText}">forms.epcRequirements.paragraph.one.normalText</span>
-                <span class="govuk-!-font-weight-bold" th:text="#{propertyCompliance.epcTask.epcMissing.requirements.paragraph.one.boldText}">propertyCompliance.epcTask.epcMissing.requirements.paragraph.one.boldText</span>
-                <span th:remove="tag" th:text="#{propertyCompliance.epcTask.epcMissing.requirements.paragraph.one.afterBold}">propertyCompliance.epcTask.epcMissing.requirements.paragraph.one.afterBold</span>
-            </p>
+            <p class="govuk-body" th:utext="#{propertyCompliance.epcTask.epcMissing.requirements.paragraph.one}">propertyCompliance.epcTask.epcMissing.requirements.paragraph.one</p>
             <ul class="govuk-list govuk-list--bullet">
                 <li>
                     <a class="govuk-link" th:href="${getNewEpcUrl}" th:text="#{forms.epcRequirements.bullet.one}" rel="noreferrer noopener" target="_blank">forms.epcRequirements.bullet.one</a>

--- a/src/main/resources/templates/forms/epcMissingForUnoccupiedProperty.html
+++ b/src/main/resources/templates/forms/epcMissingForUnoccupiedProperty.html
@@ -17,11 +17,7 @@
                 <a class="govuk-link" th:href="${getNewEpcUrl}" th:text="#{propertyCompliance.epcTask.epcMissingUnoccupied.epcRequirements.forAdvertising.link}" rel="noreferrer noopener" target="_blank">propertyCompliance.epcTask.epcMissingUnoccupied.epcRequirements.forAdvertising.link</a>
             </p>
             <h3 class="govuk-heading-s" th:text="#{propertyCompliance.epcTask.epcMissingUnoccupied.epcRequirements.forLetting.heading}">propertyCompliance.epcTask.epcMissingUnoccupied.epcRequirements.forLetting.heading</h3>
-            <p class="govuk-body">
-                <span th:remove="tag" th:text="#{propertyCompliance.epcTask.epcMissingUnoccupied.epcRequirements.forLetting.paragraph.normalText}">propertyCompliance.epcTask.epcMissingUnoccupied.epcRequirements.forLetting.paragraph.normalText</span>
-                <span class="govuk-!-font-weight-bold" th:text="#{propertyCompliance.epcTask.epcMissingUnoccupied.epcRequirements.forLetting.paragraph.boldText}">propertyCompliance.epcTask.epcMissingUnoccupied.epcRequirements.forLetting.paragraph.boldText</span>
-                <span th:remove="tag" th:text="#{propertyCompliance.epcTask.epcMissingUnoccupied.epcRequirements.forLetting.paragraph.afterBold}">propertyCompliance.epcTask.epcMissingUnoccupied.epcRequirements.forLetting.paragraph.afterBold</span>
-            </p>
+            <p class="govuk-body" th:utext="#{propertyCompliance.epcTask.epcMissingUnoccupied.epcRequirements.forLetting.paragraph}">propertyCompliance.epcTask.epcMissingUnoccupied.epcRequirements.forLetting.paragraph</p>
             <p class="govuk-body" th:text="#{forms.epcRequirements.paragraph.two}">forms.epcRequirements.paragraph.two</p>
             <ul class="govuk-list govuk-list--bullet">
                 <li>

--- a/src/main/resources/templates/forms/hasCertForm.html
+++ b/src/main/resources/templates/forms/hasCertForm.html
@@ -22,10 +22,7 @@
                 </section>
                 <section>
                     <h2 class="govuk-heading-m" th:text="#{propertyCompliance.epcTask.hasEpc.epcRequirements.toLet.heading}">propertyCompliance.epcTask.hasEpc.epcRequirements.toLet.heading</h2>
-                    <p class="govuk-body">
-                        <span th:remove="tag" th:text="#{propertyCompliance.epcTask.hasEpc.epcRequirements.toLet.paragraph.one.beforeBold}">propertyCompliance.epcTask.hasEpc.epcRequirements.toLet.paragraph.one.beforeBold</span>
-                        <strong th:text="#{propertyCompliance.epcTask.hasEpc.epcRequirements.toLet.paragraph.one.bold}">propertyCompliance.epcTask.hasEpc.epcRequirements.toLet.paragraph.one.bold</strong><span th:remove="tag" th:text="#{propertyCompliance.epcTask.hasEpc.epcRequirements.toLet.paragraph.one.afterBold}">propertyCompliance.epcTask.hasEpc.epcRequirements.toLet.paragraph.one.afterBold</span>
-                    </p>
+                        <p class="govuk-body" th:utext="#{propertyCompliance.epcTask.hasEpc.epcRequirements.toLet.paragraph.one}">propertyCompliance.epcTask.hasEpc.epcRequirements.toLet.paragraph.one</p>
                     <ul class="govuk-list govuk-list--bullet">
                         <li th:text="#{propertyCompliance.epcTask.hasEpc.epcRequirements.toLet.bullet.one}">propertyCompliance.epcTask.hasEpc.epcRequirements.toLet.bullet.one</li>
                         <li th:text="#{propertyCompliance.epcTask.hasEpc.epcRequirements.toLet.bullet.two}">propertyCompliance.epcTask.hasEpc.epcRequirements.toLet.bullet.two</li>

--- a/src/main/resources/templates/forms/lowEnergyRatingOccupiedForm.html
+++ b/src/main/resources/templates/forms/lowEnergyRatingOccupiedForm.html
@@ -12,11 +12,7 @@
             <h1 class="govuk-heading-l" th:text="#{propertyCompliance.epcTask.lowEnergyRatingOccupied.heading}">propertyCompliance.epcTask.lowEnergyRatingOccupied.heading</h1>
         </header>
         <section>
-            <p class="govuk-body">
-                <span th:remove="tag" th:text="#{propertyCompliance.epcTask.lowEnergyRatingOccupied.paragraph.one.normalText}">propertyCompliance.epcTask.lowEnergyRatingOccupied.paragraph.one.normalText</span>
-                <span class="govuk-!-font-weight-bold" th:text="#{propertyCompliance.epcTask.lowEnergyRatingOccupied.paragraph.one.boldText}">propertyCompliance.epcTask.lowEnergyRatingOccupied.paragraph.one.boldText</span>
-                <span th:remove="tag" th:text="#{propertyCompliance.epcTask.lowEnergyRatingOccupied.paragraph.one.afterBold}">propertyCompliance.epcTask.lowEnergyRatingOccupied.paragraph.one.afterBold</span>
-            </p>
+            <p class="govuk-body" th:utext="#{propertyCompliance.epcTask.lowEnergyRatingOccupied.paragraph.one}">propertyCompliance.epcTask.lowEnergyRatingOccupied.paragraph.one</p>
         </section>
         <section th:replace="~{fragments/content/epcRequirementsContent :: epcRequirementsContent(${getNewEpcUrl}, ${registeredEnergyExemptionGuideUrl})}"></section>
         <section>

--- a/src/main/resources/templates/forms/lowEnergyRatingUnoccupiedForm.html
+++ b/src/main/resources/templates/forms/lowEnergyRatingUnoccupiedForm.html
@@ -15,10 +15,7 @@
             <div class="govuk-inset-text" th:text="#{propertyCompliance.epcTask.lowEnergyRatingUnoccupied.insetText}">propertyCompliance.epcTask.lowEnergyRatingUnoccupied.insetText</div>
             <p class="govuk-body" th:text="#{propertyCompliance.epcTask.lowEnergyRatingUnoccupied.reasonList.intro}">propertyCompliance.epcTask.lowEnergyRatingUnoccupied.reasonList.intro</p>
             <ul class="govuk-list govuk-list--bullet">
-                <li>
-                    <span th:remove="tag" th:text="#{propertyCompliance.epcTask.lowEnergyRatingUnoccupied.reasonList.bullet.one.beforeBold}">propertyCompliance.epcTask.lowEnergyRatingUnoccupied.reasonList.bullet.one.beforeBold</span>
-                    <strong th:text="#{propertyCompliance.epcTask.lowEnergyRatingUnoccupied.reasonList.bullet.one.bold}">propertyCompliance.epcTask.lowEnergyRatingUnoccupied.reasonList.bullet.one.bold</strong>
-                </li>
+                <li th:utext="#{propertyCompliance.epcTask.lowEnergyRatingUnoccupied.reasonList.bullet.one}">propertyCompliance.epcTask.lowEnergyRatingUnoccupied.reasonList.bullet.one</li>
                 <li th:text="#{propertyCompliance.epcTask.lowEnergyRatingUnoccupied.reasonList.bullet.two}">propertyCompliance.epcTask.lowEnergyRatingUnoccupied.reasonList.bullet.two</li>
             </ul>
         </section>

--- a/src/main/resources/templates/forms/meesExemptionCheckForm.html
+++ b/src/main/resources/templates/forms/meesExemptionCheckForm.html
@@ -12,10 +12,7 @@
         <h1 class="govuk-heading-l" th:text="#{propertyCompliance.epcTask.meesExemptionCheck.heading}">propertyCompliance.epcTask.meesExemptionCheck.heading</h1>
     </header>
     <section>
-        <p class="govuk-body">
-            <span th:remove="tag" th:text="#{propertyCompliance.epcTask.meesExemptionCheck.paragraph.one.normalText}">propertyCompliance.epcTask.meesExemptionCheck.paragraph.one.normalText</span>
-            <span class="govuk-!-font-weight-bold" th:text="#{propertyCompliance.epcTask.meesExemptionCheck.paragraph.one.boldText}">propertyCompliance.epcTask.meesExemptionCheck.paragraph.one.boldText</span>
-        </p>
+        <p class="govuk-body" th:utext="#{propertyCompliance.epcTask.meesExemptionCheck.paragraph.one}">propertyCompliance.epcTask.meesExemptionCheck.paragraph.one</p>
         <p class="govuk-body">
             <span th:remove="tag" th:text="#{propertyCompliance.epcTask.meesExemptionCheck.paragraph.two.beforeLink}">propertyCompliance.epcTask.meesExemptionCheck.paragraph.two.beforeLink</span>
             <a class="govuk-link" th:text="#{propertyCompliance.epcTask.meesExemptionCheck.paragraph.two.link}" th:href="${meesExemptionGuideUrl}" rel="noreferrer noopener" target="_blank">

--- a/src/main/resources/templates/forms/meesExemptionReasonForm.html
+++ b/src/main/resources/templates/forms/meesExemptionReasonForm.html
@@ -12,10 +12,7 @@
             <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
                 <h1 class="govuk-fieldset__heading" th:text="#{propertyCompliance.epcTask.meesExemptionReason.heading}">propertyCompliance.epcTask.meesExemptionReason.heading</h1>
             </legend>
-            <div id="exemptionReason-hint" class="govuk-hint">
-                <span th:remove="tag" th:text="#{propertyCompliance.epcTask.meesExemptionReason.hint.beforeBold}">propertyCompliance.epcTask.meesExemptionReason.hint.beforeBold</span>
-                <strong th:text="#{propertyCompliance.epcTask.meesExemptionReason.hint.bold}">propertyCompliance.epcTask.meesExemptionReason.hint.bold</strong>
-            </div>
+            <div id="exemptionReason-hint" class="govuk-hint" th:utext="#{propertyCompliance.epcTask.meesExemptionReason.hint}">propertyCompliance.epcTask.meesExemptionReason.hint</div>
             <div th:replace="~{fragments/forms/radios :: radios(null, 'exemptionReason', null, ${radioOptions})}"></div>
         </fieldset>
     </div>

--- a/src/main/resources/templates/fragments/content/epcRequirementsContent.html
+++ b/src/main/resources/templates/fragments/content/epcRequirementsContent.html
@@ -1,10 +1,7 @@
 <th:block th:fragment="epcRequirementsContent(getNewEpcUrl, registeredEnergyExemptionGuideUrl)">
     <section>
         <h2 class="govuk-heading-m" th:text="#{forms.epcRequirements.heading}">forms.epcRequirements.heading</h2>
-        <p class="govuk-body">
-            <span th:remove="tag" th:text="#{forms.epcRequirements.paragraph.one.normalText}">forms.epcRequirements.paragraph.one.normalText</span>
-            <span class="govuk-!-font-weight-bold" th:text="#{forms.epcRequirements.paragraph.one.boldText}">forms.epcRequirements.paragraph.one.boldText</span>
-        </p>
+        <p class="govuk-body" th:utext="#{forms.epcRequirements.paragraph.one}">forms.epcRequirements.paragraph.one</p>
         <p class="govuk-body" th:text="#{forms.epcRequirements.paragraph.two}">forms.epcRequirements.paragraph.two</p>
         <ul class="govuk-list govuk-list--bullet">
             <li>


### PR DESCRIPTION
## Ticket number

PDJB-NONE

## Goal of change

Unify the way we make text bold in yamls

## Description of main change(s)

I noticed we had started using "beforeBold" etc. in the same way we did links on some bold text in property compliance, whereas the rest of the codebase used <strong> tags in the yaml. I believe the <strong> way is cleaner and more readable, and makes the yamls less bloaty so I fixed it.

## Checklist

Delete any that are not applicable, and add explanation below for any that are applicable but haven't been done

- [ ] Test suite has been run in full locally and is passing
- [ ] Branch has been rebased onto main and run locally, with everything working as expected (both for your new feature
  and any related functionality)