### PR TITLE
PDJB-829: Add Plausible Flow custom event for Sankey diagrams

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/config/PlausibleInterceptorConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/config/PlausibleInterceptorConfig.kt
@@ -1,0 +1,13 @@
+package uk.gov.communities.prsdb.webapp.config
+
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
+import uk.gov.communities.prsdb.webapp.annotations.webAnnotations.PrsdbWebConfiguration
+import uk.gov.communities.prsdb.webapp.config.interceptors.PlausibleInterceptor
+
+@PrsdbWebConfiguration
+class PlausibleInterceptorConfig : WebMvcConfigurer {
+    override fun addInterceptors(registry: InterceptorRegistry) {
+        registry.addInterceptor(PlausibleInterceptor())
+    }
+}

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/config/interceptors/PlausibleInterceptor.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/config/interceptors/PlausibleInterceptor.kt
@@ -1,0 +1,62 @@
+package uk.gov.communities.prsdb.webapp.config.interceptors
+
+import jakarta.servlet.RequestDispatcher
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.web.servlet.HandlerInterceptor
+import org.springframework.web.servlet.ModelAndView
+import org.springframework.web.servlet.view.RedirectView
+import java.net.URI
+import java.net.URISyntaxException
+
+class PlausibleInterceptor : HandlerInterceptor {
+    override fun postHandle(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        handler: Any,
+        modelAndView: ModelAndView?,
+    ) {
+        if (modelAndView == null) return
+        if (modelAndView.view is RedirectView ||
+            modelAndView.viewName?.startsWith("redirect:") == true ||
+            modelAndView.viewName?.startsWith("forward:") == true
+        ) {
+            return
+        }
+
+        modelAndView.modelMap.addAttribute(CURRENT_URL_ATTR, resolveCurrentUrl(request))
+        modelAndView.modelMap.addAttribute(REFERRER_ATTR, resolveReferrer(request))
+    }
+
+    private fun resolveCurrentUrl(request: HttpServletRequest): String {
+        val errorUri = request.getAttribute(RequestDispatcher.ERROR_REQUEST_URI) as? String
+        return errorUri ?: request.requestURI
+    }
+
+    private fun resolveReferrer(request: HttpServletRequest): String {
+        val refererHeader = request.getHeader("Referer") ?: return EXTERNAL
+        return try {
+            // The Referer header is supplied by the client and may be malformed
+            // (e.g. invalid percent-encoding, bad characters). URI(String) throws
+            // URISyntaxException for any value that does not parse per RFC 2396;
+            // we treat such values as external rather than propagating a 500.
+            val refererUri = URI(refererHeader)
+            // Require an explicit host that matches the request server. Hostless,
+            // bare-token, or cross-origin referrers are all reported as "external".
+            if (refererUri.host == null || !refererUri.host.equals(request.serverName, ignoreCase = true)) {
+                EXTERNAL
+            } else {
+                val path = refererUri.path
+                if (path.isNullOrEmpty()) "/" else path
+            }
+        } catch (_: URISyntaxException) {
+            EXTERNAL
+        }
+    }
+
+    companion object {
+        const val CURRENT_URL_ATTR = "plausibleEventCurrentUrl"
+        const val REFERRER_ATTR = "plausibleEventReferrer"
+        private const val EXTERNAL = "external"
+    }
+}

--- a/src/main/resources/templates/fragments/layout.html
+++ b/src/main/resources/templates/fragments/layout.html
@@ -1,6 +1,8 @@
 <!--/*@thymesVar id="navLinks" type="java.util.List<String>"*/-->
 <!--/*@thymesVar id="plausibleUrl" type="String"*/-->
 <!--/*@thymesVar id="serverGeneratedNonce" type="String"*/-->
+<!--/*@thymesVar id="plausibleEventReferrer" type="String"*/-->
+<!--/*@thymesVar id="plausibleEventCurrentUrl" type="String"*/-->
 <!DOCTYPE html>
 <html th:fragment="layout(title, content, hasErrors)" lang="en" class="govuk-template govuk-template--rebranded">
 <head>
@@ -28,6 +30,18 @@
                 return payload
             }
         })
+    </script>
+    <script th:nonce="${serverGeneratedNonce}" th:inline="javascript">
+        const plausibleEventReferrer = [[${plausibleEventReferrer}]]
+        const plausibleEventCurrentUrl = [[${plausibleEventCurrentUrl}]]
+        if (plausibleEventReferrer && plausibleEventCurrentUrl) {
+            plausible('Flow', {
+                props: {
+                    referrer: plausibleEventReferrer,
+                    currentUrl: plausibleEventCurrentUrl
+                }
+            })
+        }
     </script>
 </head>
 <body class="govuk-template__body">

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/config/interceptors/PlausibleInterceptorTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/config/interceptors/PlausibleInterceptorTests.kt
@@ -1,0 +1,173 @@
+package uk.gov.communities.prsdb.webapp.config.interceptors
+
+import jakarta.servlet.RequestDispatcher
+import jakarta.servlet.http.HttpServletResponse
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.springframework.mock.web.MockHttpServletRequest
+import org.springframework.web.servlet.ModelAndView
+import org.springframework.web.servlet.view.RedirectView
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+@ExtendWith(MockitoExtension::class)
+class PlausibleInterceptorTests {
+    private val mockRequest = MockHttpServletRequest()
+
+    @Mock
+    private lateinit var mockResponse: HttpServletResponse
+
+    @InjectMocks
+    private lateinit var plausibleInterceptor: PlausibleInterceptor
+
+    private fun callPostHandle(modelAndView: ModelAndView?) =
+        plausibleInterceptor.postHandle(mockRequest, mockResponse, Any(), modelAndView)
+
+    private fun newModelAndView(viewName: String? = "some-view"): ModelAndView = ModelAndView().apply { this.viewName = viewName }
+
+    @Test
+    fun `postHandle adds currentUrl model attribute from request URI`() {
+        mockRequest.requestURI = "/landlord/register-as-a-landlord/name"
+        val modelAndView = newModelAndView()
+        callPostHandle(modelAndView)
+        assertEquals("/landlord/register-as-a-landlord/name", modelAndView.modelMap["plausibleEventCurrentUrl"])
+    }
+
+    @Test
+    fun `postHandle currentUrl excludes query string`() {
+        mockRequest.requestURI = "/landlord/register-as-a-landlord/name"
+        mockRequest.queryString = "foo=bar&baz=qux"
+        val modelAndView = newModelAndView()
+        callPostHandle(modelAndView)
+        assertEquals("/landlord/register-as-a-landlord/name", modelAndView.modelMap["plausibleEventCurrentUrl"])
+    }
+
+    @Test
+    fun `postHandle sets referrer from Referer header path only`() {
+        mockRequest.requestURI = "/page-b"
+        mockRequest.serverName = "example.com"
+        mockRequest.addHeader("Referer", "https://example.com/page-a")
+        val modelAndView = newModelAndView()
+        callPostHandle(modelAndView)
+        assertEquals("/page-a", modelAndView.modelMap["plausibleEventReferrer"])
+    }
+
+    @Test
+    fun `postHandle referrer excludes query string`() {
+        mockRequest.requestURI = "/page-b"
+        mockRequest.serverName = "example.com"
+        mockRequest.addHeader("Referer", "https://example.com/page-a?token=abc")
+        val modelAndView = newModelAndView()
+        callPostHandle(modelAndView)
+        assertEquals("/page-a", modelAndView.modelMap["plausibleEventReferrer"])
+    }
+
+    @Test
+    fun `postHandle sets referrer to external when Referer header is missing`() {
+        mockRequest.requestURI = "/page"
+        val modelAndView = newModelAndView()
+        callPostHandle(modelAndView)
+        assertEquals("external", modelAndView.modelMap["plausibleEventReferrer"])
+    }
+
+    @Test
+    fun `postHandle sets referrer to external when Referer header is malformed`() {
+        mockRequest.requestURI = "/page"
+        mockRequest.addHeader("Referer", "::not a url::")
+        val modelAndView = newModelAndView()
+        callPostHandle(modelAndView)
+        assertEquals("external", modelAndView.modelMap["plausibleEventReferrer"])
+    }
+
+    @Test
+    fun `postHandle sets referrer to external when Referer host differs from request host`() {
+        mockRequest.requestURI = "/page"
+        mockRequest.serverName = "example.com"
+        mockRequest.addHeader("Referer", "https://other-site.test/some/path")
+        val modelAndView = newModelAndView()
+        callPostHandle(modelAndView)
+        assertEquals("external", modelAndView.modelMap["plausibleEventReferrer"])
+    }
+
+    @Test
+    fun `postHandle sets referrer to external when Referer is a hostless relative path`() {
+        mockRequest.requestURI = "/page"
+        mockRequest.addHeader("Referer", "/page-a")
+        val modelAndView = newModelAndView()
+        callPostHandle(modelAndView)
+        assertEquals("external", modelAndView.modelMap["plausibleEventReferrer"])
+    }
+
+    @Test
+    fun `postHandle sets referrer to external when Referer is a bare token`() {
+        mockRequest.requestURI = "/page"
+        mockRequest.addHeader("Referer", "page-a")
+        val modelAndView = newModelAndView()
+        callPostHandle(modelAndView)
+        assertEquals("external", modelAndView.modelMap["plausibleEventReferrer"])
+    }
+
+    @Test
+    fun `postHandle sets referrer to external when Referer host-only string has no scheme`() {
+        mockRequest.requestURI = "/page"
+        mockRequest.addHeader("Referer", "example.com/page-a")
+        val modelAndView = newModelAndView()
+        callPostHandle(modelAndView)
+        assertEquals("external", modelAndView.modelMap["plausibleEventReferrer"])
+    }
+
+    @Test
+    fun `postHandle normalises root-path same-host referrer to forward slash`() {
+        mockRequest.requestURI = "/page"
+        mockRequest.serverName = "example.com"
+        mockRequest.addHeader("Referer", "https://example.com")
+        val modelAndView = newModelAndView()
+        callPostHandle(modelAndView)
+        assertEquals("/", modelAndView.modelMap["plausibleEventReferrer"])
+    }
+
+    @Test
+    fun `postHandle uses ERROR_REQUEST_URI when present for currentUrl`() {
+        mockRequest.requestURI = "/error"
+        mockRequest.setAttribute(RequestDispatcher.ERROR_REQUEST_URI, "/landlord/some-broken-page")
+        val modelAndView = newModelAndView()
+        callPostHandle(modelAndView)
+        assertEquals("/landlord/some-broken-page", modelAndView.modelMap["plausibleEventCurrentUrl"])
+    }
+
+    @Test
+    fun `postHandle does nothing when modelAndView is null`() {
+        mockRequest.requestURI = "/page"
+        callPostHandle(null)
+    }
+
+    @Test
+    fun `postHandle does not add attributes when view is a redirect prefix`() {
+        mockRequest.requestURI = "/page"
+        val modelAndView = newModelAndView(viewName = "redirect:/somewhere")
+        callPostHandle(modelAndView)
+        assertNull(modelAndView.modelMap["plausibleEventCurrentUrl"])
+        assertNull(modelAndView.modelMap["plausibleEventReferrer"])
+    }
+
+    @Test
+    fun `postHandle does not add attributes when view is a forward prefix`() {
+        mockRequest.requestURI = "/page"
+        val modelAndView = newModelAndView(viewName = "forward:/somewhere")
+        callPostHandle(modelAndView)
+        assertNull(modelAndView.modelMap["plausibleEventCurrentUrl"])
+        assertNull(modelAndView.modelMap["plausibleEventReferrer"])
+    }
+
+    @Test
+    fun `postHandle does not add attributes when view is a RedirectView instance`() {
+        mockRequest.requestURI = "/page"
+        val modelAndView = ModelAndView().apply { view = RedirectView("/somewhere") }
+        callPostHandle(modelAndView)
+        assertNull(modelAndView.modelMap["plausibleEventCurrentUrl"])
+        assertNull(modelAndView.modelMap["plausibleEventReferrer"])
+    }
+}


### PR DESCRIPTION
## Ticket number

PDJB-829

## Goal of change

Adds a Plausible "Flow" custom event so user journeys can be visualised as Sankey diagrams.

## Description of main change(s)

- Adds a `PlausibleInterceptor` that populates `plausibleEventReferrer` and `plausibleEventCurrentUrl` model attributes on every successful HTML page response (skipped for redirects, forwards, and null `ModelAndView`).
- Same-origin `Referer` headers are reduced to a path; cross-origin, hostless, malformed, or missing referrers are reported as `external`. Query strings are excluded from both props (matching Plausible's built-in `event:page`).
- For error dispatches, `RequestDispatcher.ERROR_REQUEST_URI` is preferred over `request.requestURI` so the Sankey records the originally requested URL rather than `/error`.
- Adds a CSP-nonce-protected inline script in `layout.html` that fires `plausible('Flow', { props: { referrer, currentUrl } })` per page, guarded against null attributes.

## Checklist

- [x] Unit tests for new logic (e.g. new service methods) have been added