### PR TITLE
PDJB-778: Use straight double quotes around "Vires" on LC privacy notice

### DIFF
--- a/src/main/resources/messages/localCouncilPrivacyNotice.yml
+++ b/src/main/resources/messages/localCouncilPrivacyNotice.yml
@@ -76,7 +76,7 @@ section:
         boldText: 'UK GDPR Article 6(1)(e)'
         normalText: '– Public Task: Processing is necessary for the performance of a task in the public interest, namely the administrative testing and validation of the PRSD’s jurisdictional access controls.'
       two:
-        boldText: 'Domestic Legal Basis (The ‘Vires’)'
+        boldText: 'Domestic Legal Basis (The "Vires")'
         normalText: '– This is supported by <strong>Section 8(d) of the Data Protection Act 2018</strong> (the exercise of a function of a Minister of the Crown) and the <strong>Secretary of State’s general common law powers</strong> to undertake preparatory work incidental to their ministerial functions.'
       three:
         boldText: 'Usage Data (Plausible)'

--- a/src/main/resources/templates/registerLocalCouncilUser.html
+++ b/src/main/resources/templates/registerLocalCouncilUser.html
@@ -1,5 +1,7 @@
+<!--/*@thymesVar id="backUrl" type="java.lang.String"*/-->
 <!DOCTYPE html>
-<html th:replace="~{fragments/layout :: layout(#{${title}}, ~{::main}, false)}">
+<html id="main-content" th:replace="~{fragments/layout :: layout(#{${title}}, ~{::#main-content/content()}, false)}">
+<a href="#" th:replace="~{fragments/forms/backLink :: backLink(${backUrl})}">Back link</a>
 <main class="govuk-main-wrapper">
     <div th:replace="~{fragments/layouts/twoThirdsLayout :: twoThirdsLayout(~{::#page-content})}">
         <div id="page-content">

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/LocalCouncilUserRegistrationJourneyTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/LocalCouncilUserRegistrationJourneyTests.kt
@@ -70,10 +70,14 @@ class LocalCouncilUserRegistrationJourneyTests : IntegrationTestWithMutableData(
         // Privacy notice page
         privacyNoticePage.form.iAgreeCheckbox.check()
         privacyNoticePage.form.submit()
-        val landingPage = assertPageIs(page, LandingPageLocalCouncilUserRegistration::class)
+        var landingPage = assertPageIs(page, LandingPageLocalCouncilUserRegistration::class)
         // Landing page - render
         assertThat(landingPage.headingCaption).containsText("Before you register")
         assertThat(landingPage.heading).containsText("Registering as a local council user")
+        // Back link returns to the privacy notice page
+        landingPage.backLink.clickAndWait()
+        assertPageIs(page, PrivacyNoticePageLocalCouncilUserRegistration::class).form.submit()
+        landingPage = assertPageIs(page, LandingPageLocalCouncilUserRegistration::class)
         // Submit and go to next page
         landingPage.clickBeginButton()
         val namePage = assertPageIs(page, NameFormPageLocalCouncilUserRegistration::class)

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/localCouncilUserRegistrationJourneyPages/LandingPageLocalCouncilUserRegistration.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/localCouncilUserRegistrationJourneyPages/LandingPageLocalCouncilUserRegistration.kt
@@ -2,6 +2,7 @@ package uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.localCounc
 
 import com.microsoft.playwright.Page
 import uk.gov.communities.prsdb.webapp.controllers.RegisterLocalCouncilUserController
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.BackLink
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.PostForm
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages.BasePage
 import uk.gov.communities.prsdb.webapp.journeys.localCouncilUserRegistration.stepConfig.LandingPageStep
@@ -15,6 +16,7 @@ class LandingPageLocalCouncilUserRegistration(
     ) {
     fun clickBeginButton() = PostForm(page).submit()
 
+    val backLink = BackLink.default(page)
     val headingCaption = page.locator(".govuk-caption-l")
     val heading = page.locator(".govuk-heading-l")
 }


### PR DESCRIPTION
## Ticket number

PDJB-778

## Goal of change

Address QA markup feedback on the Local Council user registration journey.

## Description of main change(s)

- Replaces curly single quotes (`‘Vires’`) with straight double quotes (`"Vires"`) in section 3 of the Local Council standalone privacy notice, so the rendered bold text matches the design.
- Adds a back link to the "Before you register / Registering as a local council user" landing page so users can return to the privacy notice step (matches the Figma design and the convention used by other journey landing pages).

## Anything you'd like to highlight to the reviewer?

This PR addresses two of the items from the PDJB-778 QA markup. The remaining items (missing back link on the standalone privacy notice opened in a new tab, major section header indentation, missing full stop after `2.1`) have been deferred pending design confirmation.

## Checklist

- [x] You have added screenshots of any visible UI changes you have made
- [x] You have added/updated relevant journey integration test steps
- [x] Branch has been rebased onto main and run locally, with everything working as expected (both for your new feature and any related functionality)
