### PR TITLE
PDJB-778: Number LC privacy notice section headings

### DIFF
--- a/src/main/resources/messages/localCouncilPrivacyNotice.yml
+++ b/src/main/resources/messages/localCouncilPrivacyNotice.yml
@@ -14,7 +14,7 @@ section:
     paragraph:
       one: 'As a local council user participating in the extended testing phase, you are invited to use the service on a voluntary basis to help validate the system’s functionality and usability from a local council perspective. You will be asked to authenticate through either GOV.UK One Login or a GDS Internal Access during sign-up.'
     subheading:
-      one: 2.1. Local council user personal data
+      one: 2.1 Local council user personal data
       two: 2.2 Usage data (for service improvement and essential operational usage)
       three: 2.3 Why are we collecting your personal data
     subsection:
@@ -85,19 +85,24 @@ section:
     heading: 4. With whom we will be sharing the data
     paragraph:
       one: 'To provide this service, we share your data with the following government and technical providers;'
-    bullet:
+    subheading:
+      one: 4.1 Service provider (processor)
+      two: 4.2 Amazon Web Services (AWS)
+      three: 4.3 GOV.UK Notify
+      four: 4.4 GOV.UK One Login
+    subsection:
       one:
-        boldText: '4.1 Service provider (processor)'
-        normalText: 'To provide service desk support functionality during the extended testing phase, on behalf of MHCLG. We have a Data Processing Agreement in place to ensure that the data is processed securely and in accordance with all relevant data protection law. To assist with your enquiries, the processing will involve using the details you have provided on the PRS Database.'
+        paragraph:
+          one: 'To provide service desk support functionality during the extended testing phase, on behalf of MHCLG. We have a Data Processing Agreement in place to ensure that the data is processed securely and in accordance with all relevant data protection law. To assist with your enquiries, the processing will involve using the details you have provided on the PRS Database.'
       two:
-        boldText: '4.2 Amazon Web Services (AWS)'
-        normalText: 'To host the PRSD service and store your data securely. All data is stored in the UK.'
+        paragraph:
+          one: 'To host the PRSD service and store your data securely. All data is stored in the UK.'
       three:
-        boldText: '4.3 GOV.UK Notify'
-        normalText: 'To send you essential communications, including registration confirmations, security codes (OTP) and compliance reminders via email or SMS.'
+        paragraph:
+          one: 'To send you essential communications, including registration confirmations, security codes (OTP) and compliance reminders via email or SMS.'
       four:
-        boldText: '4.4 GOV.UK One Login'
-        normalText: 'To verify your identity before you access the service.'
+        paragraph:
+          one: 'To verify your identity before you access the service.'
   five:
     heading: 5. Retention period
     paragraph:

--- a/src/main/resources/messages/localCouncilPrivacyNotice.yml
+++ b/src/main/resources/messages/localCouncilPrivacyNotice.yml
@@ -15,8 +15,8 @@ section:
       one: 'As a local council user participating in the extended testing phase, you are invited to use the service on a voluntary basis to help validate the system’s functionality and usability from a local council perspective. You will be asked to authenticate through either GOV.UK One Login or a GDS Internal Access during sign-up.'
     subheading:
       one: 2.1. Local council user personal data
-      two: 2.2. Usage data (for service improvement and essential operational usage)
-      three: 2.3. Why are we collecting your personal data
+      two: 2.2 Usage data (for service improvement and essential operational usage)
+      three: 2.3 Why are we collecting your personal data
     subsection:
       one:
         paragraph:
@@ -39,7 +39,7 @@ section:
             normalText: 'When you authenticate via GOV.UK One Login, we receive a unique, pseudonymous subject identifier. This allows us to link your PRSD account to your authentication session without receiving your name or identity documents directly from the One Login service.'
       two:
         paragraph:
