### PR TITLE
PDJB-714: Make PRN bold on property registration confirmation page

### DIFF
--- a/src/main/resources/templates/registerPropertyConfirmation.html
+++ b/src/main/resources/templates/registerPropertyConfirmation.html
@@ -18,8 +18,9 @@
                th:utext="#{registerProperty.confirmation.prn.label}">
                 registerProperty.confirmation.prn.label
             </p>
-            <div class="govuk-inset-text"
-                 th:text="${prn}">L-GD47-39FX</div>
+            <div class="govuk-inset-text">
+                <strong th:text="${prn}">L-GD47-39FX</strong>
+            </div>
 
             <p class="govuk-body"
                th:text="#{registerProperty.confirmation.keepNumber}">


### PR DESCRIPTION
## Ticket number

PDJB-714

## Goal of change

Fix QA feedback: make the Property Registration Number (PRN) bold on the confirmation page to match the Figma design.

## Description of main change(s)

- Wraps the PRN text in a `<strong>` tag inside the `govuk-inset-text` div on the property registration confirmation page

## Anything you'd like to highlight to the reviewer?

Minimal change — single template edit. The existing integration tests use `textContent()` to read the PRN, which strips HTML tags, so they are unaffected by the added `<strong>` wrapper.

## Checklist

- [x] Branch has been rebased onto main and run locally, with everything working as expected
- [x] TODO comments referencing this JIRA ticket have been searched for and removed - no TODOs found
