### PR TITLE
PDJB-779: Update LC registration confirmation page content

### DIFF
--- a/src/main/resources/messages/registerLocalCouncilUser.yml
+++ b/src/main/resources/messages/registerLocalCouncilUser.yml
@@ -24,11 +24,11 @@ success:
     title: 'You’ve registered as a {0,,localCouncil} user'
   whatHappensNext:
     paragraph:
-      one: You now have access to the database.
+      one: You now have full access to the database.
       two: 'Head to your dashboard to:'
     bullet:
-      one: search and view property and landlord information
-      two: view compliance information for registered properties
+      one: view property and landlord information
+      two: request compliance updates
 privacyNotice:
   heading: Read and agree to the privacy notice
   paragraph:


### PR DESCRIPTION
## Ticket number

PDJB-779

## Goal of change

Update the content on the Local Council user registration confirmation page to match the latest Figma designs.

## Description of main change(s)

- Updated three message strings in `registerLocalCouncilUser.yml`:
  - Added "full" to the database access paragraph ("You now have full access to the database.")
  - Simplified the first bullet to "view property and landlord information"
  - Changed the second bullet to "request compliance updates"

## Anything you'd like to highlight to the reviewer?

Content-only change — no template, controller, or code changes. The page structure is unchanged.

## Checklist

- [ ] Screenshots of any UI changes have been added
- [x] Branch has been rebased onto main and run locally, with everything working as expected (both for your new feature and any related functionality)
- [x] TODO comments referencing this JIRA ticket have been searched for and removed - if a future PR will address them, mention that here