### PR TITLE
PDJB-670: fix epc reason text

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/helpers/converters/MessageKeyConverter.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/helpers/converters/MessageKeyConverter.kt
@@ -124,7 +124,7 @@ class MessageKeyConverter {
         private fun convertEpcExemptionReason(epcExemptionReason: EpcExemptionReason): String =
             when (epcExemptionReason) {
                 EpcExemptionReason.ANNUAL_USE_LESS_THAN_4_MONTHS -> {
-                    "forms.epcExemptionReason.radios.annualUseLessThan4Months.label"
+                    "propertyCompliance.epcTask.epcExemption.radios.annualUseLessThan4Months.label"
                 }
 
                 EpcExemptionReason.ANNUAL_ENERGY_CONSUMPTION_LESS_THAN_25_PERCENT -> {
@@ -132,19 +132,19 @@ class MessageKeyConverter {
                 }
 
                 EpcExemptionReason.TEMPORARY_BUILDING -> {
-                    "forms.epcExemptionReason.radios.temporaryBuilding.label"
+                    "propertyCompliance.epcTask.epcExemption.radios.temporaryBuilding.label"
                 }
 
                 EpcExemptionReason.STANDALONE_SMALL_BUILDING -> {
-                    "forms.epcExemptionReason.radios.standaloneSmallBuilding.label"
+                    "propertyCompliance.epcTask.epcExemption.radios.standaloneSmallBuilding.label"
                 }
 
                 EpcExemptionReason.DUE_FOR_DEMOLITION -> {
-                    "forms.epcExemptionReason.radios.dueForDemolition.label"
+                    "propertyCompliance.epcTask.epcExemption.radios.dueForDemolition.label"
                 }
 
                 EpcExemptionReason.PROTECTED_ARCHITECTURAL_OR_HISTORICAL_MERIT -> {
-                    "forms.epcExemptionReason.radios.protectedArchitecturalOrHistoricalMerit.label"
+                    "propertyCompliance.epcTask.epcExemption.radios.protectedArchitecturalOrHistoricalMerit.label"
                 }
             }
 

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/helpers/converters/MessageKeyConverterTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/helpers/converters/MessageKeyConverterTests.kt
@@ -1,0 +1,22 @@
+package uk.gov.communities.prsdb.webapp.helpers.converters
+
+import org.junit.jupiter.api.Assertions.assertNotEquals
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.EnumSource
+import uk.gov.communities.prsdb.webapp.config.YamlMessageSource
+import uk.gov.communities.prsdb.webapp.constants.enums.EpcExemptionReason
+import java.util.Locale
+
+class MessageKeyConverterTests {
+    private val messageSource = YamlMessageSource("classpath:messages")
+
+    @ParameterizedTest
+    @EnumSource(EpcExemptionReason::class)
+    fun `convert returns a resolvable message key for every EpcExemptionReason`(reason: EpcExemptionReason) {
+        val messageKey = MessageKeyConverter.convert(reason)
+        val resolvedMessage = messageSource.getMessage(messageKey, null, messageKey, Locale.getDefault())
+        assertNotEquals(messageKey, resolvedMessage) {
+            "Message key '$messageKey' for $reason does not resolve to a message"
+        }
+    }
+}

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/helpers/converters/MessageKeyConverterTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/helpers/converters/MessageKeyConverterTests.kt
@@ -1,22 +1,109 @@
 package uk.gov.communities.prsdb.webapp.helpers.converters
 
 import org.junit.jupiter.api.Assertions.assertNotEquals
+import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.EnumSource
 import uk.gov.communities.prsdb.webapp.config.YamlMessageSource
+import uk.gov.communities.prsdb.webapp.constants.enums.BillsIncluded
+import uk.gov.communities.prsdb.webapp.constants.enums.ComplianceCertStatus
+import uk.gov.communities.prsdb.webapp.constants.enums.EicrExemptionReason
 import uk.gov.communities.prsdb.webapp.constants.enums.EpcExemptionReason
+import uk.gov.communities.prsdb.webapp.constants.enums.FileUploadStatus
+import uk.gov.communities.prsdb.webapp.constants.enums.FurnishedStatus
+import uk.gov.communities.prsdb.webapp.constants.enums.GasSafetyExemptionReason
+import uk.gov.communities.prsdb.webapp.constants.enums.LicensingType
+import uk.gov.communities.prsdb.webapp.constants.enums.MeesExemptionReason
+import uk.gov.communities.prsdb.webapp.constants.enums.OwnershipType
+import uk.gov.communities.prsdb.webapp.constants.enums.PropertyType
+import uk.gov.communities.prsdb.webapp.constants.enums.RentFrequency
 import java.util.Locale
 
 class MessageKeyConverterTests {
     private val messageSource = YamlMessageSource("classpath:messages")
 
-    @ParameterizedTest
-    @EnumSource(EpcExemptionReason::class)
-    fun `convert returns a resolvable message key for every EpcExemptionReason`(reason: EpcExemptionReason) {
-        val messageKey = MessageKeyConverter.convert(reason)
+    private fun assertMessageKeyResolves(messageKey: String) {
         val resolvedMessage = messageSource.getMessage(messageKey, null, messageKey, Locale.getDefault())
         assertNotEquals(messageKey, resolvedMessage) {
-            "Message key '$messageKey' for $reason does not resolve to a message"
+            "Message key '$messageKey' does not resolve — it would display as the raw key on the page"
         }
+    }
+
+    @Test
+    fun `convert returns resolvable message keys for booleans`() {
+        assertMessageKeyResolves(MessageKeyConverter.convert(true))
+        assertMessageKeyResolves(MessageKeyConverter.convert(false))
+    }
+
+    @ParameterizedTest
+    @EnumSource(PropertyType::class)
+    fun `convert returns a resolvable message key for every PropertyType`(value: PropertyType) {
+        assertMessageKeyResolves(MessageKeyConverter.convert(value))
+    }
+
+    @ParameterizedTest
+    @EnumSource(OwnershipType::class)
+    fun `convert returns a resolvable message key for every OwnershipType`(value: OwnershipType) {
+        assertMessageKeyResolves(MessageKeyConverter.convert(value))
+    }
+
+    @ParameterizedTest
+    @EnumSource(LicensingType::class)
+    fun `convert returns a resolvable message key for every LicensingType`(value: LicensingType) {
+        assertMessageKeyResolves(MessageKeyConverter.convert(value))
+    }
+
+    @ParameterizedTest
+    @EnumSource(FurnishedStatus::class)
+    fun `convert returns a resolvable message key for every FurnishedStatus`(value: FurnishedStatus) {
+        assertMessageKeyResolves(MessageKeyConverter.convert(value))
+    }
+
+    @ParameterizedTest
+    @EnumSource(RentFrequency::class, mode = EnumSource.Mode.EXCLUDE, names = ["OTHER"])
+    fun `convert returns a resolvable message key for every RentFrequency`(value: RentFrequency) {
+        assertMessageKeyResolves(MessageKeyConverter.convert(value))
+    }
+
+    @ParameterizedTest
+    @EnumSource(BillsIncluded::class, mode = EnumSource.Mode.EXCLUDE, names = ["SOMETHING_ELSE"])
+    fun `convert returns a resolvable message key for every BillsIncluded`(value: BillsIncluded) {
+        assertMessageKeyResolves(MessageKeyConverter.convert(value))
+    }
+
+    @ParameterizedTest
+    @EnumSource(GasSafetyExemptionReason::class)
+    fun `convert returns a resolvable message key for every GasSafetyExemptionReason`(value: GasSafetyExemptionReason) {
+        assertMessageKeyResolves(MessageKeyConverter.convert(value))
+    }
+
+    @ParameterizedTest
+    @EnumSource(EicrExemptionReason::class)
+    fun `convert returns a resolvable message key for every EicrExemptionReason`(value: EicrExemptionReason) {
+        assertMessageKeyResolves(MessageKeyConverter.convert(value))
+    }
+
+    @ParameterizedTest
+    @EnumSource(EpcExemptionReason::class)
+    fun `convert returns a resolvable message key for every EpcExemptionReason`(value: EpcExemptionReason) {
+        assertMessageKeyResolves(MessageKeyConverter.convert(value))
+    }
+
+    @ParameterizedTest
+    @EnumSource(MeesExemptionReason::class)
+    fun `convert returns a resolvable message key for every MeesExemptionReason`(value: MeesExemptionReason) {
+        assertMessageKeyResolves(MessageKeyConverter.convert(value))
+    }
+
+    @ParameterizedTest
+    @EnumSource(ComplianceCertStatus::class)
+    fun `convert returns a resolvable message key for every ComplianceCertStatus`(value: ComplianceCertStatus) {
+        assertMessageKeyResolves(MessageKeyConverter.convert(value))
+    }
+
+    @ParameterizedTest
+    @EnumSource(FileUploadStatus::class)
+    fun `convert returns a resolvable message key for every FileUploadStatus`(value: FileUploadStatus) {
+        assertMessageKeyResolves(MessageKeyConverter.convert(value))
     }
 }


### PR DESCRIPTION
## Ticket number

PDJB-670

## Goal of change

Fix copy on cya page for no epc reason

## Description of main change(s)

The reason for a no epc property with an exemption wasn't displaying properly for protected architectural or historical merit. This fixes that, and makes sure we're using the new text for the form. 
Also adds tests for all converters.

## Checklist

Delete any that are not applicable, and add explanation below for any that are applicable but haven't been done

- [ ] Unit tests for new logic (e.g. new service methods) have been added
- [ ] Test suite has been run in full locally and is passing
- [ ] Branch has been rebased onto main and run locally, with everything working as expected (both for your new feature
  and any related functionality)
- [ ] TODO comments referencing this JIRA ticket have been searched for and removed - if a future PR will address them,
  mention that here
- [ ] QA instructions have been added to the ticket (particularly if this is the last PR required to complete the ticket)
