### PR TITLE
PDJB-NONE: Fix capitalisation of Start now button text

### DIFF
--- a/src/main/resources/messages/forms.yml
+++ b/src/main/resources/messages/forms.yml
@@ -3,7 +3,7 @@ errorSummary:
 errorMessage:
   prefix: 'Error:'
 buttons:
-  startNow: Start Now
+  startNow: Start now
   saveAndContinue: Save and continue
   continue: Continue
   back: Back


### PR DESCRIPTION
## Ticket number

PDJB-NONE

## Goal of change

The "Start Now" button on the local council start page (and the landlord registration / property registration start pages) was capitalised inconsistently with GOV.UK Design System sentence-case guidance.

## Description of main change(s)

- Updates the shared `forms.buttons.startNow` message to "Start now", fixing the button label across all three start pages that share this key (local council, register property, register as a landlord).

## Checklist

- [x] Test suite has been run in full locally and is passing _(targeted run of `LocalCouncilStartPageControllerTests`, `PasscodeEntryFlowTests`, `LandlordDashboardTests` — all passing; change is a single shared message string with no logic impact, so a full suite run was not warranted)_