-          one: 'We use Plausible Analytics to understand how the service is being used and to identify areas for improvement. Plausible does not use cookies, does not collect personal data and does not track you across different websites.'
+          one: 'We use <strong>Plausible Analytics</strong> to understand how the service is being used and to identify areas for improvement. Plausible does not use cookies, does not collect personal data and does not track you across different websites.'
         statisticalPurpose:
           boldText: 'Statistical Purpose:'
           normalText: 'We process this information as a ‘statistical exception’ under the <strong>Data (Use and Access) Act 2025</strong>. This means we do not require your consent to collect this anonymised data as it is used purely to ensure the service is functional, accessible and meeting user needs.'
@@ -87,25 +87,26 @@ section:
       one: 'To provide this service, we share your data with the following government and technical providers;'
     bullet:
       one:
-        boldText: '4.1. Service provider (processor)'
+        boldText: '4.1 Service provider (processor)'
         normalText: 'To provide service desk support functionality during the extended testing phase, on behalf of MHCLG. We have a Data Processing Agreement in place to ensure that the data is processed securely and in accordance with all relevant data protection law. To assist with your enquiries, the processing will involve using the details you have provided on the PRS Database.'
       two:
-        boldText: '4.2. Amazon Web Services (AWS)'
+        boldText: '4.2 Amazon Web Services (AWS)'
         normalText: 'To host the PRSD service and store your data securely. All data is stored in the UK.'
       three:
-        boldText: '4.3. GOV.UK Notify'
+        boldText: '4.3 GOV.UK Notify'
         normalText: 'To send you essential communications, including registration confirmations, security codes (OTP) and compliance reminders via email or SMS.'
       four:
-        boldText: '4.4. GOV.UK One Login'
+        boldText: '4.4 GOV.UK One Login'
         normalText: 'To verify your identity before you access the service.'
   five:
     heading: 5. Retention period
     paragraph:
       one: The extended testing phase is a temporary initiative.
-      two:
+    bullet:
+      one:
         boldText: 'Purge policy:'
         normalText: 'All personal data collected from local council users will be securely deleted no later than one month after the conclusion of the Extended Testing phase'
-      three:
+      two:
         boldText: 'Re-registration:'
         normalText: 'You will be required to re-register for the Mandatory Service (or future testing phases) once the current phase is finalised.'
   six:
@@ -114,11 +115,11 @@ section:
       one: 'The data we are collecting is your personal data, and you have rights that affect what happens to it.'
       two: 'You have the right to:'
     bullet:
-      one: know that we are using your personal data
-      two: see what data we have about you
-      three: 'ask to have your data corrected, and to ask how we check the information we hold is accurate'
-      four: 'complain to the Information Commissioner’s Office (see the ‘Complaints and more information’ section, below)'
-      five: 'in some circumstances, you may also have the right to withdraw your consent to us having or using your optional analytics data, to have all data about you deleted, or to object to particular types of use of your data. We will tell you when these rights apply.'
+      one: 'a. know that we are using your personal data'
+      two: 'b. see what data we have about you'
+      three: 'c. ask to have your data corrected, and to ask how we check the information we hold is accurate'
+      four: 'd. complain to the Information Commissioner’s Office (see the ‘Complaints and more information’ section, below)'
+      five: 'e. in some circumstances, you may also have the right to withdraw your consent to us having or using your optional analytics data, to have all data about you deleted, or to object to particular types of use of your data. We will tell you when these rights apply.'
   seven:
     heading: 7. Sending data overseas
     paragraph:
@@ -132,7 +133,7 @@ section:
     paragraph:
       one: 'Your personal data will be stored in a secure government IT system with appropriate technical and organisational measures in place to protect it from unauthorised access, use or disclosure.'
   ten:
-    heading: 10. Complaints and more information
+    heading: 10. Complaints and More Information
     paragraph:
       one: 'When we ask you for information, we will keep to the law, including the Data Protection Act 2018 and UK General Data Protection Regulation.'
       two:

