### PR TITLE
PDJB-778: Update LC privacy notice

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/RegisterLocalCouncilUserController.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/RegisterLocalCouncilUserController.kt
@@ -12,8 +12,8 @@ import org.springframework.web.servlet.ModelAndView
 import uk.gov.communities.prsdb.webapp.annotations.webAnnotations.PrsdbController
 import uk.gov.communities.prsdb.webapp.constants.CONFIRMATION_PATH_SEGMENT
 import uk.gov.communities.prsdb.webapp.constants.INVALID_LINK_PAGE_PATH_SEGMENT
-import uk.gov.communities.prsdb.webapp.constants.LANDING_PAGE_PATH_SEGMENT
 import uk.gov.communities.prsdb.webapp.constants.LOCAL_COUNCIL_PATH_SEGMENT
+import uk.gov.communities.prsdb.webapp.constants.PRIVACY_NOTICE_PATH_SEGMENT
 import uk.gov.communities.prsdb.webapp.constants.REGISTER_LOCAL_COUNCIL_USER_JOURNEY_URL
 import uk.gov.communities.prsdb.webapp.constants.TOKEN
 import uk.gov.communities.prsdb.webapp.controllers.LocalCouncilDashboardController.Companion.LOCAL_COUNCIL_DASHBOARD_URL
