### PR TITLE
PDJB-816: Show section heading on compliance mini check-your-answers pages

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/PropertyRegistrationJourneyFactory.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/PropertyRegistrationJourneyFactory.kt
@@ -208,15 +208,6 @@ class PropertyRegistrationJourneyFactory(
                 withAdditionalContentProperty { "title" to "registerProperty.title" }
             }
             configureFirst { backDestination { journey.returnToCyaPageDestination } }
-            configureStep(journey.checkGasSafetyAnswersStep) {
-                withAdditionalContentProperty { "sectionHeaderInfo" to null }
-            }
-            configureStep(journey.checkElectricalSafetyAnswersStep) {
-                withAdditionalContentProperty { "sectionHeaderInfo" to null }
-            }
-            configureStep(journey.checkEpcAnswersStep) {
-                withAdditionalContentProperty { "sectionHeaderInfo" to null }
-            }
             step(journey.taskListStep) {
                 routeSegment(TASK_LIST_PATH_SEGMENT)
                 initialStep()

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/PropertyRegistrationJourneyTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/PropertyRegistrationJourneyTests.kt
@@ -356,6 +356,7 @@ class PropertyRegistrationJourneyTests : IntegrationTestWithMutableData("data-lo
         val checkGasSafetyAnswersPage = assertPageIs(page, CheckGasSafetyAnswersFormPagePropertyRegistration::class)
 
         // Check Gas Safety Answers - render page
+        assertThat(checkGasSafetyAnswersPage.sectionHeader).containsText("Section 1 of 2 — Register your property details")
         assertThat(checkGasSafetyAnswersPage.heading).containsText("Gas safety certificate")
         checkGasSafetyAnswersPage.form.submit()
         val hasElectricalCertPage = assertPageIs(page, HasElectricalCertFormPagePropertyRegistration::class)
@@ -416,6 +417,7 @@ class PropertyRegistrationJourneyTests : IntegrationTestWithMutableData("data-lo
             )
 
         // Check Electrical Safety Answers - render page
+        assertThat(checkElectricalSafetyAnswersPage.sectionHeader).containsText("Section 1 of 2 — Register your property details")
         assertThat(checkElectricalSafetyAnswersPage.heading).containsText("Electrical safety certificate")
         checkElectricalSafetyAnswersPage.form.submit()
 
@@ -460,6 +462,7 @@ class PropertyRegistrationJourneyTests : IntegrationTestWithMutableData("data-lo
         val checkEpcAnswersPage = assertPageIs(page, CheckEpcAnswersFormPagePropertyRegistration::class)
 
         // Check EPC Answers - render page
+        assertThat(checkEpcAnswersPage.sectionHeader).containsText("Section 1 of 2 — Register your property details")
         assertThat(checkEpcAnswersPage.heading).containsText("Energy performance certificate (EPC)")
         checkEpcAnswersPage.form.submit()
         val checkAnswersPage = assertPageIs(page, CheckAnswersPagePropertyRegistration::class)

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/propertyRegistrationJourneyPages/CheckElectricalSafetyAnswersFormPagePropertyRegistration.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/propertyRegistrationJourneyPages/CheckElectricalSafetyAnswersFormPagePropertyRegistration.kt
@@ -3,6 +3,7 @@ package uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyRe
 import com.microsoft.playwright.Page
 import uk.gov.communities.prsdb.webapp.controllers.RegisterPropertyController
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.Form
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.FormWithSectionHeader.SectionHeader
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.Heading
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.SummaryList
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages.BasePage
@@ -12,6 +13,7 @@ class CheckElectricalSafetyAnswersFormPagePropertyRegistration(
     page: Page,
 ) : BasePage(page, "${RegisterPropertyController.PROPERTY_REGISTRATION_ROUTE}/${CheckElectricalSafetyAnswersStep.ROUTE_SEGMENT}") {
     val heading = Heading(page.locator("h1"))
+    val sectionHeader = SectionHeader(page.locator("main"))
     val form = Form(page)
     val summaryList = ElectricalSafetySummaryList(page)
 

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/propertyRegistrationJourneyPages/CheckEpcAnswersFormPagePropertyRegistration.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/propertyRegistrationJourneyPages/CheckEpcAnswersFormPagePropertyRegistration.kt
@@ -3,6 +3,7 @@ package uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyRe
 import com.microsoft.playwright.Page
 import uk.gov.communities.prsdb.webapp.controllers.RegisterPropertyController
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.Form
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.FormWithSectionHeader.SectionHeader
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.Heading
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.SummaryCard
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.SummaryList
@@ -13,6 +14,7 @@ class CheckEpcAnswersFormPagePropertyRegistration(
     page: Page,
 ) : BasePage(page, "${RegisterPropertyController.PROPERTY_REGISTRATION_ROUTE}/${CheckEpcAnswersStep.ROUTE_SEGMENT}") {
     val heading = Heading(page.locator("h1"))
+    val sectionHeader = SectionHeader(page.locator("main"))
     val form = Form(page)
 
     val epcCard = SummaryCard(page, "Your EPC")

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/propertyRegistrationJourneyPages/CheckGasSafetyAnswersFormPagePropertyRegistration.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/propertyRegistrationJourneyPages/CheckGasSafetyAnswersFormPagePropertyRegistration.kt
@@ -3,6 +3,7 @@ package uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyRe
 import com.microsoft.playwright.Page
 import uk.gov.communities.prsdb.webapp.controllers.RegisterPropertyController
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.Form
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.FormWithSectionHeader.SectionHeader
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.Heading
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.SummaryList
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages.BasePage
@@ -12,6 +13,7 @@ class CheckGasSafetyAnswersFormPagePropertyRegistration(
     page: Page,
 ) : BasePage(page, "${RegisterPropertyController.PROPERTY_REGISTRATION_ROUTE}/${CheckGasSafetyAnswersStep.ROUTE_SEGMENT}") {
     val heading = Heading(page.locator("h1"))
+    val sectionHeader = SectionHeader(page.locator("main"))
     val form = Form(page)
     val gasSupplySummaryList = GasSupplySummaryList(page)
     val certSummaryList = CertSummaryList(page)


### PR DESCRIPTION
## Ticket number

PDJB-816

## Goal of change

Show the section heading `"Section 1 of 2 — Register your property details"` on the three mini check-your-answers pages within the property registration journey's compliance tasks (Gas safety, Electrical safety, EPC), so they are consistent with every other step in the same section.

## Description of main change(s)

- Removed three per-step `configureStep { withAdditionalContentProperty { "sectionHeaderInfo" to null } }` overrides in `PropertyRegistrationJourneyFactory.mainJourneyMap()` that were suppressing the section's auto-injected header on the gas / electrical / EPC mini CYA pages.
- The surrounding `section { withHeadingMessageKey("registerProperty.taskList.register.heading") ... }` block now supplies the section header to those steps automatically, matching the behaviour of every other step in the same section.

## Anything you'd like to highlight to the reviewer?

- The standalone `PropertyComplianceJourney` (used for post-registration compliance updates) is unaffected — it never had these overrides. The change only touches the embedded compliance tasks in `PropertyRegistrationJourney`.
- Section-header assertions added in `PropertyRegistrationJourneyTests` only on the first (happy-path) walkthrough, mirroring the existing convention for sibling pages.

## Checklist

- [x] Screenshots added
- [x] Test suite has been run in full locally and is passing _(`PropertyRegistrationJourneyTests` BUILD SUCCESSFUL)_
- [x] Branch has been rebased onto main and run locally, with everything working as expected (both for your new feature and any related functionality)

<img width="1011" height="880" alt="image" src="https://github.com/user-attachments/assets/8b629104-00b7-4358-ab21-9d90c3eeb6aa" />
<img width="877" height="869" alt="image" src="https://github.com/user-attachments/assets/9cf6ec6c-a77d-4aac-946f-1209aef2c491" />
<img width="936" height="884" alt="image" src="https://github.com/user-attachments/assets/573c449a-43c4-47a4-9a9f-f3195ae5b7a1" />

