### PR TITLE
PDJB-655: Add download links for certificates on gas safety CYA page

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/CheckGasSafetyAnswersStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/CheckGasSafetyAnswersStepConfig.kt
@@ -8,10 +8,14 @@ import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.GasS
 import uk.gov.communities.prsdb.webapp.journeys.shared.Complete
 import uk.gov.communities.prsdb.webapp.journeys.shared.YesOrNo
 import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.NoInputFormModel
+import uk.gov.communities.prsdb.webapp.models.viewModels.DownloadableFileViewModel
 import uk.gov.communities.prsdb.webapp.models.viewModels.summaryModels.SummaryListRowViewModel
+import uk.gov.communities.prsdb.webapp.services.UploadService
 
 @JourneyFrameworkComponent
-class CheckGasSafetyAnswersStepConfig : AbstractRequestableStepConfig<Complete, NoInputFormModel, GasSafetyState>() {
+class CheckGasSafetyAnswersStepConfig(
+    private val uploadService: UploadService,
+) : AbstractRequestableStepConfig<Complete, NoInputFormModel, GasSafetyState>() {
     override val formModelClass = NoInputFormModel::class
 
     override fun getStepSpecificContent(state: GasSafetyState): Map<String, Any?> {
@@ -59,11 +63,17 @@ class CheckGasSafetyAnswersStepConfig : AbstractRequestableStepConfig<Complete, 
         }
 
     private fun getUploadedCertRows(state: GasSafetyState): List<SummaryListRowViewModel> {
-        val uploadFileNames =
+        val uploadFiles =
             state.gasUploadMap
                 .toList()
                 .sortedBy { it.first }
-                .map { (_, upload) -> upload.fileName }
+                .map { (_, upload) ->
+                    val uploadRecord = uploadService.getFileUploadById(upload.fileUploadId)
+                    DownloadableFileViewModel(
+                        fileName = upload.fileName,
+                        downloadUrl = uploadService.getDownloadUrlOrNull(uploadRecord, upload.fileName),
+                    )
+                }
 
         return listOf(
             SummaryListRowViewModel.forCheckYourAnswersPage(
@@ -78,7 +88,7 @@ class CheckGasSafetyAnswersStepConfig : AbstractRequestableStepConfig<Complete, 
             ),
             SummaryListRowViewModel.forCheckYourAnswersPage(
                 fieldHeading = "checkGasSafety.yourCertificate.fieldHeading",
-                fieldValue = uploadFileNames,
+                fieldValue = uploadFiles,
                 destination = Destination(state.checkGasCertUploadsStep),
             ),
         )

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/DownloadableFileViewModel.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/DownloadableFileViewModel.kt
@@ -1,0 +1,6 @@
+package uk.gov.communities.prsdb.webapp.models.viewModels
+
+data class DownloadableFileViewModel(
+    val fileName: String,
+    val downloadUrl: String?,
+)

--- a/src/main/resources/templates/fragments/summaryRow.html
+++ b/src/main/resources/templates/fragments/summaryRow.html
@@ -9,11 +9,23 @@
            class="govuk-link"
            th:text="${#messages.msgOrNull(values)} ?: ${{values}}">
         </a>
-        <!--/* If and only if there is a single value (as opposed to a list) we should th:remove the p tag to avoid unnecessary nesting */-->
-        <p th:if="${valueUrl} == null"
-           th:remove="${iteratorStatus.size == 1} ? tag : none"
-           th:each="value, iteratorStatus: ${values}" class="govuk-body"
-           th:text="${#messages.msgOrNull(value)} ?: ${{value}}">row.convertedFieldValue</p>
+        <th:block th:if="${valueUrl} == null" th:each="value, iteratorStatus : ${values}">
+            <!--/* Downloadable file: render as link when URL available, plain text when still scanning */-->
+            <p th:if="${value instanceof T(uk.gov.communities.prsdb.webapp.models.viewModels.DownloadableFileViewModel)}"
+               th:remove="${iteratorStatus.size == 1} ? tag : none" class="govuk-body">
+                <a th:if="${value.downloadUrl != null}"
+                   th:href="@{${value.downloadUrl}}"
+                   class="govuk-link"
+                   th:text="${value.fileName}">filename</a>
+                <th:block th:if="${value.downloadUrl == null}"
+                          th:text="${value.fileName}">filename</th:block>
+            </p>
+            <!--/* All other value types: existing behaviour */-->
+            <p th:unless="${value instanceof T(uk.gov.communities.prsdb.webapp.models.viewModels.DownloadableFileViewModel)}"
+               th:remove="${iteratorStatus.size == 1} ? tag : none"
+               class="govuk-body"
+               th:text="${#messages.msgOrNull(value)} ?: ${{value}}">row.convertedFieldValue</p>
+        </th:block>
     </dd>
     <dd class="govuk-summary-list__actions" th:attr="aria-label=${withAriaLabelForAction} ? #{${withAriaLabelForAction}} : null">
         <ul class="govuk-summary-list__actions-list">

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/CheckGasSafetyAnswersStepConfigTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/CheckGasSafetyAnswersStepConfigTests.kt
@@ -10,11 +10,14 @@ import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
+import uk.gov.communities.prsdb.webapp.database.entity.FileUpload
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.CertificateUpload
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.GasSafetyState
 import uk.gov.communities.prsdb.webapp.journeys.shared.Complete
 import uk.gov.communities.prsdb.webapp.journeys.shared.YesOrNo
+import uk.gov.communities.prsdb.webapp.models.viewModels.DownloadableFileViewModel
 import uk.gov.communities.prsdb.webapp.models.viewModels.summaryModels.SummaryListRowViewModel
+import uk.gov.communities.prsdb.webapp.services.UploadService
 import uk.gov.communities.prsdb.webapp.testHelpers.mockObjects.AlwaysTrueValidator
 
 @ExtendWith(MockitoExtension::class)
@@ -22,13 +25,16 @@ class CheckGasSafetyAnswersStepConfigTests {
     @Mock
     lateinit var mockState: GasSafetyState
 
+    @Mock
+    lateinit var mockUploadService: UploadService
+
     private val mockHasGasSupplyStep: HasGasSupplyStep = mock()
     private val mockHasGasCertStep: HasGasCertStep = mock()
     private val mockGasCertIssueDateStep: GasCertIssueDateStep = mock()
     private val mockCheckGasCertUploadsStep: CheckGasCertUploadsStep = mock()
 
     private fun setupStepConfig(): CheckGasSafetyAnswersStepConfig {
-        val stepConfig = CheckGasSafetyAnswersStepConfig()
+        val stepConfig = CheckGasSafetyAnswersStepConfig(mockUploadService)
         stepConfig.routeSegment = CheckGasSafetyAnswersStep.ROUTE_SEGMENT
         stepConfig.validator = AlwaysTrueValidator()
         return stepConfig
@@ -124,6 +130,10 @@ class CheckGasSafetyAnswersStepConfigTests {
                 mapOf(1 to CertificateUpload(1L, "cert.pdf")),
             )
 
+            val mockFileUpload: FileUpload = mock()
+            whenever(mockUploadService.getFileUploadById(1L)).thenReturn(mockFileUpload)
+            whenever(mockUploadService.getDownloadUrlOrNull(mockFileUpload, "cert.pdf")).thenReturn("https://s3.example.com/cert.pdf")
+
             // Act
             val content = stepConfig.getStepSpecificContent(mockState)
 
@@ -136,7 +146,11 @@ class CheckGasSafetyAnswersStepConfigTests {
             assertEquals(3, certRows.size)
             assertEquals(true, certRows[0].fieldValue)
             assertEquals(issueDate, certRows[1].fieldValue)
-            assertEquals(listOf("cert.pdf"), certRows[2].fieldValue)
+            val uploadValues = certRows[2].fieldValue as List<*>
+            assertEquals(1, uploadValues.size)
+            val downloadableFile = uploadValues[0] as DownloadableFileViewModel
+            assertEquals("cert.pdf", downloadableFile.fileName)
+            assertEquals("https://s3.example.com/cert.pdf", downloadableFile.downloadUrl)
 
             assertNull(content["insetTextKey"])
             assertEquals("forms.buttons.saveAndContinue", content["submitButtonText"])
@@ -163,12 +177,59 @@ class CheckGasSafetyAnswersStepConfigTests {
                 ),
             )
 
+            val mockFileUpload1: FileUpload = mock()
+            val mockFileUpload2: FileUpload = mock()
+            val mockFileUpload3: FileUpload = mock()
+            whenever(mockUploadService.getFileUploadById(1L)).thenReturn(mockFileUpload1)
+            whenever(mockUploadService.getFileUploadById(2L)).thenReturn(mockFileUpload2)
+            whenever(mockUploadService.getFileUploadById(3L)).thenReturn(mockFileUpload3)
+            whenever(mockUploadService.getDownloadUrlOrNull(mockFileUpload1, "first.pdf")).thenReturn("https://s3.example.com/first.pdf")
+            whenever(mockUploadService.getDownloadUrlOrNull(mockFileUpload2, "second.pdf")).thenReturn("https://s3.example.com/second.pdf")
+            whenever(mockUploadService.getDownloadUrlOrNull(mockFileUpload3, "third.pdf")).thenReturn("https://s3.example.com/third.pdf")
+
             // Act
             val content = stepConfig.getStepSpecificContent(mockState)
 
             // Assert
             val certRows = getCertRows(content)
-            assertEquals(listOf("first.pdf", "second.pdf", "third.pdf"), certRows[2].fieldValue)
+            val uploadValues = certRows[2].fieldValue as List<*>
+            assertEquals(3, uploadValues.size)
+            assertEquals("first.pdf", (uploadValues[0] as DownloadableFileViewModel).fileName)
+            assertEquals("second.pdf", (uploadValues[1] as DownloadableFileViewModel).fileName)
+            assertEquals("third.pdf", (uploadValues[2] as DownloadableFileViewModel).fileName)
+        }
+
+        @Test
+        fun `getStepSpecificContent returns null downloadUrl when file is not yet downloadable`() {
+            // Arrange
+            val stepConfig = setupStepConfig()
+            setupCommonStateMocks()
+            whenever(mockHasGasSupplyStep.outcome).thenReturn(YesOrNo.YES)
+            whenever(mockHasGasCertStep.outcome).thenReturn(HasGasCertMode.HAS_CERTIFICATE)
+            whenever(mockState.getGasSafetyCertificateIsOutdated()).thenReturn(false)
+            whenever(mockState.getGasSafetyCertificateIssueDateIfReachable()).thenReturn(LocalDate(2024, 6, 15))
+            whenever(mockState.gasCertIssueDateStep).thenReturn(mockGasCertIssueDateStep)
+            whenever(mockState.checkGasCertUploadsStep).thenReturn(mockCheckGasCertUploadsStep)
+            whenever(mockGasCertIssueDateStep.currentJourneyId).thenReturn("test-journey-id")
+            whenever(mockCheckGasCertUploadsStep.currentJourneyId).thenReturn("test-journey-id")
+            whenever(mockState.gasUploadMap).thenReturn(
+                mapOf(1 to CertificateUpload(1L, "scanning.pdf")),
+            )
+
+            val mockFileUpload: FileUpload = mock()
+            whenever(mockUploadService.getFileUploadById(1L)).thenReturn(mockFileUpload)
+            whenever(mockUploadService.getDownloadUrlOrNull(mockFileUpload, "scanning.pdf")).thenReturn(null)
+
+            // Act
+            val content = stepConfig.getStepSpecificContent(mockState)
+
+            // Assert
+            val certRows = getCertRows(content)
+            val uploadValues = certRows[2].fieldValue as List<*>
+            assertEquals(1, uploadValues.size)
+            val downloadableFile = uploadValues[0] as DownloadableFileViewModel
+            assertEquals("scanning.pdf", downloadableFile.fileName)
+            assertNull(downloadableFile.downloadUrl)
         }
     }
 


### PR DESCRIPTION
## Ticket number

PDJB-655

## Goal of change

Render uploaded certificate file names as clickable download links on the gas safety Check Your Answers page, falling back to plain text when files are still being scanned.

## Description of main change(s)

- Introduces `DownloadableFileViewModel` data class pairing a file name with an optional download URL
- Updates the shared `summaryRow.html` template to render `DownloadableFileViewModel` items as GOV.UK-styled links (or plain text when the URL is null), preserving existing behaviour for all other value types
- Updates `CheckGasSafetyAnswersStepConfig` to inject `UploadService` and build `DownloadableFileViewModel` instances from uploaded certificate data, following the established pattern in `CheckGasCertUploadsStepConfig`

## Anything you'd like to highlight to the reviewer?

The `summaryRow.html` template is shared across the entire app. The change uses an `instanceof` branch so all existing usages are unaffected — they hit the `th:unless` path. Property registration integration tests have been run to verify no regressions.

The `DownloadableFileViewModel` and template changes are designed to be reusable for the electrical safety CYA page when it lands on main.

## Checklist

- [ ] Screenshots of any UI changes have been added
- [x] Unit tests for new logic (e.g. new service methods) have been added
- [x] Test suite has been run in full locally and is passing
- [x] Branch has been rebased onto main and run locally, with everything working as expected (both for your new feature and any related functionality)
- [x] TODO comments referencing this JIRA ticket have been searched for and removed - if a future PR will address them, mention that here

Remaining PDJB-655 TODOs are for the electrical safety CYA page (separate branch `feat/PDJB-655-electrical-safety-cya-page`) and are not in scope for this PR.