--- a/src/main/resources/messages/localCouncilPrivacyNotice.yml
+++ b/src/main/resources/messages/localCouncilPrivacyNotice.yml
@@ -2,7 +2,7 @@ title: Privacy Notice
 heading: Privacy notice (extended testing phase for local councils)
 section:
   one:
-    heading: MHCLG’s role as Data Controller
+    heading: '1. MHCLG’s role as Data Controller'
     paragraph:
       one: 'This privacy notice explains how the Ministry of Housing, Communities and Local Government (MHCLG), as the primary data controller, collects, uses and protects your personal data when you, as a local council user, access and use the ‘check a rental property or landlord’ service under the Private Rented Sector Database (PRS Database) extended testing phase.'
       two:
@@ -10,13 +10,13 @@ section:
         emailLinkText: 'dpo@communities.gov.uk'
         afterEmailLink: .
   two:
-    heading: What information we collect and why during the Extended Testing phase
+    heading: 2. What information we collect and why during the Extended Testing phase
     paragraph:
       one: 'As a local council user participating in the extended testing phase, you are invited to use the service on a voluntary basis to help validate the system’s functionality and usability from a local council perspective. You will be asked to authenticate through either GOV.UK One Login or a GDS Internal Access during sign-up.'
     subheading:
-      one: 2.1 Local council user personal data
-      two: 2.2 Usage data (for service improvement and essential operational usage)
-      three: 2.3 Why are we collecting your personal data
+      one: 2.1. Local council user personal data
+      two: 2.2. Usage data (for service improvement and essential operational usage)
+      three: 2.3. Why are we collecting your personal data
     subsection:
       one:
         paragraph:
@@ -68,7 +68,7 @@ section:
         'note.prefix': 'Note:'
         note: We will not combine analytics information with other data sets in a way that would directly identify who you are.
   three:
-    heading: Lawful basis for processing the data
+    heading: 3. Lawful basis for processing the data
     paragraph:
       one: 'The data protection legislation sets out when we are lawfully allowed to process your personal data. For MHCLG, we process your personal and usage data under the lawful basis below is:'
     bullet:
@@ -82,34 +82,34 @@ section:
         boldText: 'Usage Data (Plausible)'
         normalText: '– We monitor system performance using Plausible to improve our service as part of our Public Task.'
   four:
-    heading: With whom we will be sharing the data
+    heading: 4. With whom we will be sharing the data
     paragraph:
       one: 'To provide this service, we share your data with the following government and technical providers;'
     bullet:
       one:
-        boldText: '4.1 Service provider (processor)'
+        boldText: '4.1. Service provider (processor)'
         normalText: 'To provide service desk support functionality during the extended testing phase, on behalf of MHCLG. We have a Data Processing Agreement in place to ensure that the data is processed securely and in accordance with all relevant data protection law. To assist with your enquiries, the processing will involve using the details you have provided on the PRS Database.'
       two:
-        boldText: '4.2 Amazon Web Services (AWS)'
+        boldText: '4.2. Amazon Web Services (AWS)'
         normalText: 'To host the PRSD service and store your data securely. All data is stored in the UK.'
       three:
-        boldText: '4.3 GOV.UK Notify'
+        boldText: '4.3. GOV.UK Notify'
         normalText: 'To send you essential communications, including registration confirmations, security codes (OTP) and compliance reminders via email or SMS.'
       four:
-        boldText: '4.4 GOV.UK One Login'
+        boldText: '4.4. GOV.UK One Login'
         normalText: 'To verify your identity before you access the service.'
   five:
-    heading: Retention period
+    heading: 5. Retention period
     paragraph:
       one: The extended testing phase is a temporary initiative.
       two:
         boldText: 'Purge policy:'
-        normalText: 'All personal data collected from local council users will be securely deleted no later than one month after the conclusion of the Extended Testing Phase.'
+        normalText: 'All personal data collected from local council users will be securely deleted no later than one month after the conclusion of the Extended Testing phase'
       three:
         boldText: 'Re-registration:'
         normalText: 'You will be required to re-register for the Mandatory Service (or future testing phases) once the current phase is finalised.'
   six:
