### PR TITLE
PDJB-718: Add compliance certificates section to property registration CYA page

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/PropertyRegistrationJourneyFactory.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/PropertyRegistrationJourneyFactory.kt
@@ -296,10 +296,7 @@ class PropertyRegistrationJourneyFactory(
                 step(journey.cyaStep) {
                     routeSegment(PropertyRegistrationCyaStep.ROUTE_SEGMENT)
                     parents {
-                        jointLandlordsStrategy.ifEnabledOrElse {
-                            ifEnabled { journey.jointLandlordsTask.isComplete() }
-                            ifDisabled { journey.occupationTask.isComplete() }
-                        }
+                        journey.epcTask.isComplete()
                     }
                     nextStep { journey.hasMissingComplianceStep }
                 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/PropertyRegistrationJourneyFactory.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/PropertyRegistrationJourneyFactory.kt
@@ -295,7 +295,6 @@ class PropertyRegistrationJourneyFactory(
                 withHeadingMessageKey("registerProperty.taskList.checkAndSubmit.heading")
                 step(journey.cyaStep) {
                     routeSegment(PropertyRegistrationCyaStep.ROUTE_SEGMENT)
-                    // TODO PDJB-718: For convenience during development you can visit CYA without completing Compliance tasks by modifying the URL
                     parents {
                         jointLandlordsStrategy.ifEnabledOrElse {
                             ifEnabled { journey.jointLandlordsTask.isComplete() }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/PropertyRegistrationCyaStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/PropertyRegistrationCyaStepConfig.kt
@@ -7,6 +7,7 @@ import uk.gov.communities.prsdb.webapp.exceptions.NotNullFormModelValueIsNullExc
 import uk.gov.communities.prsdb.webapp.journeys.Destination
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.JointLandlordsPropertyRegistrationStrategy
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.PropertyRegistrationJourneyState
+import uk.gov.communities.prsdb.webapp.journeys.shared.helpers.ComplianceDetailsHelper
 import uk.gov.communities.prsdb.webapp.journeys.shared.helpers.LicensingDetailsHelper
 import uk.gov.communities.prsdb.webapp.journeys.shared.helpers.OccupancyDetailsHelper
 import uk.gov.communities.prsdb.webapp.journeys.shared.stepConfig.AbstractCheckYourAnswersStep
@@ -21,6 +22,7 @@ class PropertyRegistrationCyaStepConfig(
     private val localCouncilService: LocalCouncilService,
     private val licensingHelper: LicensingDetailsHelper,
     private val occupancyDetailsHelper: OccupancyDetailsHelper,
+    private val complianceDetailsHelper: ComplianceDetailsHelper,
     private val messageSource: MessageSource,
     private val jointLandlordsStrategy: JointLandlordsPropertyRegistrationStrategy,
 ) : AbstractCheckYourAnswersStepConfig<PropertyRegistrationJourneyState>() {
@@ -42,6 +44,10 @@ class PropertyRegistrationCyaStepConfig(
         jointLandlordsStrategy.ifEnabled {
             content["jointLandlordsDetails"] = getJointLandLordsSummaryRow(state)
         }
+
+        content += complianceDetailsHelper.getGasSafetyCyaContent(state)
+        content += complianceDetailsHelper.getElectricalSafetyCyaContent(state)
+        content += complianceDetailsHelper.getEpcCyaContent(state)
 
         return content
     }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/shared/helpers/ComplianceDetailsHelper.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/shared/helpers/ComplianceDetailsHelper.kt
@@ -1,0 +1,47 @@
+package uk.gov.communities.prsdb.webapp.journeys.shared.helpers
+
+import uk.gov.communities.prsdb.webapp.annotations.webAnnotations.PrsdbWebService
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.ElectricalSafetyRegistrationCyaSummaryRowsFactory
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.EpcRegistrationCyaSummaryRowsFactory
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.GasSafetyRegistrationCyaSummaryRowsFactory
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.ElectricalSafetyState
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.EpcState
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.GasSafetyState
+import uk.gov.communities.prsdb.webapp.services.EpcCertificateUrlProvider
+
+@PrsdbWebService
+class ComplianceDetailsHelper(
+    private val epcCertificateUrlProvider: EpcCertificateUrlProvider,
+) {
+    fun getGasSafetyCyaContent(state: GasSafetyState): Map<String, Any?> {
+        val factory = GasSafetyRegistrationCyaSummaryRowsFactory(state)
+        return mapOf(
+            "gasSupplyRows" to factory.createGasSupplyRows(),
+            "gasCertRows" to factory.createCertRows(),
+            "gasInsetTextKey" to factory.getInsetTextKey(),
+        )
+    }
+
+    fun getElectricalSafetyCyaContent(state: ElectricalSafetyState): Map<String, Any?> {
+        val factory = ElectricalSafetyRegistrationCyaSummaryRowsFactory(state)
+        return mapOf(
+            "electricalRows" to factory.createRows(),
+            "electricalInsetTextKey" to factory.getInsetTextKey(),
+        )
+    }
+
+    fun getEpcCyaContent(state: EpcState): Map<String, Any?> {
+        val factory = EpcRegistrationCyaSummaryRowsFactory(epcCertificateUrlProvider, state)
+        return mapOf(
+            "epcCardTitle" to factory.createEpcCardTitle(),
+            "epcCardActions" to factory.createEpcCardActions(),
+            "epcCardRows" to factory.createEpcCardRows(),
+            "epcExpiredTextKey" to factory.getEpcExpiredTextKey(),
+            "tenancyCheckRows" to factory.createTenancyCheckRows(),
+            "lowRatingTextKey" to factory.getLowRatingTextKey(),
+            "exemptionReasonRows" to factory.createExemptionReasonRows(),
+            "nonEpcRows" to factory.createNonEpcRows(),
+            "epcInsetTextKey" to factory.getInsetTextKey(),
+        )
+    }
+}

--- a/src/main/resources/messages/registerProperty.yml
+++ b/src/main/resources/messages/registerProperty.yml
@@ -69,6 +69,9 @@ taskList:
     checkAnswers: Check and submit your answers
     addAnotherProperty: Add another property
     payForYourProperties: Pay for your properties
+checkAnswers:
+  complianceCertificates:
+    heading: Compliance certificates
 deleteIncompleteProperties:
   incompleteProperties:
     title: Delete incomplete property

--- a/src/main/resources/templates/forms/propertyRegistrationCheckAnswersForm.html
+++ b/src/main/resources/templates/forms/propertyRegistrationCheckAnswersForm.html
@@ -7,6 +7,20 @@
 <!--/*@thymesVar id="licensingDetails" type="java.lang.Object"*/-->
 <!--/*@thymesVar id="tenancyDetails" type="java.lang.Object"*/-->
 <!--/*@thymesVar id="jointLandlordsDetails" type="java.lang.Object"*/-->
+<!--/*@thymesVar id="gasSupplyRows" type="java.util.List"*/-->
+<!--/*@thymesVar id="gasCertRows" type="java.util.List"*/-->
+<!--/*@thymesVar id="gasInsetTextKey" type="java.lang.String"*/-->
+<!--/*@thymesVar id="electricalRows" type="java.util.List"*/-->
+<!--/*@thymesVar id="electricalInsetTextKey" type="java.lang.String"*/-->
+<!--/*@thymesVar id="epcCardTitle" type="java.lang.String"*/-->
+<!--/*@thymesVar id="epcCardActions" type="java.util.List"*/-->
+<!--/*@thymesVar id="epcCardRows" type="java.util.List"*/-->
+<!--/*@thymesVar id="epcExpiredTextKey" type="java.lang.String"*/-->
+<!--/*@thymesVar id="tenancyCheckRows" type="java.util.List"*/-->
+<!--/*@thymesVar id="lowRatingTextKey" type="java.lang.String"*/-->
+<!--/*@thymesVar id="exemptionReasonRows" type="java.util.List"*/-->
+<!--/*@thymesVar id="nonEpcRows" type="java.util.List"*/-->
+<!--/*@thymesVar id="epcInsetTextKey" type="java.lang.String"*/-->
 <!--/*@thymesVar id="submittedFilteredJourneyData" type="java.lang.String"*/-->
 <!--/*@thymesVar id="submitButtonText" type="java.lang.String"*/-->
 <!--/*@thymesVar id="insetText" type="java.lang.String"*/-->
@@ -31,6 +45,39 @@
             <h2 class="govuk-heading-m" th:text="#{forms.checkPropertyAnswers.jointLandlordsDetails.heading}"></h2>
             <dl th:replace="~{fragments/summaryList :: summaryList(${jointLandlordsDetails})}"></dl>
         </th:block>
+        <h2 class="govuk-heading-m" th:text="#{registerProperty.checkAnswers.complianceCertificates.heading}"></h2>
+        <h3 class="govuk-heading-s" th:text="#{checkGasSafety.heading}"></h3>
+        <dl th:replace="~{fragments/summaryList :: summaryList(${gasSupplyRows})}"></dl>
+        <th:block th:if="${gasCertRows != null and !gasCertRows.isEmpty()}">
+            <h4 class="govuk-heading-s" th:text="#{checkGasSafety.certSubHeading}"></h4>
+            <dl th:replace="~{fragments/summaryList :: summaryList(${gasCertRows})}"></dl>
+        </th:block>
+        <th:block th:if="${gasInsetTextKey != null}">
+            <div class="govuk-inset-text" th:text="#{${gasInsetTextKey}}"></div>
+        </th:block>
+        <h3 class="govuk-heading-s" th:text="#{checkElectricalSafety.heading}"></h3>
+        <dl th:replace="~{fragments/summaryList :: summaryList(${electricalRows})}"></dl>
+        <th:block th:if="${electricalInsetTextKey != null}">
+            <div class="govuk-inset-text" th:text="#{${electricalInsetTextKey}}"></div>
+        </th:block>
+        <h3 class="govuk-heading-s" th:text="#{propertyCompliance.epcTask.checkEpcAnswers.heading}"></h3>
+        <th:block th:if="${epcCardTitle != null}">
+            <div th:replace="~{fragments/summaryCard :: summaryCard(#{${epcCardTitle}}, null, ${epcCardActions}, ${epcCardRows})}"></div>
+        </th:block>
+        <p th:if="${epcExpiredTextKey != null}" class="govuk-body" th:text="#{${epcExpiredTextKey}}"></p>
+        <th:block th:if="${!#lists.isEmpty(tenancyCheckRows)}">
+            <dl th:replace="~{fragments/summaryList :: summaryList(${tenancyCheckRows})}"></dl>
+        </th:block>
+        <p th:if="${lowRatingTextKey != null}" class="govuk-body" th:utext="#{${lowRatingTextKey}}"></p>
+        <th:block th:if="${!#lists.isEmpty(exemptionReasonRows)}">
+            <dl th:replace="~{fragments/summaryList :: summaryList(${exemptionReasonRows})}"></dl>
+        </th:block>
+        <th:block th:if="${!#lists.isEmpty(nonEpcRows)}">
+            <dl th:replace="~{fragments/summaryList :: summaryList(${nonEpcRows})}"></dl>
+        </th:block>
+        <div th:if="${epcInsetTextKey != null}" class="govuk-inset-text">
+            <p class="govuk-body" th:text="#{${epcInsetTextKey}}"></p>
+        </div>
         <div th:replace="~{fragments/warningText :: warningText(#{forms.warning})}">forms.update.warning</div>
     </th:block>
     <th:block id="form-content">

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/PropertyRegistrationJourneyTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/PropertyRegistrationJourneyTests.kt
@@ -471,6 +471,10 @@ class PropertyRegistrationJourneyTests : IntegrationTestWithMutableData("data-lo
         // Check answers - render page
         assertThat(checkAnswersPage.heading).containsText("Check your answers for:")
         assertThat(checkAnswersPage.sectionHeader).containsText("Section 2 of 2 — Check and submit your property details")
+        assertThat(checkAnswersPage.complianceCertificatesHeading).isVisible()
+        assertThat(checkAnswersPage.gasSafetyHeading).isVisible()
+        assertThat(checkAnswersPage.electricalSafetyHeading).isVisible()
+        assertThat(checkAnswersPage.epcHeading).isVisible()
         // submit
         checkAnswersPage.confirm()
         val confirmationPage = assertPageIs(page, ConfirmationPagePropertyRegistration::class)

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/propertyRegistrationJourneyPages/CheckAnswersPagePropertyRegistration.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/propertyRegistrationJourneyPages/CheckAnswersPagePropertyRegistration.kt
@@ -25,6 +25,18 @@ class CheckAnswersPagePropertyRegistration(
     val jointLandlordsHeading =
         Heading(page.locator("h2.govuk-heading-m", Page.LocatorOptions().setHasText("Invite joint landlords")))
 
+    val complianceCertificatesHeading =
+        Heading(page.locator("h2.govuk-heading-m", Page.LocatorOptions().setHasText("Compliance certificates")))
+
+    val gasSafetyHeading =
+        Heading(page.locator("h3.govuk-heading-s", Page.LocatorOptions().setHasText("Gas safety certificate")))
+
+    val electricalSafetyHeading =
+        Heading(page.locator("h3.govuk-heading-s", Page.LocatorOptions().setHasText("Electrical safety certificate")))
+
+    val epcHeading =
+        Heading(page.locator("h3.govuk-heading-s", Page.LocatorOptions().setHasText("Energy performance certificate (EPC)")))
+
     class CheckAnswersPropertyRegistrationSummaryList(
         page: Page,
     ) : SummaryList(page) {

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/shared/helpers/ComplianceDetailsHelperTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/shared/helpers/ComplianceDetailsHelperTests.kt
@@ -1,0 +1,181 @@
+package uk.gov.communities.prsdb.webapp.journeys.shared.helpers
+
+import kotlinx.datetime.LocalDate
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.CertificateUpload
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.ElectricalSafetyState
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.EpcState
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.GasSafetyState
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.CheckGasCertUploadsStep
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.GasCertIssueDateStep
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.HasElectricalCertMode
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.HasElectricalCertStep
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.HasEpcMode
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.HasEpcStep
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.HasGasCertMode
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.HasGasCertStep
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.HasGasSupplyStep
+import uk.gov.communities.prsdb.webapp.journeys.shared.YesOrNo
+import uk.gov.communities.prsdb.webapp.models.viewModels.summaryModels.SummaryListRowViewModel
+import uk.gov.communities.prsdb.webapp.services.EpcCertificateUrlProvider
+
+@ExtendWith(MockitoExtension::class)
+class ComplianceDetailsHelperTests {
+    @Mock
+    lateinit var mockEpcCertificateUrlProvider: EpcCertificateUrlProvider
+
+    private val helper by lazy { ComplianceDetailsHelper(mockEpcCertificateUrlProvider) }
+
+    @Nested
+    inner class GetGasSafetyCyaContent {
+        @Mock
+        lateinit var mockState: GasSafetyState
+
+        private val mockHasGasSupplyStep: HasGasSupplyStep = mock()
+        private val mockHasGasCertStep: HasGasCertStep = mock()
+
+        @Test
+        fun `no gas supply returns gasSupplyRows with 1 row, empty certRows, and noGasSupply inset text key`() {
+            whenever(mockState.hasGasSupplyStep).thenReturn(mockHasGasSupplyStep)
+            whenever(mockHasGasSupplyStep.currentJourneyId).thenReturn("test-journey-id")
+            whenever(mockHasGasSupplyStep.outcome).thenReturn(YesOrNo.NO)
+
+            val content = helper.getGasSafetyCyaContent(mockState)
+
+            @Suppress("UNCHECKED_CAST")
+            val gasSupplyRows = content["gasSupplyRows"] as List<SummaryListRowViewModel>
+
+            @Suppress("UNCHECKED_CAST")
+            val gasCertRows = content["gasCertRows"] as List<SummaryListRowViewModel>
+            val insetTextKey = content["gasInsetTextKey"]
+
+            assertEquals(1, gasSupplyRows.size)
+            assertEquals(0, gasCertRows.size)
+            assertEquals("checkGasSafety.noGasSupplyInsetText", insetTextKey)
+        }
+
+        @Test
+        fun `uploaded certificate returns gasSupplyRows with 1 row, certRows with 3 rows, and null inset text key`() {
+            val mockGasCertIssueDateStep: GasCertIssueDateStep = mock()
+            val mockCheckGasCertUploadsStep: CheckGasCertUploadsStep = mock()
+
+            whenever(mockState.hasGasSupplyStep).thenReturn(mockHasGasSupplyStep)
+            whenever(mockState.hasGasCertStep).thenReturn(mockHasGasCertStep)
+            whenever(mockHasGasSupplyStep.currentJourneyId).thenReturn("test-journey-id")
+            whenever(mockHasGasCertStep.currentJourneyId).thenReturn("test-journey-id")
+            whenever(mockHasGasSupplyStep.outcome).thenReturn(YesOrNo.YES)
+            whenever(mockHasGasCertStep.outcome).thenReturn(HasGasCertMode.HAS_CERTIFICATE)
+            whenever(mockState.getGasSafetyCertificateIsOutdated()).thenReturn(false)
+            whenever(mockState.getGasSafetyCertificateIssueDateIfReachable()).thenReturn(LocalDate(2024, 1, 15))
+            whenever(mockState.gasCertIssueDateStep).thenReturn(mockGasCertIssueDateStep)
+            whenever(mockState.checkGasCertUploadsStep).thenReturn(mockCheckGasCertUploadsStep)
+            whenever(mockGasCertIssueDateStep.currentJourneyId).thenReturn("test-journey-id")
+            whenever(mockCheckGasCertUploadsStep.currentJourneyId).thenReturn("test-journey-id")
+            whenever(mockState.gasUploadMap).thenReturn(mapOf(1 to CertificateUpload(1L, "cert.pdf")))
+
+            val content = helper.getGasSafetyCyaContent(mockState)
+
+            @Suppress("UNCHECKED_CAST")
+            val gasSupplyRows = content["gasSupplyRows"] as List<SummaryListRowViewModel>
+
+            @Suppress("UNCHECKED_CAST")
+            val gasCertRows = content["gasCertRows"] as List<SummaryListRowViewModel>
+            val insetTextKey = content["gasInsetTextKey"]
+
+            assertEquals(1, gasSupplyRows.size)
+            assertEquals(3, gasCertRows.size)
+            assertNull(insetTextKey)
+        }
+    }
+
+    @Nested
+    inner class GetElectricalSafetyCyaContent {
+        @Mock
+        lateinit var mockState: ElectricalSafetyState
+
+        private val mockHasElectricalCertStep: HasElectricalCertStep = mock()
+
+        @Test
+        fun `provide later for occupied property returns 1 row and null inset text key`() {
+            whenever(mockState.hasElectricalCertStep).thenReturn(mockHasElectricalCertStep)
+            whenever(mockHasElectricalCertStep.currentJourneyId).thenReturn("test-journey-id")
+            whenever(mockHasElectricalCertStep.outcome).thenReturn(HasElectricalCertMode.PROVIDE_THIS_LATER)
+            whenever(mockState.isOccupied).thenReturn(true)
+
+            val content = helper.getElectricalSafetyCyaContent(mockState)
+
+            @Suppress("UNCHECKED_CAST")
+            val rows = content["electricalRows"] as List<SummaryListRowViewModel>
+            val insetTextKey = content["electricalInsetTextKey"]
+
+            assertEquals(1, rows.size)
+            assertNull(insetTextKey)
+        }
+
+        @Test
+        fun `no cert for occupied property returns 1 row and occupiedNoCert inset text key`() {
+            whenever(mockState.hasElectricalCertStep).thenReturn(mockHasElectricalCertStep)
+            whenever(mockHasElectricalCertStep.currentJourneyId).thenReturn("test-journey-id")
+            whenever(mockHasElectricalCertStep.outcome).thenReturn(HasElectricalCertMode.NO_CERTIFICATE)
+            whenever(mockState.isOccupied).thenReturn(true)
+
+            val content = helper.getElectricalSafetyCyaContent(mockState)
+
+            @Suppress("UNCHECKED_CAST")
+            val rows = content["electricalRows"] as List<SummaryListRowViewModel>
+            val insetTextKey = content["electricalInsetTextKey"]
+
+            assertEquals(1, rows.size)
+            assertEquals("checkElectricalSafety.occupiedNoCertInsetText", insetTextKey)
+        }
+    }
+
+    @Nested
+    inner class GetEpcCyaContent {
+        @Mock
+        lateinit var mockState: EpcState
+
+        private val mockHasEpcStep: HasEpcStep = mock()
+
+        @Test
+        fun `skipped occupied returns all expected keys with null epcCardTitle and non-empty nonEpcRows`() {
+            whenever(mockState.hasEpcStep).thenReturn(mockHasEpcStep)
+            whenever(mockHasEpcStep.outcome).thenReturn(HasEpcMode.PROVIDE_LATER)
+            whenever(mockHasEpcStep.currentJourneyId).thenReturn("test-journey-id")
+            whenever(mockState.isOccupied).thenReturn(true)
+
+            val content = helper.getEpcCyaContent(mockState)
+
+            assertEquals(
+                setOf(
+                    "epcCardTitle",
+                    "epcCardActions",
+                    "epcCardRows",
+                    "epcExpiredTextKey",
+                    "tenancyCheckRows",
+                    "lowRatingTextKey",
+                    "exemptionReasonRows",
+                    "nonEpcRows",
+                    "epcInsetTextKey",
+                ),
+                content.keys,
+            )
+            assertNull(content["epcCardTitle"])
+            assertNull(content["epcCardActions"])
+            assertNull(content["epcCardRows"])
+
+            @Suppress("UNCHECKED_CAST")
+            val nonEpcRows = content["nonEpcRows"] as List<SummaryListRowViewModel>
+            assertTrue(nonEpcRows.isNotEmpty())
+        }
+    }
+}

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/testHelpers/builders/EpcStateBuilder.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/testHelpers/builders/EpcStateBuilder.kt
@@ -208,4 +208,9 @@ interface EpcStateBuilder<SelfType : EpcStateBuilder<SelfType>> {
         withSubmittedValue(EpcMissingStep.ROUTE_SEGMENT, NoInputFormModel())
         return self()
     }
+
+    fun withCheckEpcAnswersComplete(): SelfType {
+        withSubmittedValue(CheckEpcAnswersStep.ROUTE_SEGMENT, NoInputFormModel())
+        return self()
+    }
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/testHelpers/builders/PropertyStateSessionBuilder.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/testHelpers/builders/PropertyStateSessionBuilder.kt
@@ -342,6 +342,7 @@ class PropertyStateSessionBuilder(
 
         fun beforePropertyRegistrationConfirmMissingCompliance() =
             beforePropertyRegistrationCheckEpcAnswersNoEpcOccupiedNotExempt()
+                .withCheckEpcAnswersComplete()
                 .withCheckedAnswers()
 
         fun beforePropertyRegistrationCheckAnswers() =


### PR DESCRIPTION
## Ticket number

PDJB-718

## Goal of change

Display the gas safety, electrical safety, and EPC details on the property registration CYA page.

## Description of main change(s)

- Adds a `ComplianceDetailsHelper` service that builds the gas safety, electrical safety, and EPC content blocks for the property registration CYA page.
- Adds new template fragments and message keys for the compliance sections.
- Adjusts the CYA step parentage so the step is reachable from the compliance tasks.

## Anything you'd like to highlight to the reviewer?

This is the first of a stack of four PRs for PDJB-718. It adds the section display only — the edit-link routing is wired up in a subsequent PR.

Authored mostly by Alexander Read; rebased onto current `main` by Travis Woodward to drop the now-merged `PDJB-NONE` row factory extraction.

## Checklist

- [x] Screenshots of UI changes attached
- [x] Unit tests for new logic (e.g. new service methods) have been added
- [x] New journey steps have been added to the appropriate journey integration test(s)
- [x] Branch has been rebased onto main and run locally, with everything working as expected (both for your new feature and any related functionality)
- [x] TODO comments referencing this JIRA ticket have been searched for and removed - if a future PR will address them, mention that here

<img width="713" height="1175" alt="image" src="https://github.com/user-attachments/assets/944783c2-79b5-42b3-8422-b5317b6730db" />
