### PR TITLE
Feat/pdjb 807 add compliance to task list

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/PropertyRegistrationTaskListStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/PropertyRegistrationTaskListStepConfig.kt
@@ -14,8 +14,7 @@ import uk.gov.communities.prsdb.webapp.models.viewModels.taskModels.TaskSectionV
 @JourneyFrameworkComponent
 class PropertyRegistrationTaskListStepConfig(
     private val jointLandlordsStrategy: JointLandlordsPropertyRegistrationStrategy,
-) :
-    AbstractRequestableStepConfig<Complete, NoInputFormModel, PropertyRegistrationJourneyState>() {
+) : AbstractRequestableStepConfig<Complete, NoInputFormModel, PropertyRegistrationJourneyState>() {
     override val formModelClass = NoInputFormModel::class
 
     override fun getStepSpecificContent(state: PropertyRegistrationJourneyState): Map<String, Any> =
@@ -37,7 +36,21 @@ class PropertyRegistrationTaskListStepConfig(
                     state.occupationTask,
                     "registerProperty.taskList.register.addTenancyInfo.hint",
                 ),
-            ) + jointLandlordsStrategy.getJointLandlordsTaskListItems(state)
+            ) + jointLandlordsStrategy.getJointLandlordsTaskListItems(state) +
+                listOf(
+                    TaskListItemViewModel.fromTask(
+                        "registerProperty.taskList.gasSafety",
+                        state.gasSafetyTask,
+                    ),
+                    TaskListItemViewModel.fromTask(
+                        "registerProperty.taskList.electricalSafety",
+                        state.electricalSafetyTask,
+                    ),
+                    TaskListItemViewModel.fromTask(
+                        "registerProperty.taskList.epc",
+                        state.epcTask,
+                    ),
+                )
 
         val sectionViewModels =
             listOf(

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/tasks/EpcTask.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/tasks/EpcTask.kt
@@ -1,6 +1,7 @@
 package uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks
 
 import uk.gov.communities.prsdb.webapp.annotations.webAnnotations.JourneyFrameworkComponent
+import uk.gov.communities.prsdb.webapp.constants.enums.TaskStatus
 import uk.gov.communities.prsdb.webapp.journeys.OrParents
 import uk.gov.communities.prsdb.webapp.journeys.Task
 import uk.gov.communities.prsdb.webapp.journeys.hasOutcome
@@ -37,6 +38,15 @@ import uk.gov.communities.prsdb.webapp.journeys.shared.YesOrNo
 class EpcTask : Task<EpcState>() {
     override fun makeSubJourney(state: EpcState) =
         subJourney(state) {
+            taskStatus {
+                when {
+                    exitStep.isStepReachable -> TaskStatus.COMPLETED
+                    journey.checkUprnMatchedEpcStep.outcome != null -> TaskStatus.IN_PROGRESS
+                    journey.hasEpcStep.outcome != null -> TaskStatus.IN_PROGRESS
+                    firstStep.isStepReachable -> TaskStatus.NOT_STARTED
+                    else -> TaskStatus.CANNOT_START
+                }
+            }
             step(journey.epcLookupByUprnStep) {
                 nextStep { mode ->
                     when (mode) {

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/PropertyRegistrationSinglePageTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/PropertyRegistrationSinglePageTests.kt
@@ -58,6 +58,16 @@ class PropertyRegistrationSinglePageTests : IntegrationTestWithImmutableData("da
             assert(taskListPage.taskHasStatus("Add information about any property licensing", "Complete"))
             assert(taskListPage.taskHasStatus("Add tenancy and rental information for the property", "Complete"))
             assert(taskListPage.taskHasStatus("Add information about any additional landlords", "Not started"))
+            assert(taskListPage.taskHasStatus("Gas safety certificate", "Cannot start"))
+            assert(taskListPage.taskHasStatus("Electrical safety certificate", "Cannot start"))
+            assert(taskListPage.taskHasStatus("Energy performance certificate (EPC)", "Cannot start"))
+        }
+
+        @Test
+        fun `EPC task (starting with an internal step) shows as Not Started when the user is on the first step they see`(page: Page) {
+            navigator.skipToPropertyRegistrationHasEpcPage()
+            val taskListPage = navigator.goToPropertyRegistrationTaskList()
+            assert(taskListPage.taskHasStatus("Energy performance certificate (EPC)", "Not started"))
         }
 
         @Test
@@ -70,6 +80,9 @@ class PropertyRegistrationSinglePageTests : IntegrationTestWithImmutableData("da
             assert(taskListPage.taskHasStatus("Add information about any property licensing", "Complete"))
             assert(taskListPage.taskHasStatus("Add tenancy and rental information for the property", "In progress"))
             assert(taskListPage.taskHasStatus("Add information about any additional landlords", "Cannot start"))
+            assert(taskListPage.taskHasStatus("Gas safety certificate", "Cannot start"))
+            assert(taskListPage.taskHasStatus("Electrical safety certificate", "Cannot start"))
+            assert(taskListPage.taskHasStatus("Energy performance certificate (EPC)", "Cannot start"))
         }
     }
 


### PR DESCRIPTION
## Ticket number

PDJB-807

## Goal of change

Add compliance tasks to the task list

## Description of main change(s)

* Add compliance tasks to the task list
* Add config to the EPC task so the the status is shown correctly
    * Custom config needed here because the task starts with an internal step, so the "Not started" status would otherwise be skipped

<img width="568" height="783" alt="image" src="https://github.com/user-attachments/assets/a33271ab-fa51-4a23-b29f-b155889e4b0c" />


## Anything you'd like to highlight to the reviewer?

Include e.g. anything unusual about the PR, where there was some debate over how to implement it, or anywhere you were
unsure of the approach to take and would like specific feedback.

## Checklist

Delete any that are not applicable, and add explanation below for any that are applicable but haven't been done

- [x] Screenshots of any UI changes have been added
- [x] Single page integration tests have been added for any unhappy-flow UI features, e.g. validation errors
- [x] Test suite has been run in full locally and is passing
- [x] Branch has been rebased onto main and run locally, with everything working as expected (both for your new feature
  and any related functionality)
- [x] TODO comments referencing this JIRA ticket have been searched for and removed - if a future PR will address them,
  mention that here (also checked for PDJB-713 - the overall task list ticket)
- [x] QA instructions have been added to the ticket (particularly if this is the last PR required to complete the ticket)
