### PR TITLE
PDJB-NONE: Use var convention for revisited pages in integration tests

### DIFF
--- a/.github/instructions/integration-tests.instructions.md
+++ b/.github/instructions/integration-tests.instructions.md
@@ -75,6 +75,26 @@ val page = navigator.skipToCheckAnswers()
 navigator.navigateToHomePage()
 ```
 
+## Revisiting Pages
+
+When a test revisits the same page type, use `var` and reassign rather than creating new variables with suffixed names:
+
+```kotlin
+// Correct — var + reassignment
+var checkJointLandlordPage = assertPageIs(page, CheckJointLandlordsFormPage::class)
+checkJointLandlordPage.form.addAnotherButton.clickAndWait()
+// ... navigate away and back ...
+checkJointLandlordPage = assertPageIs(page, CheckJointLandlordsFormPage::class)
+checkJointLandlordPage.form.submit()
+
+// Wrong — new val each time
+val firstCheckJointLandlordPage = assertPageIs(page, CheckJointLandlordsFormPage::class)
+// ...
+val secondCheckJointLandlordPage = assertPageIs(page, CheckJointLandlordsFormPage::class)
+```
+
+If a navigator method is called with different arguments pointing to genuinely different pages, those remain as separate `val` declarations.
+
 ## Test Structure
 ```kotlin
 @Test

--- a/docs/IntegrationTestReadMe.md
+++ b/docs/IntegrationTestReadMe.md
@@ -88,3 +88,24 @@ navigation method:
 * `skipToX` - perform some set-up*, then navigate to X and return a page object
 
 *Make calls to endpoints that configure the session to make the page reachable.
