### PR TITLE
PDJB-389 display custom property type on property page

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/summaryModels/PropertyDetailsViewModel.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/summaryModels/PropertyDetailsViewModel.kt
@@ -69,7 +69,7 @@ class PropertyDetailsViewModel(
                 )
                 addRow(
                     "propertyDetails.propertyRecord.propertyType",
-                    MessageKeyConverter.convert(propertyOwnership.propertyBuildType),
+                    propertyOwnership.customPropertyType ?: MessageKeyConverter.convert(propertyOwnership.propertyBuildType),
                 )
                 addRow(
                     "propertyDetails.propertyRecord.ownershipType",

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/PropertyDetailsTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/PropertyDetailsTests.kt
@@ -85,6 +85,13 @@ class PropertyDetailsTests : IntegrationTestWithImmutableData("data-local.sql") 
             )
         }
 
+        @Test
+        fun `the property details page displays the custom property type when set`(page: Page) {
+            val detailsPage = navigator.goToPropertyDetailsLandlordView(37)
+
+            assertThat(detailsPage.propertyDetailsSummaryList.propertyTypeRow).containsText("End terrace")
+        }
+
         @Nested
         inner class NotificationBanner {
             // TODO PDJB-80: Reinstate notification banner assertions when notifications are re-enabled
@@ -270,6 +277,13 @@ class PropertyDetailsTests : IntegrationTestWithImmutableData("data-local.sql") 
             val detailsPage = navigator.goToPropertyDetailsLocalCouncilView(1)
             detailsPage.backLink.clickAndWait()
             assertPageIs(page, LocalCouncilDashboardPage::class)
+        }
+
+        @Test
+        fun `the property details page displays the custom property type when set`(page: Page) {
+            val detailsPage = navigator.goToPropertyDetailsLocalCouncilView(37)
+
+            assertThat(detailsPage.propertyDetailsSummaryList.propertyTypeRow).containsText("End terrace")
         }
 
         @Test

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/basePages/PropertyDetailsBasePage.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/basePages/PropertyDetailsBasePage.kt
@@ -35,6 +35,7 @@ abstract class PropertyDetailsBasePage(
     class PropertyDetailsPropertyInformationSummaryList(
         page: Page,
     ) : SummaryList(page) {
+        val propertyTypeRow = getRow("Property type")
         val ownershipTypeRow = getRow("Ownership type")
         val occupancyRow = getRow("Occupied by tenants")
         val numberOfHouseholdsRow = getRow("Number of households")

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/summaryModels/PropertyDetailsViewModelTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/summaryModels/PropertyDetailsViewModelTests.kt
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Test
 import uk.gov.communities.prsdb.webapp.constants.enums.FurnishedStatus
 import uk.gov.communities.prsdb.webapp.constants.enums.LicensingType
+import uk.gov.communities.prsdb.webapp.constants.enums.PropertyType
 import uk.gov.communities.prsdb.webapp.constants.enums.RentFrequency
 import uk.gov.communities.prsdb.webapp.database.entity.License
 import uk.gov.communities.prsdb.webapp.testHelpers.mockObjects.MockLandlordData.Companion.createAddress
@@ -357,6 +358,41 @@ class PropertyDetailsViewModelTests {
                 .single { it.fieldHeading == "propertyDetails.propertyRecord.licensingInformation.licensingType" }
 
         assertEquals("forms.checkPropertyAnswers.propertyDetails.noLicensing", propertyRecordNullLicense.fieldValue)
+    }
+
+    @Test
+    fun `Property type row displays the custom property type when it is set`() {
+        val customType = "End terrace"
+        val propertyOwnership =
+            createPropertyOwnership(
+                propertyBuildType = PropertyType.OTHER,
+                customPropertyType = customType,
+            )
+
+        val viewModel = PropertyDetailsViewModel(propertyOwnership, messageSource = mockMessageSource)
+
+        val propertyTypeRow =
+            viewModel.propertyRecord
+                .single { it.fieldHeading == "propertyDetails.propertyRecord.propertyType" }
+
+        assertEquals(customType, propertyTypeRow.fieldValue)
+    }
+
+    @Test
+    fun `Property type row displays the message key when custom property type is not set`() {
+        val propertyOwnership =
+            createPropertyOwnership(
+                propertyBuildType = PropertyType.SEMI_DETACHED_HOUSE,
+                customPropertyType = null,
+            )
+
+        val viewModel = PropertyDetailsViewModel(propertyOwnership, messageSource = mockMessageSource)
+
+        val propertyTypeRow =
+            viewModel.propertyRecord
+                .single { it.fieldHeading == "propertyDetails.propertyRecord.propertyType" }
+
+        assertEquals("forms.propertyType.radios.option.semiDetachedHouse.label", propertyTypeRow.fieldValue)
     }
 
     @Test


### PR DESCRIPTION
## Ticket number

PDJB-389

## Goal of change

Adds the custom property type to the property page per the designs

## Description of main change(s)

Adds the type without "other" preceding it unlike in the cya page.
Adds unit & integration tests

<img width="1012" height="630" alt="image" src="https://github.com/user-attachments/assets/e3066452-bd92-4cd0-b31c-2c11eb39d3ee" />

## Checklist

Delete any that are not applicable, and add explanation below for any that are applicable but haven't been done

- [ ] Screenshots of any UI changes have been added
- [ ] Unit tests for new logic (e.g. new service methods) have been added
- [ ] Single page integration tests have been added for any unhappy-flow UI features, e.g. validation errors
- [ ] Test suite has been run in full locally and is passing
- [ ] QA instructions have been added to the ticket (particularly if this is the last PR required to complete the ticket)
