### PR TITLE
PDJB-653: Always track highest member id

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/PropertyRegistrationJourneyFactory.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/PropertyRegistrationJourneyFactory.kt
@@ -425,9 +425,9 @@ class PropertyRegistrationJourney(
         occupied.formModelOrNull?.occupied ?: throw PrsdbWebException("Cannot use isOccupied until after the occupation step")
 
     override var gasUploadMap: Map<Int, CertificateUpload> by delegateProvider.requiredDelegate("gasUploadMap", mapOf())
-    override var nextGasUploadMemberId: Int? by delegateProvider.nullableDelegate("nextGasUploadMemberId")
+    override var highestAssignedGasMemberId: Int? by delegateProvider.nullableDelegate("highestGasUploadMemberId")
     override var electricalUploadMap: Map<Int, CertificateUpload> by delegateProvider.requiredDelegate("electricalUploadMap", mapOf())
-    override var nextElectricalUploadMemberId: Int? by delegateProvider.nullableDelegate("nextElectricalUploadMemberId")
+    override var highestAssignedElectricalMemberId: Int? by delegateProvider.nullableDelegate("highestAssignedElectricalMemberId")
 
     override val uprn: Long? get() = selectAddressStep.formModelOrNull?.address?.let { getMatchingAddress(it)?.uprn }
 

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/states/ElectricalSafetyState.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/states/ElectricalSafetyState.kt
@@ -38,7 +38,8 @@ interface ElectricalSafetyState : JourneyState {
     val isOccupied: Boolean?
 
     var electricalUploadMap: Map<Int, CertificateUpload>
-    var nextElectricalUploadMemberId: Int?
+    var highestAssignedElectricalMemberId: Int?
+    val nextElectricalUploadMemberId: Int get() = highestAssignedElectricalMemberId?.let { it + 1 } ?: 1
 
     val hasElectricalCertStep: HasElectricalCertStep
     val electricalCertExpiryDateStep: ElectricalCertExpiryDateStep

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/states/ElectricalSafetyState.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/states/ElectricalSafetyState.kt
@@ -39,7 +39,8 @@ interface ElectricalSafetyState : JourneyState {
 
     var electricalUploadMap: Map<Int, CertificateUpload>
     var highestAssignedElectricalMemberId: Int?
-    val nextElectricalUploadMemberId: Int get() = highestAssignedElectricalMemberId?.let { it + 1 } ?: 1
+
+    fun getNextElectricalUploadMemberId(): Int = highestAssignedElectricalMemberId?.let { it + 1 } ?: 1
 
     val hasElectricalCertStep: HasElectricalCertStep
     val electricalCertExpiryDateStep: ElectricalCertExpiryDateStep

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/states/GasSafetyState.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/states/GasSafetyState.kt
@@ -40,7 +40,8 @@ interface GasSafetyState : JourneyState {
         }
 
     var gasUploadMap: Map<Int, CertificateUpload>
-    var nextGasUploadMemberId: Int?
+    var highestAssignedGasMemberId: Int?
+    val nextGasUploadMemberId: Int get() = highestAssignedGasMemberId?.let { it + 1 } ?: 1
 
     val hasGasSupplyStep: HasGasSupplyStep
     val hasGasCertStep: HasGasCertStep

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/states/GasSafetyState.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/states/GasSafetyState.kt
@@ -41,7 +41,8 @@ interface GasSafetyState : JourneyState {
 
     var gasUploadMap: Map<Int, CertificateUpload>
     var highestAssignedGasMemberId: Int?
-    val nextGasUploadMemberId: Int get() = highestAssignedGasMemberId?.let { it + 1 } ?: 1
+
+    fun getNextGasUploadMemberId(): Int = highestAssignedGasMemberId?.let { it + 1 } ?: 1
 
     val hasGasSupplyStep: HasGasSupplyStep
     val hasGasCertStep: HasGasCertStep

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/CheckElectricalCertUploadsStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/CheckElectricalCertUploadsStepConfig.kt
@@ -29,7 +29,7 @@ class CheckElectricalCertUploadsStepConfig(
             "uploadRows" to getUploadRows(state),
             "addAnotherUrl" to
                 Destination(state.uploadElectricalCertStep)
-                    .withUrlParameter(memberIdService.createParameterPair(state.nextElectricalUploadMemberId ?: 1))
+                    .withUrlParameter(memberIdService.createParameterPair(state.getNextElectricalUploadMemberId()))
                     .toUrlStringOrNull(),
         )
 

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/CheckGasCertUploadsStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/CheckGasCertUploadsStepConfig.kt
@@ -29,7 +29,7 @@ class CheckGasCertUploadsStepConfig(
             "uploadRows" to getUploadRows(state),
             "addAnotherUrl" to
                 Destination(state.uploadGasCertStep)
-                    .withUrlParameter(memberIdService.createParameterPair(state.nextGasUploadMemberId ?: 1))
+                    .withUrlParameter(memberIdService.createParameterPair(state.getNextGasUploadMemberId()))
                     .toUrlStringOrNull(),
         )
 

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/UploadElectricalCertStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/UploadElectricalCertStepConfig.kt
@@ -15,6 +15,7 @@ import uk.gov.communities.prsdb.webapp.services.CollectionKeyParameterService
 import uk.gov.communities.prsdb.webapp.services.FileUploadCookieService
 import uk.gov.communities.prsdb.webapp.services.VirusScanCallbackService
 import kotlin.collections.set
+import kotlin.math.max
 
 @JourneyFrameworkComponent
 class UploadElectricalCertStepConfig(
@@ -30,7 +31,9 @@ class UploadElectricalCertStepConfig(
         val fieldSetHeading =
             when (state.getElectricalCertificateType()) {
                 HasElectricalSafetyCertificate.HAS_EIC -> "forms.uploadCertificate.eic.fieldSetHeading"
+
                 HasElectricalSafetyCertificate.HAS_EICR -> "forms.uploadCertificate.eicr.fieldSetHeading"
+
                 else -> throw PrsdbWebException(
                     "Upload electrical cert step reached without a valid electrical certificate type selection",
                 )
@@ -60,21 +63,16 @@ class UploadElectricalCertStepConfig(
             )
 
             val formModel = getFormModelFromState(state)
+
+            val keyToUpdate = memberIdService.getParameterOrNull() ?: state.nextElectricalUploadMemberId
+
             val currentMap = state.electricalUploadMap.toMutableMap()
-
-            val keyToUpdate = memberIdService.getParameterOrNull()
-            formModel.let {
-                if (keyToUpdate != null) {
-                    currentMap[keyToUpdate] = CertificateUpload(fileUploadId, it.name)
-                } else {
-                    // We need entries to have unique indexes as if a user goes back to the delete page of an old upload, we want to ensure they can't delete a file they didn't mean to
-                    val nextKey = state.nextElectricalUploadMemberId ?: ((currentMap.keys.maxOrNull() ?: 0) + 1)
-
-                    currentMap[nextKey] = CertificateUpload(fileUploadId, it.name)
-                    state.nextElectricalUploadMemberId = nextKey + 1
-                }
-            }
+            currentMap[keyToUpdate] = CertificateUpload(fileUploadId, formModel.name)
             state.electricalUploadMap = currentMap
+
+            // We need entries to have unique indexes as if a user goes back to the delete page of an old upload, we want to ensure they can't delete a file they didn't mean to
+            state.highestAssignedElectricalMemberId = max(keyToUpdate, state.highestAssignedElectricalMemberId ?: 0)
+
             state.uploadElectricalCertStep.clearFormData()
         }
     }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/UploadElectricalCertStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/UploadElectricalCertStepConfig.kt
@@ -64,7 +64,7 @@ class UploadElectricalCertStepConfig(
 
             val formModel = getFormModelFromState(state)
 
-            val keyToUpdate = memberIdService.getParameterOrNull() ?: state.nextElectricalUploadMemberId
+            val keyToUpdate = memberIdService.getParameterOrNull() ?: state.getNextElectricalUploadMemberId()
 
             val currentMap = state.electricalUploadMap.toMutableMap()
             currentMap[keyToUpdate] = CertificateUpload(fileUploadId, formModel.name)

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/UploadGasCertStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/UploadGasCertStepConfig.kt
@@ -13,6 +13,7 @@ import uk.gov.communities.prsdb.webapp.services.CollectionKeyParameterService
 import uk.gov.communities.prsdb.webapp.services.FileUploadCookieService
 import uk.gov.communities.prsdb.webapp.services.VirusScanCallbackService
 import kotlin.collections.set
+import kotlin.math.max
 
 @JourneyFrameworkComponent
 class UploadGasCertStepConfig(
@@ -49,21 +50,16 @@ class UploadGasCertStepConfig(
             )
 
             val formModel = getFormModelFromState(state)
+
+            val keyToUpdate = memberIdService.getParameterOrNull() ?: state.nextGasUploadMemberId
+
             val currentMap = state.gasUploadMap.toMutableMap()
-
-            val keyToUpdate = memberIdService.getParameterOrNull()
-            formModel.let {
-                if (keyToUpdate != null) {
-                    currentMap[keyToUpdate] = CertificateUpload(fileUploadId, it.name)
-                } else {
-                    // We need entries to have unique indexes as if a user goes back to the delete page of an old upload, we want to ensure they can't delete a file they didn't mean to
-                    val nextKey = state.nextGasUploadMemberId ?: ((currentMap.keys.maxOrNull() ?: 0) + 1)
-
-                    currentMap[nextKey] = CertificateUpload(fileUploadId, it.name)
-                    state.nextGasUploadMemberId = nextKey + 1
-                }
-            }
+            currentMap[keyToUpdate] = CertificateUpload(fileUploadId, formModel.name)
             state.gasUploadMap = currentMap
+
+            // We need entries to have unique indexes as if a user goes back to the delete page of an old upload, we want to ensure they can't delete a file they didn't mean to
+            state.highestAssignedGasMemberId = max(keyToUpdate, state.highestAssignedGasMemberId ?: 0)
+
             state.uploadGasCertStep.clearFormData()
         }
     }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/UploadGasCertStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/UploadGasCertStepConfig.kt
@@ -51,7 +51,7 @@ class UploadGasCertStepConfig(
 
             val formModel = getFormModelFromState(state)
 
-            val keyToUpdate = memberIdService.getParameterOrNull() ?: state.nextGasUploadMemberId
+            val keyToUpdate = memberIdService.getParameterOrNull() ?: state.getNextGasUploadMemberId()
 
             val currentMap = state.gasUploadMap.toMutableMap()
             currentMap[keyToUpdate] = CertificateUpload(fileUploadId, formModel.name)

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/states/ElectricalSafetyStateTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/states/ElectricalSafetyStateTests.kt
@@ -119,7 +119,7 @@ class ElectricalSafetyStateTests {
         object : AbstractJourneyState(journeyStateService = mock()), ElectricalSafetyState {
             override val isOccupied: Boolean = true
             override var electricalUploadMap: Map<Int, CertificateUpload> = mapOf()
-            override var nextElectricalUploadMemberId: Int? = null
+            override var highestAssignedElectricalMemberId: Int? = null
             override val uploadElectricalCertStep = mock<UploadElectricalCertStep>()
             override val hasUploadedElectricalCert = mock<HasAnyInCollectionStep>()
             override val checkElectricalCertUploadsStep = mock<CheckElectricalCertUploadsStep>()

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/states/GasSafetyStateTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/states/GasSafetyStateTests.kt
@@ -97,7 +97,7 @@ class GasSafetyStateTests {
         object : AbstractJourneyState(journeyStateService = mock()), GasSafetyState {
             override val isOccupied: Boolean = false
             override var gasUploadMap: Map<Int, CertificateUpload> = emptyMap()
-            override var nextGasUploadMemberId: Int? = null
+            override var highestAssignedGasMemberId: Int? = null
             override val hasGasSupplyStep = mock<HasGasSupplyStep>()
             override val hasGasCertStep = mock<HasGasCertStep>()
             override val uploadGasCertStep = mock<UploadGasCertStep>()

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/UploadElectricalCertStepConfigTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/UploadElectricalCertStepConfigTests.kt
@@ -92,7 +92,7 @@ class UploadElectricalCertStepConfigTests {
             mapOf("name" to "cert.pdf", "fileUploadId" to "42"),
         )
         whenever(mockState.electricalUploadMap).thenReturn(mapOf())
-        whenever(mockState.nextElectricalUploadMemberId).thenReturn(1)
+        whenever(mockState.getNextElectricalUploadMemberId()).thenReturn(1)
         whenever(mockState.journeyId).thenReturn("test-journey-id")
         whenever(mockState.uploadElectricalCertStep).thenReturn(uploadElectricalCertStep)
         whenever(memberIdService.getParameterOrNull()).thenReturn(null)

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/UploadElectricalCertStepConfigTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/UploadElectricalCertStepConfigTests.kt
@@ -8,7 +8,6 @@ import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.argumentCaptor
-import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import uk.gov.communities.prsdb.webapp.constants.enums.CertificateType
@@ -93,7 +92,7 @@ class UploadElectricalCertStepConfigTests {
             mapOf("name" to "cert.pdf", "fileUploadId" to "42"),
         )
         whenever(mockState.electricalUploadMap).thenReturn(mapOf())
-        whenever(mockState.nextElectricalUploadMemberId).thenReturn(null)
+        whenever(mockState.nextElectricalUploadMemberId).thenReturn(1)
         whenever(mockState.journeyId).thenReturn("test-journey-id")
         whenever(mockState.uploadElectricalCertStep).thenReturn(uploadElectricalCertStep)
         whenever(memberIdService.getParameterOrNull()).thenReturn(null)
@@ -106,7 +105,7 @@ class UploadElectricalCertStepConfigTests {
         val updatedMapCaptor = argumentCaptor<Map<Int, CertificateUpload>>()
         verify(mockState).electricalUploadMap = updatedMapCaptor.capture()
         assertEquals(CertificateUpload(42L, "cert.pdf"), updatedMapCaptor.firstValue[1])
-        verify(mockState).nextElectricalUploadMemberId = 2
+        verify(mockState).highestAssignedElectricalMemberId = 1
         verify(uploadElectricalCertStep).clearFormData()
     }
 
@@ -126,7 +125,7 @@ class UploadElectricalCertStepConfigTests {
         val updatedMapCaptor = argumentCaptor<Map<Int, CertificateUpload>>()
         verify(mockState).electricalUploadMap = updatedMapCaptor.capture()
         assertEquals(CertificateUpload(55L, "updated.pdf"), updatedMapCaptor.firstValue[3])
-        verify(mockState, never()).nextElectricalUploadMemberId = 4
+        verify(mockState).highestAssignedElectricalMemberId = 3
     }
 
     private fun setupStepConfig(): UploadElectricalCertStepConfig {


### PR DESCRIPTION
## Ticket number
PDJB-653

## Goal of change
Fix issue where we do not assign a new `nextMemberId` when using a member ID set in the url