### PR TITLE
PDJB-NONE: Upgrade Spring Boot to 3.5.14

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
     kotlin("jvm") version "1.9.25"
     kotlin("plugin.spring") version "1.9.25"
     kotlin("plugin.serialization") version "2.0.20"
-    id("org.springframework.boot") version "3.5.13"
+    id("org.springframework.boot") version "3.5.14"
     id("io.spring.dependency-management") version "1.1.7"
     kotlin("plugin.jpa") version "1.9.25"
     id("org.jlleitschuh.gradle.ktlint") version "12.1.1"


### PR DESCRIPTION
## Ticket number

PDJB-NONE

## Goal of change

Upgrades the Spring Boot version to pick up the latest patch release.

## Description of main change(s)

- Bumps Spring Boot from 3.5.13 to 3.5.14
