### PR TITLE
PDJB-714: Update property registration confirmation page with three variants

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/RegisterPropertyController.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/RegisterPropertyController.kt
@@ -93,16 +93,16 @@ class RegisterPropertyController(
             RegistrationNumberDataModel.fromRegistrationNumber(propertyOwnership.registrationNumber).toString(),
         )
 
-        val hasIncompleteCompliance =
+        val actionRequiredForCompliance =
             if (propertyOwnership.isOccupied) {
                 val compliance = propertyComplianceService.getComplianceForPropertyOrNull(propertyOwnership.id)
                 compliance == null || compliance.isGasSafetyCertMissing || compliance.isEicrMissing || compliance.isEpcMissing
             } else {
                 false
             }
-        model.addAttribute("hasIncompleteCompliance", hasIncompleteCompliance)
+        model.addAttribute("actionRequiredForCompliance", actionRequiredForCompliance)
 
-        if (hasIncompleteCompliance) {
+        if (actionRequiredForCompliance) {
             val completeByDate =
                 CompleteByDateHelper.getIncompletePropertyCompleteByDateFromCreatedDate(propertyOwnership.createdDate)
             val formattedDate =

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/RegisterPropertyController.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/RegisterPropertyController.kt
@@ -1,6 +1,7 @@
 package uk.gov.communities.prsdb.webapp.controllers
 
 import jakarta.servlet.http.HttpServletRequest
+import kotlinx.datetime.toJavaLocalDate
 import org.apache.commons.fileupload2.core.FileItemInputIterator
 import org.springframework.http.HttpStatus
 import org.springframework.http.MediaType
@@ -27,6 +28,7 @@ import uk.gov.communities.prsdb.webapp.constants.TASK_LIST_PATH_SEGMENT
 import uk.gov.communities.prsdb.webapp.controllers.LandlordController.Companion.LANDLORD_DASHBOARD_URL
 import uk.gov.communities.prsdb.webapp.controllers.RegisterPropertyController.Companion.PROPERTY_REGISTRATION_ROUTE
 import uk.gov.communities.prsdb.webapp.helpers.CertificateUploadHelper
+import uk.gov.communities.prsdb.webapp.helpers.CompleteByDateHelper
 import uk.gov.communities.prsdb.webapp.helpers.PropertyComplianceJourneyHelper
 import uk.gov.communities.prsdb.webapp.journeys.FormData
 import uk.gov.communities.prsdb.webapp.journeys.JourneyIdProvider
@@ -36,9 +38,12 @@ import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.PropertyReg
 import uk.gov.communities.prsdb.webapp.models.dataModels.RegistrationNumberDataModel
 import uk.gov.communities.prsdb.webapp.services.CollectionKeyParameterService
 import uk.gov.communities.prsdb.webapp.services.FileUploadCookieService.Companion.FILE_UPLOAD_COOKIE_NAME
+import uk.gov.communities.prsdb.webapp.services.PropertyComplianceService
 import uk.gov.communities.prsdb.webapp.services.PropertyOwnershipService
 import uk.gov.communities.prsdb.webapp.services.PropertyRegistrationConfirmationService
 import java.security.Principal
+import java.time.format.DateTimeFormatter
+import java.util.Locale
 
 @PreAuthorize("hasRole('LANDLORD')")
 @PrsdbController
@@ -48,6 +53,7 @@ class RegisterPropertyController(
     private val propertyOwnershipService: PropertyOwnershipService,
     private val propertyRegistrationConfirmationService: PropertyRegistrationConfirmationService,
     private val certificateUploadHelper: CertificateUploadHelper,
+    private val propertyComplianceService: PropertyComplianceService,
 ) {
     @GetMapping
     fun index(model: Model): String {
@@ -81,13 +87,29 @@ class RegisterPropertyController(
                     "No property ownership with registration number $propertyRegistrationNumber was found in the database",
                 )
 
-        model.addAttribute("singleLineAddress", propertyOwnership.address.singleLineAddress)
+        model.addAttribute("addressParts", propertyOwnership.address.singleLineAddress.split(", "))
         model.addAttribute(
             "prn",
             RegistrationNumberDataModel.fromRegistrationNumber(propertyOwnership.registrationNumber).toString(),
         )
-        model.addAttribute("isOccupied", propertyOwnership.isOccupied)
-        model.addAttribute("propertyComplianceUrl", PropertyComplianceController.getPropertyCompliancePath(propertyOwnership.id))
+
+        val hasIncompleteCompliance =
+            if (propertyOwnership.isOccupied) {
+                val compliance = propertyComplianceService.getComplianceForPropertyOrNull(propertyOwnership.id)
+                compliance == null || compliance.isGasSafetyCertMissing || compliance.isEicrMissing || compliance.isEpcMissing
+            } else {
+                false
+            }
+        model.addAttribute("hasIncompleteCompliance", hasIncompleteCompliance)
+
+        if (hasIncompleteCompliance) {
+            val completeByDate =
+                CompleteByDateHelper.getIncompletePropertyCompleteByDateFromCreatedDate(propertyOwnership.createdDate)
+            val formattedDate =
+                completeByDate.toJavaLocalDate().format(DateTimeFormatter.ofPattern("d MMMM yyyy", Locale.UK))
+            model.addAttribute("completeByDate", formattedDate)
+        }
+
         model.addAttribute("landlordDashboardUrl", LANDLORD_DASHBOARD_URL)
 
         return "registerPropertyConfirmation"

--- a/src/main/resources/messages/registerProperty.yml
+++ b/src/main/resources/messages/registerProperty.yml
@@ -33,33 +33,17 @@ beforeYouBegin:
     six: 'if occupied, the number of households and people in the property'
 confirmation:
   banner:
-    heading: You have registered a property on the database
-  table:
-    address:
-      heading: Property address
-    prn:
-      heading: Property Registration Number
-  whatHappensNext:
-    paragraph:
-      one: 'We’ve sent you an email including the <strong>Property Registration Number</strong>.'
-      two: We’ve also now sent the invitations to this property’s joint landlords. We’ll email you when they respond.
-      three: 'When advertising this property to rent, you must include:'
-    bullet:
-        one: the Property Registration Number
-        two: each landlord’s Landlord Registration Number
-  addCompliance: Add compliance for this property
-  beforeYouLetThisProperty:
-    heading: Before you let this property
-    paragraph:
-      two: 'Once you let this property, you’ll need to return to the database to mark it as occupied. You’ll then have 28 days to add compliance information for the property.'
-      three: You can now return to your dashboard.
-  common:
-    usePrnInAdverts:
-      paragraph: You need to include your Landlord Registration Number and a Property Registration Number on any property advertisements.
-  youMustAddCompliance:
-    heading: You must add compliance information
-    paragraph:
-      one: 'As the property is occupied by tenants, you have 28 days to add compliance information for this property.'
+    heading: Property registered
+  prn:
+    label: 'Your <strong>Property Registration Number</strong> is:'
+  keepNumber: Keep this number for your records. We’ve sent it to you in an email.
+  useInAdverts: Use this Property Registration Number when advertising this property, alongside each landlord’s Landlord Registration Number.
+  whatYouNeedToDoNext:
+    heading: What you need to do next
+    uploadCompliance:
+      heading: Upload compliance certificates
+      paragraph: 'To keep this property registered, upload its certificates <strong>before {0}</strong>.'
+  goToDashboard: Go to dashboard
 taskList:
   heading: Follow these steps to register your property
   subtitle:

--- a/src/main/resources/templates/fragments/content/propertyRegistrationConfirmationOccupiedContent.html
+++ b/src/main/resources/templates/fragments/content/propertyRegistrationConfirmationOccupiedContent.html
@@ -1,6 +1,0 @@
-<section th:fragment="propertyRegistrationConfirmationOccupiedContent()">
-    <h2 class="govuk-heading-m" th:text="#{registerProperty.confirmation.youMustAddCompliance.heading}">registerProperty.confirmation.youMustAddCompliance.heading</h2>
-    <p class="govuk-body" th:utext="#{registerProperty.confirmation.youMustAddCompliance.paragraph.one}">
-        registerProperty.confirmation.beforeYouLetThisProperty.paragraph.one
-    </p>
-</section>

--- a/src/main/resources/templates/fragments/content/propertyRegistrationConfirmationUnoccupiedContent.html
+++ b/src/main/resources/templates/fragments/content/propertyRegistrationConfirmationUnoccupiedContent.html
@@ -1,8 +1,0 @@
-<section th:fragment="propertyRegistrationConfirmationUnoccupiedContent()">
-    <p class="govuk-body" th:text="#{registerProperty.confirmation.beforeYouLetThisProperty.paragraph.two}">
-        registerProperty.confirmation.beforeYouLetThisProperty.paragraph.two
-    </p>
-    <p class="govuk-body" th:text="#{registerProperty.confirmation.beforeYouLetThisProperty.paragraph.three}">
-        registerProperty.confirmation.beforeYouLetThisProperty.paragraph.three
-    </p>
-</section>

--- a/src/main/resources/templates/registerPropertyConfirmation.html
+++ b/src/main/resources/templates/registerPropertyConfirmation.html
@@ -3,52 +3,55 @@
     <main class="govuk-main-wrapper" id="main-content">
         <div id="page-contents" th:replace="~{fragments/layouts/twoThirdsLayout :: twoThirdsLayout(~{::#page-contents/content()})}">
 
-            <div id="confirmation-banner" th:replace="~{fragments/banners/confirmationPageBanner :: confirmationPageBanner(#{registerProperty.confirmation.banner.heading}, ~{::#confirmation-banner/content()})}"></div>
-
-            <section>
-                <table th:replace="~{fragments/tables/table :: table(${ {'registerProperty.confirmation.table.address.heading','registerProperty.confirmation.table.prn.heading'} }, ~{::tbody}, null)}">
-                    <tbody class="govuk-table__body">
-                        <tr class="govuk_table__row">
-                            <td class="govuk-table__cell govuk-!-width-one-half" th:text="${singleLineAddress}"></td>
-                            <td class="govuk-table__cell govuk-!-width-one-half" th:text="${prn}"></td>
-                        </tr>
-                    </tbody>
-                </table>
-                <h2 class="govuk-heading-m" th:text="#{common.confirmationPage.whatHappensNext}">common.confirmationPage.whatHappensNext</h2>
-                <p class="govuk-body" th:utext="#{registerProperty.confirmation.whatHappensNext.paragraph.one}">
-                    registerProperty.confirmation.whatHappensNext.paragraph.one
-                </p>
-                <p class="govuk-body" th:text="#{registerProperty.confirmation.whatHappensNext.paragraph.two}">
-                    registerProperty.confirmation.whatHappensNext.paragraph.two
-                </p>
-                <h2 th:unless="${isOccupied}" class="govuk-heading-m" th:text="#{registerProperty.confirmation.beforeYouLetThisProperty.heading}">
-                    registerProperty.confirmation.beforeYouLetThisProperty.heading
-                </h2>
-                <p class="govuk-body" th:text="#{registerProperty.confirmation.whatHappensNext.paragraph.three}">registerProperty.confirmation.whatHappensNext.paragraph.three</p>
-                <ul class="govuk-list govuk-list--bullet">
-                    <li th:text="#{registerProperty.confirmation.whatHappensNext.bullet.one}">registerProperty.confirmation.whatHappensNext.bullet.one</li>
-                    <li th:text="#{registerProperty.confirmation.whatHappensNext.bullet.two}">registerProperty.confirmation.whatHappensNext.bullet.two</li>
-                </ul>
-            </section>
-            <th:block th:if="${isOccupied}">
-                <section th:replace="~{fragments/content/propertyRegistrationConfirmationOccupiedContent :: propertyRegistrationConfirmationOccupiedContent()}">
-                    fragments/content/propertyRegistrationConfirmationOccupiedContent
-                </section>
-                <div class="govuk-button-group">
-                    <a th:replace="~{fragments/buttons/primaryButtonLink :: primaryButtonLink(@{${propertyComplianceUrl}}, #{registerProperty.confirmation.addCompliance})}">
-                        registerProperty.confirmation.addCompliance
-                    </a>
-                    <a th:replace="~{fragments/buttons/secondaryButtonLink :: secondaryButtonLink(@{${landlordDashboardUrl}}, #{common.confirmationPage.goToDashboard})}">
-                        common.confirmationPage.goToDashboard
-                    </a>
+            <div class="govuk-panel govuk-panel--confirmation">
+                <h1 class="govuk-panel__title"
+                    th:text="#{registerProperty.confirmation.banner.heading}">Property registered</h1>
+                <div class="govuk-panel__body">
+                    <th:block th:each="part, iter : ${addressParts}">
+                        <span th:text="${part}">Flat 1</span>
+                        <br th:if="${!iter.last}" />
+                    </th:block>
                 </div>
+            </div>
+
+            <p class="govuk-body"
+               th:utext="#{registerProperty.confirmation.prn.label}">
+                Your <strong>Property Registration Number</strong> is:
+            </p>
+            <div class="govuk-inset-text"
+                 th:text="${prn}">L-GD47-39FX</div>
+
+            <p class="govuk-body"
+               th:text="#{registerProperty.confirmation.keepNumber}">
+                Keep this number for your records. We've sent it to you in an email.
+            </p>
+            <p class="govuk-body"
+               th:text="#{registerProperty.confirmation.useInAdverts}">
+                Use this Property Registration Number when advertising this property,
+                alongside each landlord's Landlord Registration Number.
+            </p>
+
+            <th:block th:if="${hasIncompleteCompliance}">
+                <h2 class="govuk-heading-m"
+                    th:text="#{registerProperty.confirmation.whatYouNeedToDoNext.heading}">
+                    What you need to do next
+                </h2>
+                <h3 class="govuk-heading-s"
+                    th:text="#{registerProperty.confirmation.whatYouNeedToDoNext.uploadCompliance.heading}">
+                    Upload compliance certificates
+                </h3>
+                <p class="govuk-body"
+                   th:utext="#{registerProperty.confirmation.whatYouNeedToDoNext.uploadCompliance.paragraph(${completeByDate})}">
+                    To keep this property registered, upload its certificates <strong>before 5 April 2026</strong>.
+                </p>
             </th:block>
-            <th:block th:unless="${isOccupied}">
-                <section th:replace="~{fragments/content/propertyRegistrationConfirmationUnoccupiedContent :: propertyRegistrationConfirmationUnoccupiedContent()}"></section>
-                <a th:replace="~{fragments/buttons/primaryButtonLink :: primaryButtonLink(@{${landlordDashboardUrl}}, #{common.confirmationPage.goToDashboard})}">
-                    common.confirmationPage.goToDashboard
-                </a>
-            </th:block>
+
+            <p class="govuk-body">
+                <a class="govuk-link"
+                   th:href="@{${landlordDashboardUrl}}"
+                   th:text="#{registerProperty.confirmation.goToDashboard}">Go to dashboard</a>
+            </p>
+
         </div>
     </main>
 </html>

--- a/src/main/resources/templates/registerPropertyConfirmation.html
+++ b/src/main/resources/templates/registerPropertyConfirmation.html
@@ -5,7 +5,7 @@
 
             <div class="govuk-panel govuk-panel--confirmation">
                 <h1 class="govuk-panel__title"
-                    th:text="#{registerProperty.confirmation.banner.heading}">Property registered</h1>
+                    th:text="#{registerProperty.confirmation.banner.heading}">registerProperty.confirmation.banner.heading</h1>
                 <div class="govuk-panel__body">
                     <th:block th:each="part, iter : ${addressParts}">
                         <span th:text="${part}">Flat 1</span>
@@ -16,40 +16,39 @@
 
             <p class="govuk-body"
                th:utext="#{registerProperty.confirmation.prn.label}">
-                Your <strong>Property Registration Number</strong> is:
+                registerProperty.confirmation.prn.label
             </p>
             <div class="govuk-inset-text"
                  th:text="${prn}">L-GD47-39FX</div>
 
             <p class="govuk-body"
                th:text="#{registerProperty.confirmation.keepNumber}">
-                Keep this number for your records. We've sent it to you in an email.
+                registerProperty.confirmation.keepNumber
             </p>
             <p class="govuk-body"
                th:text="#{registerProperty.confirmation.useInAdverts}">
-                Use this Property Registration Number when advertising this property,
-                alongside each landlord's Landlord Registration Number.
+                registerProperty.confirmation.useInAdverts
             </p>
 
             <th:block th:if="${hasIncompleteCompliance}">
                 <h2 class="govuk-heading-m"
                     th:text="#{registerProperty.confirmation.whatYouNeedToDoNext.heading}">
-                    What you need to do next
+                    registerProperty.confirmation.whatYouNeedToDoNext.heading
                 </h2>
                 <h3 class="govuk-heading-s"
                     th:text="#{registerProperty.confirmation.whatYouNeedToDoNext.uploadCompliance.heading}">
-                    Upload compliance certificates
+                    registerProperty.confirmation.whatYouNeedToDoNext.uploadCompliance.heading
                 </h3>
                 <p class="govuk-body"
                    th:utext="#{registerProperty.confirmation.whatYouNeedToDoNext.uploadCompliance.paragraph(${completeByDate})}">
-                    To keep this property registered, upload its certificates <strong>before 5 April 2026</strong>.
+                    registerProperty.confirmation.whatYouNeedToDoNext.uploadCompliance.paragraph
                 </p>
             </th:block>
 
             <p class="govuk-body">
                 <a class="govuk-link"
                    th:href="@{${landlordDashboardUrl}}"
-                   th:text="#{registerProperty.confirmation.goToDashboard}">Go to dashboard</a>
+                   th:text="#{registerProperty.confirmation.goToDashboard}">registerProperty.confirmation.goToDashboard</a>
             </p>
 
         </div>

--- a/src/main/resources/templates/registerPropertyConfirmation.html
+++ b/src/main/resources/templates/registerPropertyConfirmation.html
@@ -30,7 +30,7 @@
                 registerProperty.confirmation.useInAdverts
             </p>
 
-            <th:block th:if="${hasIncompleteCompliance}">
+            <th:block th:if="${actionRequiredForCompliance}">
                 <h2 class="govuk-heading-m"
                     th:text="#{registerProperty.confirmation.whatYouNeedToDoNext.heading}">
                     registerProperty.confirmation.whatYouNeedToDoNext.heading

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/controllers/RegisterPropertyControllerTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/controllers/RegisterPropertyControllerTests.kt
@@ -1,6 +1,9 @@
 package uk.gov.communities.prsdb.webapp.controllers
 
+import kotlinx.datetime.toJavaLocalDate
 import org.junit.jupiter.api.Test
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
@@ -15,12 +18,18 @@ import uk.gov.communities.prsdb.webapp.constants.PROPERTY_REGISTRATION_NUMBER
 import uk.gov.communities.prsdb.webapp.constants.RESUME_PAGE_PATH_SEGMENT
 import uk.gov.communities.prsdb.webapp.constants.TASK_LIST_PATH_SEGMENT
 import uk.gov.communities.prsdb.webapp.constants.enums.RegistrationNumberType
+import uk.gov.communities.prsdb.webapp.database.entity.PropertyCompliance
 import uk.gov.communities.prsdb.webapp.database.entity.RegistrationNumber
 import uk.gov.communities.prsdb.webapp.helpers.CertificateUploadHelper
+import uk.gov.communities.prsdb.webapp.helpers.CompleteByDateHelper
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.PropertyRegistrationJourneyFactory
+import uk.gov.communities.prsdb.webapp.models.dataModels.RegistrationNumberDataModel
+import uk.gov.communities.prsdb.webapp.services.PropertyComplianceService
 import uk.gov.communities.prsdb.webapp.services.PropertyOwnershipService
 import uk.gov.communities.prsdb.webapp.services.PropertyRegistrationConfirmationService
 import uk.gov.communities.prsdb.webapp.testHelpers.mockObjects.MockLandlordData.Companion.createPropertyOwnership
+import java.time.format.DateTimeFormatter
+import java.util.Locale
 
 @WebMvcTest(RegisterPropertyController::class)
 class RegisterPropertyControllerTests(
@@ -37,6 +46,9 @@ class RegisterPropertyControllerTests(
 
     @MockitoBean
     private lateinit var propertyConfirmationService: PropertyRegistrationConfirmationService
+
+    @MockitoBean
+    private lateinit var propertyComplianceService: PropertyComplianceService
 
     @Test
     fun `index returns a redirect for unauthenticated user`() {
@@ -67,7 +79,50 @@ class RegisterPropertyControllerTests(
 
     @Test
     @WithMockUser(roles = ["LANDLORD"])
-    fun `getConfirmation returns 200 if a property has been registered`() {
+    fun `getConfirmation returns 200 with correct model attributes for an occupied property with incomplete compliance`() {
+        val propertyRegistrationNumber = 0L
+        val propertyOwnership =
+            createPropertyOwnership(
+                registrationNumber = RegistrationNumber(RegistrationNumberType.PROPERTY, propertyRegistrationNumber),
+                currentNumTenants = 2,
+                currentNumHouseholds = 1,
+                numberOfBedrooms = 1,
+                furnishedStatus = uk.gov.communities.prsdb.webapp.constants.enums.FurnishedStatus.FURNISHED,
+                rentFrequency = uk.gov.communities.prsdb.webapp.constants.enums.RentFrequency.MONTHLY,
+                rentAmount = java.math.BigDecimal("1000"),
+            )
+
+        val expectedPrn =
+            RegistrationNumberDataModel
+                .fromRegistrationNumber(propertyOwnership.registrationNumber)
+                .toString()
+        val expectedCompleteByDate =
+            CompleteByDateHelper
+                .getIncompletePropertyCompleteByDateFromCreatedDate(propertyOwnership.createdDate)
+                .toJavaLocalDate()
+                .format(DateTimeFormatter.ofPattern("d MMMM yyyy", Locale.UK))
+
+        whenever(propertyConfirmationService.getLastPrnRegisteredThisSession()).thenReturn(propertyRegistrationNumber)
+        whenever(propertyOwnershipService.retrievePropertyOwnership(propertyRegistrationNumber)).thenReturn(propertyOwnership)
+        whenever(propertyComplianceService.getComplianceForPropertyOrNull(propertyOwnership.id)).thenReturn(null)
+
+        mvc
+            .perform(
+                MockMvcRequestBuilders
+                    .get("${RegisterPropertyController.PROPERTY_REGISTRATION_ROUTE}/$CONFIRMATION_PATH_SEGMENT")
+                    .sessionAttr(PROPERTY_REGISTRATION_NUMBER, propertyRegistrationNumber),
+            ).andExpect(MockMvcResultMatchers.status().isOk)
+            .andExpect(MockMvcResultMatchers.view().name("registerPropertyConfirmation"))
+            .andExpect(MockMvcResultMatchers.model().attribute("prn", expectedPrn))
+            .andExpect(MockMvcResultMatchers.model().attribute("hasIncompleteCompliance", true))
+            .andExpect(MockMvcResultMatchers.model().attribute("completeByDate", expectedCompleteByDate))
+            .andExpect(MockMvcResultMatchers.model().attributeExists("addressParts"))
+            .andExpect(MockMvcResultMatchers.model().attribute("landlordDashboardUrl", LandlordController.LANDLORD_DASHBOARD_URL))
+    }
+
+    @Test
+    @WithMockUser(roles = ["LANDLORD"])
+    fun `getConfirmation returns hasIncompleteCompliance false for an unoccupied property`() {
         val propertyRegistrationNumber = 0L
         val propertyOwnership =
             createPropertyOwnership(
@@ -84,13 +139,45 @@ class RegisterPropertyControllerTests(
                     .sessionAttr(PROPERTY_REGISTRATION_NUMBER, propertyRegistrationNumber),
             ).andExpect(MockMvcResultMatchers.status().isOk)
             .andExpect(MockMvcResultMatchers.view().name("registerPropertyConfirmation"))
-            .andExpect(MockMvcResultMatchers.model().attribute("singleLineAddress", propertyOwnership.address.singleLineAddress))
-            .andExpect(
-                MockMvcResultMatchers.model().attribute(
-                    "propertyComplianceUrl",
-                    PropertyComplianceController.getPropertyCompliancePath(propertyOwnership.id),
-                ),
-            ).andExpect(MockMvcResultMatchers.model().attribute("landlordDashboardUrl", LandlordController.LANDLORD_DASHBOARD_URL))
+            .andExpect(MockMvcResultMatchers.model().attribute("hasIncompleteCompliance", false))
+            .andExpect(MockMvcResultMatchers.model().attributeDoesNotExist("completeByDate"))
+    }
+
+    @Test
+    @WithMockUser(roles = ["LANDLORD"])
+    fun `getConfirmation returns hasIncompleteCompliance false for occupied property with complete compliance`() {
+        val propertyRegistrationNumber = 0L
+        val propertyOwnership =
+            createPropertyOwnership(
+                registrationNumber = RegistrationNumber(RegistrationNumberType.PROPERTY, propertyRegistrationNumber),
+                currentNumTenants = 2,
+                currentNumHouseholds = 1,
+                numberOfBedrooms = 1,
+                furnishedStatus = uk.gov.communities.prsdb.webapp.constants.enums.FurnishedStatus.FURNISHED,
+                rentFrequency = uk.gov.communities.prsdb.webapp.constants.enums.RentFrequency.MONTHLY,
+                rentAmount = java.math.BigDecimal("1000"),
+            )
+
+        val compliance =
+            mock<PropertyCompliance> {
+                on { isGasSafetyCertMissing } doReturn false
+                on { isEicrMissing } doReturn false
+                on { isEpcMissing } doReturn false
+            }
+
+        whenever(propertyConfirmationService.getLastPrnRegisteredThisSession()).thenReturn(propertyRegistrationNumber)
+        whenever(propertyOwnershipService.retrievePropertyOwnership(propertyRegistrationNumber)).thenReturn(propertyOwnership)
+        whenever(propertyComplianceService.getComplianceForPropertyOrNull(propertyOwnership.id)).thenReturn(compliance)
+
+        mvc
+            .perform(
+                MockMvcRequestBuilders
+                    .get("${RegisterPropertyController.PROPERTY_REGISTRATION_ROUTE}/$CONFIRMATION_PATH_SEGMENT")
+                    .sessionAttr(PROPERTY_REGISTRATION_NUMBER, propertyRegistrationNumber),
+            ).andExpect(MockMvcResultMatchers.status().isOk)
+            .andExpect(MockMvcResultMatchers.view().name("registerPropertyConfirmation"))
+            .andExpect(MockMvcResultMatchers.model().attribute("hasIncompleteCompliance", false))
+            .andExpect(MockMvcResultMatchers.model().attributeDoesNotExist("completeByDate"))
     }
 
     @Test

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/controllers/RegisterPropertyControllerTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/controllers/RegisterPropertyControllerTests.kt
@@ -17,7 +17,9 @@ import uk.gov.communities.prsdb.webapp.constants.CONFIRMATION_PATH_SEGMENT
 import uk.gov.communities.prsdb.webapp.constants.PROPERTY_REGISTRATION_NUMBER
 import uk.gov.communities.prsdb.webapp.constants.RESUME_PAGE_PATH_SEGMENT
 import uk.gov.communities.prsdb.webapp.constants.TASK_LIST_PATH_SEGMENT
+import uk.gov.communities.prsdb.webapp.constants.enums.FurnishedStatus
 import uk.gov.communities.prsdb.webapp.constants.enums.RegistrationNumberType
+import uk.gov.communities.prsdb.webapp.constants.enums.RentFrequency
 import uk.gov.communities.prsdb.webapp.database.entity.PropertyCompliance
 import uk.gov.communities.prsdb.webapp.database.entity.RegistrationNumber
 import uk.gov.communities.prsdb.webapp.helpers.CertificateUploadHelper
@@ -28,6 +30,7 @@ import uk.gov.communities.prsdb.webapp.services.PropertyComplianceService
 import uk.gov.communities.prsdb.webapp.services.PropertyOwnershipService
 import uk.gov.communities.prsdb.webapp.services.PropertyRegistrationConfirmationService
 import uk.gov.communities.prsdb.webapp.testHelpers.mockObjects.MockLandlordData.Companion.createPropertyOwnership
+import java.math.BigDecimal
 import java.time.format.DateTimeFormatter
 import java.util.Locale
 
@@ -87,9 +90,9 @@ class RegisterPropertyControllerTests(
                 currentNumTenants = 2,
                 currentNumHouseholds = 1,
                 numberOfBedrooms = 1,
-                furnishedStatus = uk.gov.communities.prsdb.webapp.constants.enums.FurnishedStatus.FURNISHED,
-                rentFrequency = uk.gov.communities.prsdb.webapp.constants.enums.RentFrequency.MONTHLY,
-                rentAmount = java.math.BigDecimal("1000"),
+                furnishedStatus = FurnishedStatus.FURNISHED,
+                rentFrequency = RentFrequency.MONTHLY,
+                rentAmount = BigDecimal("1000"),
             )
 
         val expectedPrn =
@@ -114,7 +117,7 @@ class RegisterPropertyControllerTests(
             ).andExpect(MockMvcResultMatchers.status().isOk)
             .andExpect(MockMvcResultMatchers.view().name("registerPropertyConfirmation"))
             .andExpect(MockMvcResultMatchers.model().attribute("prn", expectedPrn))
-            .andExpect(MockMvcResultMatchers.model().attribute("hasIncompleteCompliance", true))
+            .andExpect(MockMvcResultMatchers.model().attribute("actionRequiredForCompliance", true))
             .andExpect(MockMvcResultMatchers.model().attribute("completeByDate", expectedCompleteByDate))
             .andExpect(MockMvcResultMatchers.model().attributeExists("addressParts"))
             .andExpect(MockMvcResultMatchers.model().attribute("landlordDashboardUrl", LandlordController.LANDLORD_DASHBOARD_URL))
@@ -122,7 +125,7 @@ class RegisterPropertyControllerTests(
 
     @Test
     @WithMockUser(roles = ["LANDLORD"])
-    fun `getConfirmation returns hasIncompleteCompliance false for an unoccupied property`() {
+    fun `getConfirmation returns actionRequiredForCompliance false for an unoccupied property`() {
         val propertyRegistrationNumber = 0L
         val propertyOwnership =
             createPropertyOwnership(
@@ -139,13 +142,13 @@ class RegisterPropertyControllerTests(
                     .sessionAttr(PROPERTY_REGISTRATION_NUMBER, propertyRegistrationNumber),
             ).andExpect(MockMvcResultMatchers.status().isOk)
             .andExpect(MockMvcResultMatchers.view().name("registerPropertyConfirmation"))
-            .andExpect(MockMvcResultMatchers.model().attribute("hasIncompleteCompliance", false))
+            .andExpect(MockMvcResultMatchers.model().attribute("actionRequiredForCompliance", false))
             .andExpect(MockMvcResultMatchers.model().attributeDoesNotExist("completeByDate"))
     }
 
     @Test
     @WithMockUser(roles = ["LANDLORD"])
-    fun `getConfirmation returns hasIncompleteCompliance false for occupied property with complete compliance`() {
+    fun `getConfirmation returns actionRequiredForCompliance false for occupied property with complete compliance`() {
         val propertyRegistrationNumber = 0L
         val propertyOwnership =
             createPropertyOwnership(
@@ -153,9 +156,9 @@ class RegisterPropertyControllerTests(
                 currentNumTenants = 2,
                 currentNumHouseholds = 1,
                 numberOfBedrooms = 1,
-                furnishedStatus = uk.gov.communities.prsdb.webapp.constants.enums.FurnishedStatus.FURNISHED,
-                rentFrequency = uk.gov.communities.prsdb.webapp.constants.enums.RentFrequency.MONTHLY,
-                rentAmount = java.math.BigDecimal("1000"),
+                furnishedStatus = FurnishedStatus.FURNISHED,
+                rentFrequency = RentFrequency.MONTHLY,
+                rentAmount = BigDecimal("1000"),
             )
 
         val compliance =
@@ -176,7 +179,7 @@ class RegisterPropertyControllerTests(
                     .sessionAttr(PROPERTY_REGISTRATION_NUMBER, propertyRegistrationNumber),
             ).andExpect(MockMvcResultMatchers.status().isOk)
             .andExpect(MockMvcResultMatchers.view().name("registerPropertyConfirmation"))
-            .andExpect(MockMvcResultMatchers.model().attribute("hasIncompleteCompliance", false))
+            .andExpect(MockMvcResultMatchers.model().attribute("actionRequiredForCompliance", false))
             .andExpect(MockMvcResultMatchers.model().attributeDoesNotExist("completeByDate"))
     }
 

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/PropertyRegistrationJourneyTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/PropertyRegistrationJourneyTests.kt
@@ -36,7 +36,6 @@ import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages.E
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages.EpcLookupBasePage.Companion.CURRENT_EXPIRED_EPC_CERTIFICATE_NUMBER
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages.EpcLookupBasePage.Companion.NONEXISTENT_EPC_CERTIFICATE_NUMBER
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages.EpcLookupBasePage.Companion.SUPERSEDED_EPC_CERTIFICATE_NUMBER
-import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyComplianceJourneyPages.StartPagePropertyCompliance
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyRegistrationJourneyPages.BillsIncludedFormPagePropertyRegistration
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyRegistrationJourneyPages.CheckAnswersPagePropertyRegistration
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyRegistrationJourneyPages.CheckElectricalCertUploadsFormPagePropertyRegistration
@@ -464,8 +463,8 @@ class PropertyRegistrationJourneyTests : IntegrationTestWithMutableData("data-lo
         verify(propertyOwnershipRepository).save(propertyOwnershipCaptor.capture())
         val expectedPropertyRegNum = RegistrationNumberDataModel.fromRegistrationNumber(propertyOwnershipCaptor.value.registrationNumber)
         assertEquals(expectedPropertyRegNum.toString(), confirmationPage.registrationNumberText)
-        assertTrue(confirmationPage.addComplianceButton.locator.isVisible)
-        assertTrue(confirmationPage.goToDashboardButton.locator.isVisible)
+        assertTrue(confirmationPage.whatYouNeedToDoNextHeading.isVisible)
+        assertTrue(confirmationPage.goToDashboardLink.locator.isVisible)
 
         // Check confirmation email
         verify(confirmationEmailSender).sendEmail(
@@ -479,9 +478,9 @@ class PropertyRegistrationJourneyTests : IntegrationTestWithMutableData("data-lo
             ),
         )
 
-        // Go to compliance journey
-        confirmationPage.addComplianceButton.clickAndWait()
-        assertPageIs(page, StartPagePropertyCompliance::class, mapOf("propertyOwnershipId" to propertyOwnershipCaptor.value.id.toString()))
+        // Go to dashboard
+        confirmationPage.goToDashboardLink.clickAndWait()
+        assertPageIs(page, LandlordDashboardPage::class)
     }
 
     @Test
@@ -643,8 +642,8 @@ class PropertyRegistrationJourneyTests : IntegrationTestWithMutableData("data-lo
         verify(propertyOwnershipRepository).save(propertyOwnershipCaptor.capture())
         val expectedPropertyRegNum = RegistrationNumberDataModel.fromRegistrationNumber(propertyOwnershipCaptor.value.registrationNumber)
         assertEquals(expectedPropertyRegNum.toString(), confirmationPage.registrationNumberText)
-        assertTrue(confirmationPage.addComplianceButton.locator.isHidden)
-        assertTrue(confirmationPage.goToDashboardButton.locator.isVisible)
+        assertTrue(confirmationPage.whatYouNeedToDoNextHeading.isHidden)
+        assertTrue(confirmationPage.goToDashboardLink.locator.isVisible)
 
         // Check confirmation email
         verify(confirmationEmailSender).sendEmail(
@@ -659,7 +658,7 @@ class PropertyRegistrationJourneyTests : IntegrationTestWithMutableData("data-lo
         )
 
         // Go to dashboard
-        confirmationPage.goToDashboardButton.clickAndWait()
+        confirmationPage.goToDashboardLink.clickAndWait()
         assertPageIs(page, LandlordDashboardPage::class)
     }
 

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/propertyRegistrationJourneyPages/ConfirmationPagePropertyRegistration.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/propertyRegistrationJourneyPages/ConfirmationPagePropertyRegistration.kt
@@ -3,15 +3,13 @@ package uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyRe
 import com.microsoft.playwright.Page
 import uk.gov.communities.prsdb.webapp.constants.CONFIRMATION_PATH_SEGMENT
 import uk.gov.communities.prsdb.webapp.controllers.RegisterPropertyController
-import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.Button
-import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.Table
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.Link
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages.BasePage
 
 class ConfirmationPagePropertyRegistration(
     page: Page,
 ) : BasePage(page, "${RegisterPropertyController.PROPERTY_REGISTRATION_ROUTE}/$CONFIRMATION_PATH_SEGMENT") {
-    private val detailTable = Table(page)
-    val registrationNumberText: String = detailTable.getCell(0, 1).text
-    val addComplianceButton = Button.byText(page, "Add compliance for this property")
-    val goToDashboardButton = Button.byText(page, "Go to Dashboard")
+    val registrationNumberText: String = page.locator(".govuk-inset-text").textContent().trim()
+    val whatYouNeedToDoNextHeading = page.locator("h2:has-text('What you need to do next')")
+    val goToDashboardLink = Link.byText(page, "Go to dashboard")
 }


### PR DESCRIPTION
## Ticket number

PDJB-714

## Goal of change

Update the property registration confirmation page to match new Figma designs with three variants: occupied with incomplete compliance, unoccupied, and occupied with complete compliance.

## Description of main change(s)

- Restructured the confirmation page template to show a green banner with the property address on multiple lines, the PRN in an inset text block, and body paragraphs about keeping the number and using it in adverts
- Added a conditional "What you need to do next" section that appears only when the property is occupied and has incomplete compliance certificates, showing a deadline for uploading them
- Added `PropertyComplianceService` dependency to `RegisterPropertyController` to determine compliance status
- Deleted two unused fragment templates (occupied and unoccupied content) that are now consolidated into the single confirmation template
- Updated integration test page object and assertions to match the new page structure

## Anything you'd like to highlight to the reviewer?

- The address is rendered using `th:each` over address parts with `th:text` (safe escaping) rather than injecting `<br>` tags via `th:utext`, to avoid XSS risk from user-controlled address data
- Currently EICR and EPC certificates are never provided during registration (only gas safety can be uploaded), so all occupied properties will show the compliance-later variant. The complete-compliance variant will activate when compliance is integrated into registration in a future ticket
- The "What you need to next" heading in the Figma design was a typo — corrected to "What you need to do next" as confirmed with the team

## Checklist

- [x] Screenshots of any UI changes have been added
- [x] Unit tests for new logic (e.g. new service methods) have been added
- [x] Controller tests for any new endpoints, including testing the relevant permissions
- [x] Test suite has been run in full locally and is passing
- [x] Branch has been rebased onto main and run locally, with everything working as expected
- [x] TODO comments referencing this JIRA ticket have been searched for and removed