### PR TITLE
PDJB-NONE: Rework Address.toMultiLineAddress()

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/database/entity/Address.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/database/entity/Address.kt
@@ -82,7 +82,7 @@ class Address() : ModifiableAuditableEntity() {
         if (hasAddressComponents()) {
             buildMultiLineAddressFromComponents()
         } else {
-            singleLineAddress.replace(", ", "\n")
+            buildMultiLineAddressFromSingleLine(singleLineAddress)
         }
 
     private fun hasAddressComponents(): Boolean = streetName != null || buildingName != null || buildingNumber != null
@@ -91,8 +91,8 @@ class Address() : ModifiableAuditableEntity() {
         listOfNotNull(
             organisation,
             subBuilding,
-            listOfNotNull(buildingNumber, streetName).joinToString(" ").ifBlank { null },
             buildingName,
+            listOfNotNull(buildingNumber, streetName).joinToString(" ").ifBlank { null },
             locality,
             townName,
             postcode,
@@ -100,5 +100,26 @@ class Address() : ModifiableAuditableEntity() {
 
     companion object {
         const val SINGLE_LINE_ADDRESS_LENGTH = 1000
+
+        private val HOUSE_NUMBER_REGEX = Regex("^\\d+[A-Za-z]?$")
+        private val UK_POSTCODE_REGEX = Regex("^[A-Z]{1,2}\\d[A-Z\\d]? ?\\d[A-Z]{2}$", RegexOption.IGNORE_CASE)
+
+        private fun buildMultiLineAddressFromSingleLine(singleLineAddress: String): String {
+            val parts = singleLineAddress.split(", ")
+            val merged = mutableListOf<String>()
+            var i = 0
+            while (i < parts.size) {
+                val current = parts[i]
+                val next = parts.getOrNull(i + 1)
+                if (current.matches(HOUSE_NUMBER_REGEX) && next != null && !next.matches(UK_POSTCODE_REGEX)) {
+                    merged.add("$current $next")
+                    i += 2
+                } else {
+                    merged.add(current)
+                    i += 1
+                }
+            }
+            return merged.joinToString("\n")
+        }
     }
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/database/entity/AddressTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/database/entity/AddressTests.kt
@@ -39,7 +39,59 @@ class AddressTests {
 
         val result = address.toMultiLineAddress()
 
-        assertEquals("123 Test Street\nThe Manor House\nLondon\nSW1A 1AA", result)
+        assertEquals("The Manor House\n123 Test Street\nLondon\nSW1A 1AA", result)
+    }
+
+    @Test
+    fun `toMultiLineAddress fallback merges isolated leading house number with street`() {
+        val addressDataModel =
+            AddressDataModel(
+                singleLineAddress = "1, SAVOY COURT, LONDON, WC2R 0EX",
+            )
+        val address = Address(addressDataModel)
+
+        val result = address.toMultiLineAddress()
+
+        assertEquals("1 SAVOY COURT\nLONDON\nWC2R 0EX", result)
+    }
+
+    @Test
+    fun `toMultiLineAddress fallback merges isolated alphanumeric house number with street`() {
+        val addressDataModel =
+            AddressDataModel(
+                singleLineAddress = "12A, HIGH STREET, LONDON, WC2R 0EX",
+            )
+        val address = Address(addressDataModel)
+
+        val result = address.toMultiLineAddress()
+
+        assertEquals("12A HIGH STREET\nLONDON\nWC2R 0EX", result)
+    }
+
+    @Test
+    fun `toMultiLineAddress fallback does not merge when next token is a postcode`() {
+        val addressDataModel =
+            AddressDataModel(
+                singleLineAddress = "1, EG1 2AB",
+            )
+        val address = Address(addressDataModel)
+
+        val result = address.toMultiLineAddress()
+
+        assertEquals("1\nEG1 2AB", result)
+    }
+
+    @Test
+    fun `toMultiLineAddress fallback preserves non-numeric first line`() {
+        val addressDataModel =
+            AddressDataModel(
+                singleLineAddress = "Flat 1, 123 Test Street, London, SW1A 1AA",
+            )
+        val address = Address(addressDataModel)
+
+        val result = address.toMultiLineAddress()
+
+        assertEquals("Flat 1\n123 Test Street\nLondon\nSW1A 1AA", result)
     }
 
     @Test


### PR DESCRIPTION
## Ticket number

PDJB-NONE

## Goal of change

Fix `Address.toMultiLineAddress()` so that multi-line addresses rendered in emails no longer have a spurious newline after the house number.

## Description of main change(s)

- Fix the fallback path (which is the only path exercised in production) so it no longer produces a newline after a bare house number. OS Places returns addresses like `1, SAVOY COURT, LONDON, WC2R 0EX` and the previous `replace(", ", "\n")` implementation split on every comma, pushing the house number onto its own line. The new parser merges a leading `\d+[A-Za-z]?` token with the next token (unless that next token is a UK postcode).
- In the structured-component path, move `buildingName` to before the `buildingNumber streetName` line so the output matches Royal Mail PAF conventions.

## Anything you'd like to highlight to the reviewer?

In production, `Address` entities only ever populate `singleLineAddress` / `uprn` / `townName` / `postcode` / `localCouncil` — the structured component fields are only populated by tests and `NftDataFaker`. So real email sends from `PropertyOwnershipService.getPropertyUpdateConfirmationEmail()` and `JointLandlordInvitationService.sendInvitation()` always hit the fallback path. The component-path ordering fix is for correctness, but the fallback fix is what callers will actually see.

## Checklist

- [x] Unit tests for new logic (e.g. new service methods) have been added
