### PR TITLE
PDJB-NONE: Extract row factories for gas safety and electrical CYA step configs

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/ElectricalSafetyRegistrationCyaSummaryRowsFactory.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/ElectricalSafetyRegistrationCyaSummaryRowsFactory.kt
@@ -1,0 +1,116 @@
+package uk.gov.communities.prsdb.webapp.journeys.propertyRegistration
+
+import uk.gov.communities.prsdb.webapp.constants.enums.HasElectricalSafetyCertificate
+import uk.gov.communities.prsdb.webapp.journeys.Destination
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.ElectricalSafetyState
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.ElectricalSafetyScenario
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.HasElectricalCertMode
+import uk.gov.communities.prsdb.webapp.models.viewModels.summaryModels.SummaryListRowViewModel
+
+class ElectricalSafetyRegistrationCyaSummaryRowsFactory(
+    private val state: ElectricalSafetyState,
+) {
+    private val scenario: ElectricalSafetyScenario = determineScenario(state)
+
+    fun createRows(): List<SummaryListRowViewModel> =
+        when (scenario) {
+            ElectricalSafetyScenario.CERT_UPLOADED -> getCertUploadedRows()
+            ElectricalSafetyScenario.PROVIDE_LATER -> listOf(getProvideLaterRow())
+            ElectricalSafetyScenario.NO_CERT, ElectricalSafetyScenario.CERT_EXPIRED -> listOf(getNoCertRow())
+        }
+
+    fun getInsetTextKey(): String? =
+        when (scenario) {
+            ElectricalSafetyScenario.NO_CERT, ElectricalSafetyScenario.CERT_EXPIRED -> {
+                if (state.isOccupied) "checkElectricalSafety.occupiedNoCertInsetText" else null
+            }
+
+            else -> {
+                null
+            }
+        }
+
+    private fun getCertUploadedRows(): List<SummaryListRowViewModel> {
+        val uploadFileNames =
+            state.electricalUploadMap
+                .toList()
+                .sortedBy { it.first }
+                .map { (_, upload) -> upload.fileName }
+
+        return listOf(
+            SummaryListRowViewModel.forCheckYourAnswersPage(
+                fieldHeading = "checkElectricalSafety.electricalCert.fieldHeading",
+                fieldValue = getCertTypeLabel(state.getElectricalCertificateType()),
+                destination = Destination(state.hasElectricalCertStep),
+            ),
+            SummaryListRowViewModel.forCheckYourAnswersPage(
+                fieldHeading = "checkElectricalSafety.expiryDate.fieldHeading",
+                fieldValue = state.getElectricalCertificateExpiryDateIfReachable(),
+                destination = Destination(state.electricalCertExpiryDateStep),
+            ),
+            SummaryListRowViewModel.forCheckYourAnswersPage(
+                fieldHeading = "checkElectricalSafety.yourCertificate.fieldHeading",
+                fieldValue = uploadFileNames,
+                destination = Destination(state.checkElectricalCertUploadsStep),
+            ),
+        )
+    }
+
+    private fun getCertTypeLabel(certType: HasElectricalSafetyCertificate?): String =
+        when (certType) {
+            HasElectricalSafetyCertificate.HAS_EIC -> "checkElectricalSafety.eicLabel"
+
+            HasElectricalSafetyCertificate.HAS_EICR -> "checkElectricalSafety.eicrLabel"
+
+            HasElectricalSafetyCertificate.NO_CERTIFICATE, null -> throw IllegalStateException(
+                "Cert uploaded scenario requires a certificate type",
+            )
+        }
+
+    private fun getProvideLaterRow(): SummaryListRowViewModel =
+        SummaryListRowViewModel.forCheckYourAnswersPage(
+            fieldHeading = "checkElectricalSafety.electricalCert.fieldHeading",
+            fieldValue =
+                if (state.isOccupied) {
+                    "checkElectricalSafety.provideThisLater.occupied"
+                } else {
+                    "checkElectricalSafety.provideThisLater.unoccupied"
+                },
+            destination = Destination(state.hasElectricalCertStep),
+        )
+
+    private fun getNoCertRow(): SummaryListRowViewModel =
+        SummaryListRowViewModel.forCheckYourAnswersPage(
+            fieldHeading = "checkElectricalSafety.electricalCert.fieldHeading",
+            fieldValue =
+                if (state.isOccupied) {
+                    "checkElectricalSafety.noneLabel"
+                } else {
+                    "checkElectricalSafety.provideThisLater.unoccupied"
+                },
+            destination = Destination(state.hasElectricalCertStep),
+        )
+
+    private fun determineScenario(state: ElectricalSafetyState): ElectricalSafetyScenario =
+        when (state.hasElectricalCertStep.outcome) {
+            HasElectricalCertMode.PROVIDE_THIS_LATER -> {
+                ElectricalSafetyScenario.PROVIDE_LATER
+            }
+
+            HasElectricalCertMode.NO_CERTIFICATE -> {
+                ElectricalSafetyScenario.NO_CERT
+            }
+
+            HasElectricalCertMode.HAS_EIC, HasElectricalCertMode.HAS_EICR -> {
+                if (state.getElectricalCertificateIsOutdated() == true) {
+                    ElectricalSafetyScenario.CERT_EXPIRED
+                } else {
+                    ElectricalSafetyScenario.CERT_UPLOADED
+                }
+            }
+
+            else -> {
+                throw IllegalStateException("CheckElectricalSafetyAnswersStep is not reachable before hasElectricalCert is answered")
+            }
+        }
+}

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/GasSafetyRegistrationCyaSummaryRowsFactory.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/GasSafetyRegistrationCyaSummaryRowsFactory.kt
@@ -1,0 +1,129 @@
+package uk.gov.communities.prsdb.webapp.journeys.propertyRegistration
+
+import uk.gov.communities.prsdb.webapp.journeys.Destination
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.GasSafetyState
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.GasSafetyScenario
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.HasGasCertMode
+import uk.gov.communities.prsdb.webapp.journeys.shared.YesOrNo
+import uk.gov.communities.prsdb.webapp.models.viewModels.summaryModels.SummaryListRowViewModel
+
+class GasSafetyRegistrationCyaSummaryRowsFactory(
+    private val state: GasSafetyState,
+) {
+    private val scenario: GasSafetyScenario = determineScenario(state)
+
+    fun createGasSupplyRows(): List<SummaryListRowViewModel> {
+        val gasSupplyRow =
+            SummaryListRowViewModel.forCheckYourAnswersPage(
+                fieldHeading = "checkGasSafety.gasSupply.fieldHeading",
+                fieldValue = state.hasGasSupplyStep.outcome == YesOrNo.YES,
+                destination = Destination(state.hasGasSupplyStep),
+            )
+
+        val certStatusRow =
+            when (scenario) {
+                GasSafetyScenario.PROVIDE_LATER -> getProvideThisLaterRow()
+                GasSafetyScenario.NO_CERT, GasSafetyScenario.CERT_EXPIRED -> getNoCertRow()
+                else -> null
+            }
+
+        return listOfNotNull(gasSupplyRow, certStatusRow)
+    }
+
+    fun createCertRows(): List<SummaryListRowViewModel> =
+        when (scenario) {
+            GasSafetyScenario.UPLOADED_CERTIFICATE -> getUploadedCertRows()
+            else -> emptyList()
+        }
+
+    fun getInsetTextKey(): String? =
+        when (scenario) {
+            GasSafetyScenario.NO_GAS_SUPPLY -> {
+                "checkGasSafety.noGasSupplyInsetText"
+            }
+
+            GasSafetyScenario.NO_CERT -> {
+                if (state.isOccupied) "checkGasSafety.occupiedNoCertInsetText" else null
+            }
+
+            GasSafetyScenario.CERT_EXPIRED -> {
+                if (state.isOccupied) "checkGasSafety.occupiedNoCertInsetText" else null
+            }
+
+            else -> {
+                null
+            }
+        }
+
+    private fun getUploadedCertRows(): List<SummaryListRowViewModel> {
+        val uploadFileNames =
+            state.gasUploadMap
+                .toList()
+                .sortedBy { it.first }
+                .map { (_, upload) -> upload.fileName }
+
+        return listOf(
+            SummaryListRowViewModel.forCheckYourAnswersPage(
+                fieldHeading = "checkGasSafety.validGasCert.fieldHeading",
+                fieldValue = true,
+                destination = Destination(state.hasGasCertStep),
+            ),
+            SummaryListRowViewModel.forCheckYourAnswersPage(
+                fieldHeading = "checkGasSafety.issueDate.fieldHeading",
+                fieldValue = state.getGasSafetyCertificateIssueDateIfReachable(),
+                destination = Destination(state.gasCertIssueDateStep),
+            ),
+            SummaryListRowViewModel.forCheckYourAnswersPage(
+                fieldHeading = "checkGasSafety.yourCertificate.fieldHeading",
+                fieldValue = uploadFileNames,
+                destination = Destination(state.checkGasCertUploadsStep),
+            ),
+        )
+    }
+
+    private fun getProvideThisLaterRow(): SummaryListRowViewModel =
+        SummaryListRowViewModel.forCheckYourAnswersPage(
+            fieldHeading = "checkGasSafety.gasCert.fieldHeading",
+            fieldValue = getProvideLaterKey(),
+            destination = Destination(state.hasGasCertStep),
+        )
+
+    private fun getNoCertRow(): SummaryListRowViewModel =
+        SummaryListRowViewModel.forCheckYourAnswersPage(
+            fieldHeading = "checkGasSafety.gasCert.fieldHeading",
+            fieldValue = if (state.isOccupied) false else getProvideLaterKey(),
+            destination = Destination(state.hasGasCertStep),
+        )
+
+    private fun getProvideLaterKey(): String =
+        if (state.isOccupied) {
+            "checkGasSafety.provideThisLater.occupied"
+        } else {
+            "checkGasSafety.provideThisLater.unoccupied"
+        }
+
+    private fun determineScenario(state: GasSafetyState): GasSafetyScenario {
+        if (state.hasGasSupplyStep.outcome == YesOrNo.NO) return GasSafetyScenario.NO_GAS_SUPPLY
+        return when (state.hasGasCertStep.outcome) {
+            HasGasCertMode.PROVIDE_THIS_LATER -> {
+                GasSafetyScenario.PROVIDE_LATER
+            }
+
+            HasGasCertMode.NO_CERTIFICATE -> {
+                GasSafetyScenario.NO_CERT
+            }
+
+            HasGasCertMode.HAS_CERTIFICATE -> {
+                if (state.getGasSafetyCertificateIsOutdated() == true) {
+                    GasSafetyScenario.CERT_EXPIRED
+                } else {
+                    GasSafetyScenario.UPLOADED_CERTIFICATE
+                }
+            }
+
+            else -> {
+                throw IllegalStateException("CheckGasSafetyAnswersStep is not reachable before hasGasCert is answered")
+            }
+        }
+    }
+}

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/CheckElectricalSafetyAnswersStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/CheckElectricalSafetyAnswersStepConfig.kt
@@ -1,24 +1,22 @@
 package uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps
 
 import uk.gov.communities.prsdb.webapp.annotations.webAnnotations.JourneyFrameworkComponent
