### PR TITLE
PDJB-682: Note allow pasting requirement in passcode script

### DIFF
--- a/scripts/generate_passcodes.js
+++ b/scripts/generate_passcodes.js
@@ -5,6 +5,7 @@
 //   2. Navigate to /system-operator/generate-passcode
 //   3. Open the browser console (F12 → Console)
 //   4. Paste this entire script and press Enter
+//      (if prompted to, type "allow pasting" and press Enter first)
 //   5. Enter the number of passcodes when prompted
 
 async function generatePasscodes(count) {


### PR DESCRIPTION
## Ticket number

PDJB-682

## Goal of change

Note the Chrome "allow pasting" requirement in the bulk passcode generation script so users do not get stuck when pasting into the browser console.

## Description of main change(s)

- Adds a note to the usage instructions at the top of `scripts/generate_passcodes.js` explaining that if the browser console blocks pasting, the user needs to type "allow pasting" and press Enter before pasting the script.

## Anything you'd like to highlight to the reviewer?

Follow-up from QA feedback on PDJB-682.