+
+## Revisiting Pages
+
+When a test revisits the same page type, use `var` and reassign rather than creating new variables with suffixed names:
+
+```kotlin
+// Correct — var + reassignment
+var checkJointLandlordPage = assertPageIs(page, CheckJointLandlordsFormPage::class)
+checkJointLandlordPage.form.addAnotherButton.clickAndWait()
+// ... navigate away and back ...
+checkJointLandlordPage = assertPageIs(page, CheckJointLandlordsFormPage::class)
+checkJointLandlordPage.form.submit()
+
+// Wrong — new val each time
+val firstCheckJointLandlordPage = assertPageIs(page, CheckJointLandlordsFormPage::class)
+// ...
+val secondCheckJointLandlordPage = assertPageIs(page, CheckJointLandlordsFormPage::class)
+```
+
+If a navigator method is called with different arguments pointing to genuinely different pages, those remain as
+separate `val` declarations.

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/GeneratePasscodeTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/GeneratePasscodeTests.kt
@@ -30,7 +30,7 @@ class GeneratePasscodeTests : IntegrationTestWithMutableData("data-local.sql") {
     @Test
     fun `refreshing the page gives the same passcode`(page: Page) {
         // Navigate to generate passcode page
-        val generatePasscodePage = navigator.goToGeneratePasscodePage()
+        var generatePasscodePage = navigator.goToGeneratePasscodePage()
 
         // Get the initial passcode
         val initialPasscode = generatePasscodePage.banner.passcode
@@ -38,17 +38,17 @@ class GeneratePasscodeTests : IntegrationTestWithMutableData("data-local.sql") {
 
         // Refresh the page
         page.reload()
-        val refreshedPage = assertPageIs(page, GeneratePasscodePage::class)
+        generatePasscodePage = assertPageIs(page, GeneratePasscodePage::class)
 
         // Verify the same passcode is displayed
-        val refreshedPasscode = refreshedPage.banner.passcode
+        val refreshedPasscode = generatePasscodePage.banner.passcode
         assertEquals(initialPasscode, refreshedPasscode)
     }
 
     @Test
     fun `clicking generate another passcode creates a new passcode`(page: Page) {
         // Navigate to generate passcode page
-        val generatePasscodePage = navigator.goToGeneratePasscodePage()
+        var generatePasscodePage = navigator.goToGeneratePasscodePage()
 
         // Get the initial passcode
         val initialPasscode = generatePasscodePage.banner.passcode
@@ -58,10 +58,10 @@ class GeneratePasscodeTests : IntegrationTestWithMutableData("data-local.sql") {
         generatePasscodePage.generateAnotherButton.clickAndWait()
 
         // Verify we're still on the generate passcode page
-        val newGeneratePasscodePage = assertPageIs(page, GeneratePasscodePage::class)
+        generatePasscodePage = assertPageIs(page, GeneratePasscodePage::class)
 
         // Get the new passcode
-        val newPasscode = newGeneratePasscodePage.banner.passcode
+        val newPasscode = generatePasscodePage.banner.passcode
         assert(newPasscode.isNotEmpty()) { "New passcode should be generated" }
         assertNotEquals(initialPasscode, newPasscode)
     }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/LandlordDetailsUpdateSinglePageTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/LandlordDetailsUpdateSinglePageTests.kt
@@ -58,7 +58,7 @@ class LandlordDetailsUpdateSinglePageTests : IntegrationTestWithImmutableData("d
             val postcode = "NOT A POSTCODE"
 
             // Lookup Address page
-            val lookupAddressPage = navigator.goToUpdateLandlordDetailsUpdateLookupAddressPage()
+            var lookupAddressPage = navigator.goToUpdateLandlordDetailsUpdateLookupAddressPage()
             lookupAddressPage.submitPostcodeAndBuildingNameOrNumber(postcode, houseNumber)
             var noAddressFoundPage = BasePage.assertPageIs(page, NoAddressFoundFormPageUpdateLandlordDetails::class)
 
@@ -68,8 +68,8 @@ class LandlordDetailsUpdateSinglePageTests : IntegrationTestWithImmutableData("d
 
             // Search again
             noAddressFoundPage.searchAgain.clickAndWait()
-            val lookupAddressPageAgain = BasePage.assertPageIs(page, LookupAddressFormPageUpdateLandlordDetails::class)
-            lookupAddressPageAgain.submitPostcodeAndBuildingNameOrNumber(postcode, houseNumber)
+            lookupAddressPage = BasePage.assertPageIs(page, LookupAddressFormPageUpdateLandlordDetails::class)
+            lookupAddressPage.submitPostcodeAndBuildingNameOrNumber(postcode, houseNumber)
             noAddressFoundPage = BasePage.assertPageIs(page, NoAddressFoundFormPageUpdateLandlordDetails::class)
 
             // Choose Manual Address

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/LandlordRegistrationSinglePageTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/LandlordRegistrationSinglePageTests.kt
@@ -274,23 +274,23 @@ class LandlordRegistrationSinglePageTests : IntegrationTestWithImmutableData("da
             // Lookup address finds no results
             val houseNumber = "NOT A HOUSE NUMBER"
             val postcode = "NOT A POSTCODE"
-            val lookupAddressPage = navigator.skipToLandlordRegistrationLookupAddressPage()
+            var lookupAddressPage = navigator.skipToLandlordRegistrationLookupAddressPage()
             lookupAddressPage.submitPostcodeAndBuildingNameOrNumber(postcode, houseNumber)
 
             // redirect to noAddressFoundPage
-            val noAddressFoundPage = assertPageIs(page, NoAddressFoundFormPageLandlordRegistration::class)
+            var noAddressFoundPage = assertPageIs(page, NoAddressFoundFormPageLandlordRegistration::class)
             BaseComponent
                 .assertThat(noAddressFoundPage.heading)
                 .containsText("No matching address in England or Wales found for $postcode and $houseNumber")
 
             // Search Again
             noAddressFoundPage.searchAgain.clickAndWait()
-            val lookupAddressPageAgain = assertPageIs(page, LookupAddressFormPageLandlordRegistration::class)
-            lookupAddressPageAgain.submitPostcodeAndBuildingNameOrNumber(postcode, houseNumber)
+            lookupAddressPage = assertPageIs(page, LookupAddressFormPageLandlordRegistration::class)
+            lookupAddressPage.submitPostcodeAndBuildingNameOrNumber(postcode, houseNumber)
 
             // Submit no address found page
-            val noAddressFoundPageAgain = assertPageIs(page, NoAddressFoundFormPageLandlordRegistration::class)
-            noAddressFoundPageAgain.form.submit()
+            noAddressFoundPage = assertPageIs(page, NoAddressFoundFormPageLandlordRegistration::class)
+            noAddressFoundPage.form.submit()
             assertPageIs(page, ManualAddressFormPageLandlordRegistration::class)
         }
     }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/PropertyRegistrationJourneyTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/PropertyRegistrationJourneyTests.kt
@@ -269,7 +269,7 @@ class PropertyRegistrationJourneyTests : IntegrationTestWithMutableData("data-lo
 
         // fill in and submit
         inviteJointLandlordPage.submitEmail("email@address.com")
-        val checkJointLandlordsPage = assertPageIs(page, CheckJointLandlordsFormPagePropertyRegistration::class)
+        var checkJointLandlordsPage = assertPageIs(page, CheckJointLandlordsFormPagePropertyRegistration::class)
         assertThat(checkJointLandlordsPage.summaryList.firstRow.value).containsText("email@address.com")
 
         // Check joint landlords - render page
@@ -282,15 +282,15 @@ class PropertyRegistrationJourneyTests : IntegrationTestWithMutableData("data-lo
         val addAnotherPage = assertPageIs(page, InviteAnotherJointLandlordFormPagePropertyRegistration::class)
         addAnotherPage.submitEmail("email2@address.com")
 
-        val newCheckJointLandlordsPage = assertPageIs(page, CheckJointLandlordsFormPagePropertyRegistration::class)
-        newCheckJointLandlordsPage.summaryList.firstRow.clickNamedActionLinkAndWait("Remove")
+        checkJointLandlordsPage = assertPageIs(page, CheckJointLandlordsFormPagePropertyRegistration::class)
+        checkJointLandlordsPage.summaryList.firstRow.clickNamedActionLinkAndWait("Remove")
 
         // Remove Joint Landlord - render page
         val removeJointLandlordsPage = assertPageIs(page, RemoveJointLandlordAreYouSureFormPagePropertyRegistration::class)
         removeJointLandlordsPage.submitWantsToProceed()
 
-        val finalCheckJointLandlordsPage = assertPageIs(page, CheckJointLandlordsFormPagePropertyRegistration::class)
-        finalCheckJointLandlordsPage.form.submit()
+        checkJointLandlordsPage = assertPageIs(page, CheckJointLandlordsFormPagePropertyRegistration::class)
+        checkJointLandlordsPage.form.submit()
 
         val hasGasSupplyPage = assertPageIs(page, HasGasSupplyFormPagePropertyRegistration::class)
 

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/PropertyRegistrationSinglePageTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/PropertyRegistrationSinglePageTests.kt
@@ -14,7 +14,6 @@ import uk.gov.communities.prsdb.webapp.constants.enums.OwnershipType
 import uk.gov.communities.prsdb.webapp.constants.enums.RentFrequency
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.BaseComponent
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.ErrorPage
-import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages.BasePage
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages.BasePage.Companion.assertPageIs
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyRegistrationJourneyPages.AlreadyRegisteredFormPagePropertyRegistration
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyRegistrationJourneyPages.CheckAnswersPagePropertyRegistration
@@ -96,24 +95,24 @@ class PropertyRegistrationSinglePageTests : IntegrationTestWithImmutableData("da
             // Lookup address finds no English results
             val houseNumber = "NOT A HOUSE NUMBER"
             val postcode = "NOT A POSTCODE"
-            val lookupAddressPage = navigator.goToPropertyRegistrationLookupAddressPage()
+            var lookupAddressPage = navigator.goToPropertyRegistrationLookupAddressPage()
             lookupAddressPage.submitPostcodeAndBuildingNameOrNumber(postcode, houseNumber)
 
             // redirect to noAddressFoundPage
-            val noAddressFoundPage = BasePage.assertPageIs(page, NoAddressFoundFormPagePropertyRegistration::class)
+            var noAddressFoundPage = assertPageIs(page, NoAddressFoundFormPagePropertyRegistration::class)
             BaseComponent
                 .assertThat(noAddressFoundPage.heading)
                 .containsText("No matching address in England found for $postcode and $houseNumber")
 
             // Search Again
             noAddressFoundPage.searchAgain.clickAndWait()
-            val lookupAddressPageAgain = BasePage.assertPageIs(page, LookupAddressFormPagePropertyRegistration::class)
-            lookupAddressPageAgain.submitPostcodeAndBuildingNameOrNumber(postcode, houseNumber)
+            lookupAddressPage = assertPageIs(page, LookupAddressFormPagePropertyRegistration::class)
+            lookupAddressPage.submitPostcodeAndBuildingNameOrNumber(postcode, houseNumber)
 
             // Submit no address found page
-            val noAddressFoundPageAgain = BasePage.assertPageIs(page, NoAddressFoundFormPagePropertyRegistration::class)
-            noAddressFoundPageAgain.form.submit()
-            BasePage.assertPageIs(page, ManualAddressFormPagePropertyRegistration::class)
+            noAddressFoundPage = assertPageIs(page, NoAddressFoundFormPagePropertyRegistration::class)
+            noAddressFoundPage.form.submit()
+            assertPageIs(page, ManualAddressFormPagePropertyRegistration::class)
         }
     }
 
@@ -130,7 +129,7 @@ class PropertyRegistrationSinglePageTests : IntegrationTestWithImmutableData("da
         fun `Clicking Search Again navigates to the previous step`(page: Page) {
             val selectAddressPage = navigator.skipToPropertyRegistrationSelectAddressPage()
             selectAddressPage.searchAgain.clickAndWait()
-            BasePage.assertPageIs(page, LookupAddressFormPagePropertyRegistration::class)
+            assertPageIs(page, LookupAddressFormPagePropertyRegistration::class)
         }
 
         @Test
@@ -138,7 +137,7 @@ class PropertyRegistrationSinglePageTests : IntegrationTestWithImmutableData("da
             val alreadyRegisteredAddress = AddressDataModel("1 Example Road", uprn = 1123456)
             val selectAddressPage = navigator.skipToPropertyRegistrationSelectAddressPage(listOf(alreadyRegisteredAddress))
             selectAddressPage.selectAddressAndSubmit(alreadyRegisteredAddress.singleLineAddress)
-            BasePage.assertPageIs(page, AlreadyRegisteredFormPagePropertyRegistration::class)
+            assertPageIs(page, AlreadyRegisteredFormPagePropertyRegistration::class)
         }
     }
 
@@ -206,7 +205,7 @@ class PropertyRegistrationSinglePageTests : IntegrationTestWithImmutableData("da
         fun `Submitting with an HMO mandatory licence redirects to the next step`(page: Page) {
             val licensingTypePage = navigator.skipToPropertyRegistrationLicensingTypePage()
             licensingTypePage.submitLicensingType(LicensingType.HMO_MANDATORY_LICENCE)
-            val licenseNumberPage = BasePage.assertPageIs(page, HmoMandatoryLicenceFormPagePropertyRegistration::class)
+            val licenseNumberPage = assertPageIs(page, HmoMandatoryLicenceFormPagePropertyRegistration::class)
             BaseComponent
                 .assertThat(licenseNumberPage.form.sectionHeader)
                 .containsText("Section 1 of 5 \u2014 Register your property details")
@@ -216,7 +215,7 @@ class PropertyRegistrationSinglePageTests : IntegrationTestWithImmutableData("da
         fun `Submitting with an HMO additional licence redirects to the next step`(page: Page) {
             val licensingTypePage = navigator.skipToPropertyRegistrationLicensingTypePage()
             licensingTypePage.submitLicensingType(LicensingType.HMO_ADDITIONAL_LICENCE)
-            val licenseNumberPage = BasePage.assertPageIs(page, HmoAdditionalLicenceFormPagePropertyRegistration::class)
+            val licenseNumberPage = assertPageIs(page, HmoAdditionalLicenceFormPagePropertyRegistration::class)
             BaseComponent
                 .assertThat(licenseNumberPage.form.sectionHeader)
                 .containsText("Section 1 of 5 \u2014 Register your property details")
@@ -252,7 +251,7 @@ class PropertyRegistrationSinglePageTests : IntegrationTestWithImmutableData("da
         fun `Submitting with a licence number redirects to the next step`(page: Page) {
             val hmoMandatoryLicencePage = navigator.skipToPropertyRegistrationHmoMandatoryLicencePage()
             hmoMandatoryLicencePage.submitLicenseNumber("licence number")
-            BasePage.assertPageIs(page, OccupancyFormPagePropertyRegistration::class)
+            assertPageIs(page, OccupancyFormPagePropertyRegistration::class)
         }
 
         @Test
@@ -282,7 +281,7 @@ class PropertyRegistrationSinglePageTests : IntegrationTestWithImmutableData("da
         fun `Submitting with a licence number redirects to the next step`(page: Page) {
             val hmoAdditionalLicencePage = navigator.skipToPropertyRegistrationHmoAdditionalLicencePage()
             hmoAdditionalLicencePage.submitLicenseNumber("licence number")
-            BasePage.assertPageIs(page, OccupancyFormPagePropertyRegistration::class)
+            assertPageIs(page, OccupancyFormPagePropertyRegistration::class)
         }
 
         @Test
@@ -405,7 +404,7 @@ class PropertyRegistrationSinglePageTests : IntegrationTestWithImmutableData("da
         ) {
             val householdsPage = navigator.skipToPropertyRegistrationHouseholdsPage()
             householdsPage.submitNumberOfHouseholds(3)
-            val peoplePage = BasePage.assertPageIs(page, NumberOfPeopleFormPagePropertyRegistration::class)
+            val peoplePage = assertPageIs(page, NumberOfPeopleFormPagePropertyRegistration::class)
             peoplePage.submitNumOfPeople(2)
             assertThat(peoplePage.form.getErrorMessage())
                 .containsText(
@@ -650,9 +649,9 @@ class PropertyRegistrationSinglePageTests : IntegrationTestWithImmutableData("da
         @Test
         fun `The link renders correctly`(page: Page) {
             val hasJointLandlordsPage = navigator.skipToPropertyRegistrationHasJointLandlordsPage()
-            BaseComponent.Companion.assertThat(hasJointLandlordsPage.legalAdviceLink).hasAttribute("href", GOV_LEGAL_ADVICE_URL)
-            BaseComponent.Companion.assertThat(hasJointLandlordsPage.legalAdviceLink).hasAttribute("rel", "noreferrer noopener")
-            BaseComponent.Companion.assertThat(hasJointLandlordsPage.legalAdviceLink).hasAttribute("target", "_blank")
+            BaseComponent.assertThat(hasJointLandlordsPage.legalAdviceLink).hasAttribute("href", GOV_LEGAL_ADVICE_URL)
+            BaseComponent.assertThat(hasJointLandlordsPage.legalAdviceLink).hasAttribute("rel", "noreferrer noopener")
+            BaseComponent.assertThat(hasJointLandlordsPage.legalAdviceLink).hasAttribute("target", "_blank")
         }
     }
 
@@ -668,8 +667,8 @@ class PropertyRegistrationSinglePageTests : IntegrationTestWithImmutableData("da
             val inviteJointLandlordsPage = navigator.skipToPropertyRegistrationInviteJointLandlordPage()
             inviteJointLandlordsPage.submitEmail("alpha@example.com")
 
-            val firstCheckJointLandlordPage = assertPageIs(page, CheckJointLandlordsFormPagePropertyRegistration::class)
-            firstCheckJointLandlordPage.summaryList.firstRow.clickNamedActionLinkAndWait("Remove")
+            val checkJointLandlordPage = assertPageIs(page, CheckJointLandlordsFormPagePropertyRegistration::class)
+            checkJointLandlordPage.summaryList.firstRow.clickNamedActionLinkAndWait("Remove")
 
             val removeJointLandlordPage = assertPageIs(page, RemoveJointLandlordAreYouSureFormPagePropertyRegistration::class)
             removeJointLandlordPage.form.submit()
@@ -682,15 +681,15 @@ class PropertyRegistrationSinglePageTests : IntegrationTestWithImmutableData("da
             val inviteJointLandlordsPage = navigator.skipToPropertyRegistrationInviteJointLandlordPage()
             inviteJointLandlordsPage.submitEmail("alpha@example.com")
 
-            val checkJointLandlordPage = assertPageIs(page, CheckJointLandlordsFormPagePropertyRegistration::class)
+            var checkJointLandlordPage = assertPageIs(page, CheckJointLandlordsFormPagePropertyRegistration::class)
             checkJointLandlordPage.summaryList.firstRow.clickNamedActionLinkAndWait("Remove")
 
             val removeJointLandlordPage = assertPageIs(page, RemoveJointLandlordAreYouSureFormPagePropertyRegistration::class)
             removeJointLandlordPage.submitDoesNotWantToProceed()
 
-            val finalCheckJointLandlordPage = assertPageIs(page, CheckJointLandlordsFormPagePropertyRegistration::class)
-            BaseComponent.assertThat(finalCheckJointLandlordPage.title).containsText("You’ve added 1 joint landlord")
-            assertThat(finalCheckJointLandlordPage.summaryList.firstRow.value).containsText("alpha@example.com")
+            checkJointLandlordPage = assertPageIs(page, CheckJointLandlordsFormPagePropertyRegistration::class)
+            BaseComponent.assertThat(checkJointLandlordPage.title).containsText("You’ve added 1 joint landlord")
+            assertThat(checkJointLandlordPage.summaryList.firstRow.value).containsText("alpha@example.com")
         }
 
         @Test
@@ -698,33 +697,33 @@ class PropertyRegistrationSinglePageTests : IntegrationTestWithImmutableData("da
             val inviteJointLandlordsPage = navigator.skipToPropertyRegistrationInviteJointLandlordPage()
             inviteJointLandlordsPage.submitEmail("alpha@example.com")
 
-            val firstCheckJointLandlordPage = assertPageIs(page, CheckJointLandlordsFormPagePropertyRegistration::class)
-            firstCheckJointLandlordPage.form.addAnotherButton.clickAndWait()
+            var checkJointLandlordPage = assertPageIs(page, CheckJointLandlordsFormPagePropertyRegistration::class)
+            checkJointLandlordPage.form.addAnotherButton.clickAndWait()
 
             val inviteAnotherJointLandlordPage = assertPageIs(page, InviteAnotherJointLandlordFormPagePropertyRegistration::class)
             inviteAnotherJointLandlordPage.submitEmail("beta@example.com")
 
-            val secondCheckJointLandlordPage = assertPageIs(page, CheckJointLandlordsFormPagePropertyRegistration::class)
-            secondCheckJointLandlordPage.summaryList.firstRow.clickNamedActionLinkAndWait("Remove")
+            checkJointLandlordPage = assertPageIs(page, CheckJointLandlordsFormPagePropertyRegistration::class)
+            checkJointLandlordPage.summaryList.firstRow.clickNamedActionLinkAndWait("Remove")
 
-            val removeWithYesSelectedPage = assertPageIs(page, RemoveJointLandlordAreYouSureFormPagePropertyRegistration::class)
-            removeWithYesSelectedPage.form.areYouSureRadios.selectValue("true")
-            removeWithYesSelectedPage.cancelLink.clickAndWait()
+            var removeJointLandlordPage = assertPageIs(page, RemoveJointLandlordAreYouSureFormPagePropertyRegistration::class)
+            removeJointLandlordPage.form.areYouSureRadios.selectValue("true")
+            removeJointLandlordPage.cancelLink.clickAndWait()
 
-            val checkAfterYesCancelPage = assertPageIs(page, CheckJointLandlordsFormPagePropertyRegistration::class)
-            BaseComponent.assertThat(checkAfterYesCancelPage.title).containsText("You’ve added 2 joint landlords")
-            assertThat(checkAfterYesCancelPage.summaryList.firstRow.value).containsText("alpha@example.com")
-            assertThat(checkAfterYesCancelPage.summaryList.getRowByIndex(1).value).containsText("beta@example.com")
-            checkAfterYesCancelPage.summaryList.firstRow.clickNamedActionLinkAndWait("Remove")
+            checkJointLandlordPage = assertPageIs(page, CheckJointLandlordsFormPagePropertyRegistration::class)
+            BaseComponent.assertThat(checkJointLandlordPage.title).containsText("You’ve added 2 joint landlords")
+            assertThat(checkJointLandlordPage.summaryList.firstRow.value).containsText("alpha@example.com")
+            assertThat(checkJointLandlordPage.summaryList.getRowByIndex(1).value).containsText("beta@example.com")
+            checkJointLandlordPage.summaryList.firstRow.clickNamedActionLinkAndWait("Remove")
 
-            val removeWithNoSelectedPage = assertPageIs(page, RemoveJointLandlordAreYouSureFormPagePropertyRegistration::class)
-            removeWithNoSelectedPage.form.areYouSureRadios.selectValue("false")
-            removeWithNoSelectedPage.cancelLink.clickAndWait()
+            removeJointLandlordPage = assertPageIs(page, RemoveJointLandlordAreYouSureFormPagePropertyRegistration::class)
+            removeJointLandlordPage.form.areYouSureRadios.selectValue("false")
+            removeJointLandlordPage.cancelLink.clickAndWait()
 
-            val checkAfterNoCancelPage = assertPageIs(page, CheckJointLandlordsFormPagePropertyRegistration::class)
-            BaseComponent.assertThat(checkAfterNoCancelPage.title).containsText("You’ve added 2 joint landlords")
-            assertThat(checkAfterNoCancelPage.summaryList.firstRow.value).containsText("alpha@example.com")
-            assertThat(checkAfterNoCancelPage.summaryList.getRowByIndex(1).value).containsText("beta@example.com")
+            checkJointLandlordPage = assertPageIs(page, CheckJointLandlordsFormPagePropertyRegistration::class)
+            BaseComponent.assertThat(checkJointLandlordPage.title).containsText("You’ve added 2 joint landlords")
+            assertThat(checkJointLandlordPage.summaryList.firstRow.value).containsText("alpha@example.com")
+            assertThat(checkJointLandlordPage.summaryList.getRowByIndex(1).value).containsText("beta@example.com")
         }
 
         @Test
@@ -732,25 +731,25 @@ class PropertyRegistrationSinglePageTests : IntegrationTestWithImmutableData("da
             val inviteJointLandlordsPage = navigator.skipToPropertyRegistrationInviteJointLandlordPage()
             inviteJointLandlordsPage.submitEmail("alpha@example.com")
 
-            val firstCheckJointLandlordPage = assertPageIs(page, CheckJointLandlordsFormPagePropertyRegistration::class)
-            firstCheckJointLandlordPage.form.addAnotherButton.clickAndWait()
+            var checkJointLandlordPage = assertPageIs(page, CheckJointLandlordsFormPagePropertyRegistration::class)
+            checkJointLandlordPage.form.addAnotherButton.clickAndWait()
 
             val inviteAnotherJointLandlordPage = assertPageIs(page, InviteAnotherJointLandlordFormPagePropertyRegistration::class)
             inviteAnotherJointLandlordPage.submitEmail("beta@example.com")
 
-            val secondCheckJointLandlordPage = assertPageIs(page, CheckJointLandlordsFormPagePropertyRegistration::class)
-            assertThat(secondCheckJointLandlordPage.summaryList.firstRow.value).containsText("alpha@example.com")
-            secondCheckJointLandlordPage.summaryList.firstRow.clickNamedActionLinkAndWait("Remove")
+            checkJointLandlordPage = assertPageIs(page, CheckJointLandlordsFormPagePropertyRegistration::class)
+            assertThat(checkJointLandlordPage.summaryList.firstRow.value).containsText("alpha@example.com")
+            checkJointLandlordPage.summaryList.firstRow.clickNamedActionLinkAndWait("Remove")
 
-            val firstRemoveJointLandlordPage = assertPageIs(page, RemoveJointLandlordAreYouSureFormPagePropertyRegistration::class)
-            firstRemoveJointLandlordPage.submitWantsToProceed()
+            var removeJointLandlordPage = assertPageIs(page, RemoveJointLandlordAreYouSureFormPagePropertyRegistration::class)
+            removeJointLandlordPage.submitWantsToProceed()
 
-            val finalCheckJointLandlordPage = assertPageIs(page, CheckJointLandlordsFormPagePropertyRegistration::class)
-            assertThat(finalCheckJointLandlordPage.summaryList.firstRow.value).containsText("beta@example.com")
-            finalCheckJointLandlordPage.summaryList.firstRow.clickNamedActionLinkAndWait("Remove")
+            checkJointLandlordPage = assertPageIs(page, CheckJointLandlordsFormPagePropertyRegistration::class)
+            assertThat(checkJointLandlordPage.summaryList.firstRow.value).containsText("beta@example.com")
+            checkJointLandlordPage.summaryList.firstRow.clickNamedActionLinkAndWait("Remove")
 
-            val secondRemoveJointLandlordPage = assertPageIs(page, RemoveJointLandlordAreYouSureFormPagePropertyRegistration::class)
-            secondRemoveJointLandlordPage.submitWantsToProceed()
+            removeJointLandlordPage = assertPageIs(page, RemoveJointLandlordAreYouSureFormPagePropertyRegistration::class)
+            removeJointLandlordPage.submitWantsToProceed()
 
             assertPageIs(page, HasJointLandlordsFormBasePagePropertyRegistration::class)
         }
@@ -760,22 +759,22 @@ class PropertyRegistrationSinglePageTests : IntegrationTestWithImmutableData("da
             val inviteJointLandlordsPage = navigator.skipToPropertyRegistrationInviteJointLandlordPage()
             inviteJointLandlordsPage.submitEmail("alpha@example.com")
 
-            val firstCheckJointLandlordPage = assertPageIs(page, CheckJointLandlordsFormPagePropertyRegistration::class)
-            firstCheckJointLandlordPage.form.addAnotherButton.clickAndWait()
+            var checkJointLandlordPage = assertPageIs(page, CheckJointLandlordsFormPagePropertyRegistration::class)
+            checkJointLandlordPage.form.addAnotherButton.clickAndWait()
 
-            val inviteAnotherJointLandlordPage = assertPageIs(page, InviteAnotherJointLandlordFormPagePropertyRegistration::class)
+            var inviteAnotherJointLandlordPage = assertPageIs(page, InviteAnotherJointLandlordFormPagePropertyRegistration::class)
             inviteAnotherJointLandlordPage.submitEmail("beta@example.com")
 
-            val secondCheckJointLandlordPage = assertPageIs(page, CheckJointLandlordsFormPagePropertyRegistration::class)
-            assertThat(secondCheckJointLandlordPage.summaryList.firstRow.value).containsText("alpha@example.com")
-            secondCheckJointLandlordPage.summaryList.firstRow.clickNamedActionLinkAndWait("Change")
+            checkJointLandlordPage = assertPageIs(page, CheckJointLandlordsFormPagePropertyRegistration::class)
+            assertThat(checkJointLandlordPage.summaryList.firstRow.value).containsText("alpha@example.com")
+            checkJointLandlordPage.summaryList.firstRow.clickNamedActionLinkAndWait("Change")
 
-            val firstEditJointLandlordPage = assertPageIs(page, InviteAnotherJointLandlordFormPagePropertyRegistration::class)
-            BaseComponent.assertThat(firstEditJointLandlordPage.form.emailInput).hasValue("alpha@example.com")
-            firstEditJointLandlordPage.submitEmail("gamma@example.com")
+            inviteAnotherJointLandlordPage = assertPageIs(page, InviteAnotherJointLandlordFormPagePropertyRegistration::class)
+            BaseComponent.assertThat(inviteAnotherJointLandlordPage.form.emailInput).hasValue("alpha@example.com")
+            inviteAnotherJointLandlordPage.submitEmail("gamma@example.com")
 
-            val finalCheckJointLandlordPage = assertPageIs(page, CheckJointLandlordsFormPagePropertyRegistration::class)
-            assertThat(finalCheckJointLandlordPage.summaryList.firstRow.value).containsText("gamma@example.com")
+            checkJointLandlordPage = assertPageIs(page, CheckJointLandlordsFormPagePropertyRegistration::class)
+            assertThat(checkJointLandlordPage.summaryList.firstRow.value).containsText("gamma@example.com")
         }
 
         @Test
@@ -783,28 +782,28 @@ class PropertyRegistrationSinglePageTests : IntegrationTestWithImmutableData("da
             val inviteJointLandlordsPage = navigator.skipToPropertyRegistrationInviteJointLandlordPage()
             inviteJointLandlordsPage.submitEmail("alpha@example.com")
 
-            val firstCheckJointLandlordPage = assertPageIs(page, CheckJointLandlordsFormPagePropertyRegistration::class)
-            BaseComponent.assertThat(firstCheckJointLandlordPage.title).containsText("You’ve added 1 joint landlord")
-            assertThat(firstCheckJointLandlordPage.summaryList.firstRow.key).containsText("Joint landlord 1")
-            assertThat(firstCheckJointLandlordPage.summaryList.firstRow.value).containsText("alpha@example.com")
-            firstCheckJointLandlordPage.form.addAnotherButton.clickAndWait()
+            var checkJointLandlordPage = assertPageIs(page, CheckJointLandlordsFormPagePropertyRegistration::class)
+            BaseComponent.assertThat(checkJointLandlordPage.title).containsText("You’ve added 1 joint landlord")
+            assertThat(checkJointLandlordPage.summaryList.firstRow.key).containsText("Joint landlord 1")
+            assertThat(checkJointLandlordPage.summaryList.firstRow.value).containsText("alpha@example.com")
+            checkJointLandlordPage.form.addAnotherButton.clickAndWait()
 
             val inviteAnotherJointLandlordPage = assertPageIs(page, InviteAnotherJointLandlordFormPagePropertyRegistration::class)
             inviteAnotherJointLandlordPage.submitEmail("beta@example.com")
 
-            val secondCheckJointLandlordPage = assertPageIs(page, CheckJointLandlordsFormPagePropertyRegistration::class)
-            BaseComponent.assertThat(secondCheckJointLandlordPage.title).containsText("You’ve added 2 joint landlords")
-            assertThat(secondCheckJointLandlordPage.summaryList.getRowByIndex(1).key).containsText("Joint landlord 2")
-            assertThat(secondCheckJointLandlordPage.summaryList.getRowByIndex(1).value).containsText("beta@example.com")
-            secondCheckJointLandlordPage.summaryList.firstRow.clickNamedActionLinkAndWait("Remove")
+            checkJointLandlordPage = assertPageIs(page, CheckJointLandlordsFormPagePropertyRegistration::class)
+            BaseComponent.assertThat(checkJointLandlordPage.title).containsText("You’ve added 2 joint landlords")
+            assertThat(checkJointLandlordPage.summaryList.getRowByIndex(1).key).containsText("Joint landlord 2")
+            assertThat(checkJointLandlordPage.summaryList.getRowByIndex(1).value).containsText("beta@example.com")
+            checkJointLandlordPage.summaryList.firstRow.clickNamedActionLinkAndWait("Remove")
 
-            val firstRemoveJointLandlordPage = assertPageIs(page, RemoveJointLandlordAreYouSureFormPagePropertyRegistration::class)
-            firstRemoveJointLandlordPage.submitWantsToProceed()
+            val removeJointLandlordPage = assertPageIs(page, RemoveJointLandlordAreYouSureFormPagePropertyRegistration::class)
+            removeJointLandlordPage.submitWantsToProceed()
 
-            val finalCheckJointLandlordPage = assertPageIs(page, CheckJointLandlordsFormPagePropertyRegistration::class)
-            BaseComponent.assertThat(finalCheckJointLandlordPage.title).containsText("You’ve added 1 joint landlord")
-            assertThat(finalCheckJointLandlordPage.summaryList.firstRow.key).containsText("Joint landlord 1")
-            assertThat(firstCheckJointLandlordPage.summaryList.firstRow.value).containsText("beta@example.com")
+            checkJointLandlordPage = assertPageIs(page, CheckJointLandlordsFormPagePropertyRegistration::class)
+            BaseComponent.assertThat(checkJointLandlordPage.title).containsText("You’ve added 1 joint landlord")
+            assertThat(checkJointLandlordPage.summaryList.firstRow.key).containsText("Joint landlord 1")
+            assertThat(checkJointLandlordPage.summaryList.firstRow.value).containsText("beta@example.com")
         }
     }
 
@@ -856,15 +855,15 @@ class PropertyRegistrationSinglePageTests : IntegrationTestWithImmutableData("da
             val inviteJointLandlordsPage = navigator.skipToPropertyRegistrationInviteJointLandlordPage()
             inviteJointLandlordsPage.submitEmail(alreadyInvitedEmail)
 
-            val checkJointLandlordPage = assertPageIs(page, CheckJointLandlordsFormPagePropertyRegistration::class)
+            var checkJointLandlordPage = assertPageIs(page, CheckJointLandlordsFormPagePropertyRegistration::class)
             checkJointLandlordPage.summaryList.firstRow.clickNamedActionLinkAndWait("Change")
 
             val editJointLandlordPage = assertPageIs(page, InviteAnotherJointLandlordFormPagePropertyRegistration::class)
             BaseComponent.assertThat(editJointLandlordPage.form.emailInput).hasValue(alreadyInvitedEmail)
             inviteJointLandlordsPage.submitEmail(alreadyInvitedEmail)
 
-            val finalCheckJointLandlordPage = assertPageIs(page, CheckJointLandlordsFormPagePropertyRegistration::class)
-            assertThat(finalCheckJointLandlordPage.summaryList.firstRow.value).containsText(alreadyInvitedEmail)
+            checkJointLandlordPage = assertPageIs(page, CheckJointLandlordsFormPagePropertyRegistration::class)
+            assertThat(checkJointLandlordPage.summaryList.firstRow.value).containsText(alreadyInvitedEmail)
         }
     }
 


### PR DESCRIPTION
## Ticket number

PDJB-NONE

## Goal of change

Standardise integration tests to use ar and reassignment when revisiting a page type, instead of creating new al variables with suffixed names.

## Description of main change(s)

- When a test revisits the same page type, the first assignment is now ar and subsequent visits reassign the same variable, replacing the old pattern of suffixed names like lookupAddressPageAgain, inalCheckJointLandlordPage, 
ewGeneratePasscodePage, etc.
- Also fixes a pre-existing bug in the "Numbering on page and tables is correct" test where the final assertion incorrectly referenced irstCheckJointLandlordPage instead of inalCheckJointLandlordPage (the refactor naturally corrected this by unifying both into a single checkJointLandlordPage variable)
- Drops misleading irst prefixes from single-visit page variables for consistency with surrounding tests
- 5 files modified, 12 test methods updated

## Anything you'd like to highlight to the reviewer?

The pre-existing bug on line 807 of PropertyRegistrationSinglePageTests (referencing irstCheckJointLandlordPage instead of inalCheckJointLandlordPage) was silently masked because Playwright locators resolve against the live DOM, so both variables pointed to the same current page state. The refactor fixes this by consolidating into one variable.

## Checklist

- [x] Test suite has been run in full locally and is passing
- [x] Branch has been rebased onto main and run locally, with everything working as expected (both for your new feature and any related functionality)