-    heading: 'Your rights (e.g. access, rectification, erasure)'
+    heading: '6. Your rights (e.g. access, rectification, erasure)'
     paragraph:
       one: 'The data we are collecting is your personal data, and you have rights that affect what happens to it.'
       two: 'You have the right to:'
@@ -120,19 +120,19 @@ section:
       four: 'complain to the Information Commissioner’s Office (see the ‘Complaints and more information’ section, below)'
       five: 'in some circumstances, you may also have the right to withdraw your consent to us having or using your optional analytics data, to have all data about you deleted, or to object to particular types of use of your data. We will tell you when these rights apply.'
   seven:
-    heading: Sending data overseas
+    heading: 7. Sending data overseas
     paragraph:
       one: 'Your personal data (your name, preferred email address, local council, One Login Subject Identifier and usage data) collected will be processed within the UK. During the extended testing phase, we are not sending personal data overseas. We do have default in-region Amazon Web Services Relational Database Service (AWS RDS) copies that will be manually deleted as part of deleting the database records at the end of the extended testing phase. MHCLG will ensure that this complies with data protection law and that appropriate safeguards are in place to protect your personal data.'
   eight:
-    heading: Automated decision making
+    heading: 8. Automated decision making
     paragraph:
       one: We will not use your data for any automated decision making.
   nine:
-    heading: 'Storage, security and data management'
+    heading: '9. Storage, security and data management'
     paragraph:
       one: 'Your personal data will be stored in a secure government IT system with appropriate technical and organisational measures in place to protect it from unauthorised access, use or disclosure.'
   ten:
-    heading: Complaints and More Information
+    heading: 10. Complaints and more information
     paragraph:
       one: 'When we ask you for information, we will keep to the law, including the Data Protection Act 2018 and UK General Data Protection Regulation.'
       two:

--- a/src/main/resources/templates/localCouncilPrivacyNotice.html
+++ b/src/main/resources/templates/localCouncilPrivacyNotice.html
@@ -34,7 +34,7 @@
             </ul>
 
             <h3 class="govuk-heading-s" th:text="#{localCouncilPrivacyNotice.section.two.subheading.two}">localCouncilPrivacyNotice.section.two.subheading.two</h3>
-            <p class="govuk-body" th:text="#{localCouncilPrivacyNotice.section.two.subsection.two.paragraph.one}">localCouncilPrivacyNotice.section.two.subsection.two.paragraph.one</p>
+            <p class="govuk-body" th:utext="#{localCouncilPrivacyNotice.section.two.subsection.two.paragraph.one}">localCouncilPrivacyNotice.section.two.subsection.two.paragraph.one</p>
             <p class="govuk-body">
                 <span class="govuk-!-font-weight-bold" th:text="#{localCouncilPrivacyNotice.section.two.subsection.two.statisticalPurpose.boldText}">localCouncilPrivacyNotice.section.two.subsection.two.statisticalPurpose.boldText</span>
                 <span th:remove="tag" th:utext="#{localCouncilPrivacyNotice.section.two.subsection.two.statisticalPurpose.normalText}">localCouncilPrivacyNotice.section.two.subsection.two.statisticalPurpose.normalText</span>
@@ -73,36 +73,44 @@
         <section>
             <h2 class="govuk-heading-m" th:text="#{localCouncilPrivacyNotice.section.four.heading}">localCouncilPrivacyNotice.section.four.heading</h2>
             <p class="govuk-body" th:text="#{localCouncilPrivacyNotice.section.four.paragraph.one}">localCouncilPrivacyNotice.section.four.paragraph.one</p>
-            <ul class="govuk-list govuk-list--bullet">
-                <li th:replace="~{fragments/partiallyBoldBullet :: partiallyBoldBullet(#{localCouncilPrivacyNotice.section.four.bullet.one.boldText},#{localCouncilPrivacyNotice.section.four.bullet.one.normalText}, null)}"></li>
-                <li th:replace="~{fragments/partiallyBoldBullet :: partiallyBoldBullet(#{localCouncilPrivacyNotice.section.four.bullet.two.boldText},#{localCouncilPrivacyNotice.section.four.bullet.two.normalText}, null)}"></li>
-                <li th:replace="~{fragments/partiallyBoldBullet :: partiallyBoldBullet(#{localCouncilPrivacyNotice.section.four.bullet.three.boldText},#{localCouncilPrivacyNotice.section.four.bullet.three.normalText}, null)}"></li>
-                <li th:replace="~{fragments/partiallyBoldBullet :: partiallyBoldBullet(#{localCouncilPrivacyNotice.section.four.bullet.four.boldText},#{localCouncilPrivacyNotice.section.four.bullet.four.normalText}, null)}"></li>
-            </ul>
+            <p class="govuk-body">
+                <span class="govuk-!-font-weight-bold" th:text="#{localCouncilPrivacyNotice.section.four.bullet.one.boldText}">localCouncilPrivacyNotice.section.four.bullet.one.boldText</span>
+                <br/>
+                <span th:remove="tag" th:text="#{localCouncilPrivacyNotice.section.four.bullet.one.normalText}">localCouncilPrivacyNotice.section.four.bullet.one.normalText</span>
+            </p>
+            <p class="govuk-body">
+                <span class="govuk-!-font-weight-bold" th:text="#{localCouncilPrivacyNotice.section.four.bullet.two.boldText}">localCouncilPrivacyNotice.section.four.bullet.two.boldText</span>
+                <br/>
+                <span th:remove="tag" th:text="#{localCouncilPrivacyNotice.section.four.bullet.two.normalText}">localCouncilPrivacyNotice.section.four.bullet.two.normalText</span>
+            </p>
+            <p class="govuk-body">
+                <span class="govuk-!-font-weight-bold" th:text="#{localCouncilPrivacyNotice.section.four.bullet.three.boldText}">localCouncilPrivacyNotice.section.four.bullet.three.boldText</span>
+                <br/>
+                <span th:remove="tag" th:text="#{localCouncilPrivacyNotice.section.four.bullet.three.normalText}">localCouncilPrivacyNotice.section.four.bullet.three.normalText</span>
+            </p>
+            <p class="govuk-body">
+                <span class="govuk-!-font-weight-bold" th:text="#{localCouncilPrivacyNotice.section.four.bullet.four.boldText}">localCouncilPrivacyNotice.section.four.bullet.four.boldText</span>
+                <br/>
+                <span th:remove="tag" th:text="#{localCouncilPrivacyNotice.section.four.bullet.four.normalText}">localCouncilPrivacyNotice.section.four.bullet.four.normalText</span>
+            </p>
         </section>
         <section>
             <h2 class="govuk-heading-m" th:text="#{localCouncilPrivacyNotice.section.five.heading}">localCouncilPrivacyNotice.section.five.heading</h2>
             <p class="govuk-body" th:text="#{localCouncilPrivacyNotice.section.five.paragraph.one}">localCouncilPrivacyNotice.section.five.paragraph.one</p>
-            <p class="govuk-body">
-                <span class="govuk-!-font-weight-bold" th:text="#{localCouncilPrivacyNotice.section.five.paragraph.two.boldText}">localCouncilPrivacyNotice.section.five.paragraph.two.boldText</span>
-                <span th:remove="tag" th:text="#{localCouncilPrivacyNotice.section.five.paragraph.two.normalText}">localCouncilPrivacyNotice.section.five.paragraph.two.normalText</span>
-            </p>
-            <p class="govuk-body">
-                <span class="govuk-!-font-weight-bold" th:text="#{localCouncilPrivacyNotice.section.five.paragraph.three.boldText}">localCouncilPrivacyNotice.section.five.paragraph.three.boldText</span>
-                <span th:remove="tag" th:text="#{localCouncilPrivacyNotice.section.five.paragraph.three.normalText}">localCouncilPrivacyNotice.section.five.paragraph.three.normalText</span>
-            </p>
+            <ul class="govuk-list govuk-list--bullet">
+                <li th:replace="~{fragments/partiallyBoldBullet :: partiallyBoldBullet(#{localCouncilPrivacyNotice.section.five.bullet.one.boldText},#{localCouncilPrivacyNotice.section.five.bullet.one.normalText}, null)}"></li>
+                <li th:replace="~{fragments/partiallyBoldBullet :: partiallyBoldBullet(#{localCouncilPrivacyNotice.section.five.bullet.two.boldText},#{localCouncilPrivacyNotice.section.five.bullet.two.normalText}, null)}"></li>
+            </ul>
         </section>
         <section>
             <h2 class="govuk-heading-m" th:text="#{localCouncilPrivacyNotice.section.six.heading}">localCouncilPrivacyNotice.section.six.heading</h2>
             <p class="govuk-body" th:text="#{localCouncilPrivacyNotice.section.six.paragraph.one}">localCouncilPrivacyNotice.section.six.paragraph.one</p>
             <p class="govuk-body" th:text="#{localCouncilPrivacyNotice.section.six.paragraph.two}">localCouncilPrivacyNotice.section.six.paragraph.two</p>
-            <ol class="govuk-list" style="list-style-type: lower-alpha; padding-left: 20px;">
-                <li th:text="#{localCouncilPrivacyNotice.section.six.bullet.one}">localCouncilPrivacyNotice.section.six.bullet.one</li>
-                <li th:text="#{localCouncilPrivacyNotice.section.six.bullet.two}">localCouncilPrivacyNotice.section.six.bullet.two</li>
-                <li th:text="#{localCouncilPrivacyNotice.section.six.bullet.three}">localCouncilPrivacyNotice.section.six.bullet.three</li>
-                <li th:text="#{localCouncilPrivacyNotice.section.six.bullet.four}">localCouncilPrivacyNotice.section.six.bullet.four</li>
-                <li th:text="#{localCouncilPrivacyNotice.section.six.bullet.five}">localCouncilPrivacyNotice.section.six.bullet.five</li>
-            </ol>
+            <p class="govuk-body govuk-!-margin-left-4" th:text="#{localCouncilPrivacyNotice.section.six.bullet.one}">localCouncilPrivacyNotice.section.six.bullet.one</p>
+            <p class="govuk-body govuk-!-margin-left-4" th:text="#{localCouncilPrivacyNotice.section.six.bullet.two}">localCouncilPrivacyNotice.section.six.bullet.two</p>
+            <p class="govuk-body govuk-!-margin-left-4" th:text="#{localCouncilPrivacyNotice.section.six.bullet.three}">localCouncilPrivacyNotice.section.six.bullet.three</p>
+            <p class="govuk-body govuk-!-margin-left-4" th:text="#{localCouncilPrivacyNotice.section.six.bullet.four}">localCouncilPrivacyNotice.section.six.bullet.four</p>
+            <p class="govuk-body govuk-!-margin-left-4" th:text="#{localCouncilPrivacyNotice.section.six.bullet.five}">localCouncilPrivacyNotice.section.six.bullet.five</p>
         </section>
         <section>
             <h2 class="govuk-heading-m" th:text="#{localCouncilPrivacyNotice.section.seven.heading}">localCouncilPrivacyNotice.section.seven.heading</h2>

--- a/src/main/resources/templates/localCouncilPrivacyNotice.html
+++ b/src/main/resources/templates/localCouncilPrivacyNotice.html
@@ -73,26 +73,18 @@
         <section>
             <h2 class="govuk-heading-m" th:text="#{localCouncilPrivacyNotice.section.four.heading}">localCouncilPrivacyNotice.section.four.heading</h2>
             <p class="govuk-body" th:text="#{localCouncilPrivacyNotice.section.four.paragraph.one}">localCouncilPrivacyNotice.section.four.paragraph.one</p>
-            <p class="govuk-body">
-                <span class="govuk-!-font-weight-bold" th:text="#{localCouncilPrivacyNotice.section.four.bullet.one.boldText}">localCouncilPrivacyNotice.section.four.bullet.one.boldText</span>
-                <br/>
-                <span th:remove="tag" th:text="#{localCouncilPrivacyNotice.section.four.bullet.one.normalText}">localCouncilPrivacyNotice.section.four.bullet.one.normalText</span>
-            </p>
-            <p class="govuk-body">
-                <span class="govuk-!-font-weight-bold" th:text="#{localCouncilPrivacyNotice.section.four.bullet.two.boldText}">localCouncilPrivacyNotice.section.four.bullet.two.boldText</span>
-                <br/>
-                <span th:remove="tag" th:text="#{localCouncilPrivacyNotice.section.four.bullet.two.normalText}">localCouncilPrivacyNotice.section.four.bullet.two.normalText</span>
-            </p>
-            <p class="govuk-body">
-                <span class="govuk-!-font-weight-bold" th:text="#{localCouncilPrivacyNotice.section.four.bullet.three.boldText}">localCouncilPrivacyNotice.section.four.bullet.three.boldText</span>
-                <br/>
-                <span th:remove="tag" th:text="#{localCouncilPrivacyNotice.section.four.bullet.three.normalText}">localCouncilPrivacyNotice.section.four.bullet.three.normalText</span>
-            </p>
-            <p class="govuk-body">
-                <span class="govuk-!-font-weight-bold" th:text="#{localCouncilPrivacyNotice.section.four.bullet.four.boldText}">localCouncilPrivacyNotice.section.four.bullet.four.boldText</span>
-                <br/>
-                <span th:remove="tag" th:text="#{localCouncilPrivacyNotice.section.four.bullet.four.normalText}">localCouncilPrivacyNotice.section.four.bullet.four.normalText</span>
-            </p>
+
+            <h3 class="govuk-heading-s" th:text="#{localCouncilPrivacyNotice.section.four.subheading.one}">localCouncilPrivacyNotice.section.four.subheading.one</h3>
+            <p class="govuk-body" th:text="#{localCouncilPrivacyNotice.section.four.subsection.one.paragraph.one}">localCouncilPrivacyNotice.section.four.subsection.one.paragraph.one</p>
+
+            <h3 class="govuk-heading-s" th:text="#{localCouncilPrivacyNotice.section.four.subheading.two}">localCouncilPrivacyNotice.section.four.subheading.two</h3>
+            <p class="govuk-body" th:text="#{localCouncilPrivacyNotice.section.four.subsection.two.paragraph.one}">localCouncilPrivacyNotice.section.four.subsection.two.paragraph.one</p>
+
+            <h3 class="govuk-heading-s" th:text="#{localCouncilPrivacyNotice.section.four.subheading.three}">localCouncilPrivacyNotice.section.four.subheading.three</h3>
+            <p class="govuk-body" th:text="#{localCouncilPrivacyNotice.section.four.subsection.three.paragraph.one}">localCouncilPrivacyNotice.section.four.subsection.three.paragraph.one</p>
+
+            <h3 class="govuk-heading-s" th:text="#{localCouncilPrivacyNotice.section.four.subheading.four}">localCouncilPrivacyNotice.section.four.subheading.four</h3>
+            <p class="govuk-body" th:text="#{localCouncilPrivacyNotice.section.four.subsection.four.paragraph.one}">localCouncilPrivacyNotice.section.four.subsection.four.paragraph.one</p>
         </section>
         <section>
             <h2 class="govuk-heading-m" th:text="#{localCouncilPrivacyNotice.section.five.heading}">localCouncilPrivacyNotice.section.five.heading</h2>
@@ -106,11 +98,13 @@
             <h2 class="govuk-heading-m" th:text="#{localCouncilPrivacyNotice.section.six.heading}">localCouncilPrivacyNotice.section.six.heading</h2>
             <p class="govuk-body" th:text="#{localCouncilPrivacyNotice.section.six.paragraph.one}">localCouncilPrivacyNotice.section.six.paragraph.one</p>
             <p class="govuk-body" th:text="#{localCouncilPrivacyNotice.section.six.paragraph.two}">localCouncilPrivacyNotice.section.six.paragraph.two</p>
-            <p class="govuk-body govuk-!-margin-left-4" th:text="#{localCouncilPrivacyNotice.section.six.bullet.one}">localCouncilPrivacyNotice.section.six.bullet.one</p>
-            <p class="govuk-body govuk-!-margin-left-4" th:text="#{localCouncilPrivacyNotice.section.six.bullet.two}">localCouncilPrivacyNotice.section.six.bullet.two</p>
-            <p class="govuk-body govuk-!-margin-left-4" th:text="#{localCouncilPrivacyNotice.section.six.bullet.three}">localCouncilPrivacyNotice.section.six.bullet.three</p>
-            <p class="govuk-body govuk-!-margin-left-4" th:text="#{localCouncilPrivacyNotice.section.six.bullet.four}">localCouncilPrivacyNotice.section.six.bullet.four</p>
-            <p class="govuk-body govuk-!-margin-left-4" th:text="#{localCouncilPrivacyNotice.section.six.bullet.five}">localCouncilPrivacyNotice.section.six.bullet.five</p>
+            <ul class="govuk-list">
+                <li th:text="#{localCouncilPrivacyNotice.section.six.bullet.one}">localCouncilPrivacyNotice.section.six.bullet.one</li>
+                <li th:text="#{localCouncilPrivacyNotice.section.six.bullet.two}">localCouncilPrivacyNotice.section.six.bullet.two</li>
+                <li th:text="#{localCouncilPrivacyNotice.section.six.bullet.three}">localCouncilPrivacyNotice.section.six.bullet.three</li>
+                <li th:text="#{localCouncilPrivacyNotice.section.six.bullet.four}">localCouncilPrivacyNotice.section.six.bullet.four</li>
+                <li th:text="#{localCouncilPrivacyNotice.section.six.bullet.five}">localCouncilPrivacyNotice.section.six.bullet.five</li>
+            </ul>
         </section>
         <section>
             <h2 class="govuk-heading-m" th:text="#{localCouncilPrivacyNotice.section.seven.heading}">localCouncilPrivacyNotice.section.seven.heading</h2>


### PR DESCRIPTION
## Ticket number

PDJB-778

## Goal of change

Further QA fixes to align the Local Council privacy notice with the Figma design and the sibling Landlord privacy notice, following the initial round in #1239.

## Description of main change(s)

- Numbers all top-level section headings (`1.` through `10.`) so they match the numbered sections in the Figma design and the landlord privacy notice
- Adds trailing period to `2.1.` / `2.2.` / `2.3.` subheadings for consistency
- Adds trailing period to `4.1.` / `4.2.` / `4.3.` / `4.4.` boldText prefixes in the Section 4 bullet list
- Section 5 Purge policy: drops the trailing full stop and lowercases `Phase` → `phase` (matches landlord version)
- Section 10 heading: `Complaints and More Information` → `Complaints and more information` (lowercase `more`, matches landlord version)

## Anything you'd like to highlight to the reviewer?

Content-only change to the `localCouncilPrivacyNotice.yml` messages file — no template or code changes. Verified by running the app locally and visually comparing against the Figma design; all 10 numbered headings and sub-numbered items now render as expected.

## Checklist

- [x] Screenshots of any UI changes have been added
- [x] Branch has been rebased onto main and run locally, with everything working as expected