-import uk.gov.communities.prsdb.webapp.constants.enums.HasElectricalSafetyCertificate
 import uk.gov.communities.prsdb.webapp.journeys.AbstractRequestableStepConfig
-import uk.gov.communities.prsdb.webapp.journeys.Destination
 import uk.gov.communities.prsdb.webapp.journeys.JourneyStep.RequestableStep
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.ElectricalSafetyRegistrationCyaSummaryRowsFactory
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.ElectricalSafetyState
 import uk.gov.communities.prsdb.webapp.journeys.shared.Complete
 import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.NoInputFormModel
-import uk.gov.communities.prsdb.webapp.models.viewModels.summaryModels.SummaryListRowViewModel
 
 @JourneyFrameworkComponent
 class CheckElectricalSafetyAnswersStepConfig : AbstractRequestableStepConfig<Complete, NoInputFormModel, ElectricalSafetyState>() {
     override val formModelClass = NoInputFormModel::class
 
     override fun getStepSpecificContent(state: ElectricalSafetyState): Map<String, Any?> {
-        val scenario = determineScenario(state)
+        val factory = ElectricalSafetyRegistrationCyaSummaryRowsFactory(state)
         return mapOf(
-            "rows" to getRows(state, scenario),
-            "insetTextKey" to getInsetTextKey(state, scenario),
+            "rows" to factory.createRows(),
+            "insetTextKey" to factory.getInsetTextKey(),
             "submitButtonText" to "forms.buttons.saveAndContinue",
         )
     }
@@ -26,114 +24,6 @@ class CheckElectricalSafetyAnswersStepConfig : AbstractRequestableStepConfig<Com
     override fun chooseTemplate(state: ElectricalSafetyState) = "forms/checkElectricalSafetyAnswersForm"
 
     override fun mode(state: ElectricalSafetyState) = getFormModelFromStateOrNull(state)?.let { Complete.COMPLETE }
-
-    private fun getRows(
-        state: ElectricalSafetyState,
-        scenario: ElectricalSafetyScenario,
-    ): List<SummaryListRowViewModel> =
-        when (scenario) {
-            ElectricalSafetyScenario.CERT_UPLOADED -> getCertUploadedRows(state)
-            ElectricalSafetyScenario.PROVIDE_LATER -> listOf(getProvideLaterRow(state))
-            ElectricalSafetyScenario.NO_CERT, ElectricalSafetyScenario.CERT_EXPIRED -> listOf(getNoCertRow(state))
-        }
-
-    private fun getCertUploadedRows(state: ElectricalSafetyState): List<SummaryListRowViewModel> {
-        val uploadFileNames =
-            state.electricalUploadMap
-                .toList()
-                .sortedBy { it.first }
-                .map { (_, upload) -> upload.fileName }
-
-        return listOf(
-            SummaryListRowViewModel.forCheckYourAnswersPage(
-                fieldHeading = "checkElectricalSafety.electricalCert.fieldHeading",
-                fieldValue = getCertTypeLabel(state.getElectricalCertificateType()),
-                destination = Destination(state.hasElectricalCertStep),
-            ),
-            SummaryListRowViewModel.forCheckYourAnswersPage(
-                fieldHeading = "checkElectricalSafety.expiryDate.fieldHeading",
-                fieldValue = state.getElectricalCertificateExpiryDateIfReachable(),
-                destination = Destination(state.electricalCertExpiryDateStep),
-            ),
-            SummaryListRowViewModel.forCheckYourAnswersPage(
-                fieldHeading = "checkElectricalSafety.yourCertificate.fieldHeading",
-                fieldValue = uploadFileNames,
-                destination = Destination(state.checkElectricalCertUploadsStep),
-            ),
-        )
-    }
-
-    private fun getCertTypeLabel(certType: HasElectricalSafetyCertificate?): String =
-        when (certType) {
-            HasElectricalSafetyCertificate.HAS_EIC -> "checkElectricalSafety.eicLabel"
-
-            HasElectricalSafetyCertificate.HAS_EICR -> "checkElectricalSafety.eicrLabel"
-
-            HasElectricalSafetyCertificate.NO_CERTIFICATE, null -> throw IllegalStateException(
-                "Cert uploaded scenario requires a certificate type",
-            )
-        }
-
-    private fun getProvideLaterRow(state: ElectricalSafetyState): SummaryListRowViewModel =
-        SummaryListRowViewModel.forCheckYourAnswersPage(
-            fieldHeading = "checkElectricalSafety.electricalCert.fieldHeading",
-            fieldValue =
-                if (state.isOccupied) {
-                    "checkElectricalSafety.provideThisLater.occupied"
-                } else {
-                    "checkElectricalSafety.provideThisLater.unoccupied"
-                },
-            destination = Destination(state.hasElectricalCertStep),
-        )
-
-    private fun getNoCertRow(state: ElectricalSafetyState): SummaryListRowViewModel =
-        SummaryListRowViewModel.forCheckYourAnswersPage(
-            fieldHeading = "checkElectricalSafety.electricalCert.fieldHeading",
-            fieldValue =
-                if (state.isOccupied) {
-                    "checkElectricalSafety.noneLabel"
-                } else {
-                    "checkElectricalSafety.provideThisLater.unoccupied"
-                },
-            destination = Destination(state.hasElectricalCertStep),
-        )
-
-    private fun getInsetTextKey(
-        state: ElectricalSafetyState,
-        scenario: ElectricalSafetyScenario,
-    ): String? =
-        when (scenario) {
-            ElectricalSafetyScenario.NO_CERT, ElectricalSafetyScenario.CERT_EXPIRED -> {
-                if (state.isOccupied) "checkElectricalSafety.occupiedNoCertInsetText" else null
-            }
-
-            else -> {
-                null
-            }
-        }
-
-    private fun determineScenario(state: ElectricalSafetyState): ElectricalSafetyScenario =
-        when (state.hasElectricalCertStep.outcome) {
-            HasElectricalCertMode.PROVIDE_THIS_LATER -> {
-                ElectricalSafetyScenario.PROVIDE_LATER
-            }
-
-            HasElectricalCertMode.NO_CERTIFICATE -> {
-                ElectricalSafetyScenario.NO_CERT
-            }
-
-            HasElectricalCertMode.HAS_EIC, HasElectricalCertMode.HAS_EICR -> {
-                if (state.getElectricalCertificateIsOutdated() == true) {
-                    ElectricalSafetyScenario.CERT_EXPIRED
-                } else {
-                    ElectricalSafetyScenario.CERT_UPLOADED
-                }
-            }
-
-            else -> {
-                throw IllegalStateException("CheckElectricalSafetyAnswersStep is not reachable before hasElectricalCert is answered")
-            }
-        }
 }
 
 enum class ElectricalSafetyScenario {

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/CheckGasSafetyAnswersStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/CheckGasSafetyAnswersStepConfig.kt
@@ -2,24 +2,22 @@ package uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps
 
 import uk.gov.communities.prsdb.webapp.annotations.webAnnotations.JourneyFrameworkComponent
 import uk.gov.communities.prsdb.webapp.journeys.AbstractRequestableStepConfig
-import uk.gov.communities.prsdb.webapp.journeys.Destination
 import uk.gov.communities.prsdb.webapp.journeys.JourneyStep.RequestableStep
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.GasSafetyRegistrationCyaSummaryRowsFactory
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.GasSafetyState
 import uk.gov.communities.prsdb.webapp.journeys.shared.Complete
-import uk.gov.communities.prsdb.webapp.journeys.shared.YesOrNo
 import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.NoInputFormModel
-import uk.gov.communities.prsdb.webapp.models.viewModels.summaryModels.SummaryListRowViewModel
 
 @JourneyFrameworkComponent
 class CheckGasSafetyAnswersStepConfig : AbstractRequestableStepConfig<Complete, NoInputFormModel, GasSafetyState>() {
     override val formModelClass = NoInputFormModel::class
 
     override fun getStepSpecificContent(state: GasSafetyState): Map<String, Any?> {
-        val scenario = determineScenario(state)
+        val factory = GasSafetyRegistrationCyaSummaryRowsFactory(state)
         return mapOf(
-            "gasSupplyRows" to getGasSupplyRows(state, scenario),
-            "certRows" to getCertRows(state, scenario),
-            "insetTextKey" to getInsetTextKey(state, scenario),
+            "gasSupplyRows" to factory.createGasSupplyRows(),
+            "certRows" to factory.createCertRows(),
+            "insetTextKey" to factory.getInsetTextKey(),
             "submitButtonText" to "forms.buttons.saveAndContinue",
         )
     }
@@ -27,130 +25,6 @@ class CheckGasSafetyAnswersStepConfig : AbstractRequestableStepConfig<Complete, 
     override fun chooseTemplate(state: GasSafetyState) = "forms/checkGasSafetyAnswersForm"
 
     override fun mode(state: GasSafetyState) = getFormModelFromStateOrNull(state)?.let { Complete.COMPLETE }
-
-    private fun getGasSupplyRows(
-        state: GasSafetyState,
-        scenario: GasSafetyScenario,
-    ): List<SummaryListRowViewModel> {
-        val gasSupplyRow =
-            SummaryListRowViewModel.forCheckYourAnswersPage(
-                fieldHeading = "checkGasSafety.gasSupply.fieldHeading",
-                fieldValue = state.hasGasSupplyStep.outcome == YesOrNo.YES,
-                destination = Destination(state.hasGasSupplyStep),
-            )
-
-        val certStatusRow =
-            when (scenario) {
-                GasSafetyScenario.PROVIDE_LATER -> getProvideThisLaterRow(state)
-                GasSafetyScenario.NO_CERT, GasSafetyScenario.CERT_EXPIRED -> getNoCertRow(state)
-                else -> null
-            }
-
-        return listOfNotNull(gasSupplyRow, certStatusRow)
-    }
-
-    private fun getCertRows(
-        state: GasSafetyState,
-        scenario: GasSafetyScenario,
-    ): List<SummaryListRowViewModel> =
-        when (scenario) {
-            GasSafetyScenario.UPLOADED_CERTIFICATE -> getUploadedCertRows(state)
-            else -> emptyList()
-        }
-
-    private fun getUploadedCertRows(state: GasSafetyState): List<SummaryListRowViewModel> {
-        val uploadFileNames =
-            state.gasUploadMap
-                .toList()
-                .sortedBy { it.first }
-                .map { (_, upload) -> upload.fileName }
-
-        return listOf(
-            SummaryListRowViewModel.forCheckYourAnswersPage(
-                fieldHeading = "checkGasSafety.validGasCert.fieldHeading",
-                fieldValue = true,
-                destination = Destination(state.hasGasCertStep),
-            ),
-            SummaryListRowViewModel.forCheckYourAnswersPage(
-                fieldHeading = "checkGasSafety.issueDate.fieldHeading",
-                fieldValue = state.getGasSafetyCertificateIssueDateIfReachable(),
-                destination = Destination(state.gasCertIssueDateStep),
-            ),
-            SummaryListRowViewModel.forCheckYourAnswersPage(
-                fieldHeading = "checkGasSafety.yourCertificate.fieldHeading",
-                fieldValue = uploadFileNames,
-                destination = Destination(state.checkGasCertUploadsStep),
-            ),
-        )
-    }
-
-    private fun getProvideThisLaterRow(state: GasSafetyState): SummaryListRowViewModel =
-        SummaryListRowViewModel.forCheckYourAnswersPage(
-            fieldHeading = "checkGasSafety.gasCert.fieldHeading",
-            fieldValue = getProvideLaterKey(state),
-            destination = Destination(state.hasGasCertStep),
-        )
-
-    private fun getNoCertRow(state: GasSafetyState): SummaryListRowViewModel =
-        SummaryListRowViewModel.forCheckYourAnswersPage(
-            fieldHeading = "checkGasSafety.gasCert.fieldHeading",
-            fieldValue = if (state.isOccupied) false else getProvideLaterKey(state),
-            destination = Destination(state.hasGasCertStep),
-        )
-
-    private fun getInsetTextKey(
-        state: GasSafetyState,
-        scenario: GasSafetyScenario,
-    ): String? =
-        when (scenario) {
-            GasSafetyScenario.NO_GAS_SUPPLY -> {
-                "checkGasSafety.noGasSupplyInsetText"
-            }
-
-            GasSafetyScenario.NO_CERT -> {
-                if (state.isOccupied) "checkGasSafety.occupiedNoCertInsetText" else null
-            }
-
-            GasSafetyScenario.CERT_EXPIRED -> {
-                if (state.isOccupied) "checkGasSafety.occupiedNoCertInsetText" else null
-            }
-
-            else -> {
-                null
-            }
-        }
-
-    private fun getProvideLaterKey(state: GasSafetyState): String =
-        if (state.isOccupied) {
-            "checkGasSafety.provideThisLater.occupied"
-        } else {
-            "checkGasSafety.provideThisLater.unoccupied"
-        }
-
-    private fun determineScenario(state: GasSafetyState): GasSafetyScenario {
-        if (state.hasGasSupplyStep.outcome == YesOrNo.NO) return GasSafetyScenario.NO_GAS_SUPPLY
-        return when (state.hasGasCertStep.outcome) {
-            HasGasCertMode.PROVIDE_THIS_LATER -> {
-                GasSafetyScenario.PROVIDE_LATER
-            }
-
-            HasGasCertMode.NO_CERTIFICATE -> {
-                GasSafetyScenario.NO_CERT
-            }
-
-            HasGasCertMode.HAS_CERTIFICATE -> {
-                if (state.getGasSafetyCertificateIsOutdated() == true) {
-                    GasSafetyScenario.CERT_EXPIRED
-                } else {
-                    GasSafetyScenario.UPLOADED_CERTIFICATE
-                }
-            }
-
-            else -> {
-                throw IllegalStateException("CheckGasSafetyAnswersStep is not reachable before hasGasCert is answered")
-            }
-        }
-    }
 }
 
 enum class GasSafetyScenario {

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/ElectricalSafetyRegistrationCyaSummaryRowsFactoryTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/ElectricalSafetyRegistrationCyaSummaryRowsFactoryTests.kt
@@ -1,0 +1,220 @@
+package uk.gov.communities.prsdb.webapp.journeys.propertyRegistration
+
+import kotlinx.datetime.LocalDate
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import uk.gov.communities.prsdb.webapp.constants.enums.HasElectricalSafetyCertificate
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.CertificateUpload
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.ElectricalSafetyState
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.CheckElectricalCertUploadsStep
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.ElectricalCertExpiryDateStep
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.HasElectricalCertMode
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.HasElectricalCertStep
+
+@ExtendWith(MockitoExtension::class)
+class ElectricalSafetyRegistrationCyaSummaryRowsFactoryTests {
+    @Mock
+    lateinit var mockState: ElectricalSafetyState
+
+    private val mockHasElectricalCertStep: HasElectricalCertStep = mock()
+    private val mockElectricalCertExpiryDateStep: ElectricalCertExpiryDateStep = mock()
+    private val mockCheckElectricalCertUploadsStep: CheckElectricalCertUploadsStep = mock()
+
+    private fun setupCommonStateMocks() {
+        whenever(mockState.hasElectricalCertStep).thenReturn(mockHasElectricalCertStep)
+        whenever(mockHasElectricalCertStep.currentJourneyId).thenReturn("test-journey-id")
+    }
+
+    @Nested
+    inner class CertUploaded {
+        @Test
+        fun `factory returns correct content for EIC with uploads`() {
+            setupCommonStateMocks()
+            whenever(mockHasElectricalCertStep.outcome).thenReturn(HasElectricalCertMode.HAS_EIC)
+            whenever(mockState.getElectricalCertificateIsOutdated()).thenReturn(false)
+            whenever(mockState.getElectricalCertificateType()).thenReturn(HasElectricalSafetyCertificate.HAS_EIC)
+
+            val expiryDate = LocalDate(2026, 6, 15)
+            whenever(mockState.getElectricalCertificateExpiryDateIfReachable()).thenReturn(expiryDate)
+
+            whenever(mockState.electricalCertExpiryDateStep).thenReturn(mockElectricalCertExpiryDateStep)
+            whenever(mockState.checkElectricalCertUploadsStep).thenReturn(mockCheckElectricalCertUploadsStep)
+            whenever(mockElectricalCertExpiryDateStep.currentJourneyId).thenReturn("test-journey-id")
+            whenever(mockCheckElectricalCertUploadsStep.currentJourneyId).thenReturn("test-journey-id")
+            whenever(mockState.electricalUploadMap).thenReturn(
+                mapOf(1 to CertificateUpload(1L, "cert.pdf")),
+            )
+
+            val factory = ElectricalSafetyRegistrationCyaSummaryRowsFactory(mockState)
+
+            val rows = factory.createRows()
+            assertEquals(3, rows.size)
+            assertEquals("checkElectricalSafety.eicLabel", rows[0].fieldValue)
+            assertEquals(expiryDate, rows[1].fieldValue)
+            assertEquals(listOf("cert.pdf"), rows[2].fieldValue)
+
+            assertNull(factory.getInsetTextKey())
+        }
+
+        @Test
+        fun `factory returns correct content for EICR with uploads`() {
+            setupCommonStateMocks()
+            whenever(mockHasElectricalCertStep.outcome).thenReturn(HasElectricalCertMode.HAS_EICR)
+            whenever(mockState.getElectricalCertificateIsOutdated()).thenReturn(false)
+            whenever(mockState.getElectricalCertificateType()).thenReturn(HasElectricalSafetyCertificate.HAS_EICR)
+
+            val expiryDate = LocalDate(2026, 6, 15)
+            whenever(mockState.getElectricalCertificateExpiryDateIfReachable()).thenReturn(expiryDate)
+
+            whenever(mockState.electricalCertExpiryDateStep).thenReturn(mockElectricalCertExpiryDateStep)
+            whenever(mockState.checkElectricalCertUploadsStep).thenReturn(mockCheckElectricalCertUploadsStep)
+            whenever(mockElectricalCertExpiryDateStep.currentJourneyId).thenReturn("test-journey-id")
+            whenever(mockCheckElectricalCertUploadsStep.currentJourneyId).thenReturn("test-journey-id")
+            whenever(mockState.electricalUploadMap).thenReturn(
+                mapOf(1 to CertificateUpload(1L, "cert.pdf")),
+            )
+
+            val factory = ElectricalSafetyRegistrationCyaSummaryRowsFactory(mockState)
+
+            val rows = factory.createRows()
+            assertEquals(3, rows.size)
+            assertEquals("checkElectricalSafety.eicrLabel", rows[0].fieldValue)
+
+            assertNull(factory.getInsetTextKey())
+        }
+
+        @Test
+        fun `factory sorts uploads by map key and returns file names`() {
+            setupCommonStateMocks()
+            whenever(mockHasElectricalCertStep.outcome).thenReturn(HasElectricalCertMode.HAS_EIC)
+            whenever(mockState.getElectricalCertificateIsOutdated()).thenReturn(false)
+            whenever(mockState.getElectricalCertificateType()).thenReturn(HasElectricalSafetyCertificate.HAS_EIC)
+            whenever(mockState.getElectricalCertificateExpiryDateIfReachable()).thenReturn(LocalDate(2026, 6, 15))
+
+            whenever(mockState.electricalCertExpiryDateStep).thenReturn(mockElectricalCertExpiryDateStep)
+            whenever(mockState.checkElectricalCertUploadsStep).thenReturn(mockCheckElectricalCertUploadsStep)
+            whenever(mockElectricalCertExpiryDateStep.currentJourneyId).thenReturn("test-journey-id")
+            whenever(mockCheckElectricalCertUploadsStep.currentJourneyId).thenReturn("test-journey-id")
+            whenever(mockState.electricalUploadMap).thenReturn(
+                mapOf(
+                    3 to CertificateUpload(3L, "third.pdf"),
+                    1 to CertificateUpload(1L, "first.pdf"),
+                    2 to CertificateUpload(2L, "second.pdf"),
+                ),
+            )
+
+            val factory = ElectricalSafetyRegistrationCyaSummaryRowsFactory(mockState)
+
+            val rows = factory.createRows()
+            assertEquals(listOf("first.pdf", "second.pdf", "third.pdf"), rows[2].fieldValue)
+        }
+    }
+
+    @Nested
+    inner class ProvideLater {
+        @Test
+        fun `factory returns correct content for provide this later when occupied`() {
+            setupCommonStateMocks()
+            whenever(mockHasElectricalCertStep.outcome).thenReturn(HasElectricalCertMode.PROVIDE_THIS_LATER)
+            whenever(mockState.isOccupied).thenReturn(true)
+
+            val factory = ElectricalSafetyRegistrationCyaSummaryRowsFactory(mockState)
+
+            val rows = factory.createRows()
+            assertEquals(1, rows.size)
+            assertEquals("checkElectricalSafety.provideThisLater.occupied", rows[0].fieldValue)
+
+            assertNull(factory.getInsetTextKey())
+        }
+
+        @Test
+        fun `factory returns correct content for provide this later when unoccupied`() {
+            setupCommonStateMocks()
+            whenever(mockHasElectricalCertStep.outcome).thenReturn(HasElectricalCertMode.PROVIDE_THIS_LATER)
+            whenever(mockState.isOccupied).thenReturn(false)
+
+            val factory = ElectricalSafetyRegistrationCyaSummaryRowsFactory(mockState)
+
+            val rows = factory.createRows()
+            assertEquals(1, rows.size)
+            assertEquals("checkElectricalSafety.provideThisLater.unoccupied", rows[0].fieldValue)
+
+            assertNull(factory.getInsetTextKey())
+        }
+    }
+
+    @Nested
+    inner class NoCert {
+        @Test
+        fun `factory returns correct content for no cert when occupied`() {
+            setupCommonStateMocks()
+            whenever(mockHasElectricalCertStep.outcome).thenReturn(HasElectricalCertMode.NO_CERTIFICATE)
+            whenever(mockState.isOccupied).thenReturn(true)
+
+            val factory = ElectricalSafetyRegistrationCyaSummaryRowsFactory(mockState)
+
+            val rows = factory.createRows()
+            assertEquals(1, rows.size)
+            assertEquals("checkElectricalSafety.noneLabel", rows[0].fieldValue)
+
+            assertEquals("checkElectricalSafety.occupiedNoCertInsetText", factory.getInsetTextKey())
+        }
+
+        @Test
+        fun `factory returns correct content for no cert when unoccupied`() {
+            setupCommonStateMocks()
+            whenever(mockHasElectricalCertStep.outcome).thenReturn(HasElectricalCertMode.NO_CERTIFICATE)
+            whenever(mockState.isOccupied).thenReturn(false)
+
+            val factory = ElectricalSafetyRegistrationCyaSummaryRowsFactory(mockState)
+
+            val rows = factory.createRows()
+            assertEquals(1, rows.size)
+            assertEquals("checkElectricalSafety.provideThisLater.unoccupied", rows[0].fieldValue)
+
+            assertNull(factory.getInsetTextKey())
+        }
+    }
+
+    @Nested
+    inner class CertExpired {
+        @Test
+        fun `factory returns correct content for expired cert when occupied`() {
+            setupCommonStateMocks()
+            whenever(mockHasElectricalCertStep.outcome).thenReturn(HasElectricalCertMode.HAS_EIC)
+            whenever(mockState.getElectricalCertificateIsOutdated()).thenReturn(true)
+            whenever(mockState.isOccupied).thenReturn(true)
+
+            val factory = ElectricalSafetyRegistrationCyaSummaryRowsFactory(mockState)
+
+            val rows = factory.createRows()
+            assertEquals(1, rows.size)
+            assertEquals("checkElectricalSafety.noneLabel", rows[0].fieldValue)
+
+            assertEquals("checkElectricalSafety.occupiedNoCertInsetText", factory.getInsetTextKey())
+        }
+
+        @Test
+        fun `factory returns correct content for expired cert when unoccupied`() {
+            setupCommonStateMocks()
+            whenever(mockHasElectricalCertStep.outcome).thenReturn(HasElectricalCertMode.HAS_EICR)
+            whenever(mockState.getElectricalCertificateIsOutdated()).thenReturn(true)
+            whenever(mockState.isOccupied).thenReturn(false)
+
+            val factory = ElectricalSafetyRegistrationCyaSummaryRowsFactory(mockState)
+
+            val rows = factory.createRows()
+            assertEquals(1, rows.size)
+            assertEquals("checkElectricalSafety.provideThisLater.unoccupied", rows[0].fieldValue)
+
+            assertNull(factory.getInsetTextKey())
+        }
+    }
+}

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/GasSafetyRegistrationCyaSummaryRowsFactoryTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/GasSafetyRegistrationCyaSummaryRowsFactoryTests.kt
@@ -1,0 +1,252 @@
+package uk.gov.communities.prsdb.webapp.journeys.propertyRegistration
+
+import kotlinx.datetime.LocalDate
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.CertificateUpload
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.GasSafetyState
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.CheckGasCertUploadsStep
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.GasCertIssueDateStep
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.HasGasCertMode
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.HasGasCertStep
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.HasGasSupplyStep
+import uk.gov.communities.prsdb.webapp.journeys.shared.YesOrNo
+import uk.gov.communities.prsdb.webapp.models.viewModels.summaryModels.SummaryListRowViewModel
+
+@ExtendWith(MockitoExtension::class)
+class GasSafetyRegistrationCyaSummaryRowsFactoryTests {
+    @Mock
+    lateinit var mockState: GasSafetyState
+
+    private val mockHasGasSupplyStep: HasGasSupplyStep = mock()
+    private val mockHasGasCertStep: HasGasCertStep = mock()
+    private val mockGasCertIssueDateStep: GasCertIssueDateStep = mock()
+    private val mockCheckGasCertUploadsStep: CheckGasCertUploadsStep = mock()
+
+    private fun setupCommonStateMocks() {
+        whenever(mockState.hasGasSupplyStep).thenReturn(mockHasGasSupplyStep)
+        whenever(mockState.hasGasCertStep).thenReturn(mockHasGasCertStep)
+        whenever(mockHasGasSupplyStep.currentJourneyId).thenReturn("test-journey-id")
+        whenever(mockHasGasCertStep.currentJourneyId).thenReturn("test-journey-id")
+    }
+
+    @Nested
+    inner class NoGasSupply {
+        @Test
+        fun `createGasSupplyRows returns single row with false when no gas supply`() {
+            whenever(mockState.hasGasSupplyStep).thenReturn(mockHasGasSupplyStep)
+            whenever(mockHasGasSupplyStep.currentJourneyId).thenReturn("test-journey-id")
+            whenever(mockHasGasSupplyStep.outcome).thenReturn(YesOrNo.NO)
+
+            val factory = GasSafetyRegistrationCyaSummaryRowsFactory(mockState)
+
+            val gasSupplyRows = factory.createGasSupplyRows()
+            assertEquals(1, gasSupplyRows.size)
+            assertEquals(false, gasSupplyRows[0].fieldValue)
+
+            val certRows = factory.createCertRows()
+            assertEquals(emptyList<SummaryListRowViewModel>(), certRows)
+
+            assertEquals("checkGasSafety.noGasSupplyInsetText", factory.getInsetTextKey())
+        }
+    }
+
+    @Nested
+    inner class UploadedCertificate {
+        @Test
+        fun `factory returns correct content for valid cert with uploads`() {
+            setupCommonStateMocks()
+            whenever(mockHasGasSupplyStep.outcome).thenReturn(YesOrNo.YES)
+            whenever(mockHasGasCertStep.outcome).thenReturn(HasGasCertMode.HAS_CERTIFICATE)
+            whenever(mockState.getGasSafetyCertificateIsOutdated()).thenReturn(false)
+
+            val issueDate = LocalDate(2024, 6, 15)
+            whenever(mockState.getGasSafetyCertificateIssueDateIfReachable()).thenReturn(issueDate)
+
+            whenever(mockState.gasCertIssueDateStep).thenReturn(mockGasCertIssueDateStep)
+            whenever(mockState.checkGasCertUploadsStep).thenReturn(mockCheckGasCertUploadsStep)
+            whenever(mockGasCertIssueDateStep.currentJourneyId).thenReturn("test-journey-id")
+            whenever(mockCheckGasCertUploadsStep.currentJourneyId).thenReturn("test-journey-id")
+            whenever(mockState.gasUploadMap).thenReturn(
+                mapOf(1 to CertificateUpload(1L, "cert.pdf")),
+            )
+
+            val factory = GasSafetyRegistrationCyaSummaryRowsFactory(mockState)
+
+            val gasSupplyRows = factory.createGasSupplyRows()
+            assertEquals(1, gasSupplyRows.size)
+            assertEquals(true, gasSupplyRows[0].fieldValue)
+
+            val certRows = factory.createCertRows()
+            assertEquals(3, certRows.size)
+            assertEquals(true, certRows[0].fieldValue)
+            assertEquals(issueDate, certRows[1].fieldValue)
+            assertEquals(listOf("cert.pdf"), certRows[2].fieldValue)
+
+            assertNull(factory.getInsetTextKey())
+        }
+
+        @Test
+        fun `factory sorts uploads by map key and returns file names`() {
+            setupCommonStateMocks()
+            whenever(mockHasGasSupplyStep.outcome).thenReturn(YesOrNo.YES)
+            whenever(mockHasGasCertStep.outcome).thenReturn(HasGasCertMode.HAS_CERTIFICATE)
+            whenever(mockState.getGasSafetyCertificateIsOutdated()).thenReturn(false)
+            whenever(mockState.getGasSafetyCertificateIssueDateIfReachable()).thenReturn(LocalDate(2024, 6, 15))
+            whenever(mockState.gasCertIssueDateStep).thenReturn(mockGasCertIssueDateStep)
+            whenever(mockState.checkGasCertUploadsStep).thenReturn(mockCheckGasCertUploadsStep)
+            whenever(mockGasCertIssueDateStep.currentJourneyId).thenReturn("test-journey-id")
+            whenever(mockCheckGasCertUploadsStep.currentJourneyId).thenReturn("test-journey-id")
+            whenever(mockState.gasUploadMap).thenReturn(
+                mapOf(
+                    3 to CertificateUpload(3L, "third.pdf"),
+                    1 to CertificateUpload(1L, "first.pdf"),
+                    2 to CertificateUpload(2L, "second.pdf"),
+                ),
+            )
+
+            val factory = GasSafetyRegistrationCyaSummaryRowsFactory(mockState)
+
+            val certRows = factory.createCertRows()
+            assertEquals(listOf("first.pdf", "second.pdf", "third.pdf"), certRows[2].fieldValue)
+        }
+    }
+
+    @Nested
+    inner class ProvideLater {
+        @Test
+        fun `factory returns correct content for provide this later when occupied`() {
+            setupCommonStateMocks()
+            whenever(mockHasGasSupplyStep.outcome).thenReturn(YesOrNo.YES)
+            whenever(mockHasGasCertStep.outcome).thenReturn(HasGasCertMode.PROVIDE_THIS_LATER)
+            whenever(mockState.isOccupied).thenReturn(true)
+
+            val factory = GasSafetyRegistrationCyaSummaryRowsFactory(mockState)
+
+            val gasSupplyRows = factory.createGasSupplyRows()
+            assertEquals(2, gasSupplyRows.size)
+            assertEquals(true, gasSupplyRows[0].fieldValue)
+            assertEquals("checkGasSafety.provideThisLater.occupied", gasSupplyRows[1].fieldValue)
+
+            val certRows = factory.createCertRows()
+            assertEquals(emptyList<SummaryListRowViewModel>(), certRows)
+
+            assertNull(factory.getInsetTextKey())
+        }
+
+        @Test
+        fun `factory returns correct content for provide this later when unoccupied`() {
+            setupCommonStateMocks()
+            whenever(mockHasGasSupplyStep.outcome).thenReturn(YesOrNo.YES)
+            whenever(mockHasGasCertStep.outcome).thenReturn(HasGasCertMode.PROVIDE_THIS_LATER)
+            whenever(mockState.isOccupied).thenReturn(false)
+
+            val factory = GasSafetyRegistrationCyaSummaryRowsFactory(mockState)
+
+            val gasSupplyRows = factory.createGasSupplyRows()
+            assertEquals(2, gasSupplyRows.size)
+            assertEquals(true, gasSupplyRows[0].fieldValue)
+            assertEquals("checkGasSafety.provideThisLater.unoccupied", gasSupplyRows[1].fieldValue)
+
+            val certRows = factory.createCertRows()
+            assertEquals(emptyList<SummaryListRowViewModel>(), certRows)
+
+            assertNull(factory.getInsetTextKey())
+        }
+    }
+
+    @Nested
+    inner class NoCert {
+        @Test
+        fun `factory returns correct content for no cert when occupied`() {
+            setupCommonStateMocks()
+            whenever(mockHasGasSupplyStep.outcome).thenReturn(YesOrNo.YES)
+            whenever(mockHasGasCertStep.outcome).thenReturn(HasGasCertMode.NO_CERTIFICATE)
+            whenever(mockState.isOccupied).thenReturn(true)
+
+            val factory = GasSafetyRegistrationCyaSummaryRowsFactory(mockState)
+
+            val gasSupplyRows = factory.createGasSupplyRows()
+            assertEquals(2, gasSupplyRows.size)
+            assertEquals(true, gasSupplyRows[0].fieldValue)
+            assertEquals(false, gasSupplyRows[1].fieldValue)
+
+            val certRows = factory.createCertRows()
+            assertEquals(emptyList<SummaryListRowViewModel>(), certRows)
+
+            assertEquals("checkGasSafety.occupiedNoCertInsetText", factory.getInsetTextKey())
+        }
+
+        @Test
+        fun `factory returns correct content for no cert when unoccupied`() {
+            setupCommonStateMocks()
+            whenever(mockHasGasSupplyStep.outcome).thenReturn(YesOrNo.YES)
+            whenever(mockHasGasCertStep.outcome).thenReturn(HasGasCertMode.NO_CERTIFICATE)
+            whenever(mockState.isOccupied).thenReturn(false)
+
+            val factory = GasSafetyRegistrationCyaSummaryRowsFactory(mockState)
+
+            val gasSupplyRows = factory.createGasSupplyRows()
+            assertEquals(2, gasSupplyRows.size)
+            assertEquals(true, gasSupplyRows[0].fieldValue)
+            assertEquals("checkGasSafety.provideThisLater.unoccupied", gasSupplyRows[1].fieldValue)
+
+            val certRows = factory.createCertRows()
+            assertEquals(emptyList<SummaryListRowViewModel>(), certRows)
+
+            assertNull(factory.getInsetTextKey())
+        }
+    }
+
+    @Nested
+    inner class CertExpired {
+        @Test
+        fun `factory returns correct content for expired cert when occupied`() {
+            setupCommonStateMocks()
+            whenever(mockHasGasSupplyStep.outcome).thenReturn(YesOrNo.YES)
+            whenever(mockHasGasCertStep.outcome).thenReturn(HasGasCertMode.HAS_CERTIFICATE)
+            whenever(mockState.getGasSafetyCertificateIsOutdated()).thenReturn(true)
+            whenever(mockState.isOccupied).thenReturn(true)
+
+            val factory = GasSafetyRegistrationCyaSummaryRowsFactory(mockState)
+
+            val gasSupplyRows = factory.createGasSupplyRows()
+            assertEquals(2, gasSupplyRows.size)
+            assertEquals(true, gasSupplyRows[0].fieldValue)
+            assertEquals(false, gasSupplyRows[1].fieldValue)
+
+            val certRows = factory.createCertRows()
+            assertEquals(emptyList<SummaryListRowViewModel>(), certRows)
+
+            assertEquals("checkGasSafety.occupiedNoCertInsetText", factory.getInsetTextKey())
+        }
+
+        @Test
+        fun `factory returns correct content for expired cert when unoccupied`() {
+            setupCommonStateMocks()
+            whenever(mockHasGasSupplyStep.outcome).thenReturn(YesOrNo.YES)
+            whenever(mockHasGasCertStep.outcome).thenReturn(HasGasCertMode.HAS_CERTIFICATE)
+            whenever(mockState.getGasSafetyCertificateIsOutdated()).thenReturn(true)
+            whenever(mockState.isOccupied).thenReturn(false)
+
+            val factory = GasSafetyRegistrationCyaSummaryRowsFactory(mockState)
+
+            val gasSupplyRows = factory.createGasSupplyRows()
+            assertEquals(2, gasSupplyRows.size)
+            assertEquals(true, gasSupplyRows[0].fieldValue)
+            assertEquals("checkGasSafety.provideThisLater.unoccupied", gasSupplyRows[1].fieldValue)
+
+            val certRows = factory.createCertRows()
+            assertEquals(emptyList<SummaryListRowViewModel>(), certRows)
+
+            assertNull(factory.getInsetTextKey())
+        }
+    }
+}

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/CheckElectricalSafetyAnswersStepConfigTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/CheckElectricalSafetyAnswersStepConfigTests.kt
@@ -1,20 +1,14 @@
 package uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps
 
-import kotlinx.datetime.LocalDate
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNull
-import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
-import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
-import uk.gov.communities.prsdb.webapp.constants.enums.HasElectricalSafetyCertificate
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.CertificateUpload
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.ElectricalSafetyState
 import uk.gov.communities.prsdb.webapp.journeys.shared.Complete
-import uk.gov.communities.prsdb.webapp.models.viewModels.summaryModels.SummaryListRowViewModel
 import uk.gov.communities.prsdb.webapp.testHelpers.mockObjects.AlwaysTrueValidator
 
 @ExtendWith(MockitoExtension::class)
@@ -22,24 +16,12 @@ class CheckElectricalSafetyAnswersStepConfigTests {
     @Mock
     lateinit var mockState: ElectricalSafetyState
 
-    private val mockHasElectricalCertStep: HasElectricalCertStep = mock()
-    private val mockElectricalCertExpiryDateStep: ElectricalCertExpiryDateStep = mock()
-    private val mockCheckElectricalCertUploadsStep: CheckElectricalCertUploadsStep = mock()
-
     private fun setupStepConfig(): CheckElectricalSafetyAnswersStepConfig {
         val stepConfig = CheckElectricalSafetyAnswersStepConfig()
         stepConfig.routeSegment = CheckElectricalSafetyAnswersStep.ROUTE_SEGMENT
         stepConfig.validator = AlwaysTrueValidator()
         return stepConfig
     }
-
-    private fun setupCommonStateMocks() {
-        whenever(mockState.hasElectricalCertStep).thenReturn(mockHasElectricalCertStep)
-        whenever(mockHasElectricalCertStep.currentJourneyId).thenReturn("test-journey-id")
-    }
-
-    @Suppress("UNCHECKED_CAST")
-    private fun getRows(content: Map<String, Any?>) = content["rows"] as List<SummaryListRowViewModel>
 
     @Test
     fun `chooseTemplate returns checkElectricalSafetyAnswersForm`() {
@@ -66,229 +48,5 @@ class CheckElectricalSafetyAnswersStepConfigTests {
         val result = stepConfig.mode(mockState)
 
         assertNull(result)
-    }
-
-    @Nested
-    inner class CertUploaded {
-        @Test
-        fun `getStepSpecificContent returns correct content for EIC with uploads`() {
-            // Arrange
-            val stepConfig = setupStepConfig()
-            setupCommonStateMocks()
-            whenever(mockHasElectricalCertStep.outcome).thenReturn(HasElectricalCertMode.HAS_EIC)
-            whenever(mockState.getElectricalCertificateIsOutdated()).thenReturn(false)
-            whenever(mockState.getElectricalCertificateType()).thenReturn(HasElectricalSafetyCertificate.HAS_EIC)
-
-            val expiryDate = LocalDate(2026, 6, 15)
-            whenever(mockState.getElectricalCertificateExpiryDateIfReachable()).thenReturn(expiryDate)
-
-            whenever(mockState.electricalCertExpiryDateStep).thenReturn(mockElectricalCertExpiryDateStep)
-            whenever(mockState.checkElectricalCertUploadsStep).thenReturn(mockCheckElectricalCertUploadsStep)
-            whenever(mockElectricalCertExpiryDateStep.currentJourneyId).thenReturn("test-journey-id")
-            whenever(mockCheckElectricalCertUploadsStep.currentJourneyId).thenReturn("test-journey-id")
-            whenever(mockState.electricalUploadMap).thenReturn(
-                mapOf(1 to CertificateUpload(1L, "cert.pdf")),
-            )
-
-            // Act
-            val content = stepConfig.getStepSpecificContent(mockState)
-
-            // Assert
-            val rows = getRows(content)
-            assertEquals(3, rows.size)
-            assertEquals("checkElectricalSafety.eicLabel", rows[0].fieldValue)
-            assertEquals(expiryDate, rows[1].fieldValue)
-            assertEquals(listOf("cert.pdf"), rows[2].fieldValue)
-
-            assertNull(content["insetTextKey"])
-            assertEquals("forms.buttons.saveAndContinue", content["submitButtonText"])
-        }
-
-        @Test
-        fun `getStepSpecificContent returns correct content for EICR with uploads`() {
-            // Arrange
-            val stepConfig = setupStepConfig()
-            setupCommonStateMocks()
-            whenever(mockHasElectricalCertStep.outcome).thenReturn(HasElectricalCertMode.HAS_EICR)
-            whenever(mockState.getElectricalCertificateIsOutdated()).thenReturn(false)
-            whenever(mockState.getElectricalCertificateType()).thenReturn(HasElectricalSafetyCertificate.HAS_EICR)
-
-            val expiryDate = LocalDate(2026, 6, 15)
-            whenever(mockState.getElectricalCertificateExpiryDateIfReachable()).thenReturn(expiryDate)
-
-            whenever(mockState.electricalCertExpiryDateStep).thenReturn(mockElectricalCertExpiryDateStep)
-            whenever(mockState.checkElectricalCertUploadsStep).thenReturn(mockCheckElectricalCertUploadsStep)
-            whenever(mockElectricalCertExpiryDateStep.currentJourneyId).thenReturn("test-journey-id")
-            whenever(mockCheckElectricalCertUploadsStep.currentJourneyId).thenReturn("test-journey-id")
-            whenever(mockState.electricalUploadMap).thenReturn(
-                mapOf(1 to CertificateUpload(1L, "cert.pdf")),
-            )
-
-            // Act
-            val content = stepConfig.getStepSpecificContent(mockState)
-
-            // Assert
-            val rows = getRows(content)
-            assertEquals(3, rows.size)
-            assertEquals("checkElectricalSafety.eicrLabel", rows[0].fieldValue)
-
-            assertNull(content["insetTextKey"])
-        }
-
-        @Test
-        fun `getStepSpecificContent sorts uploads by map key and returns file names`() {
-            // Arrange
-            val stepConfig = setupStepConfig()
-            setupCommonStateMocks()
-            whenever(mockHasElectricalCertStep.outcome).thenReturn(HasElectricalCertMode.HAS_EIC)
-            whenever(mockState.getElectricalCertificateIsOutdated()).thenReturn(false)
-            whenever(mockState.getElectricalCertificateType()).thenReturn(HasElectricalSafetyCertificate.HAS_EIC)
-            whenever(mockState.getElectricalCertificateExpiryDateIfReachable()).thenReturn(LocalDate(2026, 6, 15))
-
-            whenever(mockState.electricalCertExpiryDateStep).thenReturn(mockElectricalCertExpiryDateStep)
-            whenever(mockState.checkElectricalCertUploadsStep).thenReturn(mockCheckElectricalCertUploadsStep)
-            whenever(mockElectricalCertExpiryDateStep.currentJourneyId).thenReturn("test-journey-id")
-            whenever(mockCheckElectricalCertUploadsStep.currentJourneyId).thenReturn("test-journey-id")
-            whenever(mockState.electricalUploadMap).thenReturn(
-                mapOf(
-                    3 to CertificateUpload(3L, "third.pdf"),
-                    1 to CertificateUpload(1L, "first.pdf"),
-                    2 to CertificateUpload(2L, "second.pdf"),
-                ),
-            )
-
-            // Act
-            val content = stepConfig.getStepSpecificContent(mockState)
-
-            // Assert
-            val rows = getRows(content)
-            assertEquals(listOf("first.pdf", "second.pdf", "third.pdf"), rows[2].fieldValue)
-        }
-    }
-
-    @Nested
-    inner class ProvideLater {
-        @Test
-        fun `getStepSpecificContent returns correct content for provide this later when occupied`() {
-            // Arrange
-            val stepConfig = setupStepConfig()
-            setupCommonStateMocks()
-            whenever(mockHasElectricalCertStep.outcome).thenReturn(HasElectricalCertMode.PROVIDE_THIS_LATER)
-            whenever(mockState.isOccupied).thenReturn(true)
-
-            // Act
-            val content = stepConfig.getStepSpecificContent(mockState)
-
-            // Assert
-            val rows = getRows(content)
-            assertEquals(1, rows.size)
-            assertEquals("checkElectricalSafety.provideThisLater.occupied", rows[0].fieldValue)
-
-            assertNull(content["insetTextKey"])
-            assertEquals("forms.buttons.saveAndContinue", content["submitButtonText"])
-        }
-
-        @Test
-        fun `getStepSpecificContent returns correct content for provide this later when unoccupied`() {
-            // Arrange
-            val stepConfig = setupStepConfig()
-            setupCommonStateMocks()
-            whenever(mockHasElectricalCertStep.outcome).thenReturn(HasElectricalCertMode.PROVIDE_THIS_LATER)
-            whenever(mockState.isOccupied).thenReturn(false)
-
-            // Act
-            val content = stepConfig.getStepSpecificContent(mockState)
-
-            // Assert
-            val rows = getRows(content)
-            assertEquals(1, rows.size)
-            assertEquals("checkElectricalSafety.provideThisLater.unoccupied", rows[0].fieldValue)
-
-            assertNull(content["insetTextKey"])
-        }
-    }
-
-    @Nested
-    inner class NoCert {
-        @Test
-        fun `getStepSpecificContent returns correct content for no cert when occupied`() {
-            // Arrange
-            val stepConfig = setupStepConfig()
-            setupCommonStateMocks()
-            whenever(mockHasElectricalCertStep.outcome).thenReturn(HasElectricalCertMode.NO_CERTIFICATE)
-            whenever(mockState.isOccupied).thenReturn(true)
-
-            // Act
-            val content = stepConfig.getStepSpecificContent(mockState)
-
-            // Assert
-            val rows = getRows(content)
-            assertEquals(1, rows.size)
-            assertEquals("checkElectricalSafety.noneLabel", rows[0].fieldValue)
-
-            assertEquals("checkElectricalSafety.occupiedNoCertInsetText", content["insetTextKey"])
-        }
-
-        @Test
-        fun `getStepSpecificContent returns correct content for no cert when unoccupied`() {
-            // Arrange
-            val stepConfig = setupStepConfig()
-            setupCommonStateMocks()
-            whenever(mockHasElectricalCertStep.outcome).thenReturn(HasElectricalCertMode.NO_CERTIFICATE)
-            whenever(mockState.isOccupied).thenReturn(false)
-
-            // Act
-            val content = stepConfig.getStepSpecificContent(mockState)
-
-            // Assert
-            val rows = getRows(content)
-            assertEquals(1, rows.size)
-            assertEquals("checkElectricalSafety.provideThisLater.unoccupied", rows[0].fieldValue)
-
-            assertNull(content["insetTextKey"])
-        }
-    }
-
-    @Nested
-    inner class CertExpired {
-        @Test
-        fun `getStepSpecificContent returns correct content for expired cert when occupied`() {
-            // Arrange
-            val stepConfig = setupStepConfig()
-            setupCommonStateMocks()
-            whenever(mockHasElectricalCertStep.outcome).thenReturn(HasElectricalCertMode.HAS_EIC)
-            whenever(mockState.getElectricalCertificateIsOutdated()).thenReturn(true)
-            whenever(mockState.isOccupied).thenReturn(true)
-
-            // Act
-            val content = stepConfig.getStepSpecificContent(mockState)
-
-            // Assert
-            val rows = getRows(content)
-            assertEquals(1, rows.size)
-            assertEquals("checkElectricalSafety.noneLabel", rows[0].fieldValue)
-
-            assertEquals("checkElectricalSafety.occupiedNoCertInsetText", content["insetTextKey"])
-        }
-
-        @Test
-        fun `getStepSpecificContent returns correct content for expired cert when unoccupied`() {
-            // Arrange
-            val stepConfig = setupStepConfig()
-            setupCommonStateMocks()
-            whenever(mockHasElectricalCertStep.outcome).thenReturn(HasElectricalCertMode.HAS_EICR)
-            whenever(mockState.getElectricalCertificateIsOutdated()).thenReturn(true)
-            whenever(mockState.isOccupied).thenReturn(false)
-
-            // Act
-            val content = stepConfig.getStepSpecificContent(mockState)
-
-            // Assert
-            val rows = getRows(content)
-            assertEquals(1, rows.size)
-            assertEquals("checkElectricalSafety.provideThisLater.unoccupied", rows[0].fieldValue)
-
-            assertNull(content["insetTextKey"])
-        }
     }
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/CheckGasSafetyAnswersStepConfigTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/CheckGasSafetyAnswersStepConfigTests.kt
@@ -1,20 +1,14 @@
 package uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps
 
-import kotlinx.datetime.LocalDate
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNull
-import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
-import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.CertificateUpload
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.GasSafetyState
 import uk.gov.communities.prsdb.webapp.journeys.shared.Complete
-import uk.gov.communities.prsdb.webapp.journeys.shared.YesOrNo
-import uk.gov.communities.prsdb.webapp.models.viewModels.summaryModels.SummaryListRowViewModel
 import uk.gov.communities.prsdb.webapp.testHelpers.mockObjects.AlwaysTrueValidator
 
 @ExtendWith(MockitoExtension::class)
@@ -22,32 +16,12 @@ class CheckGasSafetyAnswersStepConfigTests {
     @Mock
     lateinit var mockState: GasSafetyState
 
-    private val mockHasGasSupplyStep: HasGasSupplyStep = mock()
-    private val mockHasGasCertStep: HasGasCertStep = mock()
-    private val mockGasCertIssueDateStep: GasCertIssueDateStep = mock()
-    private val mockCheckGasCertUploadsStep: CheckGasCertUploadsStep = mock()
-
     private fun setupStepConfig(): CheckGasSafetyAnswersStepConfig {
         val stepConfig = CheckGasSafetyAnswersStepConfig()
         stepConfig.routeSegment = CheckGasSafetyAnswersStep.ROUTE_SEGMENT
         stepConfig.validator = AlwaysTrueValidator()
         return stepConfig
     }
-
-    private fun setupCommonStateMocks() {
-        whenever(mockState.hasGasSupplyStep).thenReturn(mockHasGasSupplyStep)
-        whenever(mockState.hasGasCertStep).thenReturn(mockHasGasCertStep)
-        whenever(mockHasGasSupplyStep.currentJourneyId).thenReturn("test-journey-id")
-        whenever(mockHasGasCertStep.currentJourneyId).thenReturn("test-journey-id")
-    }
-
-    @Suppress("UNCHECKED_CAST")
-    private fun getGasSupplyRows(content: Map<String, Any?>): List<SummaryListRowViewModel> =
-        content["gasSupplyRows"] as List<SummaryListRowViewModel>
-
-    @Suppress("UNCHECKED_CAST")
-    private fun getCertRows(content: Map<String, Any?>): List<SummaryListRowViewModel> =
-        content["certRows"] as List<SummaryListRowViewModel>
 
     @Test
     fun `chooseTemplate returns checkGasSafetyAnswersForm`() {
@@ -74,256 +48,5 @@ class CheckGasSafetyAnswersStepConfigTests {
         val result = stepConfig.mode(mockState)
 
         assertNull(result)
-    }
-
-    @Nested
-    inner class NoGasSupply {
-        @Test
-        fun `getStepSpecificContent returns correct content when there is no gas supply`() {
-            // Arrange
-            val stepConfig = setupStepConfig()
-            whenever(mockState.hasGasSupplyStep).thenReturn(mockHasGasSupplyStep)
-            whenever(mockHasGasSupplyStep.currentJourneyId).thenReturn("test-journey-id")
-            whenever(mockHasGasSupplyStep.outcome).thenReturn(YesOrNo.NO)
-
-            // Act
-            val content = stepConfig.getStepSpecificContent(mockState)
-
-            // Assert
-            val gasSupplyRows = getGasSupplyRows(content)
-            assertEquals(1, gasSupplyRows.size)
-            assertEquals(false, gasSupplyRows[0].fieldValue)
-
-            val certRows = getCertRows(content)
-            assertEquals(emptyList<SummaryListRowViewModel>(), certRows)
-
-            assertEquals("checkGasSafety.noGasSupplyInsetText", content["insetTextKey"])
-            assertEquals("forms.buttons.saveAndContinue", content["submitButtonText"])
-        }
-    }
-
-    @Nested
-    inner class UploadedCertificate {
-        @Test
-        fun `getStepSpecificContent returns correct content for valid cert with uploads`() {
-            // Arrange
-            val stepConfig = setupStepConfig()
-            setupCommonStateMocks()
-            whenever(mockHasGasSupplyStep.outcome).thenReturn(YesOrNo.YES)
-            whenever(mockHasGasCertStep.outcome).thenReturn(HasGasCertMode.HAS_CERTIFICATE)
-            whenever(mockState.getGasSafetyCertificateIsOutdated()).thenReturn(false)
-
-            val issueDate = LocalDate(2024, 6, 15)
-            whenever(mockState.getGasSafetyCertificateIssueDateIfReachable()).thenReturn(issueDate)
-
-            whenever(mockState.gasCertIssueDateStep).thenReturn(mockGasCertIssueDateStep)
-            whenever(mockState.checkGasCertUploadsStep).thenReturn(mockCheckGasCertUploadsStep)
-            whenever(mockGasCertIssueDateStep.currentJourneyId).thenReturn("test-journey-id")
-            whenever(mockCheckGasCertUploadsStep.currentJourneyId).thenReturn("test-journey-id")
-            whenever(mockState.gasUploadMap).thenReturn(
-                mapOf(1 to CertificateUpload(1L, "cert.pdf")),
-            )
-
-            // Act
-            val content = stepConfig.getStepSpecificContent(mockState)
-
-            // Assert
-            val gasSupplyRows = getGasSupplyRows(content)
-            assertEquals(1, gasSupplyRows.size)
-            assertEquals(true, gasSupplyRows[0].fieldValue)
-
-            val certRows = getCertRows(content)
-            assertEquals(3, certRows.size)
-            assertEquals(true, certRows[0].fieldValue)
-            assertEquals(issueDate, certRows[1].fieldValue)
-            assertEquals(listOf("cert.pdf"), certRows[2].fieldValue)
-
-            assertNull(content["insetTextKey"])
-            assertEquals("forms.buttons.saveAndContinue", content["submitButtonText"])
-        }
-
-        @Test
-        fun `getStepSpecificContent sorts uploads by map key and returns file names`() {
-            // Arrange
-            val stepConfig = setupStepConfig()
-            setupCommonStateMocks()
-            whenever(mockHasGasSupplyStep.outcome).thenReturn(YesOrNo.YES)
-            whenever(mockHasGasCertStep.outcome).thenReturn(HasGasCertMode.HAS_CERTIFICATE)
-            whenever(mockState.getGasSafetyCertificateIsOutdated()).thenReturn(false)
-            whenever(mockState.getGasSafetyCertificateIssueDateIfReachable()).thenReturn(LocalDate(2024, 6, 15))
-            whenever(mockState.gasCertIssueDateStep).thenReturn(mockGasCertIssueDateStep)
-            whenever(mockState.checkGasCertUploadsStep).thenReturn(mockCheckGasCertUploadsStep)
-            whenever(mockGasCertIssueDateStep.currentJourneyId).thenReturn("test-journey-id")
-            whenever(mockCheckGasCertUploadsStep.currentJourneyId).thenReturn("test-journey-id")
-            whenever(mockState.gasUploadMap).thenReturn(
-                mapOf(
-                    3 to CertificateUpload(3L, "third.pdf"),
-                    1 to CertificateUpload(1L, "first.pdf"),
-                    2 to CertificateUpload(2L, "second.pdf"),
-                ),
-            )
-
-            // Act
-            val content = stepConfig.getStepSpecificContent(mockState)
-
-            // Assert
-            val certRows = getCertRows(content)
-            assertEquals(listOf("first.pdf", "second.pdf", "third.pdf"), certRows[2].fieldValue)
-        }
-    }
-
-    @Nested
-    inner class ProvideLater {
-        @Test
-        fun `getStepSpecificContent returns correct content for provide this later when occupied`() {
-            // Arrange
-            val stepConfig = setupStepConfig()
-            setupCommonStateMocks()
-            whenever(mockHasGasSupplyStep.outcome).thenReturn(YesOrNo.YES)
-            whenever(mockHasGasCertStep.outcome).thenReturn(HasGasCertMode.PROVIDE_THIS_LATER)
-            whenever(mockState.isOccupied).thenReturn(true)
-
-            // Act
-            val content = stepConfig.getStepSpecificContent(mockState)
-
-            // Assert
-            val gasSupplyRows = getGasSupplyRows(content)
-            assertEquals(2, gasSupplyRows.size)
-            assertEquals(true, gasSupplyRows[0].fieldValue)
-            assertEquals("checkGasSafety.provideThisLater.occupied", gasSupplyRows[1].fieldValue)
-
-            val certRows = getCertRows(content)
-            assertEquals(emptyList<SummaryListRowViewModel>(), certRows)
-
-            assertNull(content["insetTextKey"])
-        }
-
-        @Test
-        fun `getStepSpecificContent returns correct content for provide this later when unoccupied`() {
-            // Arrange
-            val stepConfig = setupStepConfig()
-            setupCommonStateMocks()
-            whenever(mockHasGasSupplyStep.outcome).thenReturn(YesOrNo.YES)
-            whenever(mockHasGasCertStep.outcome).thenReturn(HasGasCertMode.PROVIDE_THIS_LATER)
-            whenever(mockState.isOccupied).thenReturn(false)
-
-            // Act
-            val content = stepConfig.getStepSpecificContent(mockState)
-
-            // Assert
-            val gasSupplyRows = getGasSupplyRows(content)
-            assertEquals(2, gasSupplyRows.size)
-            assertEquals(true, gasSupplyRows[0].fieldValue)
-            assertEquals("checkGasSafety.provideThisLater.unoccupied", gasSupplyRows[1].fieldValue)
-
-            val certRows = getCertRows(content)
-            assertEquals(emptyList<SummaryListRowViewModel>(), certRows)
-
-            assertNull(content["insetTextKey"])
-        }
-    }
-
-    @Nested
-    inner class NoCert {
-        @Test
-        fun `getStepSpecificContent returns correct content for no cert when occupied`() {
-            // Arrange
-            val stepConfig = setupStepConfig()
-            setupCommonStateMocks()
-            whenever(mockHasGasSupplyStep.outcome).thenReturn(YesOrNo.YES)
-            whenever(mockHasGasCertStep.outcome).thenReturn(HasGasCertMode.NO_CERTIFICATE)
-            whenever(mockState.isOccupied).thenReturn(true)
-
-            // Act
-            val content = stepConfig.getStepSpecificContent(mockState)
-
-            // Assert
-            val gasSupplyRows = getGasSupplyRows(content)
-            assertEquals(2, gasSupplyRows.size)
-            assertEquals(true, gasSupplyRows[0].fieldValue)
-            assertEquals(false, gasSupplyRows[1].fieldValue)
-
-            val certRows = getCertRows(content)
-            assertEquals(emptyList<SummaryListRowViewModel>(), certRows)
-
-            assertEquals("checkGasSafety.occupiedNoCertInsetText", content["insetTextKey"])
-        }
-
-        @Test
-        fun `getStepSpecificContent returns correct content for no cert when unoccupied`() {
-            // Arrange
-            val stepConfig = setupStepConfig()
-            setupCommonStateMocks()
-            whenever(mockHasGasSupplyStep.outcome).thenReturn(YesOrNo.YES)
-            whenever(mockHasGasCertStep.outcome).thenReturn(HasGasCertMode.NO_CERTIFICATE)
-            whenever(mockState.isOccupied).thenReturn(false)
-
-            // Act
-            val content = stepConfig.getStepSpecificContent(mockState)
-
-            // Assert
-            val gasSupplyRows = getGasSupplyRows(content)
-            assertEquals(2, gasSupplyRows.size)
-            assertEquals(true, gasSupplyRows[0].fieldValue)
-            assertEquals("checkGasSafety.provideThisLater.unoccupied", gasSupplyRows[1].fieldValue)
-
-            val certRows = getCertRows(content)
-            assertEquals(emptyList<SummaryListRowViewModel>(), certRows)
-
-            assertNull(content["insetTextKey"])
-        }
-    }
-
-    @Nested
-    inner class CertExpired {
-        @Test
-        fun `getStepSpecificContent returns correct content for expired cert when occupied`() {
-            // Arrange
-            val stepConfig = setupStepConfig()
-            setupCommonStateMocks()
-            whenever(mockHasGasSupplyStep.outcome).thenReturn(YesOrNo.YES)
-            whenever(mockHasGasCertStep.outcome).thenReturn(HasGasCertMode.HAS_CERTIFICATE)
-            whenever(mockState.getGasSafetyCertificateIsOutdated()).thenReturn(true)
-            whenever(mockState.isOccupied).thenReturn(true)
-
-            // Act
-            val content = stepConfig.getStepSpecificContent(mockState)
-
-            // Assert
-            val gasSupplyRows = getGasSupplyRows(content)
-            assertEquals(2, gasSupplyRows.size)
-            assertEquals(true, gasSupplyRows[0].fieldValue)
-            assertEquals(false, gasSupplyRows[1].fieldValue)
-
-            val certRows = getCertRows(content)
-            assertEquals(emptyList<SummaryListRowViewModel>(), certRows)
-
-            assertEquals("checkGasSafety.occupiedNoCertInsetText", content["insetTextKey"])
-        }
-
-        @Test
-        fun `getStepSpecificContent returns correct content for expired cert when unoccupied`() {
-            // Arrange
-            val stepConfig = setupStepConfig()
-            setupCommonStateMocks()
-            whenever(mockHasGasSupplyStep.outcome).thenReturn(YesOrNo.YES)
-            whenever(mockHasGasCertStep.outcome).thenReturn(HasGasCertMode.HAS_CERTIFICATE)
-            whenever(mockState.getGasSafetyCertificateIsOutdated()).thenReturn(true)
-            whenever(mockState.isOccupied).thenReturn(false)
-
-            // Act
-            val content = stepConfig.getStepSpecificContent(mockState)
-
-            // Assert
-            val gasSupplyRows = getGasSupplyRows(content)
-            assertEquals(2, gasSupplyRows.size)
-            assertEquals(true, gasSupplyRows[0].fieldValue)
-            assertEquals("checkGasSafety.provideThisLater.unoccupied", gasSupplyRows[1].fieldValue)
-
-            val certRows = getCertRows(content)
-            assertEquals(emptyList<SummaryListRowViewModel>(), certRows)
-
-            assertNull(content["insetTextKey"])
-        }
     }
 }


### PR DESCRIPTION
## Ticket number

PDJB-NONE

## Goal of change

Extract row generation logic from gas safety and electrical safety CYA step configs into dedicated factory classes, consistent with the existing EPC pattern.

## Description of main change(s)

- Creates `GasSafetyRegistrationCyaSummaryRowsFactory` and `ElectricalSafetyRegistrationCyaSummaryRowsFactory`, mirroring the existing `EpcRegistrationCyaSummaryRowsFactory` pattern
- Strips `CheckGasSafetyAnswersStepConfig` and `CheckElectricalSafetyAnswersStepConfig` down to thin delegation shells that instantiate the factory and return its results
- Moves scenario-specific tests from the step config test files to new factory test files, keeping only template/mode tests in the step config tests

## Anything you'd like to highlight to the reviewer?

Pure structural refactor with no behaviour changes. The factories follow the same pattern as `EpcRegistrationCyaSummaryRowsFactory` — scenario enums remain in their respective step config files for consistency with the EPC precedent.

## Checklist

- [x] Unit tests for new logic (e.g. new service methods) have been added
