### PR TITLE
PDJB-616: Update placeholder contact details to public beta values

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/constants/ExternalEmails.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/constants/ExternalEmails.kt
@@ -4,4 +4,4 @@ const val DATA_PROTECTION_COMMUNITIES_EMAILS = "dataprotection@communities.gov.u
 
 const val DPO_COMMUNITIES_EMAILS = "dpo@communities.gov.uk"
 
-const val PRSD_EMAIL = "PRSDatabase@communities.gov.uk"
+const val PRSD_EMAIL = "prs.beta@communities.gov.uk"

--- a/src/main/resources/messages/betaBannerFeedback.yml
+++ b/src/main/resources/messages/betaBannerFeedback.yml
@@ -8,7 +8,7 @@ buttonText: Send feedback
 'heading.two': Other ways to give feedback
 'heading.three': Email
 paragraph:
-  one: 'PRSDatabase@communities.gov.uk'
+  one: 'prs.beta@communities.gov.uk'
 error:
   missing: Enter your feedback about the service
   tooLong: 'Your feedback must be 1,200 characters or fewer'

--- a/src/main/resources/messages/footer.yml
+++ b/src/main/resources/messages/footer.yml
@@ -1,7 +1,7 @@
 supportLinks: Support links
 email:
   beforeLink: 'If you need help using this private beta, get in touch by email:'
-  link: 'PRSDatabase@communities.gov.uk'
+  link: 'prs.beta@communities.gov.uk'
   afterLink: .
 cookies:
   link: Cookies

--- a/src/main/resources/messages/forms.yml
+++ b/src/main/resources/messages/forms.yml
@@ -246,7 +246,7 @@ alreadyRegistered:
       one: The previous owner of the property may need to remove their association with the property.
       two:
         beforeEmailLink: 'Contact the Ministry of Housing, Communities and Local Government by email:'
-        email: 'PRSDatabase@communities.gov.uk'
+        email: 'prs.beta@communities.gov.uk'
 propertyType:
   fieldSetHeading: What type of property are you registering?
   radios:

--- a/src/main/resources/messages/joinProperty.yml
+++ b/src/main/resources/messages/joinProperty.yml
@@ -22,11 +22,10 @@ otherWays:
   summary: Other ways to confirm you’re a landlord
   content:
     paragraph: You can also contact us to get added to a property. We’ll need to see proof that you’re a landlord.
-    # TODO: PDJB-616 - Replace placeholder contact information with real values
-    phone: "Phone: 0009 988 8799"
+    phone: "Phone: 0303 444 7000"
     phoneHours: Monday to Friday, 9am to 5pm
     email: "Email:"
-    emailAddress: mhclg@example.com
+    emailAddress: prs.beta@communities.gov.uk
 responsibilities:
   heading: Your responsibilities after joining
   paragraph:
@@ -51,11 +50,10 @@ noMatchingProperties:
       afterLink: "."
     askLandlord: If you do not know this number, ask a landlord already registered on the property to invite you.
     contactUs: If you cannot speak to a landlord, contact us for help.
-    # TODO: PDJB-616 - Replace placeholder contact information with real values
-    phone: "Phone: 0009 988 8799"
+    phone: "Phone: 0303 444 7000"
     phoneHours: Monday to Friday, 9am to 5pm
     email: "Email:"
-    emailAddress: mhclg@example.com
+    emailAddress: prs.beta@communities.gov.uk
 
 selectProperty:
   heading: Select a property
@@ -67,11 +65,10 @@ selectProperty:
     prnLink: use the Property Registration Number to find the property
     askLandlord: If you do not know this number, ask a landlord already registered on the property to invite you.
     contactUs: If you cannot speak to a landlord, contact us for help.
-    # TODO: PDJB-616 - Replace placeholder contact information with real values
-    phone: "Phone: 0009 988 8799"
+    phone: "Phone: 0303 444 7000"
     phoneHours: Monday to Friday, 9am to 5pm
     email: "Email:"
-    emailAddress: mhclg@example.com
+    emailAddress: prs.beta@communities.gov.uk
   error:
     missing: Select the property you want to join
     invalidSelection: Select the property you want to join

--- a/src/main/resources/templates/forms/selectFromListForm.html
+++ b/src/main/resources/templates/forms/selectFromListForm.html
@@ -39,11 +39,11 @@
                 <p class="govuk-body" th:text="#{joinProperty.selectProperty.notListed.contactUs}">
                     If you cannot speak to a landlord, contact us for help.
                 </p>
-                <p class="govuk-body" th:text="#{joinProperty.selectProperty.notListed.phone}">Phone: 0009 988 8799</p>
+                <p class="govuk-body" th:text="#{joinProperty.selectProperty.notListed.phone}">Phone: 0303 444 7000</p>
                 <p class="govuk-body" th:text="#{joinProperty.selectProperty.notListed.phoneHours}">Monday to Friday, 9am to 5pm</p>
                 <p class="govuk-body">
                     <span th:text="#{joinProperty.selectProperty.notListed.email}">Email:</span>
-                    <a class="govuk-link" th:href="'mailto:' + #{joinProperty.selectProperty.notListed.emailAddress}" th:text="#{joinProperty.selectProperty.notListed.emailAddress}">mhclg@example.com</a>
+                    <a class="govuk-link" th:href="'mailto:' + #{joinProperty.selectProperty.notListed.emailAddress}" th:text="#{joinProperty.selectProperty.notListed.emailAddress}">prs.beta@communities.gov.uk</a>
                 </p>
             </div>
         </details>

--- a/src/main/resources/templates/maintenancePage.html
+++ b/src/main/resources/templates/maintenancePage.html
@@ -79,7 +79,7 @@
                 <h2 class="govuk-visually-hidden">Support links</h2>
                 <div class="govuk-footer__meta-custom">
                     <span>If you need help using this private beta, get in touch by email:</span>
-                    <a class="govuk-footer__link" href="mailto: PRSDatabase@communities.gov.uk">PRSDatabase@communities.gov.uk</a>
+                    <a class="govuk-footer__link" href="mailto:prs.beta@communities.gov.uk">prs.beta@communities.gov.uk</a>
                     <span>.</span>
                 </div>
                 <div class="govuk-footer__meta-custom">


### PR DESCRIPTION
## Ticket number

PDJB-616

## Goal of change

Replace all placeholder and outdated contact details across the codebase with the correct public beta values before launch.

## Description of main change(s)

- Replaces placeholder phone number (`0009 988 8799`) with `0303 444 7000` in the join property journey contact sections
- Replaces placeholder email (`mhclg@example.com`) with `prs.beta@communities.gov.uk` in the join property journey contact sections
- Updates the `PRSD_EMAIL` constant and all hardcoded instances of `PRSDatabase@communities.gov.uk` to `prs.beta@communities.gov.uk` across the footer, feedback page, forms, and maintenance page
- Removes three TODO comments that were tracking this ticket
- Fixes a pre-existing spurious space in the maintenance page's `mailto:` link

## Anything you'd like to highlight to the reviewer?

The maintenance page (`maintenancePage.html`) has the email hardcoded as a static string rather than using the `PRSD_EMAIL` constant or a message key. This is intentional because the maintenance page is served when the application is down, so Thymeleaf model attributes may be unavailable. If the contact email changes again in future, this file will need a separate update.

## Checklist

- [x] Test suite has been run in full locally and is passing
- [x] Branch has been rebased onto main and run locally, with everything working as expected (both for your new feature and any related functionality)
- [x] TODO comments referencing this JIRA ticket have been searched for and removed