### PR TITLE
PDJB-778: Fix LC privacy notice content to match Figma design

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/LocalCouncilPrivacyNoticeController.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/LocalCouncilPrivacyNoticeController.kt
@@ -10,7 +10,6 @@ import uk.gov.communities.prsdb.webapp.constants.DPO_COMMUNITIES_EMAILS
 import uk.gov.communities.prsdb.webapp.constants.INFORMATION_COMMISSIONERS_OFFICE_URL
 import uk.gov.communities.prsdb.webapp.constants.LOCAL_COUNCIL_PATH_SEGMENT
 import uk.gov.communities.prsdb.webapp.constants.PRIVACY_NOTICE_PATH_SEGMENT
-import uk.gov.communities.prsdb.webapp.controllers.LocalCouncilDashboardController.Companion.LOCAL_COUNCIL_DASHBOARD_URL
 import uk.gov.communities.prsdb.webapp.controllers.LocalCouncilPrivacyNoticeController.Companion.LOCAL_COUNCIL_PRIVACY_NOTICE_ROUTE
 
 @PrsdbController
@@ -19,7 +18,6 @@ class LocalCouncilPrivacyNoticeController {
     @GetMapping
     fun getPrivacyNoticePage(model: Model): String {
         model.addAttribute("complaintsProcedureUrl", COMPLAINTS_PROCEDURE_URL)
-        model.addAttribute("backUrl", LOCAL_COUNCIL_DASHBOARD_URL)
         model.addAttribute("informationCommissionersOfficeUrl", INFORMATION_COMMISSIONERS_OFFICE_URL)
         model.addAttribute("dataProtectionCommunitiesEmails", DATA_PROTECTION_COMMUNITIES_EMAILS)
         model.addAttribute("dataProtectionOfficerEmail", DPO_COMMUNITIES_EMAILS)

--- a/src/main/resources/messages/localCouncilPrivacyNotice.yml
+++ b/src/main/resources/messages/localCouncilPrivacyNotice.yml
@@ -14,9 +14,9 @@ section:
     paragraph:
       one: 'As a local council user participating in the extended testing phase, you are invited to use the service on a voluntary basis to help validate the system’s functionality and usability from a local council perspective. You will be asked to authenticate through either GOV.UK One Login or a GDS Internal Access during sign-up.'
     subheading:
-      one: Local council user personal data
-      two: Usage data (for service improvement and essential operational usage)
-      three: Why are we collecting your personal data
+      one: 2.1 Local council user personal data
+      two: 2.2 Usage data (for service improvement and essential operational usage)
+      three: 2.3 Why are we collecting your personal data
     subsection:
       one:
         paragraph:
@@ -39,11 +39,12 @@ section:
             normalText: 'When you authenticate via GOV.UK One Login, we receive a unique, pseudonymous subject identifier. This allows us to link your PRSD account to your authentication session without receiving your name or identity documents directly from the One Login service.'
       two:
         paragraph:
-          one: 'To understand how the service is being used and to identify areas for improvement. Plausible does not use cookies, does not collect personal data and does not track you across different websites.'
+          one: 'We use Plausible Analytics to understand how the service is being used and to identify areas for improvement. Plausible does not use cookies, does not collect personal data and does not track you across different websites.'
         statisticalPurpose:
           boldText: 'Statistical Purpose:'
           normalText: 'We process this information as a ‘statistical exception’ under the <strong>Data (Use and Access) Act 2025</strong>. This means we do not require your consent to collect this anonymised data as it is used purely to ensure the service is functional, accessible and meeting user needs.'
         important:
+          prefix: 'Important Note:'
           note: 'Any significant changes to the types of data collected, the purposes for which it is used, or the entities with whom it is shared during this extended testing phase will be clearly communicated to you through updated privacy notices and direct notifications in advance of their implementation.'
       three:
         paragraph:
@@ -86,19 +87,24 @@ section:
       one: 'To provide this service, we share your data with the following government and technical providers;'
     bullet:
       one:
-        boldText: 'Service provider (processor)'
+        boldText: '4.1 Service provider (processor)'
         normalText: 'To provide service desk support functionality during the extended testing phase, on behalf of MHCLG. We have a Data Processing Agreement in place to ensure that the data is processed securely and in accordance with all relevant data protection law. To assist with your enquiries, the processing will involve using the details you have provided on the PRS Database.'
       two:
-        boldText: 'Amazon Web Services (AWS)'
+        boldText: '4.2 Amazon Web Services (AWS)'
         normalText: 'To host the PRSD service and store your data securely. All data is stored in the UK.'
-      three: 'To send you essential communications, including registration confirmations, security codes (OTP) and compliance reminders via email or SMS.'
-      four: 'To verify your identity before you access the service.'
+      three:
+        boldText: '4.3 GOV.UK Notify'
+        normalText: 'To send you essential communications, including registration confirmations, security codes (OTP) and compliance reminders via email or SMS.'
+      four:
+        boldText: '4.4 GOV.UK One Login'
+        normalText: 'To verify your identity before you access the service.'
   five:
     heading: Retention period
     paragraph:
       one: The extended testing phase is a temporary initiative.
       two:
-        bold: All personal data collected from local council users will be securely deleted no later than one month after the conclusion of the Extended Testing Phase.
+        boldText: 'Purge policy:'
+        normalText: 'All personal data collected from local council users will be securely deleted no later than one month after the conclusion of the Extended Testing Phase.'
       three:
         boldText: 'Re-registration:'
         normalText: 'You will be required to re-register for the Mandatory Service (or future testing phases) once the current phase is finalised.'

--- a/src/main/resources/templates/localCouncilPrivacyNotice.html
+++ b/src/main/resources/templates/localCouncilPrivacyNotice.html
@@ -1,13 +1,12 @@
-<!--/*@thymesVar id="backUrl" type="java.lang.String"*/-->
 <!--/*@thymesVar id="informationCommissionersOfficeUrl" type="java.lang.String"*/-->
 <!--/*@thymesVar id="complaintsProcedureUrl" type="java.lang.String"*/-->
 <!DOCTYPE html>
 <html th:replace="~{fragments/layout :: layout(#{localCouncilPrivacyNotice.title}, ~{::main}, false)}">
-<a href="#" th:replace="~{fragments/forms/backLink :: backLink(${backUrl})}">Back link</a>
 <main class="govuk-main-wrapper" id="main-content">
     <div id="page-contents"
          th:replace="~{fragments/layouts/twoThirdsLayout :: twoThirdsLayout(~{::#page-contents/content()})}">
         <section>
+            <span class="govuk-caption-l" th:text="#{localCouncilServiceName}">localCouncilServiceName</span>
             <h1 class="govuk-heading-l" th:text="#{localCouncilPrivacyNotice.heading}">localCouncilPrivacyNotice.heading</h1>
         </section>
         <section>
@@ -40,7 +39,10 @@
                 <span class="govuk-!-font-weight-bold" th:text="#{localCouncilPrivacyNotice.section.two.subsection.two.statisticalPurpose.boldText}">localCouncilPrivacyNotice.section.two.subsection.two.statisticalPurpose.boldText</span>
                 <span th:remove="tag" th:utext="#{localCouncilPrivacyNotice.section.two.subsection.two.statisticalPurpose.normalText}">localCouncilPrivacyNotice.section.two.subsection.two.statisticalPurpose.normalText</span>
             </p>
-            <p class="govuk-body" th:text="#{localCouncilPrivacyNotice.section.two.subsection.two.important.note}">localCouncilPrivacyNotice.section.two.subsection.two.important.note</p>
+            <p class="govuk-body">
+                <span class="govuk-!-font-weight-bold" th:text="#{localCouncilPrivacyNotice.section.two.subsection.two.important.prefix}">localCouncilPrivacyNotice.section.two.subsection.two.important.prefix</span>
+                <span th:remove="tag" th:text="#{localCouncilPrivacyNotice.section.two.subsection.two.important.note}">localCouncilPrivacyNotice.section.two.subsection.two.important.note</span>
+            </p>
 
             <h3 class="govuk-heading-s" th:text="#{localCouncilPrivacyNotice.section.two.subheading.three}">localCouncilPrivacyNotice.section.two.subheading.three</h3>
             <p class="govuk-body" th:text="#{localCouncilPrivacyNotice.section.two.subsection.three.paragraph.one}">localCouncilPrivacyNotice.section.two.subsection.three.paragraph.one</p>
@@ -74,14 +76,17 @@
             <ul class="govuk-list govuk-list--bullet">
                 <li th:replace="~{fragments/partiallyBoldBullet :: partiallyBoldBullet(#{localCouncilPrivacyNotice.section.four.bullet.one.boldText},#{localCouncilPrivacyNotice.section.four.bullet.one.normalText}, null)}"></li>
                 <li th:replace="~{fragments/partiallyBoldBullet :: partiallyBoldBullet(#{localCouncilPrivacyNotice.section.four.bullet.two.boldText},#{localCouncilPrivacyNotice.section.four.bullet.two.normalText}, null)}"></li>
-                <li th:text="#{localCouncilPrivacyNotice.section.four.bullet.three}">localCouncilPrivacyNotice.section.four.bullet.three</li>
-                <li th:text="#{localCouncilPrivacyNotice.section.four.bullet.four}">localCouncilPrivacyNotice.section.four.bullet.four</li>
+                <li th:replace="~{fragments/partiallyBoldBullet :: partiallyBoldBullet(#{localCouncilPrivacyNotice.section.four.bullet.three.boldText},#{localCouncilPrivacyNotice.section.four.bullet.three.normalText}, null)}"></li>
+                <li th:replace="~{fragments/partiallyBoldBullet :: partiallyBoldBullet(#{localCouncilPrivacyNotice.section.four.bullet.four.boldText},#{localCouncilPrivacyNotice.section.four.bullet.four.normalText}, null)}"></li>
             </ul>
         </section>
         <section>
             <h2 class="govuk-heading-m" th:text="#{localCouncilPrivacyNotice.section.five.heading}">localCouncilPrivacyNotice.section.five.heading</h2>
             <p class="govuk-body" th:text="#{localCouncilPrivacyNotice.section.five.paragraph.one}">localCouncilPrivacyNotice.section.five.paragraph.one</p>
-            <p class="govuk-body govuk-!-font-weight-bold" th:text="#{localCouncilPrivacyNotice.section.five.paragraph.two.bold}">localCouncilPrivacyNotice.section.five.paragraph.two.bold</p>
+            <p class="govuk-body">
+                <span class="govuk-!-font-weight-bold" th:text="#{localCouncilPrivacyNotice.section.five.paragraph.two.boldText}">localCouncilPrivacyNotice.section.five.paragraph.two.boldText</span>
+                <span th:remove="tag" th:text="#{localCouncilPrivacyNotice.section.five.paragraph.two.normalText}">localCouncilPrivacyNotice.section.five.paragraph.two.normalText</span>
+            </p>
             <p class="govuk-body">
                 <span class="govuk-!-font-weight-bold" th:text="#{localCouncilPrivacyNotice.section.five.paragraph.three.boldText}">localCouncilPrivacyNotice.section.five.paragraph.three.boldText</span>
                 <span th:remove="tag" th:text="#{localCouncilPrivacyNotice.section.five.paragraph.three.normalText}">localCouncilPrivacyNotice.section.five.paragraph.three.normalText</span>


### PR DESCRIPTION
## Ticket number

PDJB-778

## Goal of change

Fix the standalone LC privacy notice page content to match the Figma design, addressing QA feedback.

## Description of main change(s)

- Adds service name caption above the page heading
- Adds numbering to section 2 subheadings (2.1, 2.2, 2.3) and section 4 bullets (4.1–4.4)
- Fixes section 2.2 Plausible Analytics paragraph text
- Adds bold "Important Note:" prefix to the important note paragraph
- Adds bold "GOV.UK Notify" and "GOV.UK One Login" labels to section 4 items
- Changes section 5 from fully bold paragraph to "Purge policy:" bold prefix style
- Removes back link from the standalone privacy notice page (not shown in Figma design)

## Anything you'd like to highlight to the reviewer?

The back link was removed entirely since this page is now opened in a new tab from the journey form. The `backUrl` model attribute and its unused import were also cleaned up from the controller.

## Checklist

- [x] Test suite has been run in full locally and is passing
- [x] Branch has been rebased onto main and run locally, with everything working as expected (both for your new feature and any related functionality)