### PR TITLE
PDJB-653: Give unique names to file uploads

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/helpers/PropertyComplianceJourneyHelper.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/helpers/PropertyComplianceJourneyHelper.kt
@@ -20,8 +20,13 @@ class PropertyComplianceJourneyHelper {
             if (memberId != null) {
                 "certificateUpload.$journeyId.$stepName.$memberId"
             } else {
-                "certificateUpload.$journeyId.$stepName"
+                "certificateUpload.$journeyId.$stepName.${randomSuffix()}"
             }
+
+        private fun randomSuffix(): String {
+            val allowedChars = ('a'..'z')
+            return String(CharArray(5) { allowedChars.random() })
+        }
 
         fun getCertFilename(
             propertyOwnershipId: Long,

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/CheckElectricalCertUploadsStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/CheckElectricalCertUploadsStepConfig.kt
@@ -27,7 +27,10 @@ class CheckElectricalCertUploadsStepConfig(
             "submitButtonText" to "forms.buttons.saveAndContinue",
             "addAnotherButtonText" to "uploads.checkUploads.buttons.addAnother",
             "uploadRows" to getUploadRows(state),
-            "addAnotherUrl" to Destination(state.uploadElectricalCertStep).toUrlStringOrNull(),
+            "addAnotherUrl" to
+                Destination(state.uploadElectricalCertStep)
+                    .withUrlParameter(memberIdService.createParameterPair(state.nextElectricalUploadMemberId ?: 1))
+                    .toUrlStringOrNull(),
         )
 
     private fun getUploadRows(state: ElectricalSafetyState): List<UploadRow> =

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/CheckGasCertUploadsStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/CheckGasCertUploadsStepConfig.kt
@@ -27,7 +27,10 @@ class CheckGasCertUploadsStepConfig(
             "submitButtonText" to "forms.buttons.saveAndContinue",
             "addAnotherButtonText" to "uploads.checkUploads.buttons.addAnother",
             "uploadRows" to getUploadRows(state),
-            "addAnotherUrl" to Destination(state.uploadGasCertStep).toUrlStringOrNull(),
+            "addAnotherUrl" to
+                Destination(state.uploadGasCertStep)
+                    .withUrlParameter(memberIdService.createParameterPair(state.nextGasUploadMemberId ?: 1))
+                    .toUrlStringOrNull(),
         )
 
     private fun getUploadRows(state: GasSafetyState): List<UploadRow> =

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/CheckElectricalCertUploadsStepConfigTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/CheckElectricalCertUploadsStepConfigTests.kt
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.Mock
 import org.mockito.Mockito.mock
 import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.whenever
 import uk.gov.communities.prsdb.webapp.constants.enums.FileUploadStatus
 import uk.gov.communities.prsdb.webapp.database.entity.FileUpload
@@ -142,6 +143,7 @@ class CheckElectricalCertUploadsStepConfigTests {
         fun `getStepSpecificContent returns empty upload rows when map is empty`() {
             setupStepMocks(includeRemoveStep = false)
             whenever(mockState.electricalUploadMap).thenReturn(emptyMap())
+            whenever(mockMemberIdService.createParameterPair(anyOrNull())).thenReturn("memberId" to "0")
 
             val content = stepConfig.getStepSpecificContent(mockState)
 


### PR DESCRIPTION
## Ticket number
PDJB-653

## Goal of change
Multiple file uploads not working when the file names clash.

## Description of main change(s)
Ensures the member id is added to the URL when adding another upload.