### PR TITLE
PDJB-NONE: Add Gradle tasks to lint and format message file apostrophes

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -172,6 +172,60 @@ flyway {
     password = "notarealpassword"
 }
 
+tasks.register("messageFileCheck") {
+    group = "verification"
+    description = "Check message YAML files for escaped unicode apostrophes (\\u2019) that should be literal curly apostrophes"
+    doLast {
+        val messagesDir = file("src/main/resources/messages")
+        val escapedApostrophe = "\\u2019"
+        val violations = mutableListOf<String>()
+
+        messagesDir.listFiles()?.filter { it.extension == "yml" }?.sorted()?.forEach { file ->
+            file.readLines().forEachIndexed { index, line ->
+                if (line.contains(escapedApostrophe)) {
+                    violations.add("${file.name}:${index + 1}: $line")
+                }
+            }
+        }
+
+        if (violations.isNotEmpty()) {
+            throw GradleException(
+                "Found escaped unicode apostrophes (\\u2019) in message files. " +
+                    "Use the literal curly apostrophe character (\u2019) instead.\n" +
+                    "Run './gradlew messageFileFormat' to auto-fix.\n\n" +
+                    violations.joinToString("\n"),
+            )
+        }
+    }
+}
+
+tasks.register("messageFileFormat") {
+    group = "verification"
+    description = "Replace escaped unicode apostrophes (\\u2019) with literal curly apostrophes in message YAML files"
+    doLast {
+        val messagesDir = file("src/main/resources/messages")
+        val escapedApostrophe = "\\u2019"
+        val curlyApostrophe = "\u2019"
+        var totalReplacements = 0
+
+        messagesDir.listFiles()?.filter { it.extension == "yml" }?.sorted()?.forEach { file ->
+            val content = file.readText()
+            if (content.contains(escapedApostrophe)) {
+                val count = content.windowed(escapedApostrophe.length).count { it == escapedApostrophe }
+                file.writeText(content.replace(escapedApostrophe, curlyApostrophe))
+                totalReplacements += count
+                println("Fixed $count occurrence(s) in ${file.name}")
+            }
+        }
+
+        if (totalReplacements > 0) {
+            println("\nReplaced $totalReplacements escaped apostrophe(s) with literal curly apostrophes.")
+        } else {
+            println("No escaped apostrophes found. All message files are clean.")
+        }
+    }
+}
+
 buildscript {
     repositories {
         mavenCentral()

--- a/src/main/resources/messages/registerAsALandlord.yml
+++ b/src/main/resources/messages/registerAsALandlord.yml
@@ -67,7 +67,7 @@ privacyNotice:
   checkBox:
     heading: Confirm you have read the privacy notice
     label: I confirm I have read the privacy notice for this private beta
-  oneLoginInset: "When you continue, you\u2019ll be asked to prove your identity using your GOV.UK One Login."
+  oneLoginInset: "When you continue, you’ll be asked to prove your identity using your GOV.UK One Login."
 section:
   privacyNotice:
     heading: Privacy notice


### PR DESCRIPTION
## Ticket number
PDJB-NONE

## Goal of change
Prevent escaped unicode apostrophes (`\u2019`) from appearing in message YAML files instead of literal curly apostrophe characters.

## Description of main change(s)
- Adds `messageFileCheck` Gradle task that fails the build if any message YAML file contains the literal `\u2019` escape sequence instead of the actual curly apostrophe character
- Adds `messageFileFormat` Gradle task that auto-fixes any violations by replacing the escape sequence with the real character
- Fixes 1 existing violation in `registerAsALandlord.yml`

## Anything you'd like to highlight to the reviewer?
Nothing unusual.

## Checklist
- [x] Test suite has been run in full locally and is passing
- [x] Branch has been rebased onto main and run locally, with everything working as expected