### PR TITLE
PDJB-588: Apply QA round 3 fixes to landlord registration journey

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/landlordRegistration/LandlordRegistrationJourneyFactory.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/landlordRegistration/LandlordRegistrationJourneyFactory.kt
@@ -5,6 +5,7 @@ import org.springframework.beans.factory.ObjectFactory
 import uk.gov.communities.prsdb.webapp.annotations.webAnnotations.JourneyFrameworkComponent
 import uk.gov.communities.prsdb.webapp.annotations.webAnnotations.PrsdbWebService
 import uk.gov.communities.prsdb.webapp.controllers.RegisterLandlordController.Companion.LANDLORD_REGISTRATION_CONFIRMATION_ROUTE
+import uk.gov.communities.prsdb.webapp.controllers.RegisterLandlordController.Companion.LANDLORD_REGISTRATION_START_PAGE_ROUTE
 import uk.gov.communities.prsdb.webapp.journeys.AbstractJourneyState
 import uk.gov.communities.prsdb.webapp.journeys.Destination
 import uk.gov.communities.prsdb.webapp.journeys.JourneyStateDelegateProvider
@@ -87,7 +88,7 @@ class LandlordRegistrationJourneyFactory(
 
     private fun mainJourneyMap(state: LandlordRegistrationJourneyState): Map<String, StepLifecycleOrchestrator> =
         journey(state) {
-            configureFirst { backDestination { journey.returnToCyaPageDestination } }
+            configureFirst { backDestination { Destination.ExternalUrl(LANDLORD_REGISTRATION_START_PAGE_ROUTE) } }
             unreachableStepStep { journey.privacyNoticeStep }
             configure {
                 withAdditionalContentProperty { "title" to "registerAsALandlord.title" }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/landlordRegistration/stepConfig/LandlordRegistrationCyaStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/landlordRegistration/stepConfig/LandlordRegistrationCyaStepConfig.kt
@@ -5,7 +5,6 @@ import uk.gov.communities.prsdb.webapp.annotations.webAnnotations.JourneyFramewo
 import uk.gov.communities.prsdb.webapp.constants.ENGLAND_OR_WALES
 import uk.gov.communities.prsdb.webapp.exceptions.NotNullFormModelValueIsNullException.Companion.notNullValue
 import uk.gov.communities.prsdb.webapp.journeys.Destination
-import uk.gov.communities.prsdb.webapp.journeys.Destination.Nowhere
 import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.LandlordRegistrationJourneyState
 import uk.gov.communities.prsdb.webapp.journeys.shared.stepConfig.AbstractCheckYourAnswersStep
 import uk.gov.communities.prsdb.webapp.journeys.shared.stepConfig.AbstractCheckYourAnswersStepConfig
@@ -28,7 +27,7 @@ class LandlordRegistrationCyaStepConfig(
             "summaryName" to "registerAsALandlord.checkAnswers.summaryName",
             "showWarning" to true,
             "submitButtonText" to "forms.buttons.confirmAndContinue",
-            "insetText" to true,
+            "insetText" to false,
             "summaryListData" to getSummaryList(state),
             "submittedFilteredJourneyData" to CheckAnswersFormModel.serializeJourneyData(state.getSubmittedStepData()),
         )
@@ -61,13 +60,17 @@ class LandlordRegistrationCyaStepConfig(
             SummaryListRowViewModel.forCheckYourAnswersPage(
                 "registerAsALandlord.checkAnswers.rowHeading.name",
                 state.getName(),
-                if (isIdentityVerified) Nowhere() else Destination.VisitableStep(state.nameStep, state.getCyaJourneyId(state.nameStep)),
+                if (isIdentityVerified) {
+                    Destination.Nowhere()
+                } else {
+                    Destination.VisitableStep(state.nameStep, state.getCyaJourneyId(state.nameStep))
+                },
             ),
             SummaryListRowViewModel.forCheckYourAnswersPage(
                 "registerAsALandlord.checkAnswers.rowHeading.dateOfBirth",
                 state.getDateOfBirth(),
                 if (isIdentityVerified) {
-                    Nowhere()
+                    Destination.Nowhere()
                 } else {
                     Destination.VisitableStep(
                         state.dateOfBirthStep,

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/landlordRegistration/tasks/IdentityTask.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/landlordRegistration/tasks/IdentityTask.kt
@@ -1,6 +1,7 @@
 package uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.tasks
 
 import uk.gov.communities.prsdb.webapp.annotations.webAnnotations.JourneyFrameworkComponent
+import uk.gov.communities.prsdb.webapp.journeys.Destination
 import uk.gov.communities.prsdb.webapp.journeys.OrParents
 import uk.gov.communities.prsdb.webapp.journeys.Task
 import uk.gov.communities.prsdb.webapp.journeys.hasOutcome
@@ -34,6 +35,7 @@ class IdentityTask : Task<IdentityState>() {
             step(journey.identityNotVerifiedStep) {
                 routeSegment(IdentityNotVerifiedStep.ROUTE_SEGMENT)
                 parents { journey.identityVerifyingStep.hasOutcome(IdentityVerifiedMode.NOT_VERIFIED) }
+                backDestination { Destination.Nowhere() }
                 nextStep { journey.nameStep }
             }
             step(journey.nameStep) {

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/landlordRegistration/tasks/LandlordRegistrationAddressTask.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/landlordRegistration/tasks/LandlordRegistrationAddressTask.kt
@@ -57,7 +57,12 @@ class LandlordRegistrationAddressTask : Task<AddressState>() {
                     )
                 }
                 nextStep { exitStep }
-                withAdditionalContentProperty { "fieldSetHeading" to "forms.manualAddress.landlordRegistration.fieldSetHeading" }
+                withAdditionalContentProperties {
+                    mapOf(
+                        "fieldSetHeading" to "forms.manualAddress.landlordRegistration.fieldSetHeading",
+                        "fieldSetHint" to "forms.manualAddress.landlordRegistration.fieldSetHint",
+                    )
+                }
             }
             exitStep {
                 parents {

--- a/src/main/resources/messages/privacyNotice.yml
+++ b/src/main/resources/messages/privacyNotice.yml
@@ -76,7 +76,7 @@ section:
     heading: '3. Lawful basis for processing the data'
     paragraph:
       one: The data protection legislation sets out when we are lawfully allowed to process your personal data.
-      'two.heading': '3.1 For MHCLG, we process your personal and usage data under the lawful basis below;'
+      'two.intro': '3.1 For MHCLG, we process your personal and usage data under the lawful basis below;'
       'two.bullet.one': '<strong>UK GDPR Article 6(1)(e) - Public Task:</strong> The processing is necessary for the performance of a task carried out in the public interest. Specifically, the department is tasked with developing, securing, and testing the national digital infrastructure required for the future Private Rented Sector Database.'
       'two.bullet.two': '<strong>Domestic Legal Basis (The "Vires"):</strong> This is supported by <strong>Section 8(d) of the Data Protection Act 2018</strong> (the exercise of a function of a Minister of the Crown) and the <strong>Secretary of State’s general common law powers</strong> to undertake preparatory work incidental to their ministerial functions.'
       'two.additional': '<strong>1. UK GDPR Article 9(2)(j)</strong> - Ethnicity data (optional): We process ethnicity data for research and statistical purposes under <strong>Article 9(2)(j)</strong> and <strong>Article 89(1)</strong>. This is supported by Schedule 1, Part 2, paragraph 8 of the Data Protection Act 2018 (equality of opportunity or treatment). We request this in the feedback survey (on an optional basis) so we can check whether our service works well for people from different backgrounds.'

--- a/src/main/resources/messages/privacyNotice.yml
+++ b/src/main/resources/messages/privacyNotice.yml
@@ -58,7 +58,7 @@ section:
       'six.bullet.three': '<strong>Research Contact</strong>: Name and email (only if you explicitly opt-in to be contacted for future user research).'
       'seven.heading': '2.4. Usage data (for service improvement and essential operational usage)'
       seven: 'We use <strong>Plausible Analytics</strong> to understand how the service is being used and to identify areas for improvement. Plausible does not use cookies, does not collect personal data and does not track you across different websites.'
-      'seven.bullet.one': '<strong>Statistical Purpose:</strong> We process this information as a "statistical exception" under the <strong>Data (Use and Access) Act 2025</strong>. This means we do not require your consent to collect this anonymised data as it is used purely to ensure the service is functional, accessible and meeting user needs.'
+      'seven.bullet.one': '<strong>Statistical Purpose</strong>: We process this information as a "statistical exception" under the <strong>Data (Use and Access) Act 2025</strong>. This means we do not require your consent to collect this anonymised data as it is used purely to ensure the service is functional, accessible and meeting user needs.'
       nine: 'Important note: Any significant changes to the types of data collected, the purposes for which it is used, or the entities with whom it is shared during this extended testing phase will be clearly communicated to you through updated privacy notices and direct notifications in advance of their implementation.'
       ten: Your responsibilities as a landlord and what data is collected may differ for the mandatory service to this extended testing phase.
       'eleven.heading': '2.5. Why we collect your data'
@@ -79,14 +79,14 @@ section:
       'two.heading': '3.1. For MHCLG, we process your personal and usage data under the lawful basis below:'
       'two.bullet.one': '<strong>UK GDPR Article 6(1)(e) - Public Task</strong> - The processing is necessary for the performance of a task carried out in the public interest. Specifically, the department is tasked with developing, securing, and testing the national digital infrastructure required for the future Private Rented Sector Database.'
       'two.bullet.two': '<strong>Domestic Legal Basis (The "Vires")</strong> - This is supported by <strong>Section 8(d) of the Data Protection Act 2018</strong> (the exercise of a function of a Minister of the Crown) and the <strong>Secretary of State’s general common law powers</strong> to undertake preparatory work incidental to their ministerial functions.'
-      'two.additional': '<strong>3.2 UK GDPR Article 9(2)(g)</strong> - ethnicity data (optional): We process ethnicity data for Substantial Public Interest. This is supported by Schedule 1, Part 2, paragraph 8 of the Data Protection Act 2018 (equality of opportunity or treatment). We request this in the feedback survey (on an optional basis) so we can check whether our service works well for people from different backgrounds.'
+      'two.additional': '3.2 <strong>UK GDPR Article 9(2)(g)</strong> - ethnicity data (optional): We process ethnicity data for Substantial Public Interest. This is supported by Schedule 1, Part 2, paragraph 8 of the Data Protection Act 2018 (equality of opportunity or treatment). We request this in the feedback survey (on an optional basis) so we can check whether our service works well for people from different backgrounds.'
   four:
     heading: '4. With whom we will be sharing the data'
     paragraph:
       one: 'We share data with a service provider, participating local councils, government and technical providers:'
       two: '4.1. Participating Local councils: Data provided by a landlord during this phase will be accessible to local councils participating in the extended testing phase. Data is shared with the local councils under strict data sharing agreements. During this testing phase, councils are restricted to usability testing and will not take enforcement action based on this data.'
       three: '4.2. Service Provider (processor): To provide service desk support functionality on behalf of MHCLG. We have a Data Processing Agreement in place to ensure that the data is processed securely and in accordance with all relevant data protection law. The processing will involve using your personal details to assist with your enquiries.'
-      four: '4.3. Amazon Web Services (AWS): To host the ''register your rental property'' service and store your data securely. All data is stored in the UK.'
+      four: '4.3. Amazon Web Services (AWS): To host the ‘register your rental property’ service and store your data securely. All data is stored in the UK.'
       five: '4.4. GOV.UK Notify: To send you essential communications, including registration confirmations, security codes (OTP) and compliance reminders via email or SMS.'
       six: '4.5. GOV.UK One Login: To verify your identity before you access the service.'
       seven: '4.6. GOV.UK Pay: To process your registration fee payments. We do not store your bank or card details; these are handled securely by GOV.UK Pay.'
@@ -152,4 +152,4 @@ section:
         numberText: 0303 123 1113 or 01625 545 745
       website:
         title: Website
-        linkText: 'https://ico.org.uk/ (opens in new tab)'
+        linkText: 'https://ico.org.uk/'

--- a/src/main/resources/messages/privacyNotice.yml
+++ b/src/main/resources/messages/privacyNotice.yml
@@ -76,10 +76,10 @@ section:
     heading: '3. Lawful basis for processing the data'
     paragraph:
       one: The data protection legislation sets out when we are lawfully allowed to process your personal data.
-      'two.heading': '3.1. For MHCLG, we process your personal and usage data under the lawful basis below:'
-      'two.bullet.one': '<strong>UK GDPR Article 6(1)(e) - Public Task</strong> - The processing is necessary for the performance of a task carried out in the public interest. Specifically, the department is tasked with developing, securing, and testing the national digital infrastructure required for the future Private Rented Sector Database.'
-      'two.bullet.two': '<strong>Domestic Legal Basis (The "Vires")</strong> - This is supported by <strong>Section 8(d) of the Data Protection Act 2018</strong> (the exercise of a function of a Minister of the Crown) and the <strong>Secretary of State’s general common law powers</strong> to undertake preparatory work incidental to their ministerial functions.'
-      'two.additional': '3.2 <strong>UK GDPR Article 9(2)(g)</strong> - ethnicity data (optional): We process ethnicity data for Substantial Public Interest. This is supported by Schedule 1, Part 2, paragraph 8 of the Data Protection Act 2018 (equality of opportunity or treatment). We request this in the feedback survey (on an optional basis) so we can check whether our service works well for people from different backgrounds.'
+      'two.heading': '3.1 For MHCLG, we process your personal and usage data under the lawful basis below;'
+      'two.bullet.one': '<strong>UK GDPR Article 6(1)(e) - Public Task:</strong> The processing is necessary for the performance of a task carried out in the public interest. Specifically, the department is tasked with developing, securing, and testing the national digital infrastructure required for the future Private Rented Sector Database.'
+      'two.bullet.two': '<strong>Domestic Legal Basis (The "Vires"):</strong> This is supported by <strong>Section 8(d) of the Data Protection Act 2018</strong> (the exercise of a function of a Minister of the Crown) and the <strong>Secretary of State’s general common law powers</strong> to undertake preparatory work incidental to their ministerial functions.'
+      'two.additional': '<strong>1. UK GDPR Article 9(2)(j)</strong> - Ethnicity data (optional): We process ethnicity data for research and statistical purposes under <strong>Article 9(2)(j)</strong> and <strong>Article 89(1)</strong>. This is supported by Schedule 1, Part 2, paragraph 8 of the Data Protection Act 2018 (equality of opportunity or treatment). We request this in the feedback survey (on an optional basis) so we can check whether our service works well for people from different backgrounds.'
   four:
     heading: '4. With whom we will be sharing the data'
     paragraph:

--- a/src/main/resources/templates/landlordPrivacyNotice.html
+++ b/src/main/resources/templates/landlordPrivacyNotice.html
@@ -99,7 +99,7 @@
         <section>
             <h2 class="govuk-heading-m" th:text="#{privacyNotice.section.three.heading}">privacyNotice.section.three.heading</h2>
             <p class="govuk-body" th:text="#{privacyNotice.section.three.paragraph.one}">privacyNotice.section.three.paragraph.one</p>
-            <p class="govuk-body" th:text="#{privacyNotice.section.three.paragraph.two.heading}">privacyNotice.section.three.paragraph.two.heading</p>
+            <p class="govuk-body" th:text="#{privacyNotice.section.three.paragraph.two.intro}">privacyNotice.section.three.paragraph.two.intro</p>
             <ul class="govuk-list govuk-list--bullet">
                 <li th:utext="#{privacyNotice.section.three.paragraph.two.bullet.one}">privacyNotice.section.three.paragraph.two.bullet.one</li>
                 <li th:utext="#{privacyNotice.section.three.paragraph.two.bullet.two}">privacyNotice.section.three.paragraph.two.bullet.two</li>

--- a/src/main/resources/templates/landlordPrivacyNotice.html
+++ b/src/main/resources/templates/landlordPrivacyNotice.html
@@ -99,7 +99,7 @@
         <section>
             <h2 class="govuk-heading-m" th:text="#{privacyNotice.section.three.heading}">privacyNotice.section.three.heading</h2>
             <p class="govuk-body" th:text="#{privacyNotice.section.three.paragraph.one}">privacyNotice.section.three.paragraph.one</p>
-            <h3 class="govuk-heading-s" th:text="#{privacyNotice.section.three.paragraph.two.heading}">privacyNotice.section.three.paragraph.two.heading</h3>
+            <p class="govuk-body" th:text="#{privacyNotice.section.three.paragraph.two.heading}">privacyNotice.section.three.paragraph.two.heading</p>
             <ul class="govuk-list govuk-list--bullet">
                 <li th:utext="#{privacyNotice.section.three.paragraph.two.bullet.one}">privacyNotice.section.three.paragraph.two.bullet.one</li>
                 <li th:utext="#{privacyNotice.section.three.paragraph.two.bullet.two}">privacyNotice.section.three.paragraph.two.bullet.two</li>
@@ -173,17 +173,15 @@
                     th:remove="tag" th:text="#{privacyNotice.section.ten.paragraph.three.afterEmailLink}">privacyNotice.section.ten.paragraph.three.afterEmailLink</span>
             </p>
             <p class="govuk-body" th:text="#{privacyNotice.section.ten.paragraph.four}">privacyNotice.section.ten.paragraph.four</p>
-            <ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-1">
+            <ul class="govuk-list govuk-list--bullet">
                 <li>
                     <span class="govuk-!-font-weight-bold" th:text="#{privacyNotice.section.ten.ico.address.title}">privacyNotice.section.ten.ico.address.title</span>:
+                    <br><span th:text="#{privacyNotice.section.ten.ico.address.line.one}">privacyNotice.section.ten.ico.address.line.one</span>
+                    <br><span th:text="#{privacyNotice.section.ten.ico.address.line.two}">privacyNotice.section.ten.ico.address.line.two</span>
+                    <br><span th:text="#{privacyNotice.section.ten.ico.address.line.three}">privacyNotice.section.ten.ico.address.line.three</span>
+                    <br><span th:text="#{privacyNotice.section.ten.ico.address.line.four}">privacyNotice.section.ten.ico.address.line.four</span>
+                    <br><span th:text="#{privacyNotice.section.ten.ico.address.line.five}">privacyNotice.section.ten.ico.address.line.five</span>
                 </li>
-            </ul>
-            <p class="govuk-body govuk-!-margin-bottom-0" th:text="#{privacyNotice.section.ten.ico.address.line.one}">privacyNotice.section.ten.ico.address.line.one</p>
-            <p class="govuk-body govuk-!-margin-bottom-0" th:text="#{privacyNotice.section.ten.ico.address.line.two}">privacyNotice.section.ten.ico.address.line.two</p>
-            <p class="govuk-body govuk-!-margin-bottom-0" th:text="#{privacyNotice.section.ten.ico.address.line.three}">privacyNotice.section.ten.ico.address.line.three</p>
-            <p class="govuk-body govuk-!-margin-bottom-0" th:text="#{privacyNotice.section.ten.ico.address.line.four}">privacyNotice.section.ten.ico.address.line.four</p>
-            <p class="govuk-body" th:text="#{privacyNotice.section.ten.ico.address.line.five}">privacyNotice.section.ten.ico.address.line.five</p>
-            <ul class="govuk-list govuk-list--bullet">
                 <li>
                     <span class="govuk-!-font-weight-bold" th:text="#{privacyNotice.section.ten.ico.phone.title}">privacyNotice.section.ten.ico.phone.title</span>:
                     <span th:remove="tag" th:text="#{privacyNotice.section.ten.ico.phone.numberText}">privacyNotice.section.ten.ico.phone.numberText</span>

--- a/src/main/resources/templates/passcodeEntry.html
+++ b/src/main/resources/templates/passcodeEntry.html
@@ -11,7 +11,7 @@
         <p class="govuk-body" th:text="#{passcodeEntry.paragraph.two}">passcodeEntry.paragraph.two</p>
 
         <form th:action="@{''}" id="passcode-form" method="post" th:object="${passcodeRequestModel}" novalidate>
-            <input th:replace="~{fragments/forms/fixedWidthTextInput :: fixedWidthTextInput(label=#{passcodeEntry.passcodeLabel}, fieldName='passcode', hint=null, fieldWidth=10, labelSize='m')}">
+            <input th:replace="~{fragments/forms/fixedWidthTextInput :: fixedWidthTextInput(label=#{passcodeEntry.passcodeLabel}, fieldName='passcode', hint=null, fieldWidth=10)}">
             <button th:replace="~{fragments/buttons/primaryButton :: primaryButton(#{forms.buttons.continue})}"></button>
         </form>
     </main>

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/LandlordPrivacyNoticePage.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/LandlordPrivacyNoticePage.kt
@@ -12,5 +12,5 @@ class LandlordPrivacyNoticePage(
     val heading = Heading(page.locator("main h1"))
     val mhclgComplaintsLink = Link.byText(page, "make a complaint")
     val dataProtectionEmailLink = Link.byText(page, "dataprotection@communities.gov.uk")
-    val icoLink = Link.byText(page, "https://ico.org.uk/ (opens in new tab)")
+    val icoLink = Link.byText(page, "https://ico.org.uk/")
 }


### PR DESCRIPTION
## Ticket number

PDJB-588

## Goal of change

Apply QA round 3 fixes to the landlord registration journey, including content corrections to the landlord privacy notice.

## Description of main change(s)

- Updates the passcode entry page copy and the manual address fieldset hint
- Corrects content in the landlord privacy notice (sections 2.4, 3.1, 3.2, 4.3 and section 10), including replacing the section 3 lawful basis content (UK GDPR Article 6(1)(e), Domestic Legal Basis, and item 1 covering Article 9(2)(j) for ethnicity data) to match the latest Figma design
- Fixes the back link on the privacy notice page in the landlord registration journey to return to the start page
- Suppresses the back link on the identity-not-verified page
- Removes the "changes in another tab" inset on the landlord registration check-your-answers page

## Anything you''d like to highlight to the reviewer?

The privacy notice section 3 content was rewritten to follow the Figma design (node 34704-153405). Item 1 ("UK GDPR Article 9(2)(j)") is currently rendered as a paragraph rather than an `<ol start="1">` because the numbered-list marker is not bold by default in govuk-frontend; bolding the "1." inline keeps the visual closer to the design.

## Checklist

- [x] Screenshots of any UI changes have been added
- [x] Branch has been rebased onto main and run locally, with everything working as expected (both for your new feature and any related functionality)
- [x] QA instructions have been added to the ticket (particularly if this is the last PR required to complete the ticket)
