### PR TITLE
PDJB-666: epc expired page

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/PropertyRegistrationJourneyFactory.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/PropertyRegistrationJourneyFactory.kt
@@ -70,6 +70,7 @@ import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.LowEn
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.MeesExemptionStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.OccupiedStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.OwnershipTypeStep
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.PropertyOccupiedCheckStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.PropertyRegistrationCyaStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.PropertyRegistrationTaskListStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.PropertyTypeStep
@@ -385,6 +386,7 @@ class PropertyRegistrationJourney(
     override val hasEpcStep: HasEpcStep,
     override val checkUprnMatchedEpcStep: ConfirmEpcRetrievedByUprnStep,
     override val epcAgeAndEnergyRatingCheckStep: EpcAgeAndEnergyRatingCheckStep,
+    override val isPropertyOccupiedCheckStep: PropertyOccupiedCheckStep,
     override val confirmEpcDetailsRetrievedByCertificateNumberStep: ConfirmEpcDetailsRetrievedByCertificateNumberStep,
     override val findYourEpcStep: FindYourEpcStep,
     override val checkSupersededEpcStep: EpcSuperseededStep,

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/states/EpcState.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/states/EpcState.kt
@@ -18,6 +18,7 @@ import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.HasMe
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.IsEpcRequiredStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.LowEnergyRatingStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.MeesExemptionStep
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.PropertyOccupiedCheckStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.ProvideEpcLaterStep
 import uk.gov.communities.prsdb.webapp.models.dataModels.EpcDataModel
 
@@ -34,6 +35,7 @@ interface EpcState : JourneyState {
     val hasEpcStep: HasEpcStep
     val checkUprnMatchedEpcStep: ConfirmEpcRetrievedByUprnStep
     val epcAgeAndEnergyRatingCheckStep: EpcAgeAndEnergyRatingCheckStep
+    val isPropertyOccupiedCheckStep: PropertyOccupiedCheckStep
     val confirmEpcDetailsRetrievedByCertificateNumberStep: ConfirmEpcDetailsRetrievedByCertificateNumberStep
     val findYourEpcStep: FindYourEpcStep
     val checkSupersededEpcStep: EpcSuperseededStep

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/states/EpcState.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/states/EpcState.kt
@@ -1,5 +1,6 @@
 package uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states
 
+import uk.gov.communities.prsdb.webapp.exceptions.PrsdbWebException
 import uk.gov.communities.prsdb.webapp.journeys.JourneyState
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.CheckEpcAnswersStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.ConfirmEpcDetailsRetrievedByCertificateNumberStep
@@ -50,4 +51,6 @@ interface EpcState : JourneyState {
     val epcMissingStep: EpcMissingStep
     val provideEpcLaterStep: ProvideEpcLaterStep
     val checkEpcAnswersStep: CheckEpcAnswersStep
+
+    fun getNotNullAcceptedEpc() = acceptedEpc ?: throw PrsdbWebException("Attempting to access accepted EPC when it is null in state")
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/EpcExpiredStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/EpcExpiredStepConfig.kt
@@ -16,7 +16,7 @@ class EpcExpiredStepConfig : AbstractRequestableStepConfig<Complete, NoInputForm
     override fun getStepSpecificContent(state: EpcState) =
         state.isOccupied?.let { isOccupied ->
             mapOf(
-                "expiryDate" to state.acceptedEpc?.expiryDateAsJavaLocalDate,
+                "expiryDate" to state.getNotNullAcceptedEpc().expiryDateAsJavaLocalDate,
                 "getNewEpcUrl" to GET_NEW_EPC_URL,
                 "registeredEnergyExemptionGuideUrl" to REGISTERED_ENERGY_EXEMPTION_GUIDE_URL,
                 "submitButtonText" to

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/EpcExpiredStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/EpcExpiredStepConfig.kt
@@ -1,28 +1,45 @@
 package uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps
 
 import uk.gov.communities.prsdb.webapp.annotations.webAnnotations.JourneyFrameworkComponent
+import uk.gov.communities.prsdb.webapp.constants.GET_NEW_EPC_URL
+import uk.gov.communities.prsdb.webapp.constants.REGISTERED_ENERGY_EXEMPTION_GUIDE_URL
 import uk.gov.communities.prsdb.webapp.journeys.AbstractRequestableStepConfig
-import uk.gov.communities.prsdb.webapp.journeys.JourneyState
 import uk.gov.communities.prsdb.webapp.journeys.JourneyStep.RequestableStep
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.EpcState
 import uk.gov.communities.prsdb.webapp.journeys.shared.Complete
 import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.NoInputFormModel
 
-// TODO PDJB-666: Implement EPC Expired page
 @JourneyFrameworkComponent("propertyRegistrationEpcExpiredStepConfig")
-class EpcExpiredStepConfig : AbstractRequestableStepConfig<Complete, NoInputFormModel, JourneyState>() {
+class EpcExpiredStepConfig : AbstractRequestableStepConfig<Complete, NoInputFormModel, EpcState>() {
     override val formModelClass = NoInputFormModel::class
 
-    override fun getStepSpecificContent(state: JourneyState) = mapOf("todoComment" to "TODO PDJB-666: Implement EPC Expired page")
+    override fun getStepSpecificContent(state: EpcState) =
+        state.isOccupied?.let { isOccupied ->
+            mapOf(
+                "expiryDate" to state.acceptedEpc?.expiryDateAsJavaLocalDate,
+                "getNewEpcUrl" to GET_NEW_EPC_URL,
+                "registeredEnergyExemptionGuideUrl" to REGISTERED_ENERGY_EXEMPTION_GUIDE_URL,
+                "submitButtonText" to
+                    if (isOccupied) "forms.buttons.continueAnyway" else "forms.buttons.continue",
+            )
+        } ?: throw IllegalStateException("EpcExpiredStep should not be reachable before isOccupied is set")
 
-    override fun chooseTemplate(state: JourneyState) = "forms/todo"
+    override fun chooseTemplate(state: EpcState): String =
+        state.isOccupied?.let { isOccupied ->
+            if (isOccupied) {
+                "forms/epcExpiredForOccupiedPropertyRegistration"
+            } else {
+                "forms/epcExpiredForUnoccupiedPropertyRegistration"
+            }
+        } ?: throw IllegalStateException("EpcExpiredStep should not be reachable before isOccupied is set")
 
-    override fun mode(state: JourneyState) = getFormModelFromStateOrNull(state)?.let { Complete.COMPLETE }
+    override fun mode(state: EpcState): Complete? = getFormModelFromStateOrNull(state)?.let { Complete.COMPLETE }
 }
 
 @JourneyFrameworkComponent("propertyRegistrationEpcExpiredStep")
 final class EpcExpiredStep(
     stepConfig: EpcExpiredStepConfig,
-) : RequestableStep<Complete, NoInputFormModel, JourneyState>(stepConfig) {
+) : RequestableStep<Complete, NoInputFormModel, EpcState>(stepConfig) {
     companion object {
         const val ROUTE_SEGMENT = "epc-expired"
     }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/IsPropertyOccupiedCheckStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/IsPropertyOccupiedCheckStepConfig.kt
@@ -8,7 +8,12 @@ import uk.gov.communities.prsdb.webapp.journeys.shared.YesOrNo
 
 @JourneyFrameworkComponent
 class PropertyOccupiedCheckStepConfig : AbstractInternalStepConfig<YesOrNo, EpcState>() {
-    override fun mode(state: EpcState): YesOrNo = if (state.isOccupied == true) YesOrNo.YES else YesOrNo.NO
+    override fun mode(state: EpcState): YesOrNo? =
+        when (state.isOccupied) {
+            true -> YesOrNo.YES
+            false -> YesOrNo.NO
+            null -> null
+        }
 }
 
 @JourneyFrameworkComponent

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/IsPropertyOccupiedCheckStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/IsPropertyOccupiedCheckStepConfig.kt
@@ -1,0 +1,17 @@
+package uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps
+
+import uk.gov.communities.prsdb.webapp.annotations.webAnnotations.JourneyFrameworkComponent
+import uk.gov.communities.prsdb.webapp.journeys.AbstractInternalStepConfig
+import uk.gov.communities.prsdb.webapp.journeys.JourneyStep
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.EpcState
+import uk.gov.communities.prsdb.webapp.journeys.shared.YesOrNo
+
+@JourneyFrameworkComponent
+class PropertyOccupiedCheckStepConfig : AbstractInternalStepConfig<YesOrNo, EpcState>() {
+    override fun mode(state: EpcState): YesOrNo = if (state.isOccupied == true) YesOrNo.YES else YesOrNo.NO
+}
+
+@JourneyFrameworkComponent
+final class PropertyOccupiedCheckStep(
+    stepConfig: PropertyOccupiedCheckStepConfig,
+) : JourneyStep.InternalStep<YesOrNo, EpcState>(stepConfig)

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/tasks/EpcTask.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/tasks/EpcTask.kt
@@ -124,7 +124,7 @@ class EpcTask : Task<EpcState>() {
                         }
 
                         EpcAgeAndEnergyRatingCheckMode.EPC_OLDER_THAN_10_YEARS -> {
-                            if (journey.isOccupied == true) journey.epcInDateAtStartOfTenancyCheckStep else journey.epcExpiredStep
+                            journey.isPropertyOccupiedCheckStep
                         }
 
                         EpcAgeAndEnergyRatingCheckMode.EPC_LOW_ENERGY_RATING -> {
@@ -165,11 +165,21 @@ class EpcTask : Task<EpcState>() {
                 nextStep { journey.checkEpcAnswersStep }
                 savable()
             }
-            step(journey.epcInDateAtStartOfTenancyCheckStep) {
-                routeSegment(EpcInDateAtStartOfTenancyCheckStep.ROUTE_SEGMENT)
-                // This should only be the parent if the property is occupied
+            step(journey.isPropertyOccupiedCheckStep) {
                 parents {
                     journey.epcAgeAndEnergyRatingCheckStep.hasOutcome(EpcAgeAndEnergyRatingCheckMode.EPC_OLDER_THAN_10_YEARS)
+                }
+                nextStep { mode ->
+                    when (mode) {
+                        YesOrNo.YES -> journey.epcInDateAtStartOfTenancyCheckStep
+                        YesOrNo.NO -> journey.epcExpiredStep
+                    }
+                }
+            }
+            step(journey.epcInDateAtStartOfTenancyCheckStep) {
+                routeSegment(EpcInDateAtStartOfTenancyCheckStep.ROUTE_SEGMENT)
+                parents {
+                    journey.isPropertyOccupiedCheckStep.hasOutcome(YesOrNo.YES)
                 }
                 nextStep { mode ->
                     when (mode) {
@@ -183,9 +193,7 @@ class EpcTask : Task<EpcState>() {
                 routeSegment(EpcExpiredStep.ROUTE_SEGMENT)
                 parents {
                     OrParents(
-                        // This should only be a parent if the property is unoccupied
-                        journey.epcAgeAndEnergyRatingCheckStep.hasOutcome(EpcAgeAndEnergyRatingCheckMode.EPC_OLDER_THAN_10_YEARS),
-                        // This should only be a parent if the property is unoccupied
+                        journey.isPropertyOccupiedCheckStep.hasOutcome(YesOrNo.NO),
                         journey.epcInDateAtStartOfTenancyCheckStep.hasOutcome(EpcInDateAtStartOfTenancyCheckMode.NOT_IN_DATE),
                     )
                 }

--- a/src/main/resources/messages/propertyCompliance.yml
+++ b/src/main/resources/messages/propertyCompliance.yml
@@ -631,7 +631,13 @@ epcTask:
     heading: This property’s EPC has expired
     occupied:
       paragraph:
-        one: 'This EPC expired on {0,,expiryDate}. This means you did not have a valid EPC when the current tenancy started.'
+        one: 'This EPC expired on <strong>{0,,expiryDate}</strong>. This means you did not have a valid EPC when the current tenancy started.'
     unoccupied:
       paragraph:
-        one: 'This EPC expired on {0,,expiryDate}.'
+        one: 'This EPC expired on <strong>{0,,expiryDate}</strong>.'
+    requirements:
+      paragraph:
+        one: 'You need a valid EPC with a rating of <strong>E or higher</strong>. This means you may need to:'
+    epcRequirements:
+      forLetting:
+        paragraph: 'You must get a valid EPC with a rating of <strong>E or higher</strong> before letting this property.'

--- a/src/main/resources/messages/propertyCompliance.yml
+++ b/src/main/resources/messages/propertyCompliance.yml
@@ -627,3 +627,11 @@ epcTask:
           when the property’s occupied. We'll ask if you have an EPC that meets the
           requirements for letting.
         two: You must do this within 28 days of the property being occupied by tenants.
+  epcExpired:
+    heading: This property’s EPC has expired
+    occupied:
+      paragraph:
+        one: 'This EPC expired on {0,,expiryDate}. This means you did not have a valid EPC when the current tenancy started.'
+    unoccupied:
+      paragraph:
+        one: 'This EPC expired on {0,,expiryDate}.'

--- a/src/main/resources/templates/forms/epcExpiredForOccupiedPropertyRegistration.html
+++ b/src/main/resources/templates/forms/epcExpiredForOccupiedPropertyRegistration.html
@@ -13,7 +13,7 @@
             <h1 class="govuk-heading-l" th:text="#{propertyCompliance.epcTask.epcExpired.heading}">propertyCompliance.epcTask.epcExpired.heading</h1>
         </header>
         <section>
-            <p class="govuk-body" th:utext="#{propertyCompliance.epcTask.epcExpired.occupied.paragraph.one(${{expiryDate}})}">propertyCompliance.epcTask.epcExpired.occupied.paragraph.one</p>
+            <p class="govuk-body" data-testid="expiry-date-paragraph" th:utext="#{propertyCompliance.epcTask.epcExpired.occupied.paragraph.one(${{expiryDate}})}">propertyCompliance.epcTask.epcExpired.occupied.paragraph.one</p>
         </section>
         <section>
             <h2 class="govuk-heading-m" th:text="#{forms.epcRequirements.heading}">forms.epcRequirements.heading</h2>

--- a/src/main/resources/templates/forms/epcExpiredForOccupiedPropertyRegistration.html
+++ b/src/main/resources/templates/forms/epcExpiredForOccupiedPropertyRegistration.html
@@ -1,0 +1,44 @@
+<!--/*@thymesVar id="title" type="java.lang.String"*/-->
+<!--/*@thymesVar id="formModel" type="java.lang.Object"*/-->
+<!--/*@thymesVar id="backUrl" type="java.lang.String"*/-->
+<!--/*@thymesVar id="sectionHeaderInfo" type="uk.gov.communities.prsdb.webapp.models.viewModels.SectionHeaderViewModel"*/-->
+<!--/*@thymesVar id="expiryDate" type="java.time.LocalDate"*/-->
+<!--/*@thymesVar id="getNewEpcUrl" type="java.lang.String"*/-->
+<!--/*@thymesVar id="registeredEnergyExemptionGuideUrl" type="java.lang.String"*/-->
+<!--/*@thymesVar id="submitButtonText" type="java.lang.String"*/-->
+<!DOCTYPE html>
+<html th:replace="~{fragments/forms/complexQuestionPage :: complexQuestionPage(#{${title}}, ${formModel}, ~{::#form-content}, ~{::#question-content}, ${backUrl}, ${sectionHeaderInfo})}">
+    <th:block id="question-content">
+        <header>
+            <h1 class="govuk-heading-l" th:text="#{propertyCompliance.epcTask.epcExpired.heading}">propertyCompliance.epcTask.epcExpired.heading</h1>
+        </header>
+        <section>
+            <p class="govuk-body" th:utext="#{propertyCompliance.epcTask.epcExpired.occupied.paragraph.one(${{expiryDate}})}">propertyCompliance.epcTask.epcExpired.occupied.paragraph.one</p>
+        </section>
+        <section>
+            <h2 class="govuk-heading-m" th:text="#{forms.epcRequirements.heading}">forms.epcRequirements.heading</h2>
+            <p class="govuk-body">
+                <span th:remove="tag" th:text="#{forms.epcRequirements.paragraph.one.normalText}">forms.epcRequirements.paragraph.one.normalText</span>
+                <span class="govuk-!-font-weight-bold" th:text="#{forms.epcRequirements.paragraph.one.boldText}">forms.epcRequirements.paragraph.one.boldText</span>
+            </p>
+            <p class="govuk-body" th:text="#{forms.epcRequirements.paragraph.two}">forms.epcRequirements.paragraph.two</p>
+            <ul class="govuk-list govuk-list--bullet">
+                <li>
+                    <a class="govuk-link" th:href="${getNewEpcUrl}" th:text="#{forms.epcRequirements.bullet.one}" rel="noreferrer noopener" target="_blank">forms.epcRequirements.bullet.one</a>
+                </li>
+                <li th:text="#{forms.epcRequirements.bullet.two}">forms.epcRequirements.bullet.two</li>
+            </ul>
+            <p class="govuk-body">
+                <span th:remove="tag" th:text="#{forms.epcRequirements.paragraph.three.beforeLink}">forms.epcRequirements.paragraph.three.beforeLink</span>
+                <a class="govuk-link" th:href="${registeredEnergyExemptionGuideUrl}" th:text="#{forms.epcRequirements.paragraph.three.link}" rel="noreferrer noopener" target="_blank">forms.epcRequirements.paragraph.three.link</a><span th:remove="tag">.</span>
+            </p>
+        </section>
+        <section>
+            <h2 class="govuk-heading-m" th:text="#{propertyCompliance.epcTask.epcMissingOccupied.breakingLaw.heading}">propertyCompliance.epcTask.epcMissingOccupied.breakingLaw.heading</h2>
+            <div th:replace="~{fragments/warningText :: warningText(#{propertyCompliance.epcTask.epcMissingOccupied.warning})}"></div>
+        </section>
+    </th:block>
+    <th:block id="form-content">
+        <button th:replace="~{fragments/buttons/secondaryButton :: secondaryButton(#{${submitButtonText}})}"></button>
+    </th:block>
+</html>

--- a/src/main/resources/templates/forms/epcExpiredForOccupiedPropertyRegistration.html
+++ b/src/main/resources/templates/forms/epcExpiredForOccupiedPropertyRegistration.html
@@ -17,11 +17,7 @@
         </section>
         <section>
             <h2 class="govuk-heading-m" th:text="#{forms.epcRequirements.heading}">forms.epcRequirements.heading</h2>
-            <p class="govuk-body">
-                <span th:remove="tag" th:text="#{forms.epcRequirements.paragraph.one.normalText}">forms.epcRequirements.paragraph.one.normalText</span>
-                <span class="govuk-!-font-weight-bold" th:text="#{forms.epcRequirements.paragraph.one.boldText}">forms.epcRequirements.paragraph.one.boldText</span>
-            </p>
-            <p class="govuk-body" th:text="#{forms.epcRequirements.paragraph.two}">forms.epcRequirements.paragraph.two</p>
+            <p class="govuk-body" th:utext="#{propertyCompliance.epcTask.epcExpired.requirements.paragraph.one}">propertyCompliance.epcTask.epcExpired.requirements.paragraph.one</p>
             <ul class="govuk-list govuk-list--bullet">
                 <li>
                     <a class="govuk-link" th:href="${getNewEpcUrl}" th:text="#{forms.epcRequirements.bullet.one}" rel="noreferrer noopener" target="_blank">forms.epcRequirements.bullet.one</a>

--- a/src/main/resources/templates/forms/epcExpiredForUnoccupiedPropertyRegistration.html
+++ b/src/main/resources/templates/forms/epcExpiredForUnoccupiedPropertyRegistration.html
@@ -13,7 +13,7 @@
             <h1 class="govuk-heading-l" th:text="#{propertyCompliance.epcTask.epcExpired.heading}">propertyCompliance.epcTask.epcExpired.heading</h1>
         </header>
         <section>
-            <p class="govuk-body" th:utext="#{propertyCompliance.epcTask.epcExpired.unoccupied.paragraph.one(${{expiryDate}})}">propertyCompliance.epcTask.epcExpired.unoccupied.paragraph.one</p>
+            <p class="govuk-body" data-testid="expiry-date-paragraph" th:utext="#{propertyCompliance.epcTask.epcExpired.unoccupied.paragraph.one(${{expiryDate}})}">propertyCompliance.epcTask.epcExpired.unoccupied.paragraph.one</p>
         </section>
         <section>
             <h2 class="govuk-heading-m" th:text="#{propertyCompliance.epcTask.epcMissingUnoccupied.epcRequirements.heading}">propertyCompliance.epcTask.epcMissingUnoccupied.epcRequirements.heading</h2>

--- a/src/main/resources/templates/forms/epcExpiredForUnoccupiedPropertyRegistration.html
+++ b/src/main/resources/templates/forms/epcExpiredForUnoccupiedPropertyRegistration.html
@@ -23,11 +23,7 @@
                 <a class="govuk-link" th:href="${getNewEpcUrl}" th:text="#{propertyCompliance.epcTask.epcMissingUnoccupied.epcRequirements.forAdvertising.link}" rel="noreferrer noopener" target="_blank">propertyCompliance.epcTask.epcMissingUnoccupied.epcRequirements.forAdvertising.link</a>
             </p>
             <h3 class="govuk-heading-s" th:text="#{propertyCompliance.epcTask.epcMissingUnoccupied.epcRequirements.forLetting.heading}">propertyCompliance.epcTask.epcMissingUnoccupied.epcRequirements.forLetting.heading</h3>
-            <p class="govuk-body">
-                <span th:remove="tag" th:text="#{propertyCompliance.epcTask.epcMissingUnoccupied.epcRequirements.forLetting.paragraph.normalText}">propertyCompliance.epcTask.epcMissingUnoccupied.epcRequirements.forLetting.paragraph.normalText</span>
-                <span class="govuk-!-font-weight-bold" th:text="#{propertyCompliance.epcTask.epcMissingUnoccupied.epcRequirements.forLetting.paragraph.boldText}">propertyCompliance.epcTask.epcMissingUnoccupied.epcRequirements.forLetting.paragraph.boldText</span>
-                <span th:remove="tag" th:text="#{propertyCompliance.epcTask.epcMissingUnoccupied.epcRequirements.forLetting.paragraph.afterBold}">propertyCompliance.epcTask.epcMissingUnoccupied.epcRequirements.forLetting.paragraph.afterBold</span>
-            </p>
+            <p class="govuk-body" th:utext="#{propertyCompliance.epcTask.epcExpired.epcRequirements.forLetting.paragraph}">propertyCompliance.epcTask.epcExpired.epcRequirements.forLetting.paragraph</p>
             <p class="govuk-body" th:text="#{forms.epcRequirements.paragraph.two}">forms.epcRequirements.paragraph.two</p>
             <ul class="govuk-list govuk-list--bullet">
                 <li>

--- a/src/main/resources/templates/forms/epcExpiredForUnoccupiedPropertyRegistration.html
+++ b/src/main/resources/templates/forms/epcExpiredForUnoccupiedPropertyRegistration.html
@@ -1,0 +1,52 @@
+<!--/*@thymesVar id="title" type="java.lang.String"*/-->
+<!--/*@thymesVar id="formModel" type="java.lang.Object"*/-->
+<!--/*@thymesVar id="backUrl" type="java.lang.String"*/-->
+<!--/*@thymesVar id="sectionHeaderInfo" type="uk.gov.communities.prsdb.webapp.models.viewModels.SectionHeaderViewModel"*/-->
+<!--/*@thymesVar id="expiryDate" type="java.time.LocalDate"*/-->
+<!--/*@thymesVar id="getNewEpcUrl" type="java.lang.String"*/-->
+<!--/*@thymesVar id="registeredEnergyExemptionGuideUrl" type="java.lang.String"*/-->
+<!--/*@thymesVar id="submitButtonText" type="java.lang.String"*/-->
+<!DOCTYPE html>
+<html th:replace="~{fragments/forms/complexQuestionPage :: complexQuestionPage(#{${title}}, ${formModel}, ~{::#form-content}, ~{::#question-content}, ${backUrl}, ${sectionHeaderInfo})}">
+    <th:block id="question-content">
+        <header>
+            <h1 class="govuk-heading-l" th:text="#{propertyCompliance.epcTask.epcExpired.heading}">propertyCompliance.epcTask.epcExpired.heading</h1>
+        </header>
+        <section>
+            <p class="govuk-body" th:utext="#{propertyCompliance.epcTask.epcExpired.unoccupied.paragraph.one(${{expiryDate}})}">propertyCompliance.epcTask.epcExpired.unoccupied.paragraph.one</p>
+        </section>
+        <section>
+            <h2 class="govuk-heading-m" th:text="#{propertyCompliance.epcTask.epcMissingUnoccupied.epcRequirements.heading}">propertyCompliance.epcTask.epcMissingUnoccupied.epcRequirements.heading</h2>
+            <h3 class="govuk-heading-s" th:text="#{propertyCompliance.epcTask.epcMissingUnoccupied.epcRequirements.forAdvertising.heading}">propertyCompliance.epcTask.epcMissingUnoccupied.epcRequirements.forAdvertising.heading</h3>
+            <p class="govuk-body" th:text="#{propertyCompliance.epcTask.epcMissingUnoccupied.epcRequirements.forAdvertising.paragraph}">propertyCompliance.epcTask.epcMissingUnoccupied.epcRequirements.forAdvertising.paragraph</p>
+            <p class="govuk-body">
+                <a class="govuk-link" th:href="${getNewEpcUrl}" th:text="#{propertyCompliance.epcTask.epcMissingUnoccupied.epcRequirements.forAdvertising.link}" rel="noreferrer noopener" target="_blank">propertyCompliance.epcTask.epcMissingUnoccupied.epcRequirements.forAdvertising.link</a>
+            </p>
+            <h3 class="govuk-heading-s" th:text="#{propertyCompliance.epcTask.epcMissingUnoccupied.epcRequirements.forLetting.heading}">propertyCompliance.epcTask.epcMissingUnoccupied.epcRequirements.forLetting.heading</h3>
+            <p class="govuk-body">
+                <span th:remove="tag" th:text="#{propertyCompliance.epcTask.epcMissingUnoccupied.epcRequirements.forLetting.paragraph.normalText}">propertyCompliance.epcTask.epcMissingUnoccupied.epcRequirements.forLetting.paragraph.normalText</span>
+                <span class="govuk-!-font-weight-bold" th:text="#{propertyCompliance.epcTask.epcMissingUnoccupied.epcRequirements.forLetting.paragraph.boldText}">propertyCompliance.epcTask.epcMissingUnoccupied.epcRequirements.forLetting.paragraph.boldText</span>
+                <span th:remove="tag" th:text="#{propertyCompliance.epcTask.epcMissingUnoccupied.epcRequirements.forLetting.paragraph.afterBold}">propertyCompliance.epcTask.epcMissingUnoccupied.epcRequirements.forLetting.paragraph.afterBold</span>
+            </p>
+            <p class="govuk-body" th:text="#{forms.epcRequirements.paragraph.two}">forms.epcRequirements.paragraph.two</p>
+            <ul class="govuk-list govuk-list--bullet">
+                <li>
+                    <a class="govuk-link" th:href="${getNewEpcUrl}" th:text="#{forms.epcRequirements.bullet.one}" rel="noreferrer noopener" target="_blank">forms.epcRequirements.bullet.one</a>
+                </li>
+                <li th:text="#{forms.epcRequirements.bullet.two}">forms.epcRequirements.bullet.two</li>
+            </ul>
+            <p class="govuk-body">
+                <span th:remove="tag" th:text="#{forms.epcRequirements.paragraph.three.beforeLink}">forms.epcRequirements.paragraph.three.beforeLink</span>
+                <a class="govuk-link" th:href="${registeredEnergyExemptionGuideUrl}" th:text="#{forms.epcRequirements.paragraph.three.link}" rel="noreferrer noopener" target="_blank">forms.epcRequirements.paragraph.three.link</a><span th:remove="tag">.</span>
+            </p>
+        </section>
+        <section>
+            <h2 class="govuk-heading-m" th:text="#{propertyCompliance.epcTask.epcMissingUnoccupied.whatYouNeedToDo.heading}">propertyCompliance.epcTask.epcMissingUnoccupied.whatYouNeedToDo.heading</h2>
+            <p class="govuk-body" th:text="#{propertyCompliance.epcTask.epcMissingUnoccupied.whatYouNeedToDo.paragraph.one}">propertyCompliance.epcTask.epcMissingUnoccupied.whatYouNeedToDo.paragraph.one</p>
+            <p class="govuk-body" th:text="#{propertyCompliance.epcTask.epcMissingUnoccupied.whatYouNeedToDo.paragraph.two}">propertyCompliance.epcTask.epcMissingUnoccupied.whatYouNeedToDo.paragraph.two</p>
+        </section>
+    </th:block>
+    <th:block id="form-content">
+        <button th:replace="~{fragments/buttons/primaryButton :: primaryButton(#{${submitButtonText}})}"></button>
+    </th:block>
+</html>

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/PropertyRegistrationJourneyTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/PropertyRegistrationJourneyTests.kt
@@ -956,7 +956,10 @@ class PropertyRegistrationJourneyTests : IntegrationTestWithMutableData("data-lo
         epcExpiryCheckPage.submitEpcExpired()
         val epcExpiredPage = assertPageIs(page, EpcExpiredFormPagePropertyRegistration::class)
 
-        // TODO PDJB-666 - expired
+        // EPC Expired - occupied variant: warning visible, "Continue anyway" button
+        assertThat(epcExpiredPage.heading).containsText("This property's EPC has expired")
+        assertThat(epcExpiredPage.warning).isVisible()
+        assertThat(epcExpiredPage.submitButton).containsText("Continue anyway")
         epcExpiredPage.form.submit()
         val checkEpcAnswersPage = assertPageIs(page, CheckEpcAnswersFormPagePropertyRegistration::class)
 
@@ -1078,7 +1081,10 @@ class PropertyRegistrationJourneyTests : IntegrationTestWithMutableData("data-lo
         confirmEpcDetailsPage.submitYes()
         val epcExpiredPage = assertPageIs(page, EpcExpiredFormPagePropertyRegistration::class)
 
-        // TODO PDJB-666 - expired
+        // EPC Expired - unoccupied variant: no warning, "Continue" button
+        assertThat(epcExpiredPage.heading).containsText("This property's EPC has expired")
+        assertThat(epcExpiredPage.warning).isHidden()
+        assertThat(epcExpiredPage.submitButton).containsText("Continue")
         epcExpiredPage.form.submit()
         val checkEpcAnswersPage = assertPageIs(page, CheckEpcAnswersFormPagePropertyRegistration::class)
 

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/PropertyRegistrationJourneyTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/PropertyRegistrationJourneyTests.kt
@@ -957,7 +957,7 @@ class PropertyRegistrationJourneyTests : IntegrationTestWithMutableData("data-lo
         val epcExpiredPage = assertPageIs(page, EpcExpiredFormPagePropertyRegistration::class)
 
         // EPC Expired - occupied variant: warning visible, "Continue anyway" button
-        assertThat(epcExpiredPage.heading).containsText("This property's EPC has expired")
+        assertThat(epcExpiredPage.heading).containsText("This property’s EPC has expired")
         assertThat(epcExpiredPage.warning).isVisible()
         assertThat(epcExpiredPage.submitButton).containsText("Continue anyway")
         epcExpiredPage.form.submit()
@@ -1082,7 +1082,7 @@ class PropertyRegistrationJourneyTests : IntegrationTestWithMutableData("data-lo
         val epcExpiredPage = assertPageIs(page, EpcExpiredFormPagePropertyRegistration::class)
 
         // EPC Expired - unoccupied variant: no warning, "Continue" button
-        assertThat(epcExpiredPage.heading).containsText("This property's EPC has expired")
+        assertThat(epcExpiredPage.heading).containsText("This property’s EPC has expired")
         assertThat(epcExpiredPage.warning).isHidden()
         assertThat(epcExpiredPage.submitButton).containsText("Continue")
         epcExpiredPage.form.submit()

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/PropertyRegistrationSinglePageTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/PropertyRegistrationSinglePageTests.kt
@@ -1100,6 +1100,25 @@ class PropertyRegistrationSinglePageTests : IntegrationTestWithImmutableData("da
     }
 
     @Nested
+    inner class EpcExpiredStep {
+        @Test
+        fun `The page renders the occupied variant for an occupied property`(page: Page) {
+            val epcExpiredPage = navigator.skipToPropertyRegistrationEpcExpiredPage(propertyIsOccupied = true)
+            BaseComponent.assertThat(epcExpiredPage.heading).containsText("This property’s EPC has expired")
+            BaseComponent.assertThat(epcExpiredPage.warning).isVisible()
+            BaseComponent.assertThat(epcExpiredPage.submitButton).hasText("Continue anyway")
+        }
+
+        @Test
+        fun `The page renders the unoccupied variant for an unoccupied property`(page: Page) {
+            val epcExpiredPage = navigator.skipToPropertyRegistrationEpcExpiredPage(propertyIsOccupied = false)
+            BaseComponent.assertThat(epcExpiredPage.heading).containsText("This property’s EPC has expired")
+            BaseComponent.assertThat(epcExpiredPage.warning).isHidden()
+            BaseComponent.assertThat(epcExpiredPage.submitButton).hasText("Continue")
+        }
+    }
+
+    @Nested
     inner class LowEnergyRatingStep {
         @Test
         fun `The page renders the occupied variant for an occupied property`(page: Page) {

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/PropertyRegistrationSinglePageTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/PropertyRegistrationSinglePageTests.kt
@@ -1116,6 +1116,18 @@ class PropertyRegistrationSinglePageTests : IntegrationTestWithImmutableData("da
             BaseComponent.assertThat(epcExpiredPage.warning).isHidden()
             BaseComponent.assertThat(epcExpiredPage.submitButton).hasText("Continue")
         }
+
+        @Test
+        fun `The expiry date is displayed in bold on the occupied variant`(page: Page) {
+            val epcExpiredPage = navigator.skipToPropertyRegistrationEpcExpiredPage(propertyIsOccupied = true)
+            assertThat(epcExpiredPage.expiryDateParagraph.locator("strong")).hasText("5 January 2022")
+        }
+
+        @Test
+        fun `The expiry date is displayed in bold on the unoccupied variant`(page: Page) {
+            val epcExpiredPage = navigator.skipToPropertyRegistrationEpcExpiredPage(propertyIsOccupied = false)
+            assertThat(epcExpiredPage.expiryDateParagraph.locator("strong")).hasText("5 January 2022")
+        }
     }
 
     @Nested

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/Navigator.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/Navigator.kt
@@ -131,6 +131,7 @@ import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyReg
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyRegistrationJourneyPages.ConfirmEpcDetailsRetrievedByUprnFormPagePropertyRegistration
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyRegistrationJourneyPages.ElectricalCertExpiryDateFormPagePropertyRegistration
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyRegistrationJourneyPages.EpcExemptionFormPagePropertyRegistration
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyRegistrationJourneyPages.EpcExpiredFormPagePropertyRegistration
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyRegistrationJourneyPages.EpcMissingFormPagePropertyRegistration
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyRegistrationJourneyPages.FindYourEpcFormPagePropertyRegistration
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyRegistrationJourneyPages.FurnishedStatusFormPagePropertyRegistration
@@ -251,6 +252,7 @@ import uk.gov.communities.prsdb.webapp.testHelpers.mockObjects.MockEpcData
 import java.util.UUID
 import kotlin.test.assertTrue
 import uk.gov.communities.prsdb.webapp.journeys.propertyDeregistration.stepConfig.ReasonStep as DeregistrationReasonStep
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.EpcExpiredStep as RegistrationEpcExpiredStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.EpcMissingStep as RegistrationEpcMissingStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.LowEnergyRatingStep as RegistrationLowEnergyRatingStep
 
@@ -724,6 +726,14 @@ class Navigator(
         )
         navigateToPropertyRegistrationJourneyStep(ProvideEpcLaterStep.ROUTE_SEGMENT)
         return createValidPage(page, ProvideEpcLaterFormPagePropertyRegistration::class)
+    }
+
+    fun skipToPropertyRegistrationEpcExpiredPage(propertyIsOccupied: Boolean = true): EpcExpiredFormPagePropertyRegistration {
+        setJourneyStateInSession(
+            PropertyStateSessionBuilder.beforePropertyRegistrationEpcExpired(propertyIsOccupied).build(),
+        )
+        navigateToPropertyRegistrationJourneyStep(RegistrationEpcExpiredStep.ROUTE_SEGMENT)
+        return createValidPage(page, EpcExpiredFormPagePropertyRegistration::class)
     }
 
     fun skipToPropertyRegistrationEpcMissingPage(propertyIsOccupied: Boolean = true): EpcMissingFormPagePropertyRegistration {

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/propertyRegistrationJourneyPages/EpcExpiredFormPagePropertyRegistration.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/propertyRegistrationJourneyPages/EpcExpiredFormPagePropertyRegistration.kt
@@ -2,15 +2,21 @@ package uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyRe
 
 import com.microsoft.playwright.Page
 import uk.gov.communities.prsdb.webapp.controllers.RegisterPropertyController
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.Button
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.Form
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.Heading
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.Warning
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages.BasePage
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.EpcExpiredStep
 
-// TODO PDJB-666: Implement EPC Expired page object
 class EpcExpiredFormPagePropertyRegistration(
     page: Page,
 ) : BasePage(page, "${RegisterPropertyController.PROPERTY_REGISTRATION_ROUTE}/${EpcExpiredStep.ROUTE_SEGMENT}") {
     val heading = Heading(page.locator("h1"))
     val form = Form(page)
+
+    // Warning component only present in the occupied variant
+    val warning = Warning.default(page)
+
+    val submitButton = Button.default(page.locator("form"))
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/propertyRegistrationJourneyPages/EpcExpiredFormPagePropertyRegistration.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/propertyRegistrationJourneyPages/EpcExpiredFormPagePropertyRegistration.kt
@@ -2,6 +2,7 @@ package uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyRe
 
 import com.microsoft.playwright.Page
 import uk.gov.communities.prsdb.webapp.controllers.RegisterPropertyController
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.BackLink
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.Button
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.Form
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.Heading
@@ -12,6 +13,7 @@ import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.EpcEx
 class EpcExpiredFormPagePropertyRegistration(
     page: Page,
 ) : BasePage(page, "${RegisterPropertyController.PROPERTY_REGISTRATION_ROUTE}/${EpcExpiredStep.ROUTE_SEGMENT}") {
+    val backLink = BackLink.default(page)
     val heading = Heading(page.locator("h1"))
     val form = Form(page)
 

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/propertyRegistrationJourneyPages/EpcExpiredFormPagePropertyRegistration.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/propertyRegistrationJourneyPages/EpcExpiredFormPagePropertyRegistration.kt
@@ -20,5 +20,7 @@ class EpcExpiredFormPagePropertyRegistration(
     // Warning component only present in the occupied variant
     val warning = Warning.default(page)
 
+    val expiryDateParagraph = page.locator("[data-testid='expiry-date-paragraph']")
+
     val submitButton = Button.default(page.locator("form"))
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/EpcExpiredStepConfigTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/EpcExpiredStepConfigTests.kt
@@ -1,0 +1,60 @@
+package uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.whenever
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.EpcState
+import uk.gov.communities.prsdb.webapp.testHelpers.mockObjects.AlwaysTrueValidator
+
+@ExtendWith(MockitoExtension::class)
+class EpcExpiredStepConfigTests {
+    @Mock
+    lateinit var mockState: EpcState
+
+    @Test
+    fun `chooseTemplate returns occupied template when isOccupied is true`() {
+        // Arrange
+        val stepConfig = setupStepConfig()
+        whenever(mockState.isOccupied).thenReturn(true)
+
+        // Act
+        val result = stepConfig.chooseTemplate(mockState)
+
+        // Assert
+        assertEquals("forms/epcExpiredForOccupiedPropertyRegistration", result)
+    }
+
+    @Test
+    fun `chooseTemplate returns unoccupied template when isOccupied is false`() {
+        // Arrange
+        val stepConfig = setupStepConfig()
+        whenever(mockState.isOccupied).thenReturn(false)
+
+        // Act
+        val result = stepConfig.chooseTemplate(mockState)
+
+        // Assert
+        assertEquals("forms/epcExpiredForUnoccupiedPropertyRegistration", result)
+    }
+
+    @Test
+    fun `chooseTemplate throws IllegalStateException when isOccupied is null`() {
+        // Arrange
+        val stepConfig = setupStepConfig()
+        whenever(mockState.isOccupied).thenReturn(null)
+
+        // Act & Assert
+        assertThrows<IllegalStateException> { stepConfig.chooseTemplate(mockState) }
+    }
+
+    private fun setupStepConfig(): EpcExpiredStepConfig {
+        val stepConfig = EpcExpiredStepConfig()
+        stepConfig.routeSegment = EpcExpiredStep.ROUTE_SEGMENT
+        stepConfig.validator = AlwaysTrueValidator()
+        return stepConfig
+    }
+}

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/PropertyOccupiedCheckStepConfigTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/PropertyOccupiedCheckStepConfigTests.kt
@@ -1,0 +1,55 @@
+package uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.whenever
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.EpcState
+import uk.gov.communities.prsdb.webapp.journeys.shared.YesOrNo
+
+@ExtendWith(MockitoExtension::class)
+class PropertyOccupiedCheckStepConfigTests {
+    @Mock
+    lateinit var mockState: EpcState
+
+    @Test
+    fun `mode returns YES when the property is occupied`() {
+        // Arrange
+        val stepConfig = PropertyOccupiedCheckStepConfig()
+        whenever(mockState.isOccupied).thenReturn(true)
+
+        // Act
+        val result = stepConfig.mode(mockState)
+
+        // Assert
+        assertEquals(YesOrNo.YES, result)
+    }
+
+    @Test
+    fun `mode returns NO when the property is unoccupied`() {
+        // Arrange
+        val stepConfig = PropertyOccupiedCheckStepConfig()
+        whenever(mockState.isOccupied).thenReturn(false)
+
+        // Act
+        val result = stepConfig.mode(mockState)
+
+        // Assert
+        assertEquals(YesOrNo.NO, result)
+    }
+
+    @Test
+    fun `mode returns null when the occupancy status is not yet set`() {
+        // Arrange
+        val stepConfig = PropertyOccupiedCheckStepConfig()
+        whenever(mockState.isOccupied).thenReturn(null)
+
+        // Act
+        val result = stepConfig.mode(mockState)
+
+        // Assert
+        assertEquals(null, result)
+    }
+}

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/testHelpers/builders/EpcStateBuilder.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/testHelpers/builders/EpcStateBuilder.kt
@@ -8,6 +8,7 @@ import uk.gov.communities.prsdb.webapp.constants.enums.MeesExemptionReason
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.CheckEpcAnswersStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.ConfirmEpcRetrievedByUprnStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.EpcExemptionStep
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.EpcInDateAtStartOfTenancyCheckStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.FindYourEpcStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.HasEpcStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.HasMeesExemptionStep
@@ -16,6 +17,7 @@ import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.MeesE
 import uk.gov.communities.prsdb.webapp.models.dataModels.EpcDataModel
 import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.CheckMatchedEpcFormModel
 import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.EpcExemptionFormModel
+import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.EpcExpiryCheckFormModel
 import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.FindEpcByCertificateNumberFormModel
 import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.FormModel
 import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.HasEpcFormModel
@@ -132,6 +134,14 @@ interface EpcStateBuilder<SelfType : EpcStateBuilder<SelfType>> {
             ),
     ): SelfType {
         withAcceptedEpcFoundByUprn(epcDataModel)
+        return self()
+    }
+
+    fun withEpcNotInDateAtStartOfTenancy(): SelfType {
+        withSubmittedValue(
+            EpcInDateAtStartOfTenancyCheckStep.ROUTE_SEGMENT,
+            EpcExpiryCheckFormModel().apply { tenancyStartedBeforeExpiry = false },
+        )
         return self()
     }
 

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/testHelpers/builders/EpcStateBuilder.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/testHelpers/builders/EpcStateBuilder.kt
@@ -125,6 +125,16 @@ interface EpcStateBuilder<SelfType : EpcStateBuilder<SelfType>> {
         return self()
     }
 
+    fun withEpcExpired(
+        epcDataModel: EpcDataModel =
+            MockEpcData.createEpcDataModel(
+                expiryDate = MockEpcData.expiryDateInThePast,
+            ),
+    ): SelfType {
+        withAcceptedEpcFoundByUprn(epcDataModel)
+        return self()
+    }
+
     fun withEpcLowEnergyRating(epcDataModel: EpcDataModel = MockEpcData.createEpcDataModel(energyRating = "F")): SelfType {
         withAcceptedEpcFoundByUprn(epcDataModel)
         return self()

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/testHelpers/builders/PropertyStateSessionBuilder.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/testHelpers/builders/PropertyStateSessionBuilder.kt
@@ -178,6 +178,10 @@ class PropertyStateSessionBuilder(
             beforePropertyRegistrationHasMeesExemption()
                 .withHasMeesExemption(true)
 
+        fun beforePropertyRegistrationEpcExpired(propertyIsOccupied: Boolean = true) =
+            beforePropertyRegistrationFindYourEpc(propertyIsOccupied)
+                .withEpcExpired()
+
         fun beforePropertyRegistrationEpcMissing(propertyIsOccupied: Boolean = true) =
             beforePropertyRegistrationFindYourEpc(propertyIsOccupied)
                 .withEpcMissing()

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/testHelpers/builders/PropertyStateSessionBuilder.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/testHelpers/builders/PropertyStateSessionBuilder.kt
@@ -181,6 +181,7 @@ class PropertyStateSessionBuilder(
         fun beforePropertyRegistrationEpcExpired(propertyIsOccupied: Boolean = true) =
             beforePropertyRegistrationFindYourEpc(propertyIsOccupied)
                 .withEpcExpired()
+                .apply { if (propertyIsOccupied) withEpcNotInDateAtStartOfTenancy() }
 
         fun beforePropertyRegistrationEpcMissing(propertyIsOccupied: Boolean = true) =
             beforePropertyRegistrationFindYourEpc(propertyIsOccupied)


### PR DESCRIPTION
## Ticket number

PDJB-666

## Goal of change

Adds an occupied/unoccupied variant for the EPC expired page. Also adds an isOccupied step to properly route the steps

## Description of main change(s)

Adds both variants + tests as per designs.

occupied:

<img width="972" height="887" alt="image" src="https://github.com/user-attachments/assets/c027cd11-37f7-47d4-baaa-e1d5dcb721ac" />

unoccupied:

<img width="984" height="1141" alt="image" src="https://github.com/user-attachments/assets/be0a9223-7c73-4820-85d5-1733f2d59986" />

## Anything you'd like to highlight to the reviewer?

Worth checking that isPropertyOccupiedCheckStep is correct

## Checklist

Delete any that are not applicable, and add explanation below for any that are applicable but haven't been done

- [x] Screenshots of any UI changes have been added
- [x] Unit tests for new logic (e.g. new service methods) have been added
- [x] Single page integration tests have been added for any unhappy-flow UI features, e.g. validation errors
- [x] New journey steps have been added to the appropriate journey integration test(s)
- [x] Test suite has been run in full locally and is passing
- [x] Branch has been rebased onto main and run locally, with everything working as expected (both for your new feature
  and any related functionality)
- [x] TODO comments referencing this JIRA ticket have been searched for and removed - if a future PR will address them,
  mention that here
- [x] QA instructions have been added to the ticket (particularly if this is the last PR required to complete the ticket)
