### PR TITLE
PDJB-670: EPC CYA page

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/EpcRegistrationCyaSummaryRowsFactory.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/EpcRegistrationCyaSummaryRowsFactory.kt
@@ -16,7 +16,7 @@ class EpcRegistrationCyaSummaryRowsFactory(
 
     fun createEpcCardActions(): List<SummaryCardActionViewModel>? {
         if (!isEpcCardShown()) return null
-        val epc = state.acceptedEpc!!
+        val epc = state.acceptedEpc ?: throw IllegalStateException("An EPC should be present when showing EPC card")
         val epcUrl = epcCertificateUrlProvider.getEpcCertificateUrl(epc.certificateNumber)
         val changeUrl = Destination(state.hasEpcStep).toUrlStringOrNull()
         return listOfNotNull(
@@ -31,7 +31,7 @@ class EpcRegistrationCyaSummaryRowsFactory(
 
     fun createEpcCardRows(): List<SummaryListRowViewModel>? {
         if (!isEpcCardShown()) return null
-        val epc = state.acceptedEpc!!
+        val epc = state.acceptedEpc ?: throw IllegalStateException("An EPC should be present when showing EPC card")
         return listOf(
             SummaryListRowViewModel.forCheckYourAnswersPage(
                 "propertyCompliance.epcTask.checkEpcAnswers.epc.address",
@@ -101,11 +101,14 @@ class EpcRegistrationCyaSummaryRowsFactory(
             EpcScenario.VALID_EPC,
             EpcScenario.EPC_EXPIRED_IN_DATE_OCCUPIED,
             -> "propertyCompliance.epcTask.checkEpcAnswers.epc.meetsRequirements"
+
             EpcScenario.LOW_ENERGY_EPC_NO_EXEMPTION_OCCUPIED,
             EpcScenario.EPC_EXPIRED_NOT_IN_DATE_OCCUPIED,
             EpcScenario.LOW_ENERGY_EPC_EXPIRED_IN_DATE_NO_EXEMPTION_OCCUPIED,
             -> "propertyCompliance.epcTask.checkEpcAnswers.epc.lowRatingOccupiedInset"
+
             EpcScenario.NO_EPC_NO_EXEMPTION_OCCUPIED -> "propertyCompliance.epcTask.checkEpcAnswers.occupiedNoEpcInset"
+
             else -> null
         }
 
@@ -119,6 +122,7 @@ class EpcRegistrationCyaSummaryRowsFactory(
             EpcScenario.LOW_ENERGY_EPC_EXPIRED_IN_DATE_MEES_EXEMPTION_OCCUPIED,
             EpcScenario.LOW_ENERGY_EPC_EXPIRED_IN_DATE_NO_EXEMPTION_OCCUPIED,
             -> true
+
             else -> false
         }
 
@@ -129,6 +133,7 @@ class EpcRegistrationCyaSummaryRowsFactory(
             EpcScenario.LOW_ENERGY_EPC_EXPIRED_IN_DATE_MEES_EXEMPTION_OCCUPIED,
             EpcScenario.LOW_ENERGY_EPC_EXPIRED_IN_DATE_NO_EXEMPTION_OCCUPIED,
             -> true
+
             else -> false
         }
 
@@ -139,6 +144,7 @@ class EpcRegistrationCyaSummaryRowsFactory(
             EpcScenario.LOW_ENERGY_EPC_EXPIRED_IN_DATE_MEES_EXEMPTION_OCCUPIED,
             EpcScenario.LOW_ENERGY_EPC_EXPIRED_IN_DATE_NO_EXEMPTION_OCCUPIED,
             -> true
+
             else -> false
         }
 
@@ -147,6 +153,7 @@ class EpcRegistrationCyaSummaryRowsFactory(
             EpcScenario.LOW_ENERGY_EPC_MEES_EXEMPTION,
             EpcScenario.LOW_ENERGY_EPC_EXPIRED_IN_DATE_MEES_EXEMPTION_OCCUPIED,
             -> true
+
             else -> false
         }
 
@@ -154,11 +161,13 @@ class EpcRegistrationCyaSummaryRowsFactory(
         val fieldValue =
             when (scenario) {
                 EpcScenario.SKIPPED_OCCUPIED -> "propertyCompliance.epcTask.checkEpcAnswers.hasEpc.provideEpcLaterOccupied"
+
                 EpcScenario.SKIPPED_UNOCCUPIED,
                 EpcScenario.EPC_EXPIRED_UNOCCUPIED,
                 EpcScenario.LOW_ENERGY_EPC_NO_EXEMPTION_UNOCCUPIED,
                 EpcScenario.NO_EPC_NO_EXEMPTION_UNOCCUPIED,
                 -> "propertyCompliance.epcTask.checkEpcAnswers.hasEpc.provideEpcLaterUnoccupied"
+
                 else -> "commonText.no"
             }
         return SummaryListRowViewModel.forCheckYourAnswersPage(
@@ -172,23 +181,31 @@ class EpcRegistrationCyaSummaryRowsFactory(
         when (scenario) {
             EpcScenario.NO_EPC_EXEMPT,
             EpcScenario.NO_EPC_NO_EXEMPTION_OCCUPIED,
-            ->
+            -> {
                 SummaryListRowViewModel.forCheckYourAnswersPage(
                     "propertyCompliance.epcTask.checkEpcAnswers.isEpcRequired",
                     state.isEpcRequiredStep.formModelIfReachableOrNull?.epcRequired,
                     Destination(state.isEpcRequiredStep),
                 )
-            else -> null
+            }
+
+            else -> {
+                null
+            }
         }
 
     private fun createEpcExemptionRow(): SummaryListRowViewModel? =
         when (scenario) {
-            EpcScenario.NO_EPC_EXEMPT ->
+            EpcScenario.NO_EPC_EXEMPT -> {
                 SummaryListRowViewModel.forCheckYourAnswersPage(
                     "propertyCompliance.epcTask.checkEpcAnswers.epcExemption",
                     state.epcExemptionStep.formModelIfReachableOrNull?.exemptionReason,
                     Destination(state.epcExemptionStep),
                 )
-            else -> null
+            }
+
+            else -> {
+                null
+            }
         }
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/EpcRegistrationCyaSummaryRowsFactory.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/EpcRegistrationCyaSummaryRowsFactory.kt
@@ -2,27 +2,24 @@ package uk.gov.communities.prsdb.webapp.journeys.propertyRegistration
 
 import uk.gov.communities.prsdb.webapp.journeys.Destination
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.EpcState
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.EpcAgeAndEnergyRatingCheckMode
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.EpcAgeCheckMode
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.EpcEnergyRatingCheckMode
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.EpcInDateAtStartOfTenancyCheckMode
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.HasEpcMode
 import uk.gov.communities.prsdb.webapp.journeys.shared.YesOrNo
 import uk.gov.communities.prsdb.webapp.models.viewModels.summaryModels.SummaryCardActionViewModel
 import uk.gov.communities.prsdb.webapp.models.viewModels.summaryModels.SummaryListRowViewModel
 import uk.gov.communities.prsdb.webapp.services.EpcCertificateUrlProvider
-import java.time.ZoneId
-import java.time.format.DateTimeFormatter
-import java.util.Locale
 
 class EpcRegistrationCyaSummaryRowsFactory(
     private val epcCertificateUrlProvider: EpcCertificateUrlProvider,
     private val state: EpcState,
 ) {
-    // --- EPC Summary Card (shown when user has an accepted EPC) ---
-
-    fun createEpcCardTitle(): String? = if (state.acceptedEpc != null) "propertyCompliance.epcTask.checkEpcAnswers.epc.yourEpc" else null
+    fun createEpcCardTitle(): String? = if (!isEpcCardHidden()) "propertyCompliance.epcTask.checkEpcAnswers.epc.yourEpc" else null
 
     fun createEpcCardActions(): List<SummaryCardActionViewModel>? {
-        val epc = state.acceptedEpc ?: return null
+        if (isEpcCardHidden()) return null
+        val epc = state.acceptedEpc!!
         val epcUrl = epcCertificateUrlProvider.getEpcCertificateUrl(epc.certificateNumber)
         val changeUrl = Destination(state.hasEpcStep).toUrlStringOrNull()
         return listOfNotNull(
@@ -36,35 +33,33 @@ class EpcRegistrationCyaSummaryRowsFactory(
     }
 
     fun createEpcCardRows(): List<SummaryListRowViewModel>? {
-        val epc = state.acceptedEpc ?: return null
+        if (isEpcCardHidden()) return null
+        val epc = state.acceptedEpc!!
         return listOf(
             SummaryListRowViewModel.forCheckYourAnswersPage(
                 "propertyCompliance.epcTask.checkEpcAnswers.epc.address",
                 epc.singleLineAddress,
-                null as String?,
+                null,
             ),
             SummaryListRowViewModel.forCheckYourAnswersPage(
                 "propertyCompliance.epcTask.checkEpcAnswers.epc.energyRating",
                 epc.energyRatingUppercase,
-                null as String?,
+                null,
             ),
             SummaryListRowViewModel.forCheckYourAnswersPage(
                 "propertyCompliance.epcTask.checkEpcAnswers.epc.expiryDate",
                 epc.expiryDateAsJavaLocalDate,
-                null as String?,
+                null,
             ),
             SummaryListRowViewModel.forCheckYourAnswersPage(
                 "propertyCompliance.epcTask.checkEpcAnswers.epc.certificateNumber",
                 epc.certificateNumber,
-                null as String?,
+                null,
             ),
         )
     }
 
-    // --- Status texts and rows below the EPC card ---
-
-    fun showEpcExpiredText(): Boolean =
-        state.epcAgeAndEnergyRatingCheckStep.outcome == EpcAgeAndEnergyRatingCheckMode.EPC_OLDER_THAN_10_YEARS
+    fun showEpcExpiredText(): Boolean = isEpcExpired() && !isEpcCardHidden()
 
     fun createTenancyCheckRows(): List<SummaryListRowViewModel> {
         val formModel = state.epcInDateAtStartOfTenancyCheckStep.formModelIfReachableOrNull ?: return emptyList()
@@ -78,86 +73,109 @@ class EpcRegistrationCyaSummaryRowsFactory(
     }
 
     fun showMeetsRequirementsInset(): Boolean {
-        val ageCheck = state.epcAgeAndEnergyRatingCheckStep.outcome
+        val energyRatingCheck = state.epcEnergyRatingCheckStep.outcome
+        if (energyRatingCheck != EpcEnergyRatingCheckMode.EPC_MEETS_ENERGY_REQUIREMENTS) return false
+
+        val ageCheck = state.epcAgeCheckStep.outcome
         val tenancyCheck = state.epcInDateAtStartOfTenancyCheckStep.outcome
-        return ageCheck == EpcAgeAndEnergyRatingCheckMode.EPC_COMPLIANT ||
+        return ageCheck == EpcAgeCheckMode.EPC_10_YEARS_OR_NEWER ||
             tenancyCheck == EpcInDateAtStartOfTenancyCheckMode.IN_DATE
     }
 
-    fun showLowRatingText(): Boolean = state.hasMeesExemptionStep.isStepReachable
+    fun showLowRatingText(): Boolean = showMeesExemptionSection()
 
     fun createAdditionalRows(): List<SummaryListRowViewModel> {
-        if (!state.hasMeesExemptionStep.isStepReachable) return emptyList()
-        return buildList {
-            add(
-                SummaryListRowViewModel.forCheckYourAnswersPage(
-                    "propertyCompliance.epcTask.checkEpcAnswers.epc.meesExemptionCheck",
-                    state.hasMeesExemptionStep.formModelIfReachableOrNull?.propertyHasExemption,
-                    Destination(state.hasMeesExemptionStep),
-                ),
-            )
+        if (!showMeesExemptionSection()) return emptyList()
+        return listOfNotNull(
+            SummaryListRowViewModel.forCheckYourAnswersPage(
+                "propertyCompliance.epcTask.checkEpcAnswers.epc.meesExemptionCheck",
+                state.hasMeesExemptionStep.formModelIfReachableOrNull?.propertyHasExemption,
+                Destination(state.hasMeesExemptionStep),
+            ),
             if (state.meesExemptionStep.isStepReachable) {
-                add(
-                    SummaryListRowViewModel.forCheckYourAnswersPage(
-                        "propertyCompliance.epcTask.checkEpcAnswers.epc.meesExemption",
-                        state.meesExemptionStep.formModelIfReachableOrNull?.exemptionReason,
-                        Destination(state.meesExemptionStep),
-                    ),
+                SummaryListRowViewModel.forCheckYourAnswersPage(
+                    "propertyCompliance.epcTask.checkEpcAnswers.epc.meesExemption",
+                    state.meesExemptionStep.formModelIfReachableOrNull?.exemptionReason,
+                    Destination(state.meesExemptionStep),
                 )
-            }
-        }
+            } else {
+                null
+            },
+        )
     }
 
-    fun showLowRatingOccupiedInset(): Boolean = state.lowEnergyRatingStep.isStepReachable && state.isOccupied == true
-
-    // --- Non-EPC rows (shown when no accepted EPC) ---
+    fun showLowRatingOccupiedInset(): Boolean =
+        state.isOccupied == true &&
+            (
+                state.lowEnergyRatingStep.isStepReachable ||
+                    (isEpcExpired() && state.epcInDateAtStartOfTenancyCheckStep.outcome == EpcInDateAtStartOfTenancyCheckMode.NOT_IN_DATE)
+            )
 
     fun createNonEpcRows(): List<SummaryListRowViewModel> {
-        if (state.acceptedEpc != null) return emptyList()
-        return buildList {
-            add(getHasEpcRow())
-            if (state.isEpcRequiredStep.isStepReachable) {
-                add(
-                    SummaryListRowViewModel.forCheckYourAnswersPage(
-                        "propertyCompliance.epcTask.checkEpcAnswers.isEpcRequired",
-                        state.isEpcRequiredStep.formModelIfReachableOrNull?.epcRequired,
-                        Destination(state.isEpcRequiredStep),
-                    ),
+        if (!isEpcCardHidden()) return emptyList()
+        return listOfNotNull(
+            getHasEpcRow(),
+            if (state.isEpcRequiredStep.isStepReachable &&
+                (state.isOccupied == true || state.isEpcRequiredStep.outcome == YesOrNo.NO)
+            ) {
+                SummaryListRowViewModel.forCheckYourAnswersPage(
+                    "propertyCompliance.epcTask.checkEpcAnswers.isEpcRequired",
+                    state.isEpcRequiredStep.formModelIfReachableOrNull?.epcRequired,
+                    Destination(state.isEpcRequiredStep),
                 )
-            }
+            } else {
+                null
+            },
             if (state.epcExemptionStep.isStepReachable) {
-                add(
-                    SummaryListRowViewModel.forCheckYourAnswersPage(
-                        "propertyCompliance.epcTask.checkEpcAnswers.epcExemption",
-                        state.epcExemptionStep.formModelIfReachableOrNull?.exemptionReason,
-                        Destination(state.epcExemptionStep),
-                    ),
+                SummaryListRowViewModel.forCheckYourAnswersPage(
+                    "propertyCompliance.epcTask.checkEpcAnswers.epcExemption",
+                    state.epcExemptionStep.formModelIfReachableOrNull?.exemptionReason,
+                    Destination(state.epcExemptionStep),
                 )
-            }
-        }
+            } else {
+                null
+            },
+        )
     }
 
     fun showOccupiedNoEpcInset(): Boolean = state.isEpcRequiredStep.outcome == YesOrNo.YES && state.isOccupied == true
 
+    private fun isEpcExpired(): Boolean = state.epcAgeCheckStep.outcome == EpcAgeCheckMode.EPC_OLDER_THAN_10_YEARS
+
+    private fun isExpiredEpcUnoccupied(): Boolean = isEpcExpired() && state.isOccupied == false
+
+    private fun isLowRatingNoExemptionUnoccupied(): Boolean =
+        state.hasMeesExemptionStep.isStepReachable &&
+            !state.meesExemptionStep.isStepReachable &&
+            state.isOccupied == false
+
+    private fun isEpcCardHiddenDueToUnoccupied(): Boolean = isExpiredEpcUnoccupied() || isLowRatingNoExemptionUnoccupied()
+
+    private fun isEpcCardHidden(): Boolean =
+        state.acceptedEpc == null ||
+            state.hasEpcStep.outcome == HasEpcMode.PROVIDE_LATER ||
+            state.hasEpcStep.outcome == HasEpcMode.NO_EPC ||
+            isEpcCardHiddenDueToUnoccupied()
+
+    private fun showMeesExemptionSection(): Boolean = state.hasMeesExemptionStep.isStepReachable && !isEpcCardHidden()
+
     private fun getHasEpcRow(): SummaryListRowViewModel {
         val fieldValue =
             when {
-                state.hasEpcStep.outcome == HasEpcMode.PROVIDE_LATER && state.isOccupied == true -> {
-                    val deadline =
-                        java.time.LocalDate
-                            .now(ZoneId.of("Europe/London"))
-                            .plusDays(28)
-                            .format(DateTimeFormatter.ofPattern("d MMMM yyyy", Locale.ENGLISH))
-                    "Provide this later (before $deadline)"
-                }
+                state.hasEpcStep.outcome == HasEpcMode.PROVIDE_LATER && state.isOccupied == true ->
+                    "propertyCompliance.epcTask.checkEpcAnswers.hasEpc.provideEpcLaterOccupied"
 
-                state.hasEpcStep.outcome == HasEpcMode.PROVIDE_LATER -> {
+                state.hasEpcStep.outcome == HasEpcMode.PROVIDE_LATER ||
+                    isEpcCardHiddenDueToUnoccupied() ||
+                    (
+                        state.hasEpcStep.outcome == HasEpcMode.NO_EPC &&
+                            state.isOccupied == false &&
+                            state.isEpcRequiredStep.outcome == YesOrNo.YES
+                    ) ->
                     "propertyCompliance.epcTask.checkEpcAnswers.hasEpc.provideEpcLaterUnoccupied"
-                }
 
-                else -> {
+                else ->
                     "commonText.no"
-                }
             }
         return SummaryListRowViewModel.forCheckYourAnswersPage(
             "propertyCompliance.epcTask.checkEpcAnswers.hasEpc.label",

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/EpcRegistrationCyaSummaryRowsFactory.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/EpcRegistrationCyaSummaryRowsFactory.kt
@@ -56,83 +56,44 @@ class EpcRegistrationCyaSummaryRowsFactory(
         )
     }
 
-    fun getEpcExpiredTextKey(): String? =
-        when (scenario) {
-            EpcScenario.EPC_EXPIRED_NOT_IN_DATE_OCCUPIED,
-            EpcScenario.EPC_EXPIRED_IN_DATE_OCCUPIED,
-            EpcScenario.LOW_ENERGY_EPC_EXPIRED_IN_DATE_MEES_EXEMPTION_OCCUPIED,
-            EpcScenario.LOW_ENERGY_EPC_EXPIRED_IN_DATE_NO_EXEMPTION_OCCUPIED,
-            -> "propertyCompliance.epcTask.checkEpcAnswers.epc.expired"
-            else -> null
-        }
+    fun getEpcExpiredTextKey(): String? = if (epcIsExpired()) "propertyCompliance.epcTask.checkEpcAnswers.epc.expired" else null
 
-    fun createTenancyCheckRows(): List<SummaryListRowViewModel> =
-        when (scenario) {
-            EpcScenario.EPC_EXPIRED_NOT_IN_DATE_OCCUPIED,
-            EpcScenario.EPC_EXPIRED_IN_DATE_OCCUPIED,
-            EpcScenario.LOW_ENERGY_EPC_EXPIRED_IN_DATE_MEES_EXEMPTION_OCCUPIED,
-            EpcScenario.LOW_ENERGY_EPC_EXPIRED_IN_DATE_NO_EXEMPTION_OCCUPIED,
-            ->
-                listOf(
-                    SummaryListRowViewModel.forCheckYourAnswersPage(
-                        "propertyCompliance.epcTask.checkEpcAnswers.epc.tenancyStartCheck",
-                        state.epcInDateAtStartOfTenancyCheckStep.formModelIfReachableOrNull?.tenancyStartedBeforeExpiry,
-                        Destination(state.epcInDateAtStartOfTenancyCheckStep),
-                    ),
-                )
-            else -> emptyList()
-        }
+    fun createTenancyCheckRows(): List<SummaryListRowViewModel> {
+        if (!epcIsExpired()) return emptyList()
+        return listOf(
+            SummaryListRowViewModel.forCheckYourAnswersPage(
+                "propertyCompliance.epcTask.checkEpcAnswers.epc.tenancyStartCheck",
+                state.epcInDateAtStartOfTenancyCheckStep.formModelIfReachableOrNull?.tenancyStartedBeforeExpiry,
+                Destination(state.epcInDateAtStartOfTenancyCheckStep),
+            ),
+        )
+    }
 
-    fun getLowRatingTextKey(): String? =
-        when (scenario) {
-            EpcScenario.LOW_ENERGY_EPC_MEES_EXEMPTION,
-            EpcScenario.LOW_ENERGY_EPC_NO_EXEMPTION_OCCUPIED,
-            EpcScenario.LOW_ENERGY_EPC_EXPIRED_IN_DATE_MEES_EXEMPTION_OCCUPIED,
-            EpcScenario.LOW_ENERGY_EPC_EXPIRED_IN_DATE_NO_EXEMPTION_OCCUPIED,
-            -> "propertyCompliance.epcTask.checkEpcAnswers.epc.lowRating"
-            else -> null
-        }
+    fun getLowRatingTextKey(): String? = if (epcIsLowRating()) "propertyCompliance.epcTask.checkEpcAnswers.epc.lowRating" else null
 
     fun createAdditionalRows(): List<SummaryListRowViewModel> {
+        if (!epcIsLowRating()) return emptyList()
         val hasMeesExemptionRow =
             SummaryListRowViewModel.forCheckYourAnswersPage(
                 "propertyCompliance.epcTask.checkEpcAnswers.epc.meesExemptionCheck",
                 state.hasMeesExemptionStep.formModelIfReachableOrNull?.propertyHasExemption,
                 Destination(state.hasMeesExemptionStep),
             )
+        if (!epcHasMeesExemption()) return listOf(hasMeesExemptionRow)
         val meesExemptionRow =
             SummaryListRowViewModel.forCheckYourAnswersPage(
                 "propertyCompliance.epcTask.checkEpcAnswers.epc.meesExemption",
                 state.meesExemptionStep.formModelIfReachableOrNull?.exemptionReason,
                 Destination(state.meesExemptionStep),
             )
-        return when (scenario) {
-            EpcScenario.LOW_ENERGY_EPC_MEES_EXEMPTION,
-            EpcScenario.LOW_ENERGY_EPC_EXPIRED_IN_DATE_MEES_EXEMPTION_OCCUPIED,
-            -> listOf(hasMeesExemptionRow, meesExemptionRow)
-            EpcScenario.LOW_ENERGY_EPC_NO_EXEMPTION_OCCUPIED,
-            EpcScenario.LOW_ENERGY_EPC_EXPIRED_IN_DATE_NO_EXEMPTION_OCCUPIED,
-            -> listOf(hasMeesExemptionRow)
-            else -> emptyList()
-        }
+        return listOf(hasMeesExemptionRow, meesExemptionRow)
     }
 
     fun createNonEpcRows(): List<SummaryListRowViewModel> =
-        when (scenario) {
-            EpcScenario.NO_EPC_EXEMPT,
-            EpcScenario.NO_EPC_NO_EXEMPTION_UNOCCUPIED,
-            EpcScenario.NO_EPC_NO_EXEMPTION_OCCUPIED,
-            EpcScenario.SKIPPED_UNOCCUPIED,
-            EpcScenario.SKIPPED_OCCUPIED,
-            EpcScenario.EPC_EXPIRED_UNOCCUPIED,
-            EpcScenario.LOW_ENERGY_EPC_NO_EXEMPTION_UNOCCUPIED,
-            ->
-                listOfNotNull(
-                    getHasEpcRow(),
-                    createIsEpcRequiredRow(),
-                    createEpcExemptionRow(),
-                )
-            else -> emptyList()
+        if (isEpcCardShown()) {
+            emptyList()
+        } else {
+            listOfNotNull(getHasEpcRow(), createIsEpcRequiredRow(), createEpcExemptionRow())
         }
 
     fun getInsetTextKey(): String? =
@@ -142,6 +103,7 @@ class EpcRegistrationCyaSummaryRowsFactory(
             -> "propertyCompliance.epcTask.checkEpcAnswers.epc.meetsRequirements"
             EpcScenario.LOW_ENERGY_EPC_NO_EXEMPTION_OCCUPIED,
             EpcScenario.EPC_EXPIRED_NOT_IN_DATE_OCCUPIED,
+            EpcScenario.LOW_ENERGY_EPC_EXPIRED_IN_DATE_NO_EXEMPTION_OCCUPIED,
             -> "propertyCompliance.epcTask.checkEpcAnswers.epc.lowRatingOccupiedInset"
             EpcScenario.NO_EPC_NO_EXEMPTION_OCCUPIED -> "propertyCompliance.epcTask.checkEpcAnswers.occupiedNoEpcInset"
             else -> null
@@ -156,6 +118,34 @@ class EpcRegistrationCyaSummaryRowsFactory(
             EpcScenario.EPC_EXPIRED_IN_DATE_OCCUPIED,
             EpcScenario.LOW_ENERGY_EPC_EXPIRED_IN_DATE_MEES_EXEMPTION_OCCUPIED,
             EpcScenario.LOW_ENERGY_EPC_EXPIRED_IN_DATE_NO_EXEMPTION_OCCUPIED,
+            -> true
+            else -> false
+        }
+
+    private fun epcIsExpired(): Boolean =
+        when (scenario) {
+            EpcScenario.EPC_EXPIRED_NOT_IN_DATE_OCCUPIED,
+            EpcScenario.EPC_EXPIRED_IN_DATE_OCCUPIED,
+            EpcScenario.LOW_ENERGY_EPC_EXPIRED_IN_DATE_MEES_EXEMPTION_OCCUPIED,
+            EpcScenario.LOW_ENERGY_EPC_EXPIRED_IN_DATE_NO_EXEMPTION_OCCUPIED,
+            -> true
+            else -> false
+        }
+
+    private fun epcIsLowRating(): Boolean =
+        when (scenario) {
+            EpcScenario.LOW_ENERGY_EPC_MEES_EXEMPTION,
+            EpcScenario.LOW_ENERGY_EPC_NO_EXEMPTION_OCCUPIED,
+            EpcScenario.LOW_ENERGY_EPC_EXPIRED_IN_DATE_MEES_EXEMPTION_OCCUPIED,
+            EpcScenario.LOW_ENERGY_EPC_EXPIRED_IN_DATE_NO_EXEMPTION_OCCUPIED,
+            -> true
+            else -> false
+        }
+
+    private fun epcHasMeesExemption(): Boolean =
+        when (scenario) {
+            EpcScenario.LOW_ENERGY_EPC_MEES_EXEMPTION,
+            EpcScenario.LOW_ENERGY_EPC_EXPIRED_IN_DATE_MEES_EXEMPTION_OCCUPIED,
             -> true
             else -> false
         }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/EpcRegistrationCyaSummaryRowsFactory.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/EpcRegistrationCyaSummaryRowsFactory.kt
@@ -1,0 +1,168 @@
+package uk.gov.communities.prsdb.webapp.journeys.propertyRegistration
+
+import uk.gov.communities.prsdb.webapp.journeys.Destination
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.EpcState
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.EpcAgeAndEnergyRatingCheckMode
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.EpcInDateAtStartOfTenancyCheckMode
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.HasEpcMode
+import uk.gov.communities.prsdb.webapp.journeys.shared.YesOrNo
+import uk.gov.communities.prsdb.webapp.models.viewModels.summaryModels.SummaryCardActionViewModel
+import uk.gov.communities.prsdb.webapp.models.viewModels.summaryModels.SummaryListRowViewModel
+import uk.gov.communities.prsdb.webapp.services.EpcCertificateUrlProvider
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+import java.util.Locale
+
+class EpcRegistrationCyaSummaryRowsFactory(
+    private val epcCertificateUrlProvider: EpcCertificateUrlProvider,
+    private val state: EpcState,
+) {
+    // --- EPC Summary Card (shown when user has an accepted EPC) ---
+
+    fun createEpcCardTitle(): String? = if (state.acceptedEpc != null) "propertyCompliance.epcTask.checkEpcAnswers.epc.yourEpc" else null
+
+    fun createEpcCardActions(): List<SummaryCardActionViewModel>? {
+        val epc = state.acceptedEpc ?: return null
+        val epcUrl = epcCertificateUrlProvider.getEpcCertificateUrl(epc.certificateNumber)
+        val changeUrl = Destination(state.hasEpcStep).toUrlStringOrNull()
+        return listOfNotNull(
+            SummaryCardActionViewModel(
+                "propertyCompliance.epcTask.checkEpcAnswers.epc.viewFullEpc",
+                epcUrl,
+                opensInNewTab = true,
+            ),
+            changeUrl?.let { SummaryCardActionViewModel("forms.links.change", it) },
+        )
+    }
+
+    fun createEpcCardRows(): List<SummaryListRowViewModel>? {
+        val epc = state.acceptedEpc ?: return null
+        return listOf(
+            SummaryListRowViewModel.forCheckYourAnswersPage(
+                "propertyCompliance.epcTask.checkEpcAnswers.epc.address",
+                epc.singleLineAddress,
+                null as String?,
+            ),
+            SummaryListRowViewModel.forCheckYourAnswersPage(
+                "propertyCompliance.epcTask.checkEpcAnswers.epc.energyRating",
+                epc.energyRatingUppercase,
+                null as String?,
+            ),
+            SummaryListRowViewModel.forCheckYourAnswersPage(
+                "propertyCompliance.epcTask.checkEpcAnswers.epc.expiryDate",
+                epc.expiryDateAsJavaLocalDate,
+                null as String?,
+            ),
+            SummaryListRowViewModel.forCheckYourAnswersPage(
+                "propertyCompliance.epcTask.checkEpcAnswers.epc.certificateNumber",
+                epc.certificateNumber,
+                null as String?,
+            ),
+        )
+    }
+
+    // --- Status texts and rows below the EPC card ---
+
+    fun showEpcExpiredText(): Boolean =
+        state.epcAgeAndEnergyRatingCheckStep.outcome == EpcAgeAndEnergyRatingCheckMode.EPC_OLDER_THAN_10_YEARS
+
+    fun createTenancyCheckRows(): List<SummaryListRowViewModel> {
+        val formModel = state.epcInDateAtStartOfTenancyCheckStep.formModelIfReachableOrNull ?: return emptyList()
+        return listOf(
+            SummaryListRowViewModel.forCheckYourAnswersPage(
+                "propertyCompliance.epcTask.checkEpcAnswers.epc.tenancyStartCheck",
+                formModel.tenancyStartedBeforeExpiry,
+                Destination(state.epcInDateAtStartOfTenancyCheckStep),
+            ),
+        )
+    }
+
+    fun showMeetsRequirementsInset(): Boolean {
+        val ageCheck = state.epcAgeAndEnergyRatingCheckStep.outcome
+        val tenancyCheck = state.epcInDateAtStartOfTenancyCheckStep.outcome
+        return ageCheck == EpcAgeAndEnergyRatingCheckMode.EPC_COMPLIANT ||
+            tenancyCheck == EpcInDateAtStartOfTenancyCheckMode.IN_DATE
+    }
+
+    fun showLowRatingText(): Boolean = state.hasMeesExemptionStep.isStepReachable
+
+    fun createAdditionalRows(): List<SummaryListRowViewModel> {
+        if (!state.hasMeesExemptionStep.isStepReachable) return emptyList()
+        return buildList {
+            add(
+                SummaryListRowViewModel.forCheckYourAnswersPage(
+                    "propertyCompliance.epcTask.checkEpcAnswers.epc.meesExemptionCheck",
+                    state.hasMeesExemptionStep.formModelIfReachableOrNull?.propertyHasExemption,
+                    Destination(state.hasMeesExemptionStep),
+                ),
+            )
+            if (state.meesExemptionStep.isStepReachable) {
+                add(
+                    SummaryListRowViewModel.forCheckYourAnswersPage(
+                        "propertyCompliance.epcTask.checkEpcAnswers.epc.meesExemption",
+                        state.meesExemptionStep.formModelIfReachableOrNull?.exemptionReason,
+                        Destination(state.meesExemptionStep),
+                    ),
+                )
+            }
+        }
+    }
+
+    fun showLowRatingOccupiedInset(): Boolean = state.lowEnergyRatingStep.isStepReachable && state.isOccupied == true
+
+    // --- Non-EPC rows (shown when no accepted EPC) ---
+
+    fun createNonEpcRows(): List<SummaryListRowViewModel> {
+        if (state.acceptedEpc != null) return emptyList()
+        return buildList {
+            add(getHasEpcRow())
+            if (state.isEpcRequiredStep.isStepReachable) {
+                add(
+                    SummaryListRowViewModel.forCheckYourAnswersPage(
+                        "propertyCompliance.epcTask.checkEpcAnswers.isEpcRequired",
+                        state.isEpcRequiredStep.formModelIfReachableOrNull?.epcRequired,
+                        Destination(state.isEpcRequiredStep),
+                    ),
+                )
+            }
+            if (state.epcExemptionStep.isStepReachable) {
+                add(
+                    SummaryListRowViewModel.forCheckYourAnswersPage(
+                        "propertyCompliance.epcTask.checkEpcAnswers.epcExemption",
+                        state.epcExemptionStep.formModelIfReachableOrNull?.exemptionReason,
+                        Destination(state.epcExemptionStep),
+                    ),
+                )
+            }
+        }
+    }
+
+    fun showOccupiedNoEpcInset(): Boolean = state.isEpcRequiredStep.outcome == YesOrNo.YES && state.isOccupied == true
+
+    private fun getHasEpcRow(): SummaryListRowViewModel {
+        val fieldValue =
+            when {
+                state.hasEpcStep.outcome == HasEpcMode.PROVIDE_LATER && state.isOccupied == true -> {
+                    val deadline =
+                        java.time.LocalDate
+                            .now(ZoneId.of("Europe/London"))
+                            .plusDays(28)
+                            .format(DateTimeFormatter.ofPattern("d MMMM yyyy", Locale.ENGLISH))
+                    "Provide this later (before $deadline)"
+                }
+
+                state.hasEpcStep.outcome == HasEpcMode.PROVIDE_LATER -> {
+                    "propertyCompliance.epcTask.checkEpcAnswers.hasEpc.provideEpcLaterUnoccupied"
+                }
+
+                else -> {
+                    "commonText.no"
+                }
+            }
+        return SummaryListRowViewModel.forCheckYourAnswersPage(
+            "propertyCompliance.epcTask.checkEpcAnswers.hasEpc.label",
+            fieldValue,
+            Destination(state.hasEpcStep),
+        )
+    }
+}

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/EpcRegistrationCyaSummaryRowsFactory.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/EpcRegistrationCyaSummaryRowsFactory.kt
@@ -2,11 +2,7 @@ package uk.gov.communities.prsdb.webapp.journeys.propertyRegistration
 
 import uk.gov.communities.prsdb.webapp.journeys.Destination
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.EpcState
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.EpcAgeCheckMode
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.EpcEnergyRatingCheckMode
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.EpcInDateAtStartOfTenancyCheckMode
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.HasEpcMode
-import uk.gov.communities.prsdb.webapp.journeys.shared.YesOrNo
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.EpcScenario
 import uk.gov.communities.prsdb.webapp.models.viewModels.summaryModels.SummaryCardActionViewModel
 import uk.gov.communities.prsdb.webapp.models.viewModels.summaryModels.SummaryListRowViewModel
 import uk.gov.communities.prsdb.webapp.services.EpcCertificateUrlProvider
@@ -14,11 +10,12 @@ import uk.gov.communities.prsdb.webapp.services.EpcCertificateUrlProvider
 class EpcRegistrationCyaSummaryRowsFactory(
     private val epcCertificateUrlProvider: EpcCertificateUrlProvider,
     private val state: EpcState,
+    private val scenario: EpcScenario,
 ) {
-    fun createEpcCardTitle(): String? = if (!isEpcCardHidden()) "propertyCompliance.epcTask.checkEpcAnswers.epc.yourEpc" else null
+    fun createEpcCardTitle(): String? = if (isEpcCardShown()) "propertyCompliance.epcTask.checkEpcAnswers.epc.yourEpc" else null
 
     fun createEpcCardActions(): List<SummaryCardActionViewModel>? {
-        if (isEpcCardHidden()) return null
+        if (!isEpcCardShown()) return null
         val epc = state.acceptedEpc!!
         val epcUrl = epcCertificateUrlProvider.getEpcCertificateUrl(epc.certificateNumber)
         val changeUrl = Destination(state.hasEpcStep).toUrlStringOrNull()
@@ -33,7 +30,7 @@ class EpcRegistrationCyaSummaryRowsFactory(
     }
 
     fun createEpcCardRows(): List<SummaryListRowViewModel>? {
-        if (isEpcCardHidden()) return null
+        if (!isEpcCardShown()) return null
         val epc = state.acceptedEpc!!
         return listOf(
             SummaryListRowViewModel.forCheckYourAnswersPage(
@@ -59,123 +56,120 @@ class EpcRegistrationCyaSummaryRowsFactory(
         )
     }
 
-    fun showEpcExpiredText(): Boolean = isEpcExpired() && !isEpcCardHidden()
+    fun getEpcExpiredTextKey(): String? =
+        when (scenario) {
+            EpcScenario.EPC_EXPIRED_NOT_IN_DATE_OCCUPIED,
+            EpcScenario.EPC_EXPIRED_IN_DATE_OCCUPIED,
+            EpcScenario.LOW_ENERGY_EPC_EXPIRED_IN_DATE_MEES_EXEMPTION_OCCUPIED,
+            EpcScenario.LOW_ENERGY_EPC_EXPIRED_IN_DATE_NO_EXEMPTION_OCCUPIED,
+            -> "propertyCompliance.epcTask.checkEpcAnswers.epc.expired"
+            else -> null
+        }
 
-    fun createTenancyCheckRows(): List<SummaryListRowViewModel> {
-        val formModel = state.epcInDateAtStartOfTenancyCheckStep.formModelIfReachableOrNull ?: return emptyList()
-        return listOf(
-            SummaryListRowViewModel.forCheckYourAnswersPage(
-                "propertyCompliance.epcTask.checkEpcAnswers.epc.tenancyStartCheck",
-                formModel.tenancyStartedBeforeExpiry,
-                Destination(state.epcInDateAtStartOfTenancyCheckStep),
-            ),
-        )
-    }
+    fun createTenancyCheckRows(): List<SummaryListRowViewModel> =
+        when (scenario) {
+            EpcScenario.EPC_EXPIRED_NOT_IN_DATE_OCCUPIED,
+            EpcScenario.EPC_EXPIRED_IN_DATE_OCCUPIED,
+            EpcScenario.LOW_ENERGY_EPC_EXPIRED_IN_DATE_MEES_EXEMPTION_OCCUPIED,
+            EpcScenario.LOW_ENERGY_EPC_EXPIRED_IN_DATE_NO_EXEMPTION_OCCUPIED,
+            ->
+                listOf(
+                    SummaryListRowViewModel.forCheckYourAnswersPage(
+                        "propertyCompliance.epcTask.checkEpcAnswers.epc.tenancyStartCheck",
+                        state.epcInDateAtStartOfTenancyCheckStep.formModelIfReachableOrNull?.tenancyStartedBeforeExpiry,
+                        Destination(state.epcInDateAtStartOfTenancyCheckStep),
+                    ),
+                )
+            else -> emptyList()
+        }
 
-    fun showMeetsRequirementsInset(): Boolean {
-        val energyRatingCheck = state.epcEnergyRatingCheckStep.outcome
-        if (energyRatingCheck != EpcEnergyRatingCheckMode.EPC_MEETS_ENERGY_REQUIREMENTS) return false
-
-        val ageCheck = state.epcAgeCheckStep.outcome
-        val tenancyCheck = state.epcInDateAtStartOfTenancyCheckStep.outcome
-        return ageCheck == EpcAgeCheckMode.EPC_10_YEARS_OR_NEWER ||
-            tenancyCheck == EpcInDateAtStartOfTenancyCheckMode.IN_DATE
-    }
-
-    fun showLowRatingText(): Boolean = showMeesExemptionSection()
+    fun getLowRatingTextKey(): String? =
+        when (scenario) {
+            EpcScenario.LOW_ENERGY_EPC_MEES_EXEMPTION,
+            EpcScenario.LOW_ENERGY_EPC_NO_EXEMPTION_OCCUPIED,
+            EpcScenario.LOW_ENERGY_EPC_EXPIRED_IN_DATE_MEES_EXEMPTION_OCCUPIED,
+            EpcScenario.LOW_ENERGY_EPC_EXPIRED_IN_DATE_NO_EXEMPTION_OCCUPIED,
+            -> "propertyCompliance.epcTask.checkEpcAnswers.epc.lowRating"
+            else -> null
+        }
 
     fun createAdditionalRows(): List<SummaryListRowViewModel> {
-        if (!showMeesExemptionSection()) return emptyList()
-        return listOfNotNull(
+        val hasMeesExemptionRow =
             SummaryListRowViewModel.forCheckYourAnswersPage(
                 "propertyCompliance.epcTask.checkEpcAnswers.epc.meesExemptionCheck",
                 state.hasMeesExemptionStep.formModelIfReachableOrNull?.propertyHasExemption,
                 Destination(state.hasMeesExemptionStep),
-            ),
-            if (state.meesExemptionStep.isStepReachable) {
-                SummaryListRowViewModel.forCheckYourAnswersPage(
-                    "propertyCompliance.epcTask.checkEpcAnswers.epc.meesExemption",
-                    state.meesExemptionStep.formModelIfReachableOrNull?.exemptionReason,
-                    Destination(state.meesExemptionStep),
-                )
-            } else {
-                null
-            },
-        )
-    }
-
-    fun showLowRatingOccupiedInset(): Boolean =
-        state.isOccupied == true &&
-            (
-                state.lowEnergyRatingStep.isStepReachable ||
-                    (isEpcExpired() && state.epcInDateAtStartOfTenancyCheckStep.outcome == EpcInDateAtStartOfTenancyCheckMode.NOT_IN_DATE)
             )
-
-    fun createNonEpcRows(): List<SummaryListRowViewModel> {
-        if (!isEpcCardHidden()) return emptyList()
-        return listOfNotNull(
-            getHasEpcRow(),
-            if (state.isEpcRequiredStep.isStepReachable &&
-                (state.isOccupied == true || state.isEpcRequiredStep.outcome == YesOrNo.NO)
-            ) {
-                SummaryListRowViewModel.forCheckYourAnswersPage(
-                    "propertyCompliance.epcTask.checkEpcAnswers.isEpcRequired",
-                    state.isEpcRequiredStep.formModelIfReachableOrNull?.epcRequired,
-                    Destination(state.isEpcRequiredStep),
-                )
-            } else {
-                null
-            },
-            if (state.epcExemptionStep.isStepReachable) {
-                SummaryListRowViewModel.forCheckYourAnswersPage(
-                    "propertyCompliance.epcTask.checkEpcAnswers.epcExemption",
-                    state.epcExemptionStep.formModelIfReachableOrNull?.exemptionReason,
-                    Destination(state.epcExemptionStep),
-                )
-            } else {
-                null
-            },
-        )
+        val meesExemptionRow =
+            SummaryListRowViewModel.forCheckYourAnswersPage(
+                "propertyCompliance.epcTask.checkEpcAnswers.epc.meesExemption",
+                state.meesExemptionStep.formModelIfReachableOrNull?.exemptionReason,
+                Destination(state.meesExemptionStep),
+            )
+        return when (scenario) {
+            EpcScenario.LOW_ENERGY_EPC_MEES_EXEMPTION,
+            EpcScenario.LOW_ENERGY_EPC_EXPIRED_IN_DATE_MEES_EXEMPTION_OCCUPIED,
+            -> listOf(hasMeesExemptionRow, meesExemptionRow)
+            EpcScenario.LOW_ENERGY_EPC_NO_EXEMPTION_OCCUPIED,
+            EpcScenario.LOW_ENERGY_EPC_EXPIRED_IN_DATE_NO_EXEMPTION_OCCUPIED,
+            -> listOf(hasMeesExemptionRow)
+            else -> emptyList()
+        }
     }
 
-    fun showOccupiedNoEpcInset(): Boolean = state.isEpcRequiredStep.outcome == YesOrNo.YES && state.isOccupied == true
+    fun createNonEpcRows(): List<SummaryListRowViewModel> =
+        when (scenario) {
+            EpcScenario.NO_EPC_EXEMPT,
+            EpcScenario.NO_EPC_NO_EXEMPTION_UNOCCUPIED,
+            EpcScenario.NO_EPC_NO_EXEMPTION_OCCUPIED,
+            EpcScenario.SKIPPED_UNOCCUPIED,
+            EpcScenario.SKIPPED_OCCUPIED,
+            EpcScenario.EPC_EXPIRED_UNOCCUPIED,
+            EpcScenario.LOW_ENERGY_EPC_NO_EXEMPTION_UNOCCUPIED,
+            ->
+                listOfNotNull(
+                    getHasEpcRow(),
+                    createIsEpcRequiredRow(),
+                    createEpcExemptionRow(),
+                )
+            else -> emptyList()
+        }
 
-    private fun isEpcExpired(): Boolean = state.epcAgeCheckStep.outcome == EpcAgeCheckMode.EPC_OLDER_THAN_10_YEARS
+    fun getInsetTextKey(): String? =
+        when (scenario) {
+            EpcScenario.VALID_EPC,
+            EpcScenario.EPC_EXPIRED_IN_DATE_OCCUPIED,
+            -> "propertyCompliance.epcTask.checkEpcAnswers.epc.meetsRequirements"
+            EpcScenario.LOW_ENERGY_EPC_NO_EXEMPTION_OCCUPIED,
+            EpcScenario.EPC_EXPIRED_NOT_IN_DATE_OCCUPIED,
+            -> "propertyCompliance.epcTask.checkEpcAnswers.epc.lowRatingOccupiedInset"
+            EpcScenario.NO_EPC_NO_EXEMPTION_OCCUPIED -> "propertyCompliance.epcTask.checkEpcAnswers.occupiedNoEpcInset"
+            else -> null
+        }
 
-    private fun isExpiredEpcUnoccupied(): Boolean = isEpcExpired() && state.isOccupied == false
-
-    private fun isLowRatingNoExemptionUnoccupied(): Boolean =
-        state.hasMeesExemptionStep.isStepReachable &&
-            !state.meesExemptionStep.isStepReachable &&
-            state.isOccupied == false
-
-    private fun isEpcCardHiddenDueToUnoccupied(): Boolean = isExpiredEpcUnoccupied() || isLowRatingNoExemptionUnoccupied()
-
-    private fun isEpcCardHidden(): Boolean =
-        state.acceptedEpc == null ||
-            state.hasEpcStep.outcome == HasEpcMode.PROVIDE_LATER ||
-            state.hasEpcStep.outcome == HasEpcMode.NO_EPC ||
-            isEpcCardHiddenDueToUnoccupied()
-
-    private fun showMeesExemptionSection(): Boolean = state.hasMeesExemptionStep.isStepReachable && !isEpcCardHidden()
+    private fun isEpcCardShown(): Boolean =
+        when (scenario) {
+            EpcScenario.VALID_EPC,
+            EpcScenario.LOW_ENERGY_EPC_MEES_EXEMPTION,
+            EpcScenario.LOW_ENERGY_EPC_NO_EXEMPTION_OCCUPIED,
+            EpcScenario.EPC_EXPIRED_NOT_IN_DATE_OCCUPIED,
+            EpcScenario.EPC_EXPIRED_IN_DATE_OCCUPIED,
+            EpcScenario.LOW_ENERGY_EPC_EXPIRED_IN_DATE_MEES_EXEMPTION_OCCUPIED,
+            EpcScenario.LOW_ENERGY_EPC_EXPIRED_IN_DATE_NO_EXEMPTION_OCCUPIED,
+            -> true
+            else -> false
+        }
 
     private fun getHasEpcRow(): SummaryListRowViewModel {
         val fieldValue =
-            when {
-                state.hasEpcStep.outcome == HasEpcMode.PROVIDE_LATER && state.isOccupied == true ->
-                    "propertyCompliance.epcTask.checkEpcAnswers.hasEpc.provideEpcLaterOccupied"
-
-                state.hasEpcStep.outcome == HasEpcMode.PROVIDE_LATER ||
-                    isEpcCardHiddenDueToUnoccupied() ||
-                    (
-                        state.hasEpcStep.outcome == HasEpcMode.NO_EPC &&
-                            state.isOccupied == false &&
-                            state.isEpcRequiredStep.outcome == YesOrNo.YES
-                    ) ->
-                    "propertyCompliance.epcTask.checkEpcAnswers.hasEpc.provideEpcLaterUnoccupied"
-
-                else ->
-                    "commonText.no"
+            when (scenario) {
+                EpcScenario.SKIPPED_OCCUPIED -> "propertyCompliance.epcTask.checkEpcAnswers.hasEpc.provideEpcLaterOccupied"
+                EpcScenario.SKIPPED_UNOCCUPIED,
+                EpcScenario.EPC_EXPIRED_UNOCCUPIED,
+                EpcScenario.LOW_ENERGY_EPC_NO_EXEMPTION_UNOCCUPIED,
+                EpcScenario.NO_EPC_NO_EXEMPTION_UNOCCUPIED,
+                -> "propertyCompliance.epcTask.checkEpcAnswers.hasEpc.provideEpcLaterUnoccupied"
+                else -> "commonText.no"
             }
         return SummaryListRowViewModel.forCheckYourAnswersPage(
             "propertyCompliance.epcTask.checkEpcAnswers.hasEpc.label",
@@ -183,4 +177,28 @@ class EpcRegistrationCyaSummaryRowsFactory(
             Destination(state.hasEpcStep),
         )
     }
+
+    private fun createIsEpcRequiredRow(): SummaryListRowViewModel? =
+        when (scenario) {
+            EpcScenario.NO_EPC_EXEMPT,
+            EpcScenario.NO_EPC_NO_EXEMPTION_OCCUPIED,
+            ->
+                SummaryListRowViewModel.forCheckYourAnswersPage(
+                    "propertyCompliance.epcTask.checkEpcAnswers.isEpcRequired",
+                    state.isEpcRequiredStep.formModelIfReachableOrNull?.epcRequired,
+                    Destination(state.isEpcRequiredStep),
+                )
+            else -> null
+        }
+
+    private fun createEpcExemptionRow(): SummaryListRowViewModel? =
+        when (scenario) {
+            EpcScenario.NO_EPC_EXEMPT ->
+                SummaryListRowViewModel.forCheckYourAnswersPage(
+                    "propertyCompliance.epcTask.checkEpcAnswers.epcExemption",
+                    state.epcExemptionStep.formModelIfReachableOrNull?.exemptionReason,
+                    Destination(state.epcExemptionStep),
+                )
+            else -> null
+        }
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/EpcRegistrationCyaSummaryRowsFactory.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/EpcRegistrationCyaSummaryRowsFactory.kt
@@ -2,7 +2,12 @@ package uk.gov.communities.prsdb.webapp.journeys.propertyRegistration
 
 import uk.gov.communities.prsdb.webapp.journeys.Destination
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.EpcState
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.EpcAgeCheckMode
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.EpcEnergyRatingCheckMode
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.EpcInDateAtStartOfTenancyCheckMode
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.EpcScenario
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.HasEpcMode
+import uk.gov.communities.prsdb.webapp.journeys.shared.Complete
 import uk.gov.communities.prsdb.webapp.models.viewModels.summaryModels.SummaryCardActionViewModel
 import uk.gov.communities.prsdb.webapp.models.viewModels.summaryModels.SummaryListRowViewModel
 import uk.gov.communities.prsdb.webapp.services.EpcCertificateUrlProvider
@@ -10,8 +15,91 @@ import uk.gov.communities.prsdb.webapp.services.EpcCertificateUrlProvider
 class EpcRegistrationCyaSummaryRowsFactory(
     private val epcCertificateUrlProvider: EpcCertificateUrlProvider,
     private val state: EpcState,
-    private val scenario: EpcScenario,
 ) {
+    private val scenario: EpcScenario = determineScenario(state)
+
+    private fun determineScenario(state: EpcState): EpcScenario {
+        val isOccupied = state.isOccupied == true
+        return when {
+            state.hasEpcStep.outcome == HasEpcMode.PROVIDE_LATER -> {
+                if (isOccupied) EpcScenario.SKIPPED_OCCUPIED else EpcScenario.SKIPPED_UNOCCUPIED
+            }
+
+            state.acceptedEpc == null -> {
+                determineNoEpcScenario(state, isOccupied)
+            }
+
+            else -> {
+                determineEpcPresentScenario(state, isOccupied)
+            }
+        }
+    }
+
+    private fun determineNoEpcScenario(
+        state: EpcState,
+        isOccupied: Boolean,
+    ): EpcScenario =
+        when {
+            state.epcExemptionStep.outcome == Complete.COMPLETE -> EpcScenario.NO_EPC_EXEMPT
+            isOccupied -> EpcScenario.NO_EPC_NO_EXEMPTION_OCCUPIED
+            else -> EpcScenario.NO_EPC_NO_EXEMPTION_UNOCCUPIED
+        }
+
+    private fun determineEpcPresentScenario(
+        state: EpcState,
+        isOccupied: Boolean,
+    ): EpcScenario {
+        val isExpired = state.epcAgeCheckStep.outcome == EpcAgeCheckMode.EPC_OLDER_THAN_10_YEARS
+        return if (!isExpired) {
+            determineNotExpiredEpcScenario(state, isOccupied)
+        } else {
+            determineExpiredEpcScenario(state, isOccupied)
+        }
+    }
+
+    private fun determineNotExpiredEpcScenario(
+        state: EpcState,
+        isOccupied: Boolean,
+    ): EpcScenario {
+        if (state.epcEnergyRatingCheckStep.outcome != EpcEnergyRatingCheckMode.EPC_LOW_ENERGY_RATING) {
+            return EpcScenario.VALID_EPC
+        }
+        return when {
+            state.meesExemptionStep.outcome == Complete.COMPLETE -> EpcScenario.LOW_ENERGY_EPC_MEES_EXEMPTION
+            isOccupied -> EpcScenario.LOW_ENERGY_EPC_NO_EXEMPTION_OCCUPIED
+            else -> EpcScenario.LOW_ENERGY_EPC_NO_EXEMPTION_UNOCCUPIED
+        }
+    }
+
+    private fun determineExpiredEpcScenario(
+        state: EpcState,
+        isOccupied: Boolean,
+    ): EpcScenario {
+        if (!isOccupied) return EpcScenario.EPC_EXPIRED_UNOCCUPIED
+        return when (state.epcInDateAtStartOfTenancyCheckStep.outcome) {
+            EpcInDateAtStartOfTenancyCheckMode.NOT_IN_DATE -> {
+                EpcScenario.EPC_EXPIRED_NOT_IN_DATE_OCCUPIED
+            }
+
+            EpcInDateAtStartOfTenancyCheckMode.IN_DATE -> {
+                if (state.epcEnergyRatingCheckStep.outcome != EpcEnergyRatingCheckMode.EPC_LOW_ENERGY_RATING) {
+                    EpcScenario.EPC_EXPIRED_IN_DATE_OCCUPIED
+                } else if (state.meesExemptionStep.outcome == Complete.COMPLETE) {
+                    EpcScenario.LOW_ENERGY_EPC_EXPIRED_IN_DATE_MEES_EXEMPTION_OCCUPIED
+                } else {
+                    EpcScenario.LOW_ENERGY_EPC_EXPIRED_IN_DATE_NO_EXEMPTION_OCCUPIED
+                }
+            }
+
+            null -> {
+                throw IllegalStateException(
+                    "CheckEpcAnswersStep is not reachable for an occupied property " +
+                        "with an expired EPC before the tenancy check is answered",
+                )
+            }
+        }
+    }
+
     fun createEpcCardTitle(): String? = if (isEpcCardShown()) "propertyCompliance.epcTask.checkEpcAnswers.epc.yourEpc" else null
 
     fun createEpcCardActions(): List<SummaryCardActionViewModel>? {

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/EpcRegistrationCyaSummaryRowsFactory.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/EpcRegistrationCyaSummaryRowsFactory.kt
@@ -71,7 +71,7 @@ class EpcRegistrationCyaSummaryRowsFactory(
 
     fun getLowRatingTextKey(): String? = if (epcIsLowRating()) "propertyCompliance.epcTask.checkEpcAnswers.epc.lowRating" else null
 
-    fun createAdditionalRows(): List<SummaryListRowViewModel> {
+    fun createExemptionReasonRows(): List<SummaryListRowViewModel> {
         if (!epcIsLowRating()) return emptyList()
         val hasMeesExemptionRow =
             SummaryListRowViewModel.forCheckYourAnswersPage(

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/PropertyRegistrationJourneyFactory.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/PropertyRegistrationJourneyFactory.kt
@@ -296,6 +296,7 @@ class PropertyRegistrationJourneyFactory(
                 withHeadingMessageKey("registerProperty.taskList.checkAndSubmit.heading")
                 step(journey.cyaStep) {
                     routeSegment(PropertyRegistrationCyaStep.ROUTE_SEGMENT)
+                    // TODO PDJB-718: For convenience during development you can visit CYA without completing Compliance tasks by modifying the URL
                     parents {
                         jointLandlordsStrategy.ifEnabledOrElse {
                             ifEnabled { journey.jointLandlordsTask.isComplete() }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/PropertyRegistrationJourneyFactory.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/PropertyRegistrationJourneyFactory.kt
@@ -295,7 +295,6 @@ class PropertyRegistrationJourneyFactory(
                 withHeadingMessageKey("registerProperty.taskList.checkAndSubmit.heading")
                 step(journey.cyaStep) {
                     routeSegment(PropertyRegistrationCyaStep.ROUTE_SEGMENT)
-                    // TODO PDJB-670: For convenience during development you can visit CYA without completing Compliance tasks by modifying the URL
                     parents {
                         jointLandlordsStrategy.ifEnabledOrElse {
                             ifEnabled { journey.jointLandlordsTask.isComplete() }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/CheckEpcAnswersStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/CheckEpcAnswersStepConfig.kt
@@ -25,7 +25,7 @@ class CheckEpcAnswersStepConfig(
             "epcExpiredTextKey" to factory.getEpcExpiredTextKey(),
             "tenancyCheckRows" to factory.createTenancyCheckRows(),
             "lowRatingTextKey" to factory.getLowRatingTextKey(),
-            "additionalRows" to factory.createAdditionalRows(),
+            "exemptionReasonRows" to factory.createExemptionReasonRows(),
             "nonEpcRows" to factory.createNonEpcRows(),
             "insetTextKey" to factory.getInsetTextKey(),
         )

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/CheckEpcAnswersStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/CheckEpcAnswersStepConfig.kt
@@ -38,12 +38,17 @@ class CheckEpcAnswersStepConfig(
     private fun determineScenario(state: EpcState): EpcScenario {
         val isOccupied = state.isOccupied == true
         return when {
-            state.hasEpcStep.outcome == HasEpcMode.PROVIDE_LATER ->
+            state.hasEpcStep.outcome == HasEpcMode.PROVIDE_LATER -> {
                 if (isOccupied) EpcScenario.SKIPPED_OCCUPIED else EpcScenario.SKIPPED_UNOCCUPIED
-            state.isEpcRequiredStep.isStepReachable ->
+            }
+
+            state.acceptedEpc == null -> {
                 determineNoEpcScenario(state, isOccupied)
-            else ->
+            }
+
+            else -> {
                 determineEpcPresentScenario(state, isOccupied)
+            }
         }
     }
 
@@ -52,7 +57,7 @@ class CheckEpcAnswersStepConfig(
         isOccupied: Boolean,
     ): EpcScenario =
         when {
-            state.epcExemptionStep.isStepReachable -> EpcScenario.NO_EPC_EXEMPT
+            state.epcExemptionStep.outcome == Complete.COMPLETE -> EpcScenario.NO_EPC_EXEMPT
             isOccupied -> EpcScenario.NO_EPC_NO_EXEMPTION_OCCUPIED
             else -> EpcScenario.NO_EPC_NO_EXEMPTION_UNOCCUPIED
         }
@@ -77,7 +82,7 @@ class CheckEpcAnswersStepConfig(
             return EpcScenario.VALID_EPC
         }
         return when {
-            state.meesExemptionStep.isStepReachable -> EpcScenario.LOW_ENERGY_EPC_MEES_EXEMPTION
+            state.meesExemptionStep.outcome == Complete.COMPLETE -> EpcScenario.LOW_ENERGY_EPC_MEES_EXEMPTION
             isOccupied -> EpcScenario.LOW_ENERGY_EPC_NO_EXEMPTION_OCCUPIED
             else -> EpcScenario.LOW_ENERGY_EPC_NO_EXEMPTION_UNOCCUPIED
         }
@@ -96,7 +101,7 @@ class CheckEpcAnswersStepConfig(
             EpcInDateAtStartOfTenancyCheckMode.IN_DATE -> {
                 if (state.epcEnergyRatingCheckStep.outcome != EpcEnergyRatingCheckMode.EPC_LOW_ENERGY_RATING) {
                     EpcScenario.EPC_EXPIRED_IN_DATE_OCCUPIED
-                } else if (state.meesExemptionStep.isStepReachable) {
+                } else if (state.meesExemptionStep.outcome == Complete.COMPLETE) {
                     EpcScenario.LOW_ENERGY_EPC_EXPIRED_IN_DATE_MEES_EXEMPTION_OCCUPIED
                 } else {
                     EpcScenario.LOW_ENERGY_EPC_EXPIRED_IN_DATE_NO_EXEMPTION_OCCUPIED

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/CheckEpcAnswersStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/CheckEpcAnswersStepConfig.kt
@@ -2,27 +2,45 @@ package uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps
 
 import uk.gov.communities.prsdb.webapp.annotations.webAnnotations.JourneyFrameworkComponent
 import uk.gov.communities.prsdb.webapp.journeys.AbstractRequestableStepConfig
-import uk.gov.communities.prsdb.webapp.journeys.JourneyState
 import uk.gov.communities.prsdb.webapp.journeys.JourneyStep.RequestableStep
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.EpcRegistrationCyaSummaryRowsFactory
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.EpcState
 import uk.gov.communities.prsdb.webapp.journeys.shared.Complete
 import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.NoInputFormModel
+import uk.gov.communities.prsdb.webapp.services.EpcCertificateUrlProvider
 
-// TODO PDJB-670: Implement Check EPC Answers page
 @JourneyFrameworkComponent
-class CheckEpcAnswersStepConfig : AbstractRequestableStepConfig<Complete, NoInputFormModel, JourneyState>() {
+class CheckEpcAnswersStepConfig(
+    private val epcCertificateUrlProvider: EpcCertificateUrlProvider,
+) : AbstractRequestableStepConfig<Complete, NoInputFormModel, EpcState>() {
     override val formModelClass = NoInputFormModel::class
 
-    override fun getStepSpecificContent(state: JourneyState) = mapOf("todoComment" to "TODO PDJB-670: Implement Check EPC Answers page")
+    override fun getStepSpecificContent(state: EpcState): Map<String, Any?> {
+        val factory = EpcRegistrationCyaSummaryRowsFactory(epcCertificateUrlProvider, state)
+        return mapOf(
+            "epcCardTitle" to factory.createEpcCardTitle(),
+            "epcCardActions" to factory.createEpcCardActions(),
+            "epcCardRows" to factory.createEpcCardRows(),
+            "epcExpiredText" to factory.showEpcExpiredText(),
+            "tenancyCheckRows" to factory.createTenancyCheckRows(),
+            "meetsRequirementsInset" to factory.showMeetsRequirementsInset(),
+            "lowRatingText" to factory.showLowRatingText(),
+            "additionalRows" to factory.createAdditionalRows(),
+            "lowRatingOccupiedInset" to factory.showLowRatingOccupiedInset(),
+            "nonEpcRows" to factory.createNonEpcRows(),
+            "occupiedNoEpcInset" to factory.showOccupiedNoEpcInset(),
+        )
+    }
 
-    override fun chooseTemplate(state: JourneyState) = "forms/todo"
+    override fun chooseTemplate(state: EpcState) = "forms/checkEpcAnswersForm"
 
-    override fun mode(state: JourneyState) = getFormModelFromStateOrNull(state)?.let { Complete.COMPLETE }
+    override fun mode(state: EpcState) = getFormModelFromStateOrNull(state)?.let { Complete.COMPLETE }
 }
 
 @JourneyFrameworkComponent
 final class CheckEpcAnswersStep(
     stepConfig: CheckEpcAnswersStepConfig,
-) : RequestableStep<Complete, NoInputFormModel, JourneyState>(stepConfig) {
+) : RequestableStep<Complete, NoInputFormModel, EpcState>(stepConfig) {
     companion object {
         const val ROUTE_SEGMENT = "check-epc-answers"
     }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/CheckEpcAnswersStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/CheckEpcAnswersStepConfig.kt
@@ -37,24 +37,25 @@ class CheckEpcAnswersStepConfig(
 
     private fun determineScenario(state: EpcState): EpcScenario {
         val isOccupied = state.isOccupied == true
-        return when (state.hasEpcStep.outcome) {
-            HasEpcMode.PROVIDE_LATER -> {
+        return when {
+            state.hasEpcStep.outcome == HasEpcMode.PROVIDE_LATER ->
                 if (isOccupied) EpcScenario.SKIPPED_OCCUPIED else EpcScenario.SKIPPED_UNOCCUPIED
-            }
-
-            HasEpcMode.NO_EPC -> {
-                when {
-                    state.epcExemptionStep.isStepReachable -> EpcScenario.NO_EPC_EXEMPT
-                    isOccupied -> EpcScenario.NO_EPC_NO_EXEMPTION_OCCUPIED
-                    else -> EpcScenario.NO_EPC_NO_EXEMPTION_UNOCCUPIED
-                }
-            }
-
-            HasEpcMode.HAS_EPC, null -> {
+            state.isEpcRequiredStep.isStepReachable ->
+                determineNoEpcScenario(state, isOccupied)
+            else ->
                 determineEpcPresentScenario(state, isOccupied)
-            }
         }
     }
+
+    private fun determineNoEpcScenario(
+        state: EpcState,
+        isOccupied: Boolean,
+    ): EpcScenario =
+        when {
+            state.epcExemptionStep.isStepReachable -> EpcScenario.NO_EPC_EXEMPT
+            isOccupied -> EpcScenario.NO_EPC_NO_EXEMPTION_OCCUPIED
+            else -> EpcScenario.NO_EPC_NO_EXEMPTION_UNOCCUPIED
+        }
 
     private fun determineEpcPresentScenario(
         state: EpcState,

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/CheckEpcAnswersStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/CheckEpcAnswersStepConfig.kt
@@ -16,25 +16,117 @@ class CheckEpcAnswersStepConfig(
     override val formModelClass = NoInputFormModel::class
 
     override fun getStepSpecificContent(state: EpcState): Map<String, Any?> {
-        val factory = EpcRegistrationCyaSummaryRowsFactory(epcCertificateUrlProvider, state)
+        val scenario = determineScenario(state)
+        val factory = EpcRegistrationCyaSummaryRowsFactory(epcCertificateUrlProvider, state, scenario)
         return mapOf(
             "epcCardTitle" to factory.createEpcCardTitle(),
             "epcCardActions" to factory.createEpcCardActions(),
             "epcCardRows" to factory.createEpcCardRows(),
-            "epcExpiredText" to factory.showEpcExpiredText(),
+            "epcExpiredTextKey" to factory.getEpcExpiredTextKey(),
             "tenancyCheckRows" to factory.createTenancyCheckRows(),
-            "meetsRequirementsInset" to factory.showMeetsRequirementsInset(),
-            "lowRatingText" to factory.showLowRatingText(),
+            "lowRatingTextKey" to factory.getLowRatingTextKey(),
             "additionalRows" to factory.createAdditionalRows(),
-            "lowRatingOccupiedInset" to factory.showLowRatingOccupiedInset(),
             "nonEpcRows" to factory.createNonEpcRows(),
-            "occupiedNoEpcInset" to factory.showOccupiedNoEpcInset(),
+            "insetTextKey" to factory.getInsetTextKey(),
         )
     }
 
     override fun chooseTemplate(state: EpcState) = "forms/checkEpcAnswersForm"
 
     override fun mode(state: EpcState) = getFormModelFromStateOrNull(state)?.let { Complete.COMPLETE }
+
+    private fun determineScenario(state: EpcState): EpcScenario {
+        val isOccupied = state.isOccupied == true
+        return when (state.hasEpcStep.outcome) {
+            HasEpcMode.PROVIDE_LATER -> {
+                if (isOccupied) EpcScenario.SKIPPED_OCCUPIED else EpcScenario.SKIPPED_UNOCCUPIED
+            }
+
+            HasEpcMode.NO_EPC -> {
+                when {
+                    state.epcExemptionStep.isStepReachable -> EpcScenario.NO_EPC_EXEMPT
+                    isOccupied -> EpcScenario.NO_EPC_NO_EXEMPTION_OCCUPIED
+                    else -> EpcScenario.NO_EPC_NO_EXEMPTION_UNOCCUPIED
+                }
+            }
+
+            HasEpcMode.HAS_EPC, null -> {
+                determineEpcPresentScenario(state, isOccupied)
+            }
+        }
+    }
+
+    private fun determineEpcPresentScenario(
+        state: EpcState,
+        isOccupied: Boolean,
+    ): EpcScenario {
+        val isExpired = state.epcAgeCheckStep.outcome == EpcAgeCheckMode.EPC_OLDER_THAN_10_YEARS
+        return if (!isExpired) {
+            determineNotExpiredEpcScenario(state, isOccupied)
+        } else {
+            determineExpiredEpcScenario(state, isOccupied)
+        }
+    }
+
+    private fun determineNotExpiredEpcScenario(
+        state: EpcState,
+        isOccupied: Boolean,
+    ): EpcScenario {
+        if (state.epcEnergyRatingCheckStep.outcome != EpcEnergyRatingCheckMode.EPC_LOW_ENERGY_RATING) {
+            return EpcScenario.VALID_EPC
+        }
+        return when {
+            state.meesExemptionStep.isStepReachable -> EpcScenario.LOW_ENERGY_EPC_MEES_EXEMPTION
+            isOccupied -> EpcScenario.LOW_ENERGY_EPC_NO_EXEMPTION_OCCUPIED
+            else -> EpcScenario.LOW_ENERGY_EPC_NO_EXEMPTION_UNOCCUPIED
+        }
+    }
+
+    private fun determineExpiredEpcScenario(
+        state: EpcState,
+        isOccupied: Boolean,
+    ): EpcScenario {
+        if (!isOccupied) return EpcScenario.EPC_EXPIRED_UNOCCUPIED
+        return when (state.epcInDateAtStartOfTenancyCheckStep.outcome) {
+            EpcInDateAtStartOfTenancyCheckMode.NOT_IN_DATE -> {
+                EpcScenario.EPC_EXPIRED_NOT_IN_DATE_OCCUPIED
+            }
+
+            EpcInDateAtStartOfTenancyCheckMode.IN_DATE -> {
+                if (state.epcEnergyRatingCheckStep.outcome != EpcEnergyRatingCheckMode.EPC_LOW_ENERGY_RATING) {
+                    EpcScenario.EPC_EXPIRED_IN_DATE_OCCUPIED
+                } else if (state.meesExemptionStep.isStepReachable) {
+                    EpcScenario.LOW_ENERGY_EPC_EXPIRED_IN_DATE_MEES_EXEMPTION_OCCUPIED
+                } else {
+                    EpcScenario.LOW_ENERGY_EPC_EXPIRED_IN_DATE_NO_EXEMPTION_OCCUPIED
+                }
+            }
+
+            null -> {
+                throw IllegalStateException(
+                    "CheckEpcAnswersStep is not reachable for an occupied property " +
+                        "with an expired EPC before the tenancy check is answered",
+                )
+            }
+        }
+    }
+}
+
+enum class EpcScenario {
+    NO_EPC_EXEMPT,
+    LOW_ENERGY_EPC_MEES_EXEMPTION,
+    VALID_EPC,
+    SKIPPED_UNOCCUPIED,
+    NO_EPC_NO_EXEMPTION_UNOCCUPIED,
+    EPC_EXPIRED_UNOCCUPIED,
+    LOW_ENERGY_EPC_NO_EXEMPTION_UNOCCUPIED,
+    SKIPPED_OCCUPIED,
+    NO_EPC_NO_EXEMPTION_OCCUPIED,
+    EPC_EXPIRED_NOT_IN_DATE_OCCUPIED,
+    LOW_ENERGY_EPC_NO_EXEMPTION_OCCUPIED,
+    EPC_EXPIRED_IN_DATE_OCCUPIED,
+    LOW_ENERGY_EPC_EXPIRED_IN_DATE_MEES_EXEMPTION_OCCUPIED,
+    LOW_ENERGY_EPC_EXPIRED_IN_DATE_NO_EXEMPTION_OCCUPIED,
 }
 
 @JourneyFrameworkComponent

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/CheckEpcAnswersStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/CheckEpcAnswersStepConfig.kt
@@ -16,8 +16,7 @@ class CheckEpcAnswersStepConfig(
     override val formModelClass = NoInputFormModel::class
 
     override fun getStepSpecificContent(state: EpcState): Map<String, Any?> {
-        val scenario = determineScenario(state)
-        val factory = EpcRegistrationCyaSummaryRowsFactory(epcCertificateUrlProvider, state, scenario)
+        val factory = EpcRegistrationCyaSummaryRowsFactory(epcCertificateUrlProvider, state)
         return mapOf(
             "epcCardTitle" to factory.createEpcCardTitle(),
             "epcCardActions" to factory.createEpcCardActions(),
@@ -34,88 +33,6 @@ class CheckEpcAnswersStepConfig(
     override fun chooseTemplate(state: EpcState) = "forms/checkEpcAnswersForm"
 
     override fun mode(state: EpcState) = getFormModelFromStateOrNull(state)?.let { Complete.COMPLETE }
-
-    private fun determineScenario(state: EpcState): EpcScenario {
-        val isOccupied = state.isOccupied == true
-        return when {
-            state.hasEpcStep.outcome == HasEpcMode.PROVIDE_LATER -> {
-                if (isOccupied) EpcScenario.SKIPPED_OCCUPIED else EpcScenario.SKIPPED_UNOCCUPIED
-            }
-
-            state.acceptedEpc == null -> {
-                determineNoEpcScenario(state, isOccupied)
-            }
-
-            else -> {
-                determineEpcPresentScenario(state, isOccupied)
-            }
-        }
-    }
-
-    private fun determineNoEpcScenario(
-        state: EpcState,
-        isOccupied: Boolean,
-    ): EpcScenario =
-        when {
-            state.epcExemptionStep.outcome == Complete.COMPLETE -> EpcScenario.NO_EPC_EXEMPT
-            isOccupied -> EpcScenario.NO_EPC_NO_EXEMPTION_OCCUPIED
-            else -> EpcScenario.NO_EPC_NO_EXEMPTION_UNOCCUPIED
-        }
-
-    private fun determineEpcPresentScenario(
-        state: EpcState,
-        isOccupied: Boolean,
-    ): EpcScenario {
-        val isExpired = state.epcAgeCheckStep.outcome == EpcAgeCheckMode.EPC_OLDER_THAN_10_YEARS
-        return if (!isExpired) {
-            determineNotExpiredEpcScenario(state, isOccupied)
-        } else {
-            determineExpiredEpcScenario(state, isOccupied)
-        }
-    }
-
-    private fun determineNotExpiredEpcScenario(
-        state: EpcState,
-        isOccupied: Boolean,
-    ): EpcScenario {
-        if (state.epcEnergyRatingCheckStep.outcome != EpcEnergyRatingCheckMode.EPC_LOW_ENERGY_RATING) {
-            return EpcScenario.VALID_EPC
-        }
-        return when {
-            state.meesExemptionStep.outcome == Complete.COMPLETE -> EpcScenario.LOW_ENERGY_EPC_MEES_EXEMPTION
-            isOccupied -> EpcScenario.LOW_ENERGY_EPC_NO_EXEMPTION_OCCUPIED
-            else -> EpcScenario.LOW_ENERGY_EPC_NO_EXEMPTION_UNOCCUPIED
-        }
-    }
-
-    private fun determineExpiredEpcScenario(
-        state: EpcState,
-        isOccupied: Boolean,
-    ): EpcScenario {
-        if (!isOccupied) return EpcScenario.EPC_EXPIRED_UNOCCUPIED
-        return when (state.epcInDateAtStartOfTenancyCheckStep.outcome) {
-            EpcInDateAtStartOfTenancyCheckMode.NOT_IN_DATE -> {
-                EpcScenario.EPC_EXPIRED_NOT_IN_DATE_OCCUPIED
-            }
-
-            EpcInDateAtStartOfTenancyCheckMode.IN_DATE -> {
-                if (state.epcEnergyRatingCheckStep.outcome != EpcEnergyRatingCheckMode.EPC_LOW_ENERGY_RATING) {
-                    EpcScenario.EPC_EXPIRED_IN_DATE_OCCUPIED
-                } else if (state.meesExemptionStep.outcome == Complete.COMPLETE) {
-                    EpcScenario.LOW_ENERGY_EPC_EXPIRED_IN_DATE_MEES_EXEMPTION_OCCUPIED
-                } else {
-                    EpcScenario.LOW_ENERGY_EPC_EXPIRED_IN_DATE_NO_EXEMPTION_OCCUPIED
-                }
-            }
-
-            null -> {
-                throw IllegalStateException(
-                    "CheckEpcAnswersStep is not reachable for an occupied property " +
-                        "with an expired EPC before the tenancy check is answered",
-                )
-            }
-        }
-    }
 }
 
 enum class EpcScenario {

--- a/src/main/resources/messages/propertyCompliance.yml
+++ b/src/main/resources/messages/propertyCompliance.yml
@@ -658,3 +658,25 @@ epcTask:
     epcRequirements:
       forLetting:
         paragraph: 'You must get a valid EPC with a rating of <strong>E or higher</strong> before letting this property.'
+  checkEpcAnswers:
+    heading: Energy performance certificate (EPC)
+    epc:
+      yourEpc: Your EPC
+      viewFullEpc: View full EPC (opens in new tab)
+      address: Address
+      energyRating: Energy efficiency rating
+      expiryDate: Expiry date
+      certificateNumber: Certificate number
+      expired: This EPC has expired.
+      lowRating: This property has an energy efficiency rating below E.
+      meetsRequirements: This EPC meets the energy efficiency requirements for rental properties.
+      tenancyStartCheck: Was the EPC still in date when the current tenancy began?
+      meesExemptionCheck: Do you have a registered energy efficiency exemption for this property?
+      meesExemption: Registered exemption
+      lowRatingOccupiedInset: "The council can see that there is no valid EPC, even though this property’s occupied."
+    hasEpc:
+      label: Do you have an EPC for this property?
+      provideEpcLaterUnoccupied: Provide EPC details later (within 28 days of the property being occupied)
+    isEpcRequired: Is an EPC required to let this property?
+    epcExemption: Why does this property not need an EPC?
+    occupiedNoEpcInset: "The council will see that there’s no valid EPC, even though the property’s occupied."

--- a/src/main/resources/messages/propertyCompliance.yml
+++ b/src/main/resources/messages/propertyCompliance.yml
@@ -668,7 +668,7 @@ epcTask:
       expiryDate: Expiry date
       certificateNumber: Certificate number
       expired: This EPC has expired.
-      lowRating: This property has an energy efficiency rating below E.
+      lowRating: 'This property has an energy efficiency rating <strong>below E</strong>.'
       meetsRequirements: This EPC meets the energy efficiency requirements for rental properties.
       tenancyStartCheck: Was the EPC still in date when the current tenancy began?
       meesExemptionCheck: Do you have a registered energy efficiency exemption for this property?
@@ -676,6 +676,7 @@ epcTask:
       lowRatingOccupiedInset: "The council can see that there is no valid EPC, even though this property’s occupied."
     hasEpc:
       label: Do you have an EPC for this property?
+      provideEpcLaterOccupied: Provide EPC details later
       provideEpcLaterUnoccupied: Provide EPC details later (within 28 days of the property being occupied)
     isEpcRequired: Is an EPC required to let this property?
     epcExemption: Why does this property not need an EPC?

--- a/src/main/resources/templates/forms/checkEpcAnswersForm.html
+++ b/src/main/resources/templates/forms/checkEpcAnswersForm.html
@@ -32,7 +32,7 @@
             <p class="govuk-body" th:text="#{propertyCompliance.epcTask.checkEpcAnswers.epc.meetsRequirements}"></p>
         </div>
 
-        <p th:if="${lowRatingText}" class="govuk-body" th:text="#{propertyCompliance.epcTask.checkEpcAnswers.epc.lowRating}"></p>
+        <p th:if="${lowRatingText}" class="govuk-body" th:utext="#{propertyCompliance.epcTask.checkEpcAnswers.epc.lowRating}"></p>
 
         <th:block th:if="${!#lists.isEmpty(additionalRows)}">
             <dl th:replace="~{fragments/summaryList :: summaryList(${additionalRows})}"></dl>

--- a/src/main/resources/templates/forms/checkEpcAnswersForm.html
+++ b/src/main/resources/templates/forms/checkEpcAnswersForm.html
@@ -1,0 +1,56 @@
+<!--/*@thymesVar id="title" type="java.lang.String"*/-->
+<!--/*@thymesVar id="formModel" type="java.lang.Object"*/-->
+<!--/*@thymesVar id="backUrl" type="java.lang.String"*/-->
+<!--/*@thymesVar id="sectionHeaderInfo" type="uk.gov.communities.prsdb.webapp.models.viewModels.SectionHeaderViewModel"*/-->
+<!--/*@thymesVar id="epcCardTitle" type="java.lang.String"*/-->
+<!--/*@thymesVar id="epcCardActions" type="java.util.List"*/-->
+<!--/*@thymesVar id="epcCardRows" type="java.util.List"*/-->
+<!--/*@thymesVar id="epcExpiredText" type="java.lang.Boolean"*/-->
+<!--/*@thymesVar id="tenancyCheckRows" type="java.util.List"*/-->
+<!--/*@thymesVar id="meetsRequirementsInset" type="java.lang.Boolean"*/-->
+<!--/*@thymesVar id="lowRatingText" type="java.lang.Boolean"*/-->
+<!--/*@thymesVar id="additionalRows" type="java.util.List"*/-->
+<!--/*@thymesVar id="lowRatingOccupiedInset" type="java.lang.Boolean"*/-->
+<!--/*@thymesVar id="nonEpcRows" type="java.util.List"*/-->
+<!--/*@thymesVar id="occupiedNoEpcInset" type="java.lang.Boolean"*/-->
+<!DOCTYPE html>
+<html th:replace="~{fragments/forms/complexQuestionPage :: complexQuestionPage(#{${title}}, ${formModel}, ~{::#form-content}, ~{::#question-content}, ${backUrl}, ${sectionHeaderInfo})}">
+    <th:block id="question-content">
+        <h1 class="govuk-heading-l" th:text="#{propertyCompliance.epcTask.checkEpcAnswers.heading}">Energy performance certificate (EPC)</h1>
+
+        <th:block th:if="${epcCardTitle != null}">
+            <div th:replace="~{fragments/summaryCard :: summaryCard(#{${epcCardTitle}}, null, ${epcCardActions}, ${epcCardRows})}"></div>
+        </th:block>
+
+        <p th:if="${epcExpiredText}" class="govuk-body" th:text="#{propertyCompliance.epcTask.checkEpcAnswers.epc.expired}"></p>
+
+        <th:block th:if="${!#lists.isEmpty(tenancyCheckRows)}">
+            <dl th:replace="~{fragments/summaryList :: summaryList(${tenancyCheckRows})}"></dl>
+        </th:block>
+
+        <div th:if="${meetsRequirementsInset}" class="govuk-inset-text">
+            <p class="govuk-body" th:text="#{propertyCompliance.epcTask.checkEpcAnswers.epc.meetsRequirements}"></p>
+        </div>
+
+        <p th:if="${lowRatingText}" class="govuk-body" th:text="#{propertyCompliance.epcTask.checkEpcAnswers.epc.lowRating}"></p>
+
+        <th:block th:if="${!#lists.isEmpty(additionalRows)}">
+            <dl th:replace="~{fragments/summaryList :: summaryList(${additionalRows})}"></dl>
+        </th:block>
+
+        <div th:if="${lowRatingOccupiedInset}" class="govuk-inset-text">
+            <p class="govuk-body" th:text="#{propertyCompliance.epcTask.checkEpcAnswers.epc.lowRatingOccupiedInset}"></p>
+        </div>
+
+        <th:block th:if="${!#lists.isEmpty(nonEpcRows)}">
+            <dl th:replace="~{fragments/summaryList :: summaryList(${nonEpcRows})}"></dl>
+        </th:block>
+
+        <div th:if="${occupiedNoEpcInset}" class="govuk-inset-text">
+            <p class="govuk-body" th:text="#{propertyCompliance.epcTask.checkEpcAnswers.occupiedNoEpcInset}"></p>
+        </div>
+    </th:block>
+    <th:block id="form-content">
+        <button th:replace="~{fragments/buttons/primaryButton :: primaryButton(#{forms.buttons.saveAndContinue})}"></button>
+    </th:block>
+</html>

--- a/src/main/resources/templates/forms/checkEpcAnswersForm.html
+++ b/src/main/resources/templates/forms/checkEpcAnswersForm.html
@@ -8,7 +8,7 @@
 <!--/*@thymesVar id="epcExpiredTextKey" type="java.lang.String"*/-->
 <!--/*@thymesVar id="tenancyCheckRows" type="java.util.List"*/-->
 <!--/*@thymesVar id="lowRatingTextKey" type="java.lang.String"*/-->
-<!--/*@thymesVar id="additionalRows" type="java.util.List"*/-->
+<!--/*@thymesVar id="exemptionReasonRows" type="java.util.List"*/-->
 <!--/*@thymesVar id="nonEpcRows" type="java.util.List"*/-->
 <!--/*@thymesVar id="insetTextKey" type="java.lang.String"*/-->
 <!DOCTYPE html>
@@ -28,8 +28,8 @@
 
         <p th:if="${lowRatingTextKey != null}" class="govuk-body" th:utext="#{${lowRatingTextKey}}"></p>
 
-        <th:block th:if="${!#lists.isEmpty(additionalRows)}">
-            <dl th:replace="~{fragments/summaryList :: summaryList(${additionalRows})}"></dl>
+        <th:block th:if="${!#lists.isEmpty(exemptionReasonRows)}">
+            <dl th:replace="~{fragments/summaryList :: summaryList(${exemptionReasonRows})}"></dl>
         </th:block>
 
         <th:block th:if="${!#lists.isEmpty(nonEpcRows)}">

--- a/src/main/resources/templates/forms/checkEpcAnswersForm.html
+++ b/src/main/resources/templates/forms/checkEpcAnswersForm.html
@@ -5,14 +5,12 @@
 <!--/*@thymesVar id="epcCardTitle" type="java.lang.String"*/-->
 <!--/*@thymesVar id="epcCardActions" type="java.util.List"*/-->
 <!--/*@thymesVar id="epcCardRows" type="java.util.List"*/-->
-<!--/*@thymesVar id="epcExpiredText" type="java.lang.Boolean"*/-->
+<!--/*@thymesVar id="epcExpiredTextKey" type="java.lang.String"*/-->
 <!--/*@thymesVar id="tenancyCheckRows" type="java.util.List"*/-->
-<!--/*@thymesVar id="meetsRequirementsInset" type="java.lang.Boolean"*/-->
-<!--/*@thymesVar id="lowRatingText" type="java.lang.Boolean"*/-->
+<!--/*@thymesVar id="lowRatingTextKey" type="java.lang.String"*/-->
 <!--/*@thymesVar id="additionalRows" type="java.util.List"*/-->
-<!--/*@thymesVar id="lowRatingOccupiedInset" type="java.lang.Boolean"*/-->
 <!--/*@thymesVar id="nonEpcRows" type="java.util.List"*/-->
-<!--/*@thymesVar id="occupiedNoEpcInset" type="java.lang.Boolean"*/-->
+<!--/*@thymesVar id="insetTextKey" type="java.lang.String"*/-->
 <!DOCTYPE html>
 <html th:replace="~{fragments/forms/complexQuestionPage :: complexQuestionPage(#{${title}}, ${formModel}, ~{::#form-content}, ~{::#question-content}, ${backUrl}, ${sectionHeaderInfo})}">
     <th:block id="question-content">
@@ -22,32 +20,24 @@
             <div th:replace="~{fragments/summaryCard :: summaryCard(#{${epcCardTitle}}, null, ${epcCardActions}, ${epcCardRows})}"></div>
         </th:block>
 
-        <p th:if="${epcExpiredText}" class="govuk-body" th:text="#{propertyCompliance.epcTask.checkEpcAnswers.epc.expired}"></p>
+        <p th:if="${epcExpiredTextKey != null}" class="govuk-body" th:text="#{${epcExpiredTextKey}}"></p>
 
         <th:block th:if="${!#lists.isEmpty(tenancyCheckRows)}">
             <dl th:replace="~{fragments/summaryList :: summaryList(${tenancyCheckRows})}"></dl>
         </th:block>
 
-        <div th:if="${meetsRequirementsInset}" class="govuk-inset-text">
-            <p class="govuk-body" th:text="#{propertyCompliance.epcTask.checkEpcAnswers.epc.meetsRequirements}"></p>
-        </div>
-
-        <p th:if="${lowRatingText}" class="govuk-body" th:utext="#{propertyCompliance.epcTask.checkEpcAnswers.epc.lowRating}"></p>
+        <p th:if="${lowRatingTextKey != null}" class="govuk-body" th:utext="#{${lowRatingTextKey}}"></p>
 
         <th:block th:if="${!#lists.isEmpty(additionalRows)}">
             <dl th:replace="~{fragments/summaryList :: summaryList(${additionalRows})}"></dl>
         </th:block>
 
-        <div th:if="${lowRatingOccupiedInset}" class="govuk-inset-text">
-            <p class="govuk-body" th:text="#{propertyCompliance.epcTask.checkEpcAnswers.epc.lowRatingOccupiedInset}"></p>
-        </div>
-
         <th:block th:if="${!#lists.isEmpty(nonEpcRows)}">
             <dl th:replace="~{fragments/summaryList :: summaryList(${nonEpcRows})}"></dl>
         </th:block>
 
-        <div th:if="${occupiedNoEpcInset}" class="govuk-inset-text">
-            <p class="govuk-body" th:text="#{propertyCompliance.epcTask.checkEpcAnswers.occupiedNoEpcInset}"></p>
+        <div th:if="${insetTextKey != null}" class="govuk-inset-text">
+            <p class="govuk-body" th:text="#{${insetTextKey}}"></p>
         </div>
     </th:block>
     <th:block id="form-content">

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/PropertyRegistrationJourneyTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/PropertyRegistrationJourneyTests.kt
@@ -446,8 +446,8 @@ class PropertyRegistrationJourneyTests : IntegrationTestWithMutableData("data-lo
         val checkEpcAnswersPage = assertPageIs(page, CheckEpcAnswersFormPagePropertyRegistration::class)
 
         // Check EPC Answers - render page
-        // TODO PDJB-670: Implement Check EPC Answers step
-        assertThat(checkEpcAnswersPage.heading).containsText("TODO")
+        // Check EPC Answers - render page
+        assertThat(checkEpcAnswersPage.heading).containsText("Energy performance certificate (EPC)")
         checkEpcAnswersPage.form.submit()
         val checkAnswersPage = assertPageIs(page, CheckAnswersPagePropertyRegistration::class)
 
@@ -625,8 +625,8 @@ class PropertyRegistrationJourneyTests : IntegrationTestWithMutableData("data-lo
         val checkEpcAnswersPage = assertPageIs(page, CheckEpcAnswersFormPagePropertyRegistration::class)
 
         // Check EPC Answers - render page
-        // TODO PDJB-670: Implement Check EPC Answers step
-        assertThat(checkEpcAnswersPage.heading).containsText("TODO")
+        // Check EPC Answers - render page
+        assertThat(checkEpcAnswersPage.heading).containsText("Energy performance certificate (EPC)")
         checkEpcAnswersPage.form.submit()
         val checkAnswersPage = assertPageIs(page, CheckAnswersPagePropertyRegistration::class)
 
@@ -719,7 +719,8 @@ class PropertyRegistrationJourneyTests : IntegrationTestWithMutableData("data-lo
         val checkEpcAnswersPage = assertPageIs(page, CheckEpcAnswersFormPagePropertyRegistration::class)
 
         // Check EPC Answers - render page
-        // TODO PDJB-670: Implement Check EPC Answers step
+        assertThat(checkEpcAnswersPage.heading).containsText("Energy performance certificate (EPC)")
+        checkEpcAnswersPage.form.submit()
     }
 
     @Test
@@ -786,7 +787,8 @@ class PropertyRegistrationJourneyTests : IntegrationTestWithMutableData("data-lo
         val checkEpcAnswersPage = assertPageIs(page, CheckEpcAnswersFormPagePropertyRegistration::class)
 
         // Check EPC Answers - render page
-        // TODO PDJB-670: Implement Check EPC Answers step
+        assertThat(checkEpcAnswersPage.heading).containsText("Energy performance certificate (EPC)")
+        checkEpcAnswersPage.form.submit()
     }
 
     @Test
@@ -855,8 +857,8 @@ class PropertyRegistrationJourneyTests : IntegrationTestWithMutableData("data-lo
         val checkEpcAnswersPage = assertPageIs(page, CheckEpcAnswersFormPagePropertyRegistration::class)
 
         // Check EPC Answers - render page
-        // TODO PDJB-670: Implement Check EPC Answers step
-        assertThat(checkEpcAnswersPage.heading).containsText("TODO")
+        // Check EPC Answers - render page
+        assertThat(checkEpcAnswersPage.heading).containsText("Energy performance certificate (EPC)")
         checkEpcAnswersPage.form.submit()
         val checkAnswersPage = assertPageIs(page, CheckAnswersPagePropertyRegistration::class)
     }
@@ -962,8 +964,8 @@ class PropertyRegistrationJourneyTests : IntegrationTestWithMutableData("data-lo
         val checkEpcAnswersPage = assertPageIs(page, CheckEpcAnswersFormPagePropertyRegistration::class)
 
         // Check EPC Answers - render page
-        // TODO PDJB-670: Implement Check EPC Answers step
-        assertThat(checkEpcAnswersPage.heading).containsText("TODO")
+        // Check EPC Answers - render page
+        assertThat(checkEpcAnswersPage.heading).containsText("Energy performance certificate (EPC)")
         checkEpcAnswersPage.form.submit()
         val checkAnswersPage = assertPageIs(page, CheckAnswersPagePropertyRegistration::class)
     }
@@ -1087,8 +1089,8 @@ class PropertyRegistrationJourneyTests : IntegrationTestWithMutableData("data-lo
         val checkEpcAnswersPage = assertPageIs(page, CheckEpcAnswersFormPagePropertyRegistration::class)
 
         // Check EPC Answers - render page
-        // TODO PDJB-670: Implement Check EPC Answers step
-        assertThat(checkEpcAnswersPage.heading).containsText("TODO")
+        // Check EPC Answers - render page
+        assertThat(checkEpcAnswersPage.heading).containsText("Energy performance certificate (EPC)")
         checkEpcAnswersPage.form.submit()
         val checkAnswersPage = assertPageIs(page, CheckAnswersPagePropertyRegistration::class)
     }
@@ -1138,8 +1140,8 @@ class PropertyRegistrationJourneyTests : IntegrationTestWithMutableData("data-lo
         val checkEpcAnswersPage = assertPageIs(page, CheckEpcAnswersFormPagePropertyRegistration::class)
 
         // Check EPC Answers - render page
-        // TODO PDJB-670: Implement Check EPC Answers step
-        assertThat(checkEpcAnswersPage.heading).containsText("TODO")
+        // Check EPC Answers - render page
+        assertThat(checkEpcAnswersPage.heading).containsText("Energy performance certificate (EPC)")
         checkEpcAnswersPage.form.submit()
         val checkAnswersPage = assertPageIs(page, CheckAnswersPagePropertyRegistration::class)
     }
@@ -1185,8 +1187,8 @@ class PropertyRegistrationJourneyTests : IntegrationTestWithMutableData("data-lo
         val checkEpcAnswersPage = assertPageIs(page, CheckEpcAnswersFormPagePropertyRegistration::class)
 
         // Check EPC Answers - render page
-        // TODO PDJB-670: Implement Check EPC Answers step
-        assertThat(checkEpcAnswersPage.heading).containsText("TODO")
+        // Check EPC Answers - render page
+        assertThat(checkEpcAnswersPage.heading).containsText("Energy performance certificate (EPC)")
         checkEpcAnswersPage.form.submit()
         val checkAnswersPage = assertPageIs(page, CheckAnswersPagePropertyRegistration::class)
     }
@@ -1205,8 +1207,8 @@ class PropertyRegistrationJourneyTests : IntegrationTestWithMutableData("data-lo
         val checkEpcAnswersPage = assertPageIs(page, CheckEpcAnswersFormPagePropertyRegistration::class)
 
         // Check EPC Answers - render page
-        // TODO PDJB-670: Implement Check EPC Answers step
-        assertThat(checkEpcAnswersPage.heading).containsText("TODO")
+        // Check EPC Answers - render page
+        assertThat(checkEpcAnswersPage.heading).containsText("Energy performance certificate (EPC)")
     }
 
     @Test
@@ -1223,8 +1225,8 @@ class PropertyRegistrationJourneyTests : IntegrationTestWithMutableData("data-lo
         val checkEpcAnswersPage = assertPageIs(page, CheckEpcAnswersFormPagePropertyRegistration::class)
 
         // Check EPC Answers - render page
-        // TODO PDJB-670: Implement Check EPC Answers step
-        assertThat(checkEpcAnswersPage.heading).containsText("TODO")
+        // Check EPC Answers - render page
+        assertThat(checkEpcAnswersPage.heading).containsText("Energy performance certificate (EPC)")
     }
 
     @Test
@@ -1236,8 +1238,8 @@ class PropertyRegistrationJourneyTests : IntegrationTestWithMutableData("data-lo
         val checkEpcAnswersPage = assertPageIs(page, CheckEpcAnswersFormPagePropertyRegistration::class)
 
         // Check EPC Answers - render page
-        // TODO PDJB-670: Implement Check EPC Answers step
-        assertThat(checkEpcAnswersPage.heading).containsText("TODO")
+        // Check EPC Answers - render page
+        assertThat(checkEpcAnswersPage.heading).containsText("Energy performance certificate (EPC)")
     }
 
     companion object {

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/PropertyRegistrationJourneyTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/PropertyRegistrationJourneyTests.kt
@@ -445,7 +445,6 @@ class PropertyRegistrationJourneyTests : IntegrationTestWithMutableData("data-lo
         val checkEpcAnswersPage = assertPageIs(page, CheckEpcAnswersFormPagePropertyRegistration::class)
 
         // Check EPC Answers - render page
-        // Check EPC Answers - render page
         assertThat(checkEpcAnswersPage.heading).containsText("Energy performance certificate (EPC)")
         checkEpcAnswersPage.form.submit()
         val checkAnswersPage = assertPageIs(page, CheckAnswersPagePropertyRegistration::class)
@@ -622,7 +621,6 @@ class PropertyRegistrationJourneyTests : IntegrationTestWithMutableData("data-lo
         epcMissingPage.form.submit()
         val checkEpcAnswersPage = assertPageIs(page, CheckEpcAnswersFormPagePropertyRegistration::class)
 
-        // Check EPC Answers - render page
         // Check EPC Answers - render page
         assertThat(checkEpcAnswersPage.heading).containsText("Energy performance certificate (EPC)")
         checkEpcAnswersPage.form.submit()
@@ -853,7 +851,6 @@ class PropertyRegistrationJourneyTests : IntegrationTestWithMutableData("data-lo
         val checkEpcAnswersPage = assertPageIs(page, CheckEpcAnswersFormPagePropertyRegistration::class)
 
         // Check EPC Answers - render page
-        // Check EPC Answers - render page
         assertThat(checkEpcAnswersPage.heading).containsText("Energy performance certificate (EPC)")
         checkEpcAnswersPage.form.submit()
         val checkAnswersPage = assertPageIs(page, CheckAnswersPagePropertyRegistration::class)
@@ -958,7 +955,6 @@ class PropertyRegistrationJourneyTests : IntegrationTestWithMutableData("data-lo
         epcExpiredPage.form.submit()
         val checkEpcAnswersPage = assertPageIs(page, CheckEpcAnswersFormPagePropertyRegistration::class)
 
-        // Check EPC Answers - render page
         // Check EPC Answers - render page
         assertThat(checkEpcAnswersPage.heading).containsText("Energy performance certificate (EPC)")
         checkEpcAnswersPage.form.submit()
@@ -1083,7 +1079,6 @@ class PropertyRegistrationJourneyTests : IntegrationTestWithMutableData("data-lo
         val checkEpcAnswersPage = assertPageIs(page, CheckEpcAnswersFormPagePropertyRegistration::class)
 
         // Check EPC Answers - render page
-        // Check EPC Answers - render page
         assertThat(checkEpcAnswersPage.heading).containsText("Energy performance certificate (EPC)")
         checkEpcAnswersPage.form.submit()
         val checkAnswersPage = assertPageIs(page, CheckAnswersPagePropertyRegistration::class)
@@ -1133,7 +1128,6 @@ class PropertyRegistrationJourneyTests : IntegrationTestWithMutableData("data-lo
         epcSupersededPage.submitContinueWithLatest()
         val checkEpcAnswersPage = assertPageIs(page, CheckEpcAnswersFormPagePropertyRegistration::class)
 
-        // Check EPC Answers - render page
         // Check EPC Answers - render page
         assertThat(checkEpcAnswersPage.heading).containsText("Energy performance certificate (EPC)")
         checkEpcAnswersPage.form.submit()
@@ -1200,7 +1194,6 @@ class PropertyRegistrationJourneyTests : IntegrationTestWithMutableData("data-lo
         val checkEpcAnswersPage = assertPageIs(page, CheckEpcAnswersFormPagePropertyRegistration::class)
 
         // Check EPC Answers - render page
-        // Check EPC Answers - render page
         assertThat(checkEpcAnswersPage.heading).containsText("Energy performance certificate (EPC)")
     }
 
@@ -1218,7 +1211,6 @@ class PropertyRegistrationJourneyTests : IntegrationTestWithMutableData("data-lo
         val checkEpcAnswersPage = assertPageIs(page, CheckEpcAnswersFormPagePropertyRegistration::class)
 
         // Check EPC Answers - render page
-        // Check EPC Answers - render page
         assertThat(checkEpcAnswersPage.heading).containsText("Energy performance certificate (EPC)")
     }
 
@@ -1230,7 +1222,6 @@ class PropertyRegistrationJourneyTests : IntegrationTestWithMutableData("data-lo
         epcExemptionPage.submitExemptionReason(EpcExemptionReason.PROTECTED_ARCHITECTURAL_OR_HISTORICAL_MERIT)
         val checkEpcAnswersPage = assertPageIs(page, CheckEpcAnswersFormPagePropertyRegistration::class)
 
-        // Check EPC Answers - render page
         // Check EPC Answers - render page
         assertThat(checkEpcAnswersPage.heading).containsText("Energy performance certificate (EPC)")
     }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/PropertyRegistrationJourneyTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/PropertyRegistrationJourneyTests.kt
@@ -1181,7 +1181,6 @@ class PropertyRegistrationJourneyTests : IntegrationTestWithMutableData("data-lo
         val checkEpcAnswersPage = assertPageIs(page, CheckEpcAnswersFormPagePropertyRegistration::class)
 
         // Check EPC Answers - render page
-        // Check EPC Answers - render page
         assertThat(checkEpcAnswersPage.heading).containsText("Energy performance certificate (EPC)")
         checkEpcAnswersPage.form.submit()
         val checkAnswersPage = assertPageIs(page, CheckAnswersPagePropertyRegistration::class)

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/PropertyRegistrationJourneyTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/PropertyRegistrationJourneyTests.kt
@@ -853,7 +853,7 @@ class PropertyRegistrationJourneyTests : IntegrationTestWithMutableData("data-lo
         // Check EPC Answers - render page
         assertThat(checkEpcAnswersPage.heading).containsText("Energy performance certificate (EPC)")
         checkEpcAnswersPage.form.submit()
-        val checkAnswersPage = assertPageIs(page, CheckAnswersPagePropertyRegistration::class)
+        assertPageIs(page, CheckAnswersPagePropertyRegistration::class)
     }
 
     @Test
@@ -958,7 +958,7 @@ class PropertyRegistrationJourneyTests : IntegrationTestWithMutableData("data-lo
         // Check EPC Answers - render page
         assertThat(checkEpcAnswersPage.heading).containsText("Energy performance certificate (EPC)")
         checkEpcAnswersPage.form.submit()
-        val checkAnswersPage = assertPageIs(page, CheckAnswersPagePropertyRegistration::class)
+        assertPageIs(page, CheckAnswersPagePropertyRegistration::class)
     }
 
     @Test
@@ -1081,7 +1081,7 @@ class PropertyRegistrationJourneyTests : IntegrationTestWithMutableData("data-lo
         // Check EPC Answers - render page
         assertThat(checkEpcAnswersPage.heading).containsText("Energy performance certificate (EPC)")
         checkEpcAnswersPage.form.submit()
-        val checkAnswersPage = assertPageIs(page, CheckAnswersPagePropertyRegistration::class)
+        assertPageIs(page, CheckAnswersPagePropertyRegistration::class)
     }
 
     @Test
@@ -1131,7 +1131,7 @@ class PropertyRegistrationJourneyTests : IntegrationTestWithMutableData("data-lo
         // Check EPC Answers - render page
         assertThat(checkEpcAnswersPage.heading).containsText("Energy performance certificate (EPC)")
         checkEpcAnswersPage.form.submit()
-        val checkAnswersPage = assertPageIs(page, CheckAnswersPagePropertyRegistration::class)
+        assertPageIs(page, CheckAnswersPagePropertyRegistration::class)
     }
 
     @Test
@@ -1177,7 +1177,7 @@ class PropertyRegistrationJourneyTests : IntegrationTestWithMutableData("data-lo
         // Check EPC Answers - render page
         assertThat(checkEpcAnswersPage.heading).containsText("Energy performance certificate (EPC)")
         checkEpcAnswersPage.form.submit()
-        val checkAnswersPage = assertPageIs(page, CheckAnswersPagePropertyRegistration::class)
+        assertPageIs(page, CheckAnswersPagePropertyRegistration::class)
     }
 
     @Test

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/propertyRegistrationJourneyPages/CheckEpcAnswersFormPagePropertyRegistration.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/propertyRegistrationJourneyPages/CheckEpcAnswersFormPagePropertyRegistration.kt
@@ -7,7 +7,6 @@ import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.Headin
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages.BasePage
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.CheckEpcAnswersStep
 
-// TODO PDJB-670: Implement Check EPC Answers page object
 class CheckEpcAnswersFormPagePropertyRegistration(
     page: Page,
 ) : BasePage(page, "${RegisterPropertyController.PROPERTY_REGISTRATION_ROUTE}/${CheckEpcAnswersStep.ROUTE_SEGMENT}") {


### PR DESCRIPTION
## Ticket number

PDJB-670

## Goal of change

Adds the check your answers page for EPC:

## Description of main change(s)

Adds pages for the following cases:

the same for both:

- no epc, exempt: shows Q's and exemption reason

<img width="973" height="651" alt="image" src="https://github.com/user-attachments/assets/060e88b1-ab16-4359-a263-038eee7fd2af" />

- valid epc: shows card and that it is valid in an insert

<img width="970" height="840" alt="image" src="https://github.com/user-attachments/assets/9a75935c-bb64-4adf-b2a3-9c754e3c8d86" />

- epc with MEES exemption: shows card and low energy warning, with mees exemption Qs

<img width="971" height="1028" alt="image" src="https://github.com/user-attachments/assets/23dc1e9a-604b-43de-85c1-b5f5161d1e81" />

unoccupied:

- skip = no epc, no exemption = epc expired = low energy, no exemption: provide later with 28 days clause

<img width="989" height="501" alt="image" src="https://github.com/user-attachments/assets/48069317-dfbc-4e9a-9868-51d629962445" />

occupied:

- no epc, no exemption, occupied: shows path and an insert saying the council will see it's invalid

<img width="973" height="649" alt="image" src="https://github.com/user-attachments/assets/8a8e9202-f849-4f13-95ab-ab166a9f3305" />

- expired, not in date when tenancy began, occupied: card, expired warning, tenancy Q & council warning

<img width="966" height="1014" alt="image" src="https://github.com/user-attachments/assets/1c475ab3-1aeb-47fc-a38a-d0bc5e716793" />

- low energy, no exemption: card, warning, no exemption Q, council can see it's invalid insert

<img width="671" height="1005" alt="image" src="https://github.com/user-attachments/assets/a11ab58a-d7c0-4ee1-80eb-8360388d491f" />

- skip: same as unoccupied but without the 28 days clause

<img width="971" height="490" alt="image" src="https://github.com/user-attachments/assets/254f52ce-9a39-48ae-901f-389e3f24aff9" />

- expired but epc in date when tenancy began: same as valid but with the expiry Q

<img width="988" height="1000" alt="image" src="https://github.com/user-attachments/assets/02a03cb1-d530-469c-ae07-f5ac1ab8e2fc" />


- epc with exemption and expired but in date when tenancy began: same as above but with expiry question and warning above the mees data

<img width="683" height="1100" alt="image" src="https://github.com/user-attachments/assets/df085d67-88c8-4f92-940d-306b49c96380" />

## Anything you'd like to highlight to the reviewer?

The change links currently just take you back to the page of that question. I can replace them with TODOs if this should be more clear / different behaviour

## Checklist

Delete any that are not applicable, and add explanation below for any that are applicable but haven't been done

- [x] Screenshots of any UI changes have been added
- [x] Unit tests for new logic (e.g. new service methods) have been added
- [x] Single page integration tests have been added for any unhappy-flow UI features, e.g. validation errors
- [x] New journey steps have been added to the appropriate journey integration test(s)
- [x] Test suite has been run in full locally and is passing
- [x] TODO comments referencing this JIRA ticket have been searched for and removed - if a future PR will address them,
  mention that here
- [ ] QA instructions have been added to the ticket (particularly if this is the last PR required to complete the ticket)
