### PR TITLE
PDJB-732:  show electrical certs as expired when expiry date is today

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/states/ElectricalSafetyState.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/states/ElectricalSafetyState.kt
@@ -22,7 +22,7 @@ interface ElectricalSafetyState : JourneyState {
 
     fun getElectricalCertificateIsOutdated(): Boolean? =
         getElectricalCertificateExpiryDateIfReachable()?.let { expiryDate ->
-            DateTimeHelper().getCurrentDateInUK() > expiryDate
+            DateTimeHelper().getCurrentDateInUK() >= expiryDate
         }
 
     fun getElectricalCertificateType(): HasElectricalSafetyCertificate? =

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/states/ElectricalSafetyStateTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/states/ElectricalSafetyStateTests.kt
@@ -74,14 +74,14 @@ class ElectricalSafetyStateTests {
     }
 
     @Test
-    fun `getElectricalCertificateIsOutdated returns false if the certificate expires today`() {
+    fun `getElectricalCertificateIsOutdated returns true if the certificate expires today`() {
         // Arrange
         val expiryDate = LocalDate.now()
         val expiryDateFormModel = AnyDateFormModel().applyFromDate(expiryDate)
         val state = buildTestElectricalSafetyState(expiryDateFormModel = expiryDateFormModel)
 
         // Act, Assert
-        assertFalse(state.getElectricalCertificateIsOutdated()!!)
+        assertTrue(state.getElectricalCertificateIsOutdated()!!)
     }
 
     @Test


### PR DESCRIPTION

## Ticket number

PDJB-732

## Goal of change

Treat electrical safety certificates as expired on their expiry date

## Description of main change(s)

As above

## Anything you'd like to highlight to the reviewer?

## Checklist

Delete any that are not applicable, and add explanation below for any that are applicable but haven't been done

- [x] Unit tests for new logic (e.g. new service methods) have been added
- [x] Test suite has been run in full locally and is passing
- [x] Branch has been rebased onto main and run locally, with everything working as expected (both for your new feature
  and any related functionality)
- [x] TODO comments referencing this JIRA ticket have been searched for and removed - if a future PR will address them,
  mention that here
- [x] QA instructions have been added to the ticket (particularly if this is the last PR required to complete the ticket)