@@ -55,7 +55,7 @@ class RegisterLocalCouncilUserController(
             "redirect:$LOCAL_COUNCIL_DASHBOARD_URL"
         } else {
             invitationService.storeTokenInSession(token)
-            "redirect:$LOCAL_COUNCIL_USER_REGISTRATION_ROUTE/$LANDING_PAGE_PATH_SEGMENT"
+            "redirect:$LOCAL_COUNCIL_USER_REGISTRATION_ROUTE/$PRIVACY_NOTICE_PATH_SEGMENT"
         }
     }
 

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/localCouncilUserRegistration/LocalCouncilUserRegistrationJourneyFactory.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/localCouncilUserRegistration/LocalCouncilUserRegistrationJourneyFactory.kt
@@ -74,24 +74,24 @@ class LocalCouncilUserRegistrationJourneyFactory(
 
     private fun mainJourneyMap(state: LocalCouncilUserRegistrationJourney): Map<String, StepLifecycleOrchestrator> =
         journey(state) {
-            unreachableStepStep { journey.landingPageStep }
+            unreachableStepStep { journey.privacyNoticeStep }
             configure {
                 withAdditionalContentProperty { "title" to "registerLocalCouncilUser.title" }
             }
             configureFirst { backDestination { journey.returnToCyaPageDestination } }
-            step(journey.landingPageStep) {
-                routeSegment(LANDING_PAGE_PATH_SEGMENT)
-                initialStep()
-                nextStep { journey.privacyNoticeStep }
-            }
             step(journey.privacyNoticeStep) {
                 routeSegment(PRIVACY_NOTICE_PATH_SEGMENT)
-                parents { journey.landingPageStep.isComplete() }
+                initialStep()
+                nextStep { journey.landingPageStep }
+            }
+            step(journey.landingPageStep) {
+                routeSegment(LANDING_PAGE_PATH_SEGMENT)
+                parents { journey.privacyNoticeStep.isComplete() }
                 nextStep { journey.nameStep }
             }
             step(journey.nameStep) {
                 routeSegment("name")
-                parents { journey.privacyNoticeStep.isComplete() }
+                parents { journey.landingPageStep.isComplete() }
                 nextStep { journey.emailStep }
             }
             step(journey.emailStep) {

--- a/src/main/resources/messages/localCouncilPrivacyNotice.yml
+++ b/src/main/resources/messages/localCouncilPrivacyNotice.yml
@@ -1,21 +1,22 @@
 title: Privacy Notice
-heading: Privacy notice for local councils
+heading: Privacy notice (extended testing phase for local councils)
 section:
   one:
-    heading: 1. MHCLG’s role as data controller
+    heading: MHCLG’s role as Data Controller
     paragraph:
-      one: 'This privacy notice explains how the Ministry of Housing, Communities and Local Government (MHCLG), as the primary data controller, collects, uses, and protects your personal data when you, as a local council user, access and use the Private Rented Sector Database (PRS Database) private beta.'
+      one: 'This privacy notice explains how the Ministry of Housing, Communities and Local Government (MHCLG), as the primary data controller, collects, uses and protects your personal data when you, as a local council user, access and use the ‘check a rental property or landlord’ service under the Private Rented Sector Database (PRS Database) extended testing phase.'
       two:
         beforeEmailLink: MHCLG is the Data Controller as described in the General Data Protection Regulation (UK GDPR) and the Data Protection Act 2018 (DPA). Our Data Protection Officer can be contacted at
         emailLinkText: 'dpo@communities.gov.uk'
         afterEmailLink: .
   two:
-    heading: 2. What personal data we are collecting and why
+    heading: What information we collect and why during the Extended Testing phase
     paragraph:
-      one: 'As a local council user participating in this private beta, you will be invited to use the PRS Database service on a voluntary basis.'
+      one: 'As a local council user participating in the extended testing phase, you are invited to use the service on a voluntary basis to help validate the system’s functionality and usability from a local council perspective. You will be asked to authenticate through either GOV.UK One Login or a GDS Internal Access during sign-up.'
     subheading:
-      one: 2.1 What data we collect
-      two: 2.2 Why are we collecting your personal data
+      one: Local council user personal data
+      two: Usage data (for service improvement and essential operational usage)
+      three: Why are we collecting your personal data
     subsection:
       one:
         paragraph:
@@ -35,93 +36,97 @@ section:
             normalText: The name of the local council you work for.
           five:
             boldText: 'One Login subject identifier:'
-            normalText: 'One Login will generate a unique subject identifier when you authenticate through it for the PRS Database service. This will only be visible to this service, and it allows us to link your PRS Database account to your One Login authentication without receiving any other personal data from One Login. We do not receive your name or any other personal data directly from the One Login service.'
-          six:
-            boldText: 'Usage data (for service improvement):'
-            normalText: 'We will collect data about your interactions with the PRS Database service through Google Analytics 4. This helps us to understand how the service is being used and to identify how to improve it. The data is collected via:'
-            ga4:
-              boldText: 'Google Analytics 4 (GA4):'
-              normalText: 'This uses cookie banners and other persistent identifiers. As a result, we will use opt-in consent with the cookie banner to collect usage data. Please note that when using GA4 for this purpose, we do not log IP addresses. It collects usage data such as pages visited, session duration, user interactions (such as scrolling), browser & OS, geolocation.'
-            essential:
-              boldText: 'Essential operational usage data:'
-              normalText: 'Basic usage data necessary for the security, performance and core functionality of the PRS Database such as login and logout timestamps, system error logs and basic page load performance. This is collected regardless of your cookie banner choices, as it is essential for the operation of the service.'
-        important:
-          note: 'Important note: Any significant changes to the types of data collected, the purposes for which it is used, or the entities with whom it is shared during this private beta will be clearly communicated to you through updated privacy notices and direct notifications in advance of their implementation.'
+            normalText: 'When you authenticate via GOV.UK One Login, we receive a unique, pseudonymous subject identifier. This allows us to link your PRSD account to your authentication session without receiving your name or identity documents directly from the One Login service.'
       two:
+        paragraph:
+          one: 'To understand how the service is being used and to identify areas for improvement. Plausible does not use cookies, does not collect personal data and does not track you across different websites.'
+        statisticalPurpose:
+          boldText: 'Statistical Purpose:'
+          normalText: 'We process this information as a ‘statistical exception’ under the <strong>Data (Use and Access) Act 2025</strong>. This means we do not require your consent to collect this anonymised data as it is used purely to ensure the service is functional, accessible and meeting user needs.'
+        important:
+          note: 'Any significant changes to the types of data collected, the purposes for which it is used, or the entities with whom it is shared during this extended testing phase will be clearly communicated to you through updated privacy notices and direct notifications in advance of their implementation.'
+      three:
         paragraph:
           one: 'Your personal data (your name, preferred email address, local council, One Login Subject Identifier and usage data) is being collected and processed for the following purposes directly related to your role as a local council user on the PRS Database:'
         bullet:
           one:
             boldText: 'Access and authentication to the PRS Database:'
-            normalText: We will use your data to verify your identity and grant you secure access to the PRS Database service. This enables you to perform tasks related to the private beta of the PRS Database service.
+            normalText: 'To verify your identity and grant secure access to the ‘Check a rental property or Landlord’ service of the PRSD.'
           two:
             boldText: 'Service administration and support:'
-            normalText: 'To administer your account, provide support, and communicate with you about the PRS Database, including any updates or changes to the service. This may involve contacting you via your preferred email address.'
+            normalText: 'To manage your account, provide technical support via our service desk, and communicate updates.'
           three:
-            boldText: 'Service improvement (private beta phase - with consent for GA4):'
-            normalText: 'Your usage data is collected to help us understand how the service performs, identify bugs, analyse user behaviour, and gather insights to improve the PRS Database’s functionality and user experience. This data is crucial for the evaluation and refinement of the pilot.'
-            ga4:
-              note: GA4 data is processed only if you provide your consent via the cookie banner.
+            boldText: 'Service improvement (extended testing phase with Plausible):'
+            normalText: 'Your usage data helps us identify ‘bugs,’ analyse system performance across different council environments, and refine the user experience before the mandatory launch.'
           four:
             boldText: 'Security, performance, and core functionality (Mandatory):'
             normalText: 'Essential operational usage data is collected to ensure the security, stability, and effective functioning of the PRS Database, detect and prevent fraudulent activity, and assist in diagnosing and resolving technical problems. This data is fundamental to providing the service.'
           five:
-            boldText: 'Local council context:'
-            normalText: To help understand service usage patterns across different local councils and tailor support or communications where necessary.
+            boldText: 'Audit log:'
+            normalText: 'To maintain a robust audit log of which users have accessed specific landlord or property records, as required for data accountability.'
         'note.prefix': 'Note:'
         note: We will not combine analytics information with other data sets in a way that would directly identify who you are.
   three:
-    heading: 3. Lawful basis for processing the data
+    heading: Lawful basis for processing the data
     paragraph:
-      one: 'The data protection legislation sets out when we are lawfully allowed to process your personal data. The lawful basis that applies to this processing is:'
+      one: 'The data protection legislation sets out when we are lawfully allowed to process your personal data. For MHCLG, we process your personal and usage data under the lawful basis below is:'
     bullet:
       one:
-        boldText: Article 6(1)(e) UK GDPR
-        normalText: – the performance of a task carried out in the public interest or in the exercise of officiallCouncil under Article 6(1)(e)) of UK GDPR.
+        boldText: 'UK GDPR Article 6(1)(e)'
+        normalText: '– Public Task: Processing is necessary for the performance of a task in the public interest, namely the administrative testing and validation of the PRSD’s jurisdictional access controls.'
       two:
-        boldText: 'Data Protection Act 2018, Part 2, Chapter 2, section 8 (d)'
-        normalText: '– the exercise of a function of the Crown, a Minister of the Crown or a government department. This specifically involves providing you with access to the service during the private beta so that MHCLG can test its functionality with both the local council and private landlord users. In doing so, MHCLG will administer, support, secure and develop the core functionality required for the service.'
+        boldText: 'Domestic Legal Basis (The ‘Vires’)'
+        normalText: '– This is supported by <strong>Section 8(d) of the Data Protection Act 2018</strong> (the exercise of a function of a Minister of the Crown) and the <strong>Secretary of State’s general common law powers</strong> to undertake preparatory work incidental to their ministerial functions.'
       three:
-        boldText: Article 6(1)(a) UK GDPR
-        normalText: '– your consent for usage data. We will obtain your consent via a cookie banner when you first access the service, allowing you to choose whether to enable the collection of this type of usage data. You can withdraw your consent at any time via the cookie settings on the PRSD website.'
-        note: You can withdraw your consent at any time via the cookie settings on the PRSD website.
+        boldText: 'Usage Data (Plausible)'
+        normalText: '– We monitor system performance using Plausible to improve our service as part of our Public Task.'
   four:
-    heading: 4. With whom will we be sharing the data
+    heading: With whom we will be sharing the data
     paragraph:
-      one: 'Processor:'
-      two: 'We have employed an external organisation to provide service desk support functionality during the private beta phase, on behalf of MHCLG. We have a Data Processing Agreement in place to ensure that the data is processed securely and in accordance with all relevant data protection law. To assist with your enquiries, the processing will involve using the details you have provided on the PRS Database.'
-  five:
-    heading: 5. Retention period
-    paragraph:
-      one: Please be aware that the PRS Database private beta is a temporary initiative designed to test and evaluate the functionality of the future PRS Database service.
+      one: 'To provide this service, we share your data with the following government and technical providers;'
+    bullet:
+      one:
+        boldText: 'Service provider (processor)'
+        normalText: 'To provide service desk support functionality during the extended testing phase, on behalf of MHCLG. We have a Data Processing Agreement in place to ensure that the data is processed securely and in accordance with all relevant data protection law. To assist with your enquiries, the processing will involve using the details you have provided on the PRS Database.'
       two:
-        bold: All personal data collected from local council users will be securely deleted no later than a month after the conclusion of private beta.
-        normal: This means that you will need to re-register for the mandatory service (and if participating in future private betas).
-      three: 'We will notify you in advance of the data deletion date, where feasible, through the preferred email address you have provided.'
-  six:
-    heading: '6. Your rights (e.g. access, rectification, erasure)'
+        boldText: 'Amazon Web Services (AWS)'
+        normalText: 'To host the PRSD service and store your data securely. All data is stored in the UK.'
+      three: 'To send you essential communications, including registration confirmations, security codes (OTP) and compliance reminders via email or SMS.'
+      four: 'To verify your identity before you access the service.'
+  five:
+    heading: Retention period
     paragraph:
-      one: 'The data we are collecting is your personal data, and you have rights that affect what happens to it. You have the right to:'
+      one: The extended testing phase is a temporary initiative.
+      two:
+        bold: All personal data collected from local council users will be securely deleted no later than one month after the conclusion of the Extended Testing Phase.
+      three:
+        boldText: 'Re-registration:'
+        normalText: 'You will be required to re-register for the Mandatory Service (or future testing phases) once the current phase is finalised.'
+  six:
+    heading: 'Your rights (e.g. access, rectification, erasure)'
+    paragraph:
+      one: 'The data we are collecting is your personal data, and you have rights that affect what happens to it.'
+      two: 'You have the right to:'
     bullet:
       one: know that we are using your personal data
       two: see what data we have about you
       three: 'ask to have your data corrected, and to ask how we check the information we hold is accurate'
       four: 'complain to the Information Commissioner’s Office (see the ‘Complaints and more information’ section, below)'
-      five: 'In some circumstances, you may also have the right to withdraw your consent to us having or using your optional analytics data, to have all data about you deleted, or to object to particular types of use of your data. We will tell you when these rights apply. You will be able to withdraw your consent to collecting GA4 analytics data via the cookie page.'
+      five: 'in some circumstances, you may also have the right to withdraw your consent to us having or using your optional analytics data, to have all data about you deleted, or to object to particular types of use of your data. We will tell you when these rights apply.'
   seven:
-    heading: 7. Sending data overseas
+    heading: Sending data overseas
     paragraph:
-      one: 'Your personal data (your name, preferred email address, local council, One Login Subject Identifier and usage data) collected will be processed within the UK. During the private beta, we are not sending personal data overseas. We do have default in-region Amazon Web Services Relational Database Service (AWS RDS) copies that will be manually deleted as part of deleting the database records at the end of the private beta. MHCLG will ensure that this complies with data protection law and that appropriate safeguards are in place to protect your personal data.'
+      one: 'Your personal data (your name, preferred email address, local council, One Login Subject Identifier and usage data) collected will be processed within the UK. During the extended testing phase, we are not sending personal data overseas. We do have default in-region Amazon Web Services Relational Database Service (AWS RDS) copies that will be manually deleted as part of deleting the database records at the end of the extended testing phase. MHCLG will ensure that this complies with data protection law and that appropriate safeguards are in place to protect your personal data.'
   eight:
-    heading: 8. Automated decision making
+    heading: Automated decision making
     paragraph:
       one: We will not use your data for any automated decision making.
   nine:
-    heading: '9. Storage, security and data management'
+    heading: 'Storage, security and data management'
     paragraph:
       one: 'Your personal data will be stored in a secure government IT system with appropriate technical and organisational measures in place to protect it from unauthorised access, use or disclosure.'
   ten:
-    heading: 10. Complaints and more information
+    heading: Complaints and More Information
     paragraph:
       one: 'When we ask you for information, we will keep to the law, including the Data Protection Act 2018 and UK General Data Protection Regulation.'
       two:

--- a/src/main/resources/templates/localCouncilPrivacyNotice.html
+++ b/src/main/resources/templates/localCouncilPrivacyNotice.html
@@ -16,7 +16,7 @@
             <p class="govuk-body">
                 <span th:remove="tag" th:text="#{localCouncilPrivacyNotice.section.one.paragraph.two.beforeEmailLink}">localCouncilPrivacyNotice.section.one.paragraph.two.beforeEmailLink</span>
                 <a class="govuk-link" th:href="'mailto:' + ${dataProtectionOfficerEmail}" th:text="#{localCouncilPrivacyNotice.section.one.paragraph.two.emailLinkText}">
-                    localCouncilPrivacyNotice.section.ten.paragraph.three.emailLinkText
+                    localCouncilPrivacyNotice.section.one.paragraph.two.emailLinkText
                 </a><span th:remove="tag" th:text="#{localCouncilPrivacyNotice.section.one.paragraph.two.afterEmailLink}">localCouncilPrivacyNotice.section.one.paragraph.two.afterEmailLink</span>
             </p>
         </section>
@@ -32,31 +32,28 @@
                 <li th:replace="~{fragments/partiallyBoldBullet :: partiallyBoldBullet(#{localCouncilPrivacyNotice.section.two.subsection.one.bullet.three.boldText},#{localCouncilPrivacyNotice.section.two.subsection.one.bullet.three.normalText}, null)}"></li>
                 <li th:replace="~{fragments/partiallyBoldBullet :: partiallyBoldBullet(#{localCouncilPrivacyNotice.section.two.subsection.one.bullet.four.boldText},#{localCouncilPrivacyNotice.section.two.subsection.one.bullet.four.normalText}, null)}"></li>
                 <li th:replace="~{fragments/partiallyBoldBullet :: partiallyBoldBullet(#{localCouncilPrivacyNotice.section.two.subsection.one.bullet.five.boldText},#{localCouncilPrivacyNotice.section.two.subsection.one.bullet.five.normalText}, null)}"></li>
-                <li id="section2UsageDataBullet" th:replace="~{fragments/partiallyBoldBullet :: partiallyBoldBullet(#{localCouncilPrivacyNotice.section.two.subsection.one.bullet.six.boldText},#{localCouncilPrivacyNotice.section.two.subsection.one.bullet.six.normalText}, ~{::#section2UsageDataBullet/content()})}">
-                    <ul class="govuk-list govuk-list--bullet">
-                        <li th:replace="~{fragments/partiallyBoldBullet :: partiallyBoldBullet(#{localCouncilPrivacyNotice.section.two.subsection.one.bullet.six.ga4.boldText},#{localCouncilPrivacyNotice.section.two.subsection.one.bullet.six.ga4.normalText}, null)}"></li>
-                        <li th:replace="~{fragments/partiallyBoldBullet :: partiallyBoldBullet(#{localCouncilPrivacyNotice.section.two.subsection.one.bullet.six.essential.boldText},#{localCouncilPrivacyNotice.section.two.subsection.one.bullet.six.essential.normalText}, null)}"></li>
-                    </ul>
-                </li>
             </ul>
-            <p class="govuk-body" th:text="#{localCouncilPrivacyNotice.section.two.subsection.one.important.note}">localCouncilPrivacyNotice.section.two.subsection.one.important.note</p>
 
             <h3 class="govuk-heading-s" th:text="#{localCouncilPrivacyNotice.section.two.subheading.two}">localCouncilPrivacyNotice.section.two.subheading.two</h3>
             <p class="govuk-body" th:text="#{localCouncilPrivacyNotice.section.two.subsection.two.paragraph.one}">localCouncilPrivacyNotice.section.two.subsection.two.paragraph.one</p>
+            <p class="govuk-body">
+                <span class="govuk-!-font-weight-bold" th:text="#{localCouncilPrivacyNotice.section.two.subsection.two.statisticalPurpose.boldText}">localCouncilPrivacyNotice.section.two.subsection.two.statisticalPurpose.boldText</span>
+                <span th:remove="tag" th:utext="#{localCouncilPrivacyNotice.section.two.subsection.two.statisticalPurpose.normalText}">localCouncilPrivacyNotice.section.two.subsection.two.statisticalPurpose.normalText</span>
+            </p>
+            <p class="govuk-body" th:text="#{localCouncilPrivacyNotice.section.two.subsection.two.important.note}">localCouncilPrivacyNotice.section.two.subsection.two.important.note</p>
+
+            <h3 class="govuk-heading-s" th:text="#{localCouncilPrivacyNotice.section.two.subheading.three}">localCouncilPrivacyNotice.section.two.subheading.three</h3>
+            <p class="govuk-body" th:text="#{localCouncilPrivacyNotice.section.two.subsection.three.paragraph.one}">localCouncilPrivacyNotice.section.two.subsection.three.paragraph.one</p>
             <ul class="govuk-list govuk-list--bullet">
-                <li th:replace="~{fragments/partiallyBoldBullet :: partiallyBoldBullet(#{localCouncilPrivacyNotice.section.two.subsection.two.bullet.one.boldText},#{localCouncilPrivacyNotice.section.two.subsection.two.bullet.one.normalText}, null)}"></li>
-                <li th:replace="~{fragments/partiallyBoldBullet :: partiallyBoldBullet(#{localCouncilPrivacyNotice.section.two.subsection.two.bullet.two.boldText},#{localCouncilPrivacyNotice.section.two.subsection.two.bullet.two.normalText}, null)}"></li>
-                <li id="section2SubSection2ServiceImprovement" th:replace="~{fragments/partiallyBoldBullet :: partiallyBoldBullet(#{localCouncilPrivacyNotice.section.two.subsection.two.bullet.three.boldText},#{localCouncilPrivacyNotice.section.two.subsection.two.bullet.three.normalText}, ~{::#section2SubSection2ServiceImprovement/content()})}">
-                    <ul class="govuk-list govuk-list--bullet">
-                        <li class="govuk-!-font-weight-bold" th:text="#{localCouncilPrivacyNotice.section.two.subsection.two.bullet.three.ga4.note}">localCouncilPrivacyNotice.section.two.subsection.two.bullet.three.ga4.note</li>
-                    </ul>
-                </li>
-                <li th:replace="~{fragments/partiallyBoldBullet :: partiallyBoldBullet(#{localCouncilPrivacyNotice.section.two.subsection.two.bullet.four.boldText},#{localCouncilPrivacyNotice.section.two.subsection.two.bullet.four.normalText}, null)}"></li>
-                <li th:replace="~{fragments/partiallyBoldBullet :: partiallyBoldBullet(#{localCouncilPrivacyNotice.section.two.subsection.two.bullet.five.boldText},#{localCouncilPrivacyNotice.section.two.subsection.two.bullet.five.normalText}, null)}"></li>
+                <li th:replace="~{fragments/partiallyBoldBullet :: partiallyBoldBullet(#{localCouncilPrivacyNotice.section.two.subsection.three.bullet.one.boldText},#{localCouncilPrivacyNotice.section.two.subsection.three.bullet.one.normalText}, null)}"></li>
+                <li th:replace="~{fragments/partiallyBoldBullet :: partiallyBoldBullet(#{localCouncilPrivacyNotice.section.two.subsection.three.bullet.two.boldText},#{localCouncilPrivacyNotice.section.two.subsection.three.bullet.two.normalText}, null)}"></li>
+                <li th:replace="~{fragments/partiallyBoldBullet :: partiallyBoldBullet(#{localCouncilPrivacyNotice.section.two.subsection.three.bullet.three.boldText},#{localCouncilPrivacyNotice.section.two.subsection.three.bullet.three.normalText}, null)}"></li>
+                <li th:replace="~{fragments/partiallyBoldBullet :: partiallyBoldBullet(#{localCouncilPrivacyNotice.section.two.subsection.three.bullet.four.boldText},#{localCouncilPrivacyNotice.section.two.subsection.three.bullet.four.normalText}, null)}"></li>
+                <li th:replace="~{fragments/partiallyBoldBullet :: partiallyBoldBullet(#{localCouncilPrivacyNotice.section.two.subsection.three.bullet.five.boldText},#{localCouncilPrivacyNotice.section.two.subsection.three.bullet.five.normalText}, null)}"></li>
             </ul>
             <p class="govuk-body">
-                <span class="govuk-!-font-weight-bold" th:text="#{localCouncilPrivacyNotice.section.two.subsection.two.note.prefix}">localCouncilPrivacyNotice.section.two.subsection.two.note.prefix</span>
-                <span th:remove="tag" th:text="#{localCouncilPrivacyNotice.section.two.subsection.two.note}">localCouncilPrivacyNotice.section.two.subsection.two.note</span>
+                <span class="govuk-!-font-weight-bold" th:text="#{localCouncilPrivacyNotice.section.two.subsection.three.note.prefix}">localCouncilPrivacyNotice.section.two.subsection.three.note.prefix</span>
+                <span th:remove="tag" th:text="#{localCouncilPrivacyNotice.section.two.subsection.three.note}">localCouncilPrivacyNotice.section.two.subsection.three.note</span>
             </p>
         </section>
         <section>
@@ -64,28 +61,37 @@
             <p class="govuk-body" th:text="#{localCouncilPrivacyNotice.section.three.paragraph.one}">localCouncilPrivacyNotice.section.three.paragraph.one</p>
             <ul class="govuk-list govuk-list--bullet">
                 <li th:replace="~{fragments/partiallyBoldBullet :: partiallyBoldBullet(#{localCouncilPrivacyNotice.section.three.bullet.one.boldText},#{localCouncilPrivacyNotice.section.three.bullet.one.normalText}, null)}"></li>
-                <li th:replace="~{fragments/partiallyBoldBullet :: partiallyBoldBullet(#{localCouncilPrivacyNotice.section.three.bullet.two.boldText},#{localCouncilPrivacyNotice.section.three.bullet.two.normalText}, null)}"></li>
+                <li>
+                    <span class="govuk-!-font-weight-bold" th:text="#{localCouncilPrivacyNotice.section.three.bullet.two.boldText}">localCouncilPrivacyNotice.section.three.bullet.two.boldText</span>
+                    <span th:remove="tag" th:utext="#{localCouncilPrivacyNotice.section.three.bullet.two.normalText}">localCouncilPrivacyNotice.section.three.bullet.two.normalText</span>
+                </li>
                 <li th:replace="~{fragments/partiallyBoldBullet :: partiallyBoldBullet(#{localCouncilPrivacyNotice.section.three.bullet.three.boldText},#{localCouncilPrivacyNotice.section.three.bullet.three.normalText}, null)}"></li>
             </ul>
         </section>
         <section>
             <h2 class="govuk-heading-m" th:text="#{localCouncilPrivacyNotice.section.four.heading}">localCouncilPrivacyNotice.section.four.heading</h2>
-            <p class="govuk-body" th:text="#{localCouncilPrivacyNotice.section.four.paragraph.one}">localCouncilPrivacyNotice.section.four.subheading.one</p>
-            <p class="govuk-body" th:text="#{localCouncilPrivacyNotice.section.four.paragraph.two}">localCouncilPrivacyNotice.section.four.paragraph.one</p>
+            <p class="govuk-body" th:text="#{localCouncilPrivacyNotice.section.four.paragraph.one}">localCouncilPrivacyNotice.section.four.paragraph.one</p>
+            <ul class="govuk-list govuk-list--bullet">
+                <li th:replace="~{fragments/partiallyBoldBullet :: partiallyBoldBullet(#{localCouncilPrivacyNotice.section.four.bullet.one.boldText},#{localCouncilPrivacyNotice.section.four.bullet.one.normalText}, null)}"></li>
+                <li th:replace="~{fragments/partiallyBoldBullet :: partiallyBoldBullet(#{localCouncilPrivacyNotice.section.four.bullet.two.boldText},#{localCouncilPrivacyNotice.section.four.bullet.two.normalText}, null)}"></li>
+                <li th:text="#{localCouncilPrivacyNotice.section.four.bullet.three}">localCouncilPrivacyNotice.section.four.bullet.three</li>
+                <li th:text="#{localCouncilPrivacyNotice.section.four.bullet.four}">localCouncilPrivacyNotice.section.four.bullet.four</li>
+            </ul>
         </section>
         <section>
             <h2 class="govuk-heading-m" th:text="#{localCouncilPrivacyNotice.section.five.heading}">localCouncilPrivacyNotice.section.five.heading</h2>
             <p class="govuk-body" th:text="#{localCouncilPrivacyNotice.section.five.paragraph.one}">localCouncilPrivacyNotice.section.five.paragraph.one</p>
+            <p class="govuk-body govuk-!-font-weight-bold" th:text="#{localCouncilPrivacyNotice.section.five.paragraph.two.bold}">localCouncilPrivacyNotice.section.five.paragraph.two.bold</p>
             <p class="govuk-body">
-                <span class="govuk-!-font-weight-bold" th:text="#{localCouncilPrivacyNotice.section.five.paragraph.two.bold}">localCouncilPrivacyNotice.section.five.paragraph.two.boldText</span>
-                <span th:remove="tag" th:text="#{localCouncilPrivacyNotice.section.five.paragraph.two.normal}">localCouncilPrivacyNotice.section.five.paragraph.two.normalText</span>
+                <span class="govuk-!-font-weight-bold" th:text="#{localCouncilPrivacyNotice.section.five.paragraph.three.boldText}">localCouncilPrivacyNotice.section.five.paragraph.three.boldText</span>
+                <span th:remove="tag" th:text="#{localCouncilPrivacyNotice.section.five.paragraph.three.normalText}">localCouncilPrivacyNotice.section.five.paragraph.three.normalText</span>
             </p>
-            <p class="govuk-body" th:text="#{localCouncilPrivacyNotice.section.five.paragraph.three}">localCouncilPrivacyNotice.section.five.paragraph.three</p>
         </section>
         <section>
             <h2 class="govuk-heading-m" th:text="#{localCouncilPrivacyNotice.section.six.heading}">localCouncilPrivacyNotice.section.six.heading</h2>
             <p class="govuk-body" th:text="#{localCouncilPrivacyNotice.section.six.paragraph.one}">localCouncilPrivacyNotice.section.six.paragraph.one</p>
-            <ol class="govuk-list govuk-list--number">
+            <p class="govuk-body" th:text="#{localCouncilPrivacyNotice.section.six.paragraph.two}">localCouncilPrivacyNotice.section.six.paragraph.two</p>
+            <ol class="govuk-list" style="list-style-type: lower-alpha; padding-left: 20px;">
                 <li th:text="#{localCouncilPrivacyNotice.section.six.bullet.one}">localCouncilPrivacyNotice.section.six.bullet.one</li>
                 <li th:text="#{localCouncilPrivacyNotice.section.six.bullet.two}">localCouncilPrivacyNotice.section.six.bullet.two</li>
                 <li th:text="#{localCouncilPrivacyNotice.section.six.bullet.three}">localCouncilPrivacyNotice.section.six.bullet.three</li>

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/controllers/RegisterLocalCouncilUserControllerTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/controllers/RegisterLocalCouncilUserControllerTests.kt
@@ -16,8 +16,8 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers
 import org.springframework.web.context.WebApplicationContext
 import uk.gov.communities.prsdb.webapp.constants.CONFIRMATION_PATH_SEGMENT
-import uk.gov.communities.prsdb.webapp.constants.LANDING_PAGE_PATH_SEGMENT
 import uk.gov.communities.prsdb.webapp.constants.LOCAL_COUNCIL_USER_ID
+import uk.gov.communities.prsdb.webapp.constants.PRIVACY_NOTICE_PATH_SEGMENT
 import uk.gov.communities.prsdb.webapp.constants.TOKEN
 import uk.gov.communities.prsdb.webapp.journeys.localCouncilUserRegistration.LocalCouncilUserRegistrationJourneyFactory
 import uk.gov.communities.prsdb.webapp.services.LocalCouncilDataService
@@ -53,13 +53,13 @@ class RegisterLocalCouncilUserControllerTests(
 
     @Test
     @WithMockUser
-    fun `acceptInvitation endpoint stores valid token in session and redirects to the registration landing page`() {
+    fun `acceptInvitation endpoint stores valid token in session and redirects to the registration privacy notice page`() {
         whenever(invitationService.getInvitationOrNull(validToken)).thenReturn(invitation)
         whenever(invitationService.getInvitationHasExpired(invitation)).thenReturn(false)
 
         mvc.get("${RegisterLocalCouncilUserController.LOCAL_COUNCIL_USER_REGISTRATION_ROUTE}?$TOKEN=$validToken").andExpect {
             status { is3xxRedirection() }
-            redirectedUrl("${RegisterLocalCouncilUserController.LOCAL_COUNCIL_USER_REGISTRATION_ROUTE}/$LANDING_PAGE_PATH_SEGMENT")
+            redirectedUrl("${RegisterLocalCouncilUserController.LOCAL_COUNCIL_USER_REGISTRATION_ROUTE}/$PRIVACY_NOTICE_PATH_SEGMENT")
         }
 
         verify(invitationService).getInvitationOrNull(validToken)

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/LocalCouncilUserRegistrationJourneyTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/LocalCouncilUserRegistrationJourneyTests.kt
@@ -65,17 +65,17 @@ class LocalCouncilUserRegistrationJourneyTests : IntegrationTestWithMutableData(
     fun `User can navigate the whole journey if pages are correctly filled in`(page: Page) {
         // Accept invitation route
         navigator.navigateToLocalCouncilUserRegistrationAcceptInvitationRoute(invitation.token.toString())
+        val privacyNoticePage = assertPageIs(page, PrivacyNoticePageLocalCouncilUserRegistration::class)
+
+        // Privacy notice page
+        privacyNoticePage.form.iAgreeCheckbox.check()
+        privacyNoticePage.form.submit()
         val landingPage = assertPageIs(page, LandingPageLocalCouncilUserRegistration::class)
         // Landing page - render
         assertThat(landingPage.headingCaption).containsText("Before you register")
         assertThat(landingPage.heading).containsText("Registering as a local council user")
         // Submit and go to next page
         landingPage.clickBeginButton()
-        val privacyNoticePage = assertPageIs(page, PrivacyNoticePageLocalCouncilUserRegistration::class)
-
-        // Privacy notice page
-        privacyNoticePage.form.iAgreeCheckbox.check()
-        privacyNoticePage.form.submit()
         val namePage = assertPageIs(page, NameFormPageLocalCouncilUserRegistration::class)
 
         // Name page - render

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/Navigator.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/Navigator.kt
@@ -373,6 +373,9 @@ class Navigator(
 
     fun navigateToLocalCouncilUserRegistrationLandingPage(token: UUID) {
         storeInvitationTokenInSession(token)
+        setJourneyStateInSession(
+            LocalCouncilUserRegistrationStateSessionBuilder.beforeLandingPage().build(),
+        )
         navigateToLocalCouncilUserRegistrationJourneyStep("landing-page")
     }
 

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/testHelpers/builders/LocalCouncilUserRegistrationStateSessionBuilder.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/testHelpers/builders/LocalCouncilUserRegistrationStateSessionBuilder.kt
@@ -47,9 +47,11 @@ class LocalCouncilUserRegistrationStateSessionBuilder :
     }
 
     companion object {
-        fun beforePrivacyNotice() = LocalCouncilUserRegistrationStateSessionBuilder().withLandingPage()
+        fun beforePrivacyNotice() = LocalCouncilUserRegistrationStateSessionBuilder()
 
-        fun beforeName() = beforePrivacyNotice().withPrivacyNotice()
+        fun beforeLandingPage() = LocalCouncilUserRegistrationStateSessionBuilder().withPrivacyNotice()
+
+        fun beforeName() = beforeLandingPage().withLandingPage()
 
         fun beforeEmail() = beforeName().withName()
 


### PR DESCRIPTION
## Ticket number

PDJB-778

## Goal of change

Update the LC privacy notice page content from 'private beta' to 'extended testing phase' terminology, and swap the privacy notice and landing page steps so privacy notice appears first in the registration journey.

## Description of main change(s)

- Swaps privacy notice and landing page steps in the LC user registration journey so privacy notice is the first step
- Rewrites the standalone privacy notice page content to 'extended testing phase' terminology
- Replaces GA4 analytics references with Plausible (privacy-focused, no cookies)
- Adds new subsections for usage data with Plausible, audit log, and domestic legal basis
- Expands data sharing section with specific processors (AWS, email/SMS provider, One Login/GDS)
- Updates section 6 rights list to lettered format (a-e)

## Anything you'd like to highlight to the reviewer?

The privacy notice content was extracted from the Figma design. The section 2.2 intro text (about Plausible) was slightly rephrased to be grammatically complete as the Figma extraction started mid-sentence. Please double-check the wording matches the intended content.

The in-journey privacy notice form page is unchanged as confirmed by the Figma design.

## Checklist

- [x] Unit tests for new logic (e.g. new service methods) have been added
- [x] Controller tests for any new endpoints, including testing the relevant permissions
- [x] New journey steps have been added to the appropriate journey integration test(s)
- [x] Test suite has been run in full locally and is passing
- [x] Branch has been rebased onto main and run locally, with everything working as expected (both for your new feature and any related functionality)