### PR TITLE
PDJB-682: Add bulk passcode generation script

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -101,6 +101,17 @@ You will need to include the following profiles:
 
 If you need to use notify, also add the `use-notify` profile
 
+### Scripts
+
+Utility scripts are in the `scripts/` directory.
+
+| Script | Purpose |
+|--------|---------|
+| `generate_passcodes.js` | Bulk-generate landlord passcodes. Paste into the browser console on `/system-operator/generate-passcode` while logged in as a system operator. Prompts for a count, generates passcodes sequentially, and downloads the results as a CSV. Requires the `require-passcode` profile. |
+| `generate_update_local_councils_migrations.js` | Generate SQL migrations for updating local council data from CSV. |
+| `generate-load-test-data.sql` | SQL script for generating load test data. |
+| `install-detect-secrets.ps1` / `.sh` | Install the detect-secrets pre-commit hook. |
+
 ### Code structure
 
 #### Backend

--- a/scripts/generate_passcodes.js
+++ b/scripts/generate_passcodes.js
@@ -1,0 +1,107 @@
+// Bulk Passcode Generator
+//
+// Usage:
+//   1. Log in as a system operator
+//   2. Navigate to /system-operator/generate-passcode
+//   3. Open the browser console (F12 → Console)
+//   4. Paste this entire script and press Enter
+//   5. Enter the number of passcodes when prompted
+
+async function generatePasscodes(count) {
+  const csrfToken = document.querySelector('input[name="_csrf"]')?.value;
+  if (!csrfToken) {
+    console.error(
+      "CSRF token not found. Are you on the /system-operator/generate-passcode page?"
+    );
+    return;
+  }
+
+  const generateUrl = "/system-operator/generate-passcode";
+  const passcodes = [];
+  const parser = new DOMParser();
+  let currentCsrfToken = csrfToken;
+
+  console.log(`Generating ${count} passcodes...`);
+
+  for (let i = 0; i < count; i++) {
+    try {
+      const response = await fetch(generateUrl, {
+        method: "POST",
+        headers: { "Content-Type": "application/x-www-form-urlencoded" },
+        body: `_csrf=${encodeURIComponent(currentCsrfToken)}`,
+        redirect: "follow",
+      });
+
+      if (!response.ok) {
+        console.error(
+          `Request failed with status ${response.status} after generating ${passcodes.length} passcodes`
+        );
+        break;
+      }
+
+      const html = parser.parseFromString(await response.text(), "text/html");
+      const passcode = html
+        .querySelector(".govuk-panel__body strong")
+        ?.textContent?.trim();
+
+      if (!passcode) {
+        console.error(
+          `Could not extract passcode from response after generating ${passcodes.length} passcodes. ` +
+            "The passcode limit may have been reached."
+        );
+        break;
+      }
+
+      passcodes.push(passcode);
+
+      const freshToken = html.querySelector('input[name="_csrf"]')?.value;
+      if (freshToken) {
+        currentCsrfToken = freshToken;
+      }
+
+      if ((i + 1) % 10 === 0 || i + 1 === count) {
+        console.log(`Generated ${i + 1}/${count}`);
+      }
+    } catch (error) {
+      console.error(
+        `Error after generating ${passcodes.length} passcodes:`,
+        error
+      );
+      break;
+    }
+  }
+
+  if (passcodes.length === 0) {
+    console.error("No passcodes were generated");
+    return;
+  }
+
+  const csv = "passcode\n" + passcodes.join("\n") + "\n";
+  const blob = new Blob([csv], { type: "text/csv" });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = "passcodes.csv";
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  URL.revokeObjectURL(url);
+
+  console.log(
+    `Done. ${passcodes.length} passcode(s) downloaded to passcodes.csv`
+  );
+}
+
+(function () {
+  const input = prompt("How many passcodes do you want to generate?");
+  if (input === null) {
+    console.log("Cancelled");
+    return;
+  }
+  const count = parseInt(input, 10);
+  if (!Number.isInteger(count) || count < 1) {
+    console.error("Count must be a positive integer");
+    return;
+  }
+  generatePasscodes(count);
+})();


### PR DESCRIPTION
## Ticket number

PDJB-682

## Goal of change

Automate bulk generation of landlord passcodes for system operators during private beta.

## Description of main change(s)

- Adds a browser console script (`scripts/generate_passcodes.js`) that bulk-generates passcodes and downloads them as a CSV file
- The operator pastes the script into the console on the generate passcode page, enters the desired count when prompted, and receives a `passcodes.csv` download
- Uses the existing POST endpoint, extracting fresh CSRF tokens from each response

## Anything you'd like to highlight to the reviewer?

This is a standalone script not integrated into the frontend build. It is intended to be pasted into the browser console by a system operator.

## Checklist

- [x] Branch has been rebased onto main and run locally, with everything working as expected (both for your new feature and any related functionality)