### PR TITLE
PDJB-769: fix styling and logic on non compliant occupied screen

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/ConfirmMissingComplianceStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/ConfirmMissingComplianceStepConfig.kt
@@ -17,7 +17,7 @@ class ConfirmMissingComplianceStepConfig :
             "title" to "registerProperty.confirmMissingCompliance.heading",
             "isGasMissing" to HasMissingComplianceStepConfig.isGasCertMissingOrExpired(state),
             "isElectricalMissing" to HasMissingComplianceStepConfig.isElectricalCertMissingOrExpired(state),
-            "isEpcMissing" to HasMissingComplianceStepConfig.isEpcMissingOrExpired(state),
+            "isEpcMissing" to HasMissingComplianceStepConfig.isEpcMissingOrInvalid(state),
             "radioOptions" to
                 listOf(
                     RadiosButtonViewModel(

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/ConfirmMissingComplianceStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/ConfirmMissingComplianceStepConfig.kt
@@ -17,7 +17,7 @@ class ConfirmMissingComplianceStepConfig :
             "title" to "registerProperty.confirmMissingCompliance.heading",
             "isGasMissing" to HasMissingComplianceStepConfig.isGasCertMissingOrExpired(state),
             "isElectricalMissing" to HasMissingComplianceStepConfig.isElectricalCertMissingOrExpired(state),
-            "isEpcMissing" to HasMissingComplianceStepConfig.isEpcMissing(state),
+            "isEpcMissing" to HasMissingComplianceStepConfig.isEpcMissingOrExpired(state),
             "radioOptions" to
                 listOf(
                     RadiosButtonViewModel(

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/HasMissingComplianceStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/HasMissingComplianceStepConfig.kt
@@ -11,7 +11,7 @@ import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.GasS
 @JourneyFrameworkComponent
 class HasMissingComplianceStepConfig : AbstractInternalStepConfig<ConfirmMissingComplianceCheckResult, CombinedComplianceCheckState>() {
     override fun mode(state: CombinedComplianceCheckState): ConfirmMissingComplianceCheckResult {
-        val anyMissing = isGasCertMissingOrExpired(state) || isElectricalCertMissingOrExpired(state) || isEpcMissingOrExpired(state)
+        val anyMissing = isGasCertMissingOrExpired(state) || isElectricalCertMissingOrExpired(state) || isEpcMissingOrInvalid(state)
         return if (state.isOccupied && anyMissing) {
             ConfirmMissingComplianceCheckResult.OCCUPIED_AND_HAS_MISSING_CERTIFICATES
         } else {
@@ -31,7 +31,7 @@ class HasMissingComplianceStepConfig : AbstractInternalStepConfig<ConfirmMissing
             return isOutdated == null || isOutdated
         }
 
-        fun isEpcMissingOrExpired(state: EpcState): Boolean {
+        fun isEpcMissingOrInvalid(state: EpcState): Boolean {
             val acceptedEpc =
                 state.acceptedEpcIfReachable
                     ?: return state.epcExemptionStep.formModelIfReachableOrNull?.exemptionReason == null

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/HasMissingComplianceStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/HasMissingComplianceStepConfig.kt
@@ -11,7 +11,7 @@ import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.GasS
 @JourneyFrameworkComponent
 class HasMissingComplianceStepConfig : AbstractInternalStepConfig<ConfirmMissingComplianceCheckResult, CombinedComplianceCheckState>() {
     override fun mode(state: CombinedComplianceCheckState): ConfirmMissingComplianceCheckResult {
-        val anyMissing = isGasCertMissingOrExpired(state) || isElectricalCertMissingOrExpired(state) || isEpcMissing(state)
+        val anyMissing = isGasCertMissingOrExpired(state) || isElectricalCertMissingOrExpired(state) || isEpcMissingOrExpired(state)
         return if (state.isOccupied && anyMissing) {
             ConfirmMissingComplianceCheckResult.OCCUPIED_AND_HAS_MISSING_CERTIFICATES
         } else {
@@ -31,9 +31,15 @@ class HasMissingComplianceStepConfig : AbstractInternalStepConfig<ConfirmMissing
             return isOutdated == null || isOutdated
         }
 
-        fun isEpcMissing(state: EpcState): Boolean {
-            if (state.acceptedEpcIfReachable != null) return false
-            return state.epcExemptionStep.formModelIfReachableOrNull?.exemptionReason == null
+        fun isEpcMissingOrExpired(state: EpcState): Boolean {
+            val acceptedEpc =
+                state.acceptedEpcIfReachable
+                    ?: return state.epcExemptionStep.formModelIfReachableOrNull?.exemptionReason == null
+            return acceptedEpc.isPastExpiryDate() ||
+                (
+                    !acceptedEpc.isEnergyRatingEOrBetter() &&
+                        state.meesExemptionStep.formModelIfReachableOrNull?.exemptionReason == null
+                )
         }
     }
 }

--- a/src/main/resources/templates/forms/confirmMissingCompliance.html
+++ b/src/main/resources/templates/forms/confirmMissingCompliance.html
@@ -80,7 +80,7 @@
     <hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
 
     <th:block id="fieldset-content"
-              th:replace="~{fragments/forms/fieldSet :: fieldSet(content=~{::#fieldset-content/content()}, fieldName='wantsToProceed', fieldSetHeading=#{registerProperty.confirmMissingCompliance.areYouSure.heading}, fieldSetHint=#{registerProperty.confirmMissingCompliance.areYouSure.hint}, legendSize='m', headingTag='h2')}">
+              th:replace="~{fragments/forms/minorFieldSet :: minorFieldSet(content=~{::#fieldset-content/content()}, fieldName='wantsToProceed', fieldSetHeading=#{registerProperty.confirmMissingCompliance.areYouSure.heading}, fieldSetHint=#{registerProperty.confirmMissingCompliance.areYouSure.hint})}">
         <th:block th:replace="~{fragments/forms/radios :: radios(null,'wantsToProceed',null, ${radioOptions})}"></th:block>
     </th:block>
 

--- a/src/main/resources/templates/fragments/forms/fieldSet.html
+++ b/src/main/resources/templates/fragments/forms/fieldSet.html
@@ -1,11 +1,8 @@
 <div th:fragment="fieldSet(content, fieldName, fieldSetHeading, fieldSetHint)" th:with="conditionalFieldName=${conditionalFieldName ?: null}" class="govuk-form-group"
      th:classappend="${conditionalFieldName != null and #fields.allErrors().size() == 1 and #fields.hasErrors(conditionalFieldName)} ? '' : (${#fields.hasAnyErrors()} ? 'govuk-form-group--error')">
     <fieldset class="govuk-fieldset" th:attr="aria-describedby=|${fieldSetHint != null ? fieldName + '-hint ' : ''}${#fields.hasAnyErrors() ? fieldName + '-error' : ''}|">
-        <legend th:if="${fieldSetHeading != null}" class="govuk-fieldset__legend" th:classappend="|govuk-fieldset__legend--${legendSize ?: 'l'}|">
-            <th:block th:with="tag=${headingTag ?: 'h1'}" th:switch="${tag}">
-                <h2 th:case="'h2'" class="govuk-fieldset__heading" th:text="${fieldSetHeading}">fieldSetHeading</h2>
-                <h1 th:case="*" class="govuk-fieldset__heading" th:text="${fieldSetHeading}">fieldSetHeading</h1>
-            </th:block>
+        <legend th:if="${fieldSetHeading != null}" class="govuk-fieldset__legend govuk-fieldset__legend--l">
+            <h1 class="govuk-fieldset__heading" th:text="${fieldSetHeading}">fieldSetHeading</h1>
         </legend>
         <div id="field-hint" th:if="${fieldSetHint != null}" th:id="${fieldName}+'-hint'" class="govuk-hint" th:text="${fieldSetHint}">fieldSetHint</div>
         <div th:replace="${content}"></div>

--- a/src/main/resources/templates/fragments/forms/fieldSet.html
+++ b/src/main/resources/templates/fragments/forms/fieldSet.html
@@ -1,8 +1,11 @@
 <div th:fragment="fieldSet(content, fieldName, fieldSetHeading, fieldSetHint)" th:with="conditionalFieldName=${conditionalFieldName ?: null}" class="govuk-form-group"
      th:classappend="${conditionalFieldName != null and #fields.allErrors().size() == 1 and #fields.hasErrors(conditionalFieldName)} ? '' : (${#fields.hasAnyErrors()} ? 'govuk-form-group--error')">
     <fieldset class="govuk-fieldset" th:attr="aria-describedby=|${fieldSetHint != null ? fieldName + '-hint ' : ''}${#fields.hasAnyErrors() ? fieldName + '-error' : ''}|">
-        <legend th:if="${fieldSetHeading != null}" class="govuk-fieldset__legend govuk-fieldset__legend--l">
-            <h1 class="govuk-fieldset__heading" th:text="${fieldSetHeading}">fieldSetHeading</h1>
+        <legend th:if="${fieldSetHeading != null}" class="govuk-fieldset__legend" th:classappend="|govuk-fieldset__legend--${legendSize ?: 'l'}|">
+            <th:block th:with="tag=${headingTag ?: 'h1'}" th:switch="${tag}">
+                <h2 th:case="'h2'" class="govuk-fieldset__heading" th:text="${fieldSetHeading}">fieldSetHeading</h2>
+                <h1 th:case="*" class="govuk-fieldset__heading" th:text="${fieldSetHeading}">fieldSetHeading</h1>
+            </th:block>
         </legend>
         <div id="field-hint" th:if="${fieldSetHint != null}" th:id="${fieldName}+'-hint'" class="govuk-hint" th:text="${fieldSetHint}">fieldSetHint</div>
         <div th:replace="${content}"></div>

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/HasMissingComplianceStepConfigTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/HasMissingComplianceStepConfigTests.kt
@@ -224,7 +224,7 @@ class HasMissingComplianceStepConfigTests {
             whenever(mockEpc.isEnergyRatingEOrBetter()).thenReturn(true)
             whenever(mockState.acceptedEpcIfReachable).thenReturn(mockEpc)
 
-            assertFalse(HasMissingComplianceStepConfig.isEpcMissingOrExpired(mockState))
+            assertFalse(HasMissingComplianceStepConfig.isEpcMissingOrInvalid(mockState))
         }
 
         @Test
@@ -233,7 +233,7 @@ class HasMissingComplianceStepConfigTests {
             whenever(mockEpc.isPastExpiryDate()).thenReturn(true)
             whenever(mockState.acceptedEpcIfReachable).thenReturn(mockEpc)
 
-            assertTrue(HasMissingComplianceStepConfig.isEpcMissingOrExpired(mockState))
+            assertTrue(HasMissingComplianceStepConfig.isEpcMissingOrInvalid(mockState))
         }
 
         @Test
@@ -246,7 +246,7 @@ class HasMissingComplianceStepConfigTests {
             whenever(mockMeesExemptionStep.formModelIfReachableOrNull).thenReturn(null)
             whenever(mockState.meesExemptionStep).thenReturn(mockMeesExemptionStep)
 
-            assertTrue(HasMissingComplianceStepConfig.isEpcMissingOrExpired(mockState))
+            assertTrue(HasMissingComplianceStepConfig.isEpcMissingOrInvalid(mockState))
         }
 
         @Test
@@ -263,7 +263,7 @@ class HasMissingComplianceStepConfigTests {
             whenever(mockMeesExemptionStep.formModelIfReachableOrNull).thenReturn(formModel)
             whenever(mockState.meesExemptionStep).thenReturn(mockMeesExemptionStep)
 
-            assertFalse(HasMissingComplianceStepConfig.isEpcMissingOrExpired(mockState))
+            assertFalse(HasMissingComplianceStepConfig.isEpcMissingOrInvalid(mockState))
         }
 
         @Test
@@ -273,7 +273,7 @@ class HasMissingComplianceStepConfigTests {
             whenever(mockEpcExemptionStep.formModelIfReachableOrNull).thenReturn(null)
             whenever(mockState.epcExemptionStep).thenReturn(mockEpcExemptionStep)
 
-            assertTrue(HasMissingComplianceStepConfig.isEpcMissingOrExpired(mockState))
+            assertTrue(HasMissingComplianceStepConfig.isEpcMissingOrInvalid(mockState))
         }
 
         @Test
@@ -287,7 +287,7 @@ class HasMissingComplianceStepConfigTests {
             whenever(mockEpcExemptionStep.formModelIfReachableOrNull).thenReturn(formModel)
             whenever(mockState.epcExemptionStep).thenReturn(mockEpcExemptionStep)
 
-            assertFalse(HasMissingComplianceStepConfig.isEpcMissingOrExpired(mockState))
+            assertFalse(HasMissingComplianceStepConfig.isEpcMissingOrInvalid(mockState))
         }
 
         @Test
@@ -298,7 +298,7 @@ class HasMissingComplianceStepConfigTests {
             whenever(mockEpcExemptionStep.formModelIfReachableOrNull).thenReturn(formModel)
             whenever(mockState.epcExemptionStep).thenReturn(mockEpcExemptionStep)
 
-            assertTrue(HasMissingComplianceStepConfig.isEpcMissingOrExpired(mockState))
+            assertTrue(HasMissingComplianceStepConfig.isEpcMissingOrInvalid(mockState))
         }
     }
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/HasMissingComplianceStepConfigTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/HasMissingComplianceStepConfigTests.kt
@@ -11,10 +11,12 @@ import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 import uk.gov.communities.prsdb.webapp.constants.enums.EpcExemptionReason
+import uk.gov.communities.prsdb.webapp.constants.enums.MeesExemptionReason
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.CombinedComplianceCheckState
 import uk.gov.communities.prsdb.webapp.models.dataModels.EpcDataModel
 import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.EpcExemptionFormModel
 import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.GasSupplyFormModel
+import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.MeesExemptionReasonFormModel
 
 @ExtendWith(MockitoExtension::class)
 class HasMissingComplianceStepConfigTests {
@@ -127,7 +129,10 @@ class HasMissingComplianceStepConfigTests {
         }
 
         private fun setupEpcPresent() {
-            whenever(mockState.acceptedEpcIfReachable).thenReturn(mock<EpcDataModel>())
+            val mockEpc = mock<EpcDataModel>()
+            whenever(mockEpc.isPastExpiryDate()).thenReturn(false)
+            whenever(mockEpc.isEnergyRatingEOrBetter()).thenReturn(true)
+            whenever(mockState.acceptedEpcIfReachable).thenReturn(mockEpc)
         }
     }
 
@@ -211,12 +216,54 @@ class HasMissingComplianceStepConfigTests {
     }
 
     @Nested
-    inner class IsEpcMissing {
+    inner class IsEpcMissingOrExpired {
         @Test
-        fun `returns false when accepted epc present`() {
-            whenever(mockState.acceptedEpcIfReachable).thenReturn(mock<EpcDataModel>())
+        fun `returns false when accepted epc present and not expired and good rating`() {
+            val mockEpc = mock<EpcDataModel>()
+            whenever(mockEpc.isPastExpiryDate()).thenReturn(false)
+            whenever(mockEpc.isEnergyRatingEOrBetter()).thenReturn(true)
+            whenever(mockState.acceptedEpcIfReachable).thenReturn(mockEpc)
 
-            assertFalse(HasMissingComplianceStepConfig.isEpcMissing(mockState))
+            assertFalse(HasMissingComplianceStepConfig.isEpcMissingOrExpired(mockState))
+        }
+
+        @Test
+        fun `returns true when accepted epc present but expired`() {
+            val mockEpc = mock<EpcDataModel>()
+            whenever(mockEpc.isPastExpiryDate()).thenReturn(true)
+            whenever(mockState.acceptedEpcIfReachable).thenReturn(mockEpc)
+
+            assertTrue(HasMissingComplianceStepConfig.isEpcMissingOrExpired(mockState))
+        }
+
+        @Test
+        fun `returns true when accepted epc has low rating and no mees exemption`() {
+            val mockEpc = mock<EpcDataModel>()
+            whenever(mockEpc.isPastExpiryDate()).thenReturn(false)
+            whenever(mockEpc.isEnergyRatingEOrBetter()).thenReturn(false)
+            whenever(mockState.acceptedEpcIfReachable).thenReturn(mockEpc)
+            val mockMeesExemptionStep = mock<MeesExemptionStep>()
+            whenever(mockMeesExemptionStep.formModelIfReachableOrNull).thenReturn(null)
+            whenever(mockState.meesExemptionStep).thenReturn(mockMeesExemptionStep)
+
+            assertTrue(HasMissingComplianceStepConfig.isEpcMissingOrExpired(mockState))
+        }
+
+        @Test
+        fun `returns false when accepted epc has low rating but has mees exemption`() {
+            val mockEpc = mock<EpcDataModel>()
+            whenever(mockEpc.isPastExpiryDate()).thenReturn(false)
+            whenever(mockEpc.isEnergyRatingEOrBetter()).thenReturn(false)
+            whenever(mockState.acceptedEpcIfReachable).thenReturn(mockEpc)
+            val mockMeesExemptionStep = mock<MeesExemptionStep>()
+            val formModel =
+                MeesExemptionReasonFormModel().apply {
+                    exemptionReason = MeesExemptionReason.ALL_IMPROVEMENTS_MADE
+                }
+            whenever(mockMeesExemptionStep.formModelIfReachableOrNull).thenReturn(formModel)
+            whenever(mockState.meesExemptionStep).thenReturn(mockMeesExemptionStep)
+
+            assertFalse(HasMissingComplianceStepConfig.isEpcMissingOrExpired(mockState))
         }
 
         @Test
@@ -226,7 +273,7 @@ class HasMissingComplianceStepConfigTests {
             whenever(mockEpcExemptionStep.formModelIfReachableOrNull).thenReturn(null)
             whenever(mockState.epcExemptionStep).thenReturn(mockEpcExemptionStep)
 
-            assertTrue(HasMissingComplianceStepConfig.isEpcMissing(mockState))
+            assertTrue(HasMissingComplianceStepConfig.isEpcMissingOrExpired(mockState))
         }
 
         @Test
@@ -240,7 +287,7 @@ class HasMissingComplianceStepConfigTests {
             whenever(mockEpcExemptionStep.formModelIfReachableOrNull).thenReturn(formModel)
             whenever(mockState.epcExemptionStep).thenReturn(mockEpcExemptionStep)
 
-            assertFalse(HasMissingComplianceStepConfig.isEpcMissing(mockState))
+            assertFalse(HasMissingComplianceStepConfig.isEpcMissingOrExpired(mockState))
         }
 
         @Test
@@ -251,7 +298,7 @@ class HasMissingComplianceStepConfigTests {
             whenever(mockEpcExemptionStep.formModelIfReachableOrNull).thenReturn(formModel)
             whenever(mockState.epcExemptionStep).thenReturn(mockEpcExemptionStep)
 
-            assertTrue(HasMissingComplianceStepConfig.isEpcMissing(mockState))
+            assertTrue(HasMissingComplianceStepConfig.isEpcMissingOrExpired(mockState))
         }
     }
 }


### PR DESCRIPTION
## Ticket number

PDJB-769

## Goal of change

Fixes logic and styling for the non compliant occupied check screen

## Description of main change(s)

<img width="878" height="1168" alt="image" src="https://github.com/user-attachments/assets/6445a45d-5fe6-495e-9ba1-5fc15e927ea3" />
Fixes an h1 and makes it an h2 instead
Fixes the case where the EPC was expired but not exempt or low energy but not MEES exempt - this counted as accepted but I'd not explicitly checked for those cases.

## Checklist

- [x] Screenshots of any UI changes have been added
- [x] Unit tests for new logic (e.g. new service methods) have been added
- [x] Test suite has been run in full locally and is passing
- [x] Branch has been rebased onto main and run locally, with everything working as expected (both for your new feature
  and any related functionality)
- [x] QA instructions have been added to the ticket (particularly if this is the last PR required to complete the ticket)
