### PR TITLE
PDJB-718: Extract details inner tasks from compliance tasks

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/PropertyRegistrationJourneyFactory.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/PropertyRegistrationJourneyFactory.kt
@@ -94,8 +94,11 @@ import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.Selec
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.TenantsStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.UploadElectricalCertStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.UploadGasCertStep
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.ElectricalSafetyDetailsTask
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.ElectricalSafetyTask
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.EpcDetailsTask
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.EpcTask
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.GasSafetyDetailsTask
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.GasSafetyTask
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.HouseholdsAndTenantsTask
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.JointLandlordsTask
@@ -398,6 +401,7 @@ class PropertyRegistrationJourney(
     override val checkJointLandlordsStep: CheckJointLandlordsStep,
     // Gas safety task
     override val gasSafetyTask: GasSafetyTask,
+    override val gasSafetyDetailsTask: GasSafetyDetailsTask,
     override val hasUploadedCert: HasAnyInCollectionStep,
     override val hasGasSupplyStep: HasGasSupplyStep,
     override val hasGasCertStep: HasGasCertStep,
@@ -411,6 +415,7 @@ class PropertyRegistrationJourney(
     override val checkGasSafetyAnswersStep: CheckGasSafetyAnswersStep,
     // Electrical safety task
     override val electricalSafetyTask: ElectricalSafetyTask,
+    override val electricalSafetyDetailsTask: ElectricalSafetyDetailsTask,
     override val hasElectricalCertStep: HasElectricalCertStep,
     override val electricalCertExpiryDateStep: ElectricalCertExpiryDateStep,
     override val uploadElectricalCertStep: UploadElectricalCertStep,
@@ -423,6 +428,7 @@ class PropertyRegistrationJourney(
     override val checkElectricalSafetyAnswersStep: CheckElectricalSafetyAnswersStep,
     // EPC task
     override val epcTask: EpcTask,
+    override val epcDetailsTask: EpcDetailsTask,
     override val epcLookupByUprnStep: EpcLookupByUprnStep,
     override val hasEpcStep: HasEpcStep,
     override val checkUprnMatchedEpcStep: ConfirmEpcRetrievedByUprnStep,

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/states/ElectricalSafetyState.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/states/ElectricalSafetyState.kt
@@ -13,8 +13,11 @@ import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.HasEl
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.ProvideElectricalCertLaterStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.RemoveElectricalCertUploadStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.UploadElectricalCertStep
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.ElectricalSafetyDetailsTask
 
 interface ElectricalSafetyState : JourneyState {
+    val electricalSafetyDetailsTask: ElectricalSafetyDetailsTask
+
     fun getElectricalCertificateExpiryDateIfReachable() =
         electricalCertExpiryDateStep.formModelIfReachableOrNull?.let { date ->
             DateTimeHelper.parseDateOrNull(date.day, date.month, date.year)

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/states/EpcState.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/states/EpcState.kt
@@ -22,9 +22,12 @@ import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.LowEn
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.MeesExemptionStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.PropertyOccupiedCheckStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.ProvideEpcLaterStep
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.EpcDetailsTask
 import uk.gov.communities.prsdb.webapp.models.dataModels.EpcDataModel
 
 interface EpcState : JourneyState {
+    val epcDetailsTask: EpcDetailsTask
+
     val isOccupied: Boolean?
     val uprn: Long?
     var epcRetrievedByUprn: EpcDataModel?

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/states/GasSafetyState.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/states/GasSafetyState.kt
@@ -16,8 +16,11 @@ import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.HasGa
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.ProvideGasCertLaterStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.RemoveGasCertUploadStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.UploadGasCertStep
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.GasSafetyDetailsTask
 
 interface GasSafetyState : JourneyState {
+    val gasSafetyDetailsTask: GasSafetyDetailsTask
+
     val isOccupied: Boolean
 
     val allowProvideCertificateLaterRoute: Boolean

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/tasks/ElectricalSafetyDetailsTask.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/tasks/ElectricalSafetyDetailsTask.kt
@@ -1,0 +1,127 @@
+package uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks
+
+import uk.gov.communities.prsdb.webapp.annotations.webAnnotations.JourneyFrameworkComponent
+import uk.gov.communities.prsdb.webapp.journeys.OrParents
+import uk.gov.communities.prsdb.webapp.journeys.Task
+import uk.gov.communities.prsdb.webapp.journeys.hasOutcome
+import uk.gov.communities.prsdb.webapp.journeys.isComplete
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.ElectricalSafetyState
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.CheckElectricalCertUploadsStep
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.ElectricalCertExpiredStep
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.ElectricalCertExpiryDateMode
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.ElectricalCertExpiryDateStep
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.ElectricalCertMissingStep
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.HasAnyInCollectionStepConfig
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.HasElectricalCertMode
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.HasElectricalCertStep
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.ProvideElectricalCertLaterStep
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.RemoveElectricalCertUploadStep
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.UploadElectricalCertStep
+import uk.gov.communities.prsdb.webapp.journeys.shared.AnyMembers
+
+@JourneyFrameworkComponent
+class ElectricalSafetyDetailsTask : Task<ElectricalSafetyState>() {
+    override fun makeSubJourney(state: ElectricalSafetyState) =
+        subJourney(state) {
+            step(journey.hasElectricalCertStep) {
+                routeSegment(HasElectricalCertStep.ROUTE_SEGMENT)
+                nextStep { mode ->
+                    when (mode) {
+                        HasElectricalCertMode.HAS_EIC -> journey.electricalCertExpiryDateStep
+                        HasElectricalCertMode.HAS_EICR -> journey.electricalCertExpiryDateStep
+                        HasElectricalCertMode.NO_CERTIFICATE -> journey.electricalCertMissingStep
+                        HasElectricalCertMode.PROVIDE_THIS_LATER -> journey.provideElectricalCertLaterStep
+                    }
+                }
+            }
+            step(journey.electricalCertExpiryDateStep) {
+                routeSegment(ElectricalCertExpiryDateStep.ROUTE_SEGMENT)
+                parents {
+                    OrParents(
+                        journey.hasElectricalCertStep.hasOutcome(HasElectricalCertMode.HAS_EIC),
+                        journey.hasElectricalCertStep.hasOutcome(HasElectricalCertMode.HAS_EICR),
+                    )
+                }
+                nextStep { mode ->
+                    when (mode) {
+                        ElectricalCertExpiryDateMode.ELECTRICAL_SAFETY_CERTIFICATE_OUTDATED -> journey.electricalCertExpiredStep
+                        ElectricalCertExpiryDateMode.ELECTRICAL_SAFETY_CERTIFICATE_IN_DATE -> journey.hasUploadedElectricalCert
+                    }
+                }
+                savable()
+            }
+            step<AnyMembers, HasAnyInCollectionStepConfig>(journey.hasUploadedElectricalCert) {
+                parents {
+                    journey.electricalCertExpiryDateStep.hasOutcome(
+                        ElectricalCertExpiryDateMode.ELECTRICAL_SAFETY_CERTIFICATE_IN_DATE,
+                    )
+                }
+                nextStep { mode ->
+                    when (mode) {
+                        AnyMembers.NO_MEMBERS -> journey.uploadElectricalCertStep
+                        AnyMembers.SOME_MEMBERS -> journey.checkElectricalCertUploadsStep
+                    }
+                }
+                stepSpecificInitialisation { collectionMap = journey.electricalUploadMap }
+            }
+            step(journey.uploadElectricalCertStep) {
+                routeSegment(UploadElectricalCertStep.ROUTE_SEGMENT)
+                parents {
+                    journey.electricalCertExpiryDateStep.hasOutcome(ElectricalCertExpiryDateMode.ELECTRICAL_SAFETY_CERTIFICATE_IN_DATE)
+                }
+                nextStep { journey.checkElectricalCertUploadsStep }
+                savable()
+            }
+            step(journey.checkElectricalCertUploadsStep) {
+                routeSegment(CheckElectricalCertUploadsStep.ROUTE_SEGMENT)
+                parents { journey.uploadElectricalCertStep.isComplete() }
+                nextStep { exitStep }
+                backStep { journey.electricalCertExpiryDateStep }
+                savable()
+            }
+            step(journey.removeElectricalCertUploadStep) {
+                routeSegment(RemoveElectricalCertUploadStep.ROUTE_SEGMENT)
+                parents {
+                    journey.hasUploadedElectricalCert.hasOutcome(AnyMembers.SOME_MEMBERS)
+                }
+                backStep { journey.checkElectricalCertUploadsStep }
+                nextStep { mode ->
+                    when (mode) {
+                        AnyMembers.SOME_MEMBERS -> journey.checkElectricalCertUploadsStep
+                        AnyMembers.NO_MEMBERS -> journey.uploadElectricalCertStep
+                    }
+                }
+                savable()
+            }
+            step(journey.electricalCertExpiredStep) {
+                routeSegment(ElectricalCertExpiredStep.ROUTE_SEGMENT)
+                parents {
+                    journey.electricalCertExpiryDateStep.hasOutcome(ElectricalCertExpiryDateMode.ELECTRICAL_SAFETY_CERTIFICATE_OUTDATED)
+                }
+                nextStep { exitStep }
+                savable()
+            }
+            step(journey.electricalCertMissingStep) {
+                routeSegment(ElectricalCertMissingStep.ROUTE_SEGMENT)
+                parents { journey.hasElectricalCertStep.hasOutcome(HasElectricalCertMode.NO_CERTIFICATE) }
+                nextStep { exitStep }
+                savable()
+            }
+            step(journey.provideElectricalCertLaterStep) {
+                routeSegment(ProvideElectricalCertLaterStep.ROUTE_SEGMENT)
+                parents { journey.hasElectricalCertStep.hasOutcome(HasElectricalCertMode.PROVIDE_THIS_LATER) }
+                nextStep { exitStep }
+                savable()
+            }
+            exitStep {
+                parents {
+                    OrParents(
+                        journey.provideElectricalCertLaterStep.isComplete(),
+                        journey.electricalCertMissingStep.isComplete(),
+                        journey.electricalCertExpiredStep.isComplete(),
+                        journey.checkElectricalCertUploadsStep.isComplete(),
+                    )
+                }
+            }
+        }
+}

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/tasks/ElectricalSafetyTask.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/tasks/ElectricalSafetyTask.kt
@@ -1,129 +1,22 @@
 package uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks
 
 import uk.gov.communities.prsdb.webapp.annotations.webAnnotations.JourneyFrameworkComponent
-import uk.gov.communities.prsdb.webapp.journeys.OrParents
 import uk.gov.communities.prsdb.webapp.journeys.Task
-import uk.gov.communities.prsdb.webapp.journeys.hasOutcome
 import uk.gov.communities.prsdb.webapp.journeys.isComplete
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.ElectricalSafetyState
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.CheckElectricalCertUploadsStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.CheckElectricalSafetyAnswersStep
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.ElectricalCertExpiredStep
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.ElectricalCertExpiryDateMode
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.ElectricalCertExpiryDateStep
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.ElectricalCertMissingStep
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.HasAnyInCollectionStepConfig
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.HasElectricalCertMode
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.HasElectricalCertStep
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.ProvideElectricalCertLaterStep
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.RemoveElectricalCertUploadStep
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.UploadElectricalCertStep
-import uk.gov.communities.prsdb.webapp.journeys.shared.AnyMembers
 
 @JourneyFrameworkComponent
 class ElectricalSafetyTask : Task<ElectricalSafetyState>() {
     override fun makeSubJourney(state: ElectricalSafetyState) =
         subJourney(state) {
-            step(journey.hasElectricalCertStep) {
-                routeSegment(HasElectricalCertStep.ROUTE_SEGMENT)
-                nextStep { mode ->
-                    when (mode) {
-                        HasElectricalCertMode.HAS_EIC -> journey.electricalCertExpiryDateStep
-                        HasElectricalCertMode.HAS_EICR -> journey.electricalCertExpiryDateStep
-                        HasElectricalCertMode.NO_CERTIFICATE -> journey.electricalCertMissingStep
-                        HasElectricalCertMode.PROVIDE_THIS_LATER -> journey.provideElectricalCertLaterStep
-                    }
-                }
-            }
-            step(journey.electricalCertExpiryDateStep) {
-                routeSegment(ElectricalCertExpiryDateStep.ROUTE_SEGMENT)
-                parents {
-                    OrParents(
-                        journey.hasElectricalCertStep.hasOutcome(HasElectricalCertMode.HAS_EIC),
-                        journey.hasElectricalCertStep.hasOutcome(HasElectricalCertMode.HAS_EICR),
-                    )
-                }
-                nextStep { mode ->
-                    when (mode) {
-                        ElectricalCertExpiryDateMode.ELECTRICAL_SAFETY_CERTIFICATE_OUTDATED -> journey.electricalCertExpiredStep
-                        ElectricalCertExpiryDateMode.ELECTRICAL_SAFETY_CERTIFICATE_IN_DATE -> journey.hasUploadedElectricalCert
-                    }
-                }
-                savable()
-            }
-            step<AnyMembers, HasAnyInCollectionStepConfig>(journey.hasUploadedElectricalCert) {
-                parents {
-                    journey.electricalCertExpiryDateStep.hasOutcome(
-                        ElectricalCertExpiryDateMode.ELECTRICAL_SAFETY_CERTIFICATE_IN_DATE,
-                    )
-                }
-                nextStep { mode ->
-                    when (mode) {
-                        AnyMembers.NO_MEMBERS -> journey.uploadElectricalCertStep
-                        AnyMembers.SOME_MEMBERS -> journey.checkElectricalCertUploadsStep
-                    }
-                }
-                stepSpecificInitialisation { collectionMap = journey.electricalUploadMap }
-            }
-            step(journey.uploadElectricalCertStep) {
-                routeSegment(UploadElectricalCertStep.ROUTE_SEGMENT)
-                parents {
-                    journey.electricalCertExpiryDateStep.hasOutcome(ElectricalCertExpiryDateMode.ELECTRICAL_SAFETY_CERTIFICATE_IN_DATE)
-                }
-                nextStep { journey.checkElectricalCertUploadsStep }
-                savable()
-            }
-            step(journey.checkElectricalCertUploadsStep) {
-                routeSegment(CheckElectricalCertUploadsStep.ROUTE_SEGMENT)
-                parents { journey.uploadElectricalCertStep.isComplete() }
-                nextStep { journey.checkElectricalSafetyAnswersStep }
-                backStep { journey.electricalCertExpiryDateStep }
-                savable()
-            }
-            step(journey.removeElectricalCertUploadStep) {
-                routeSegment(RemoveElectricalCertUploadStep.ROUTE_SEGMENT)
-                parents {
-                    journey.hasUploadedElectricalCert.hasOutcome(AnyMembers.SOME_MEMBERS)
-                }
-                backStep { journey.checkElectricalCertUploadsStep }
-                nextStep { mode ->
-                    when (mode) {
-                        AnyMembers.SOME_MEMBERS -> journey.checkElectricalCertUploadsStep
-                        AnyMembers.NO_MEMBERS -> journey.uploadElectricalCertStep
-                    }
-                }
-                savable()
-            }
-            step(journey.electricalCertExpiredStep) {
-                routeSegment(ElectricalCertExpiredStep.ROUTE_SEGMENT)
-                parents {
-                    journey.electricalCertExpiryDateStep.hasOutcome(ElectricalCertExpiryDateMode.ELECTRICAL_SAFETY_CERTIFICATE_OUTDATED)
-                }
-                nextStep { journey.checkElectricalSafetyAnswersStep }
-                savable()
-            }
-            step(journey.electricalCertMissingStep) {
-                routeSegment(ElectricalCertMissingStep.ROUTE_SEGMENT)
-                parents { journey.hasElectricalCertStep.hasOutcome(HasElectricalCertMode.NO_CERTIFICATE) }
-                nextStep { journey.checkElectricalSafetyAnswersStep }
-                savable()
-            }
-            step(journey.provideElectricalCertLaterStep) {
-                routeSegment(ProvideElectricalCertLaterStep.ROUTE_SEGMENT)
-                parents { journey.hasElectricalCertStep.hasOutcome(HasElectricalCertMode.PROVIDE_THIS_LATER) }
+            task(journey.electricalSafetyDetailsTask) {
                 nextStep { journey.checkElectricalSafetyAnswersStep }
                 savable()
             }
             step(journey.checkElectricalSafetyAnswersStep) {
                 routeSegment(CheckElectricalSafetyAnswersStep.ROUTE_SEGMENT)
-                parents {
-                    OrParents(
-                        journey.provideElectricalCertLaterStep.isComplete(),
-                        journey.electricalCertMissingStep.isComplete(),
-                        journey.electricalCertExpiredStep.isComplete(),
-                        journey.checkElectricalCertUploadsStep.isComplete(),
-                    )
-                }
+                parents { journey.electricalSafetyDetailsTask.isComplete() }
                 nextStep { exitStep }
                 savable()
             }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/tasks/EpcDetailsTask.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/tasks/EpcDetailsTask.kt
@@ -1,0 +1,257 @@
+package uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks
+
+import uk.gov.communities.prsdb.webapp.annotations.webAnnotations.JourneyFrameworkComponent
+import uk.gov.communities.prsdb.webapp.journeys.OrParents
+import uk.gov.communities.prsdb.webapp.journeys.Task
+import uk.gov.communities.prsdb.webapp.journeys.hasOutcome
+import uk.gov.communities.prsdb.webapp.journeys.isComplete
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.EpcState
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.ConfirmEpcDetailsRetrievedByCertificateNumberStep
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.ConfirmEpcDetailsRetrievedByCertificateNumberStepConfig
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.ConfirmEpcRetrievedByUprnStep
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.ConfirmEpcRetrievedByUprnStepConfig
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.EpcAgeCheckMode
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.EpcEnergyRatingCheckMode
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.EpcExemptionStep
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.EpcExpiredStep
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.EpcInDateAtStartOfTenancyCheckMode
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.EpcInDateAtStartOfTenancyCheckStep
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.EpcLookupByUprnMode
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.EpcMissingStep
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.EpcNotFoundStep
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.EpcSuperseededStep
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.FindYourEpcMode
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.FindYourEpcStep
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.HasEpcMode
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.HasEpcStep
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.HasMeesExemptionMode
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.HasMeesExemptionStep
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.IsEpcRequiredStep
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.LowEnergyRatingStep
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.MeesExemptionStep
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.ProvideEpcLaterStep
+import uk.gov.communities.prsdb.webapp.journeys.shared.YesOrNo
+
+@JourneyFrameworkComponent("propertyRegistrationEpcDetailsTask")
+class EpcDetailsTask : Task<EpcState>() {
+    override fun makeSubJourney(state: EpcState) =
+        subJourney(state) {
+            step(journey.epcLookupByUprnStep) {
+                nextStep { mode ->
+                    when (mode) {
+                        EpcLookupByUprnMode.EPC_FOUND -> journey.checkUprnMatchedEpcStep
+                        EpcLookupByUprnMode.NOT_FOUND -> journey.hasEpcStep
+                    }
+                }
+            }
+            step<YesOrNo, ConfirmEpcRetrievedByUprnStepConfig>(journey.checkUprnMatchedEpcStep) {
+                routeSegment(ConfirmEpcRetrievedByUprnStep.ROUTE_SEGMENT)
+                parents { journey.epcLookupByUprnStep.hasOutcome(EpcLookupByUprnMode.EPC_FOUND) }
+                nextStep { mode ->
+                    when (mode) {
+                        YesOrNo.NO -> journey.hasEpcStep
+                        YesOrNo.YES -> journey.epcAgeCheckStep
+                    }
+                }
+                stepSpecificInitialisation {
+                    usingEpc { epcRetrievedByUprn }
+                }
+                savable()
+            }
+            step(journey.hasEpcStep) {
+                routeSegment(HasEpcStep.ROUTE_SEGMENT)
+                parents {
+                    OrParents(
+                        journey.epcLookupByUprnStep.hasOutcome(EpcLookupByUprnMode.NOT_FOUND),
+                        journey.checkUprnMatchedEpcStep.hasOutcome(YesOrNo.NO),
+                    )
+                }
+                nextStep { mode ->
+                    when (mode) {
+                        HasEpcMode.HAS_EPC -> journey.findYourEpcStep
+                        HasEpcMode.NO_EPC -> journey.isEpcRequiredStep
+                        HasEpcMode.PROVIDE_LATER -> journey.provideEpcLaterStep
+                    }
+                }
+                savable()
+            }
+            step(journey.findYourEpcStep) {
+                routeSegment(FindYourEpcStep.ROUTE_SEGMENT)
+                parents { journey.hasEpcStep.hasOutcome(HasEpcMode.HAS_EPC) }
+                nextStep { mode ->
+                    when (mode) {
+                        FindYourEpcMode.LATEST_EPC_FOUND -> journey.confirmEpcDetailsRetrievedByCertificateNumberStep
+                        FindYourEpcMode.SUPERSEDED_EPC_FOUND -> journey.checkSupersededEpcStep
+                        FindYourEpcMode.NOT_FOUND -> journey.epcNotFoundStep
+                    }
+                }
+                savable()
+            }
+            step<YesOrNo, ConfirmEpcDetailsRetrievedByCertificateNumberStepConfig>(
+                journey.confirmEpcDetailsRetrievedByCertificateNumberStep,
+            ) {
+                routeSegment(ConfirmEpcDetailsRetrievedByCertificateNumberStep.ROUTE_SEGMENT)
+                parents { journey.findYourEpcStep.hasOutcome(FindYourEpcMode.LATEST_EPC_FOUND) }
+                nextStep { mode ->
+                    when (mode) {
+                        YesOrNo.NO -> journey.findYourEpcStep
+                        YesOrNo.YES -> journey.epcAgeCheckStep
+                    }
+                }
+                stepSpecificInitialisation {
+                    usingEpc { epcRetrievedByCertificateNumber }
+                }
+                savable()
+            }
+            step(journey.checkSupersededEpcStep) {
+                routeSegment(EpcSuperseededStep.ROUTE_SEGMENT)
+                parents { journey.findYourEpcStep.hasOutcome(FindYourEpcMode.SUPERSEDED_EPC_FOUND) }
+                nextStep { journey.epcAgeCheckStep }
+                savable()
+            }
+            step(journey.epcAgeCheckStep) {
+                parents {
+                    OrParents(
+                        journey.confirmEpcDetailsRetrievedByCertificateNumberStep.hasOutcome(YesOrNo.YES),
+                        journey.checkUprnMatchedEpcStep.hasOutcome(YesOrNo.YES),
+                        journey.checkSupersededEpcStep.isComplete(),
+                    )
+                }
+                nextStep { mode ->
+                    when (mode) {
+                        EpcAgeCheckMode.EPC_10_YEARS_OR_NEWER -> journey.epcEnergyRatingCheckStep
+                        EpcAgeCheckMode.EPC_OLDER_THAN_10_YEARS -> journey.isPropertyOccupiedCheckStep
+                    }
+                }
+            }
+            step(journey.isPropertyOccupiedCheckStep) {
+                parents {
+                    journey.epcAgeCheckStep.hasOutcome(EpcAgeCheckMode.EPC_OLDER_THAN_10_YEARS)
+                }
+                nextStep { mode ->
+                    when (mode) {
+                        YesOrNo.YES -> journey.epcInDateAtStartOfTenancyCheckStep
+                        YesOrNo.NO -> journey.epcExpiredStep
+                    }
+                }
+            }
+            step(journey.epcNotFoundStep) {
+                routeSegment(EpcNotFoundStep.ROUTE_SEGMENT)
+                parents { journey.findYourEpcStep.hasOutcome(FindYourEpcMode.NOT_FOUND) }
+                nextStep { journey.isEpcRequiredStep }
+                savable()
+            }
+            step(journey.epcInDateAtStartOfTenancyCheckStep) {
+                routeSegment(EpcInDateAtStartOfTenancyCheckStep.ROUTE_SEGMENT)
+                parents {
+                    journey.isPropertyOccupiedCheckStep.hasOutcome(YesOrNo.YES)
+                }
+                nextStep { mode ->
+                    when (mode) {
+                        EpcInDateAtStartOfTenancyCheckMode.IN_DATE -> journey.epcEnergyRatingCheckStep
+                        EpcInDateAtStartOfTenancyCheckMode.NOT_IN_DATE -> journey.epcExpiredStep
+                    }
+                }
+                savable()
+            }
+            step(journey.epcExpiredStep) {
+                routeSegment(EpcExpiredStep.ROUTE_SEGMENT)
+                parents {
+                    OrParents(
+                        journey.isPropertyOccupiedCheckStep.hasOutcome(YesOrNo.NO),
+                        journey.epcInDateAtStartOfTenancyCheckStep.hasOutcome(EpcInDateAtStartOfTenancyCheckMode.NOT_IN_DATE),
+                    )
+                }
+                nextStep { exitStep }
+                savable()
+            }
+            step(journey.isEpcRequiredStep) {
+                routeSegment(IsEpcRequiredStep.ROUTE_SEGMENT)
+                parents {
+                    OrParents(
+                        journey.hasEpcStep.hasOutcome(HasEpcMode.NO_EPC),
+                        journey.epcNotFoundStep.isComplete(),
+                    )
+                }
+                nextStep { mode ->
+                    when (mode) {
+                        YesOrNo.YES -> journey.epcMissingStep
+                        YesOrNo.NO -> journey.epcExemptionStep
+                    }
+                }
+                savable()
+            }
+            step(journey.epcExemptionStep) {
+                routeSegment(EpcExemptionStep.ROUTE_SEGMENT)
+                parents {
+                    journey.isEpcRequiredStep.hasOutcome(YesOrNo.NO)
+                }
+                nextStep { exitStep }
+                savable()
+            }
+            step(journey.epcMissingStep) {
+                routeSegment(EpcMissingStep.ROUTE_SEGMENT)
+                parents { journey.isEpcRequiredStep.hasOutcome(YesOrNo.YES) }
+                nextStep { exitStep }
+                savable()
+            }
+            step(journey.epcEnergyRatingCheckStep) {
+                parents {
+                    OrParents(
+                        journey.epcAgeCheckStep.hasOutcome(EpcAgeCheckMode.EPC_10_YEARS_OR_NEWER),
+                        journey.epcInDateAtStartOfTenancyCheckStep.hasOutcome(EpcInDateAtStartOfTenancyCheckMode.IN_DATE),
+                    )
+                }
+                nextStep { mode ->
+                    when (mode) {
+                        EpcEnergyRatingCheckMode.EPC_MEETS_ENERGY_REQUIREMENTS -> exitStep
+                        EpcEnergyRatingCheckMode.EPC_LOW_ENERGY_RATING -> journey.hasMeesExemptionStep
+                    }
+                }
+            }
+            step(journey.hasMeesExemptionStep) {
+                routeSegment(HasMeesExemptionStep.ROUTE_SEGMENT)
+                parents {
+                    journey.epcEnergyRatingCheckStep.hasOutcome(EpcEnergyRatingCheckMode.EPC_LOW_ENERGY_RATING)
+                }
+                nextStep { mode ->
+                    when (mode) {
+                        HasMeesExemptionMode.HAS_EXEMPTION -> journey.meesExemptionStep
+                        HasMeesExemptionMode.NO_EXEMPTION -> journey.lowEnergyRatingStep
+                    }
+                }
+                savable()
+            }
+            step(journey.meesExemptionStep) {
+                routeSegment(MeesExemptionStep.ROUTE_SEGMENT)
+                parents { journey.hasMeesExemptionStep.hasOutcome(HasMeesExemptionMode.HAS_EXEMPTION) }
+                nextStep { exitStep }
+                savable()
+            }
+            step(journey.lowEnergyRatingStep) {
+                routeSegment(LowEnergyRatingStep.ROUTE_SEGMENT)
+                parents { journey.hasMeesExemptionStep.hasOutcome(HasMeesExemptionMode.NO_EXEMPTION) }
+                nextStep { exitStep }
+                savable()
+            }
+            step(journey.provideEpcLaterStep) {
+                routeSegment(ProvideEpcLaterStep.ROUTE_SEGMENT)
+                parents { journey.hasEpcStep.hasOutcome(HasEpcMode.PROVIDE_LATER) }
+                nextStep { exitStep }
+                savable()
+            }
+            exitStep {
+                parents {
+                    OrParents(
+                        journey.epcEnergyRatingCheckStep.hasOutcome(EpcEnergyRatingCheckMode.EPC_MEETS_ENERGY_REQUIREMENTS),
+                        journey.epcExpiredStep.isComplete(),
+                        journey.meesExemptionStep.isComplete(),
+                        journey.lowEnergyRatingStep.isComplete(),
+                        journey.epcExemptionStep.isComplete(),
+                        journey.epcMissingStep.isComplete(),
+                        journey.provideEpcLaterStep.isComplete(),
+                    )
+                }
+            }
+        }
+}

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/tasks/EpcTask.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/tasks/EpcTask.kt
@@ -2,37 +2,10 @@ package uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks
 
 import uk.gov.communities.prsdb.webapp.annotations.webAnnotations.JourneyFrameworkComponent
 import uk.gov.communities.prsdb.webapp.constants.enums.TaskStatus
-import uk.gov.communities.prsdb.webapp.journeys.OrParents
 import uk.gov.communities.prsdb.webapp.journeys.Task
-import uk.gov.communities.prsdb.webapp.journeys.hasOutcome
 import uk.gov.communities.prsdb.webapp.journeys.isComplete
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.EpcState
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.CheckEpcAnswersStep
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.ConfirmEpcDetailsRetrievedByCertificateNumberStep
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.ConfirmEpcDetailsRetrievedByCertificateNumberStepConfig
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.ConfirmEpcRetrievedByUprnStep
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.ConfirmEpcRetrievedByUprnStepConfig
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.EpcAgeCheckMode
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.EpcEnergyRatingCheckMode
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.EpcExemptionStep
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.EpcExpiredStep
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.EpcInDateAtStartOfTenancyCheckMode
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.EpcInDateAtStartOfTenancyCheckStep
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.EpcLookupByUprnMode
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.EpcMissingStep
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.EpcNotFoundStep
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.EpcSuperseededStep
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.FindYourEpcMode
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.FindYourEpcStep
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.HasEpcMode
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.HasEpcStep
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.HasMeesExemptionMode
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.HasMeesExemptionStep
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.IsEpcRequiredStep
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.LowEnergyRatingStep
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.MeesExemptionStep
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.ProvideEpcLaterStep
-import uk.gov.communities.prsdb.webapp.journeys.shared.YesOrNo
 
 @JourneyFrameworkComponent("propertyRegistrationEpcTask")
 class EpcTask : Task<EpcState>() {
@@ -43,227 +16,17 @@ class EpcTask : Task<EpcState>() {
                     exitStep.isStepReachable -> TaskStatus.COMPLETED
                     journey.checkUprnMatchedEpcStep.outcome != null -> TaskStatus.IN_PROGRESS
                     journey.hasEpcStep.outcome != null -> TaskStatus.IN_PROGRESS
-                    firstStep.isStepReachable -> TaskStatus.NOT_STARTED
+                    journey.epcLookupByUprnStep.isStepReachable -> TaskStatus.NOT_STARTED
                     else -> TaskStatus.CANNOT_START
                 }
             }
-            step(journey.epcLookupByUprnStep) {
-                nextStep { mode ->
-                    when (mode) {
-                        EpcLookupByUprnMode.EPC_FOUND -> journey.checkUprnMatchedEpcStep
-                        EpcLookupByUprnMode.NOT_FOUND -> journey.hasEpcStep
-                    }
-                }
-            }
-            step<YesOrNo, ConfirmEpcRetrievedByUprnStepConfig>(journey.checkUprnMatchedEpcStep) {
-                routeSegment(ConfirmEpcRetrievedByUprnStep.ROUTE_SEGMENT)
-                parents { journey.epcLookupByUprnStep.hasOutcome(EpcLookupByUprnMode.EPC_FOUND) }
-                nextStep { mode ->
-                    when (mode) {
-                        YesOrNo.NO -> journey.hasEpcStep
-                        YesOrNo.YES -> journey.epcAgeCheckStep
-                    }
-                }
-                stepSpecificInitialisation {
-                    usingEpc { epcRetrievedByUprn }
-                }
-                savable()
-            }
-            step(journey.hasEpcStep) {
-                routeSegment(HasEpcStep.ROUTE_SEGMENT)
-                parents {
-                    OrParents(
-                        journey.epcLookupByUprnStep.hasOutcome(EpcLookupByUprnMode.NOT_FOUND),
-                        journey.checkUprnMatchedEpcStep.hasOutcome(YesOrNo.NO),
-                    )
-                }
-                nextStep { mode ->
-                    when (mode) {
-                        HasEpcMode.HAS_EPC -> journey.findYourEpcStep
-                        HasEpcMode.NO_EPC -> journey.isEpcRequiredStep
-                        HasEpcMode.PROVIDE_LATER -> journey.provideEpcLaterStep
-                    }
-                }
-                savable()
-            }
-            step(journey.findYourEpcStep) {
-                routeSegment(FindYourEpcStep.ROUTE_SEGMENT)
-                parents { journey.hasEpcStep.hasOutcome(HasEpcMode.HAS_EPC) }
-                nextStep { mode ->
-                    when (mode) {
-                        FindYourEpcMode.LATEST_EPC_FOUND -> journey.confirmEpcDetailsRetrievedByCertificateNumberStep
-                        FindYourEpcMode.SUPERSEDED_EPC_FOUND -> journey.checkSupersededEpcStep
-                        FindYourEpcMode.NOT_FOUND -> journey.epcNotFoundStep
-                    }
-                }
-                savable()
-            }
-            step<YesOrNo, ConfirmEpcDetailsRetrievedByCertificateNumberStepConfig>(
-                journey.confirmEpcDetailsRetrievedByCertificateNumberStep,
-            ) {
-                routeSegment(ConfirmEpcDetailsRetrievedByCertificateNumberStep.ROUTE_SEGMENT)
-                parents { journey.findYourEpcStep.hasOutcome(FindYourEpcMode.LATEST_EPC_FOUND) }
-                nextStep { mode ->
-                    when (mode) {
-                        YesOrNo.NO -> journey.findYourEpcStep
-                        YesOrNo.YES -> journey.epcAgeCheckStep
-                    }
-                }
-                stepSpecificInitialisation {
-                    usingEpc { epcRetrievedByCertificateNumber }
-                }
-                savable()
-            }
-            step(journey.checkSupersededEpcStep) {
-                routeSegment(EpcSuperseededStep.ROUTE_SEGMENT)
-                parents { journey.findYourEpcStep.hasOutcome(FindYourEpcMode.SUPERSEDED_EPC_FOUND) }
-                nextStep { journey.epcAgeCheckStep }
-                savable()
-            }
-            step(journey.epcAgeCheckStep) {
-                parents {
-                    OrParents(
-                        journey.confirmEpcDetailsRetrievedByCertificateNumberStep.hasOutcome(YesOrNo.YES),
-                        journey.checkUprnMatchedEpcStep.hasOutcome(YesOrNo.YES),
-                        journey.checkSupersededEpcStep.isComplete(),
-                    )
-                }
-                nextStep { mode ->
-                    when (mode) {
-                        EpcAgeCheckMode.EPC_10_YEARS_OR_NEWER -> journey.epcEnergyRatingCheckStep
-                        EpcAgeCheckMode.EPC_OLDER_THAN_10_YEARS -> journey.isPropertyOccupiedCheckStep
-                    }
-                }
-            }
-            step(journey.isPropertyOccupiedCheckStep) {
-                parents {
-                    journey.epcAgeCheckStep.hasOutcome(EpcAgeCheckMode.EPC_OLDER_THAN_10_YEARS)
-                }
-                nextStep { mode ->
-                    when (mode) {
-                        YesOrNo.YES -> journey.epcInDateAtStartOfTenancyCheckStep
-                        YesOrNo.NO -> journey.epcExpiredStep
-                    }
-                }
-            }
-            step(journey.epcNotFoundStep) {
-                routeSegment(EpcNotFoundStep.ROUTE_SEGMENT)
-                parents { journey.findYourEpcStep.hasOutcome(FindYourEpcMode.NOT_FOUND) }
-                nextStep { journey.isEpcRequiredStep }
-                savable()
-            }
-            step(journey.epcInDateAtStartOfTenancyCheckStep) {
-                routeSegment(EpcInDateAtStartOfTenancyCheckStep.ROUTE_SEGMENT)
-                parents {
-                    journey.isPropertyOccupiedCheckStep.hasOutcome(YesOrNo.YES)
-                }
-                nextStep { mode ->
-                    when (mode) {
-                        EpcInDateAtStartOfTenancyCheckMode.IN_DATE -> journey.epcEnergyRatingCheckStep
-                        EpcInDateAtStartOfTenancyCheckMode.NOT_IN_DATE -> journey.epcExpiredStep
-                    }
-                }
-                savable()
-            }
-            step(journey.epcExpiredStep) {
-                routeSegment(EpcExpiredStep.ROUTE_SEGMENT)
-                parents {
-                    OrParents(
-                        journey.isPropertyOccupiedCheckStep.hasOutcome(YesOrNo.NO),
-                        journey.epcInDateAtStartOfTenancyCheckStep.hasOutcome(EpcInDateAtStartOfTenancyCheckMode.NOT_IN_DATE),
-                    )
-                }
-                nextStep { journey.checkEpcAnswersStep }
-                savable()
-            }
-            step(journey.isEpcRequiredStep) {
-                routeSegment(IsEpcRequiredStep.ROUTE_SEGMENT)
-                parents {
-                    OrParents(
-                        journey.hasEpcStep.hasOutcome(HasEpcMode.NO_EPC),
-                        journey.epcNotFoundStep.isComplete(),
-                    )
-                }
-                nextStep { mode ->
-                    when (mode) {
-                        YesOrNo.YES -> journey.epcMissingStep
-                        YesOrNo.NO -> journey.epcExemptionStep
-                    }
-                }
-                savable()
-            }
-            step(journey.epcExemptionStep) {
-                routeSegment(EpcExemptionStep.ROUTE_SEGMENT)
-                parents {
-                    journey.isEpcRequiredStep.hasOutcome(YesOrNo.NO)
-                }
-                nextStep { journey.checkEpcAnswersStep }
-                savable()
-            }
-            step(journey.epcMissingStep) {
-                routeSegment(EpcMissingStep.ROUTE_SEGMENT)
-                parents { journey.isEpcRequiredStep.hasOutcome(YesOrNo.YES) }
-                nextStep { journey.checkEpcAnswersStep }
-                savable()
-            }
-            step(journey.epcEnergyRatingCheckStep) {
-                parents {
-                    OrParents(
-                        journey.epcAgeCheckStep.hasOutcome(EpcAgeCheckMode.EPC_10_YEARS_OR_NEWER),
-                        journey.epcInDateAtStartOfTenancyCheckStep.hasOutcome(EpcInDateAtStartOfTenancyCheckMode.IN_DATE),
-                    )
-                }
-                nextStep { mode ->
-                    when (mode) {
-                        EpcEnergyRatingCheckMode.EPC_MEETS_ENERGY_REQUIREMENTS -> journey.checkEpcAnswersStep
-                        EpcEnergyRatingCheckMode.EPC_LOW_ENERGY_RATING -> journey.hasMeesExemptionStep
-                    }
-                }
-            }
-            step(journey.hasMeesExemptionStep) {
-                routeSegment(HasMeesExemptionStep.ROUTE_SEGMENT)
-                parents {
-                    journey.epcEnergyRatingCheckStep.hasOutcome(EpcEnergyRatingCheckMode.EPC_LOW_ENERGY_RATING)
-                }
-                nextStep { mode ->
-                    when (mode) {
-                        HasMeesExemptionMode.HAS_EXEMPTION -> journey.meesExemptionStep
-                        HasMeesExemptionMode.NO_EXEMPTION -> journey.lowEnergyRatingStep
-                    }
-                }
-                savable()
-            }
-            step(journey.meesExemptionStep) {
-                routeSegment(MeesExemptionStep.ROUTE_SEGMENT)
-                parents { journey.hasMeesExemptionStep.hasOutcome(HasMeesExemptionMode.HAS_EXEMPTION) }
-                nextStep { journey.checkEpcAnswersStep }
-                savable()
-            }
-            step(journey.lowEnergyRatingStep) {
-                routeSegment(LowEnergyRatingStep.ROUTE_SEGMENT)
-                parents { journey.hasMeesExemptionStep.hasOutcome(HasMeesExemptionMode.NO_EXEMPTION) }
-                nextStep { journey.checkEpcAnswersStep }
-                savable()
-            }
-            step(journey.provideEpcLaterStep) {
-                routeSegment(ProvideEpcLaterStep.ROUTE_SEGMENT)
-                parents { journey.hasEpcStep.hasOutcome(HasEpcMode.PROVIDE_LATER) }
+            task(journey.epcDetailsTask) {
                 nextStep { journey.checkEpcAnswersStep }
                 savable()
             }
             step(journey.checkEpcAnswersStep) {
                 routeSegment(CheckEpcAnswersStep.ROUTE_SEGMENT)
-                parents {
-                    OrParents(
-                        journey.epcEnergyRatingCheckStep.hasOutcome(EpcEnergyRatingCheckMode.EPC_MEETS_ENERGY_REQUIREMENTS),
-                        journey.epcExpiredStep.isComplete(),
-                        journey.meesExemptionStep.isComplete(),
-                        journey.lowEnergyRatingStep.isComplete(),
-                        journey.epcExemptionStep.isComplete(),
-                        journey.epcMissingStep.isComplete(),
-                        journey.provideEpcLaterStep.isComplete(),
-                    )
-                }
+                parents { journey.epcDetailsTask.isComplete() }
                 nextStep { exitStep }
                 savable()
             }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/tasks/GasSafetyDetailsTask.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/tasks/GasSafetyDetailsTask.kt
@@ -1,0 +1,130 @@
+package uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks
+
+import uk.gov.communities.prsdb.webapp.annotations.webAnnotations.JourneyFrameworkComponent
+import uk.gov.communities.prsdb.webapp.journeys.OrParents
+import uk.gov.communities.prsdb.webapp.journeys.Task
+import uk.gov.communities.prsdb.webapp.journeys.hasOutcome
+import uk.gov.communities.prsdb.webapp.journeys.isComplete
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.GasSafetyState
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.CheckGasCertUploadsStep
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.GasCertExpiredStep
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.GasCertIssueDateMode
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.GasCertIssueDateStep
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.GasCertMissingStep
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.HasAnyInCollectionStepConfig
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.HasGasCertMode
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.HasGasCertStep
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.HasGasSupplyStep
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.ProvideGasCertLaterStep
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.RemoveGasCertUploadStep
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.UploadGasCertStep
+import uk.gov.communities.prsdb.webapp.journeys.shared.AnyMembers
+import uk.gov.communities.prsdb.webapp.journeys.shared.YesOrNo
+
+@JourneyFrameworkComponent("propertyRegistrationGasSafetyDetailsTask")
+class GasSafetyDetailsTask : Task<GasSafetyState>() {
+    override fun makeSubJourney(state: GasSafetyState) =
+        subJourney(state) {
+            step(journey.hasGasSupplyStep) {
+                routeSegment(HasGasSupplyStep.ROUTE_SEGMENT)
+                nextStep { mode ->
+                    when (mode) {
+                        YesOrNo.YES -> journey.hasGasCertStep
+                        YesOrNo.NO -> exitStep
+                    }
+                }
+                savable()
+            }
+            step(journey.hasGasCertStep) {
+                routeSegment(HasGasCertStep.ROUTE_SEGMENT)
+                parents { journey.hasGasSupplyStep.hasOutcome(YesOrNo.YES) }
+                nextStep { mode ->
+                    when (mode) {
+                        HasGasCertMode.HAS_CERTIFICATE -> journey.gasCertIssueDateStep
+                        HasGasCertMode.NO_CERTIFICATE -> journey.gasCertMissingStep
+                        HasGasCertMode.PROVIDE_THIS_LATER -> journey.provideGasCertLaterStep
+                    }
+                }
+                savable()
+            }
+            step(journey.gasCertIssueDateStep) {
+                routeSegment(GasCertIssueDateStep.ROUTE_SEGMENT)
+                parents { journey.hasGasCertStep.hasOutcome(HasGasCertMode.HAS_CERTIFICATE) }
+                nextStep { mode ->
+                    when (mode) {
+                        GasCertIssueDateMode.GAS_SAFETY_CERTIFICATE_IN_DATE -> journey.hasUploadedCert
+                        GasCertIssueDateMode.GAS_SAFETY_CERTIFICATE_OUTDATED -> journey.gasCertExpiredStep
+                    }
+                }
+                savable()
+            }
+            step<AnyMembers, HasAnyInCollectionStepConfig>(journey.hasUploadedCert) {
+                parents { journey.gasCertIssueDateStep.hasOutcome(GasCertIssueDateMode.GAS_SAFETY_CERTIFICATE_IN_DATE) }
+                nextStep { mode ->
+                    when (mode) {
+                        AnyMembers.NO_MEMBERS -> journey.uploadGasCertStep
+                        AnyMembers.SOME_MEMBERS -> journey.checkGasCertUploadsStep
+                    }
+                }
+                stepSpecificInitialisation { collectionMap = journey.gasUploadMap }
+            }
+            step(journey.uploadGasCertStep) {
+                routeSegment(UploadGasCertStep.ROUTE_SEGMENT)
+                parents { journey.gasCertIssueDateStep.hasOutcome(GasCertIssueDateMode.GAS_SAFETY_CERTIFICATE_IN_DATE) }
+                nextStep { journey.checkGasCertUploadsStep }
+                savable()
+            }
+            step(journey.checkGasCertUploadsStep) {
+                routeSegment(CheckGasCertUploadsStep.ROUTE_SEGMENT)
+                parents { journey.uploadGasCertStep.isComplete() }
+                nextStep { exitStep }
+                backStep { journey.gasCertIssueDateStep }
+                savable()
+            }
+            step(journey.removeGasCertUploadStep) {
+                parents {
+                    journey.hasUploadedCert.hasOutcome(AnyMembers.SOME_MEMBERS)
+                }
+                backStep { journey.checkGasCertUploadsStep }
+                nextStep { mode ->
+                    when (mode) {
+                        AnyMembers.SOME_MEMBERS -> journey.checkGasCertUploadsStep
+                        AnyMembers.NO_MEMBERS -> journey.uploadGasCertStep
+                    }
+                }
+                routeSegment(RemoveGasCertUploadStep.ROUTE_SEGMENT)
+                savable()
+            }
+            step(journey.gasCertExpiredStep) {
+                routeSegment(GasCertExpiredStep.ROUTE_SEGMENT)
+                parents {
+                    journey.gasCertIssueDateStep.hasOutcome(GasCertIssueDateMode.GAS_SAFETY_CERTIFICATE_OUTDATED)
+                }
+                nextStep { exitStep }
+                savable()
+            }
+            step(journey.gasCertMissingStep) {
+                routeSegment(GasCertMissingStep.ROUTE_SEGMENT)
+                parents { journey.hasGasCertStep.hasOutcome(HasGasCertMode.NO_CERTIFICATE) }
+                nextStep { exitStep }
+                savable()
+            }
+            step(journey.provideGasCertLaterStep) {
+                routeSegment(ProvideGasCertLaterStep.ROUTE_SEGMENT)
+                parents { journey.hasGasCertStep.hasOutcome(HasGasCertMode.PROVIDE_THIS_LATER) }
+                nextStep { exitStep }
+                savable()
+            }
+            exitStep {
+                parents {
+                    OrParents(
+                        journey.hasGasSupplyStep.hasOutcome(YesOrNo.NO),
+                        journey.provideGasCertLaterStep.isComplete(),
+                        journey.gasCertMissingStep.isComplete(),
+                        journey.gasCertExpiredStep.isComplete(),
+                        journey.checkGasCertUploadsStep.isComplete(),
+                    )
+                }
+            }
+        }
+}

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/tasks/GasSafetyTask.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/tasks/GasSafetyTask.kt
@@ -1,132 +1,22 @@
 package uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks
 
 import uk.gov.communities.prsdb.webapp.annotations.webAnnotations.JourneyFrameworkComponent
-import uk.gov.communities.prsdb.webapp.journeys.OrParents
 import uk.gov.communities.prsdb.webapp.journeys.Task
-import uk.gov.communities.prsdb.webapp.journeys.hasOutcome
 import uk.gov.communities.prsdb.webapp.journeys.isComplete
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.GasSafetyState
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.CheckGasCertUploadsStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.CheckGasSafetyAnswersStep
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.GasCertExpiredStep
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.GasCertIssueDateMode
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.GasCertIssueDateStep
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.GasCertMissingStep
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.HasAnyInCollectionStepConfig
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.HasGasCertMode
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.HasGasCertStep
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.HasGasSupplyStep
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.ProvideGasCertLaterStep
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.RemoveGasCertUploadStep
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.UploadGasCertStep
-import uk.gov.communities.prsdb.webapp.journeys.shared.AnyMembers
-import uk.gov.communities.prsdb.webapp.journeys.shared.YesOrNo
 
 @JourneyFrameworkComponent("propertyRegistrationGasSafetyTask")
 class GasSafetyTask : Task<GasSafetyState>() {
     override fun makeSubJourney(state: GasSafetyState) =
         subJourney(state) {
-            step(journey.hasGasSupplyStep) {
-                routeSegment(HasGasSupplyStep.ROUTE_SEGMENT)
-                nextStep { mode ->
-                    when (mode) {
-                        YesOrNo.YES -> journey.hasGasCertStep
-                        YesOrNo.NO -> journey.checkGasSafetyAnswersStep
-                    }
-                }
-                savable()
-            }
-            step(journey.hasGasCertStep) {
-                routeSegment(HasGasCertStep.ROUTE_SEGMENT)
-                parents { journey.hasGasSupplyStep.hasOutcome(YesOrNo.YES) }
-                nextStep { mode ->
-                    when (mode) {
-                        HasGasCertMode.HAS_CERTIFICATE -> journey.gasCertIssueDateStep
-                        HasGasCertMode.NO_CERTIFICATE -> journey.gasCertMissingStep
-                        HasGasCertMode.PROVIDE_THIS_LATER -> journey.provideGasCertLaterStep
-                    }
-                }
-                savable()
-            }
-            step(journey.gasCertIssueDateStep) {
-                routeSegment(GasCertIssueDateStep.ROUTE_SEGMENT)
-                parents { journey.hasGasCertStep.hasOutcome(HasGasCertMode.HAS_CERTIFICATE) }
-                nextStep { mode ->
-                    when (mode) {
-                        GasCertIssueDateMode.GAS_SAFETY_CERTIFICATE_IN_DATE -> journey.hasUploadedCert
-                        GasCertIssueDateMode.GAS_SAFETY_CERTIFICATE_OUTDATED -> journey.gasCertExpiredStep
-                    }
-                }
-                savable()
-            }
-            step<AnyMembers, HasAnyInCollectionStepConfig>(journey.hasUploadedCert) {
-                parents { journey.gasCertIssueDateStep.hasOutcome(GasCertIssueDateMode.GAS_SAFETY_CERTIFICATE_IN_DATE) }
-                nextStep { mode ->
-                    when (mode) {
-                        AnyMembers.NO_MEMBERS -> journey.uploadGasCertStep
-                        AnyMembers.SOME_MEMBERS -> journey.checkGasCertUploadsStep
-                    }
-                }
-                stepSpecificInitialisation { collectionMap = journey.gasUploadMap }
-            }
-            step(journey.uploadGasCertStep) {
-                routeSegment(UploadGasCertStep.ROUTE_SEGMENT)
-                parents { journey.gasCertIssueDateStep.hasOutcome(GasCertIssueDateMode.GAS_SAFETY_CERTIFICATE_IN_DATE) }
-                nextStep { journey.checkGasCertUploadsStep }
-                savable()
-            }
-            step(journey.checkGasCertUploadsStep) {
-                routeSegment(CheckGasCertUploadsStep.ROUTE_SEGMENT)
-                parents { journey.uploadGasCertStep.isComplete() }
-                nextStep { journey.checkGasSafetyAnswersStep }
-                backStep { journey.gasCertIssueDateStep }
-                savable()
-            }
-            step(journey.removeGasCertUploadStep) {
-                parents {
-                    journey.hasUploadedCert.hasOutcome(AnyMembers.SOME_MEMBERS)
-                }
-                backStep { journey.checkGasCertUploadsStep }
-                nextStep { mode ->
-                    when (mode) {
-                        AnyMembers.SOME_MEMBERS -> journey.checkGasCertUploadsStep
-                        AnyMembers.NO_MEMBERS -> journey.uploadGasCertStep
-                    }
-                }
-                routeSegment(RemoveGasCertUploadStep.ROUTE_SEGMENT)
-                savable()
-            }
-            step(journey.gasCertExpiredStep) {
-                routeSegment(GasCertExpiredStep.ROUTE_SEGMENT)
-                parents {
-                    journey.gasCertIssueDateStep.hasOutcome(GasCertIssueDateMode.GAS_SAFETY_CERTIFICATE_OUTDATED)
-                }
-                nextStep { journey.checkGasSafetyAnswersStep }
-                savable()
-            }
-            step(journey.gasCertMissingStep) {
-                routeSegment(GasCertMissingStep.ROUTE_SEGMENT)
-                parents { journey.hasGasCertStep.hasOutcome(HasGasCertMode.NO_CERTIFICATE) }
-                nextStep { journey.checkGasSafetyAnswersStep }
-                savable()
-            }
-            step(journey.provideGasCertLaterStep) {
-                routeSegment(ProvideGasCertLaterStep.ROUTE_SEGMENT)
-                parents { journey.hasGasCertStep.hasOutcome(HasGasCertMode.PROVIDE_THIS_LATER) }
+            task(journey.gasSafetyDetailsTask) {
                 nextStep { journey.checkGasSafetyAnswersStep }
                 savable()
             }
             step(journey.checkGasSafetyAnswersStep) {
                 routeSegment(CheckGasSafetyAnswersStep.ROUTE_SEGMENT)
-                parents {
-                    OrParents(
-                        journey.hasGasSupplyStep.hasOutcome(YesOrNo.NO),
-                        journey.provideGasCertLaterStep.isComplete(),
-                        journey.gasCertMissingStep.isComplete(),
-                        journey.gasCertExpiredStep.isComplete(),
-                        journey.checkGasCertUploadsStep.isComplete(),
-                    )
-                }
+                parents { journey.gasSafetyDetailsTask.isComplete() }
                 nextStep { exitStep }
                 savable()
             }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/update/gasSafety/UpdateGasSafetyJourneyFactory.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/update/gasSafety/UpdateGasSafetyJourneyFactory.kt
@@ -25,6 +25,7 @@ import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.HasGa
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.ProvideGasCertLaterStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.RemoveGasCertUploadStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.UploadGasCertStep
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.GasSafetyDetailsTask
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.GasSafetyTask
 import uk.gov.communities.prsdb.webapp.services.PropertyOwnershipService
 import java.security.Principal
@@ -86,6 +87,7 @@ class UpdateGasSafetyJourney(
     journeyStateService: JourneyStateService,
     journeyName: String = "gasSafety",
     override val gasSafetyTask: GasSafetyTask,
+    override val gasSafetyDetailsTask: GasSafetyDetailsTask,
     override val hasGasSupplyStep: HasGasSupplyStep,
     override val hasGasCertStep: HasGasCertStep,
     override val gasCertIssueDateStep: GasCertIssueDateStep,

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/states/ElectricalSafetyStateTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/states/ElectricalSafetyStateTests.kt
@@ -20,6 +20,7 @@ import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.HasEl
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.ProvideElectricalCertLaterStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.RemoveElectricalCertUploadStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.UploadElectricalCertStep
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.ElectricalSafetyDetailsTask
 import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.AnyDateFormModel
 import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.HasElectricalCertFormModel
 import java.time.LocalDate
@@ -128,6 +129,8 @@ class ElectricalSafetyStateTests {
             override val electricalCertMissingStep = mock<ElectricalCertMissingStep>()
             override val provideElectricalCertLaterStep = mock<ProvideElectricalCertLaterStep>()
             override val checkElectricalSafetyAnswersStep = mock<CheckElectricalSafetyAnswersStep>()
+            override val electricalSafetyDetailsTask =
+                mock<ElectricalSafetyDetailsTask>()
 
             override val hasElectricalCertStep =
                 mock<HasElectricalCertStep>().apply {

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/states/EpcStateTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/states/EpcStateTests.kt
@@ -26,6 +26,7 @@ import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.LowEn
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.MeesExemptionStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.PropertyOccupiedCheckStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.ProvideEpcLaterStep
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.EpcDetailsTask
 import uk.gov.communities.prsdb.webapp.models.dataModels.EpcDataModel
 
 class EpcStateTests {
@@ -116,5 +117,6 @@ class EpcStateTests {
             override val epcMissingStep = mock<EpcMissingStep>()
             override val provideEpcLaterStep = mock<ProvideEpcLaterStep>()
             override val checkEpcAnswersStep = mock<CheckEpcAnswersStep>()
+            override val epcDetailsTask = mock<EpcDetailsTask>()
         }
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/states/GasSafetyStateTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/states/GasSafetyStateTests.kt
@@ -21,6 +21,7 @@ import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.HasGa
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.ProvideGasCertLaterStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.RemoveGasCertUploadStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.UploadGasCertStep
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.GasSafetyDetailsTask
 import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.TodayOrPastDateFormModel
 import java.time.LocalDate
 
@@ -108,6 +109,7 @@ class GasSafetyStateTests {
             override val gasCertMissingStep = mock<GasCertMissingStep>()
             override val provideGasCertLaterStep = mock<ProvideGasCertLaterStep>()
             override val checkGasSafetyAnswersStep = mock<CheckGasSafetyAnswersStep>()
+            override val gasSafetyDetailsTask = mock<GasSafetyDetailsTask>()
             override val hasUploadedCert: HasAnyInCollectionStep = mock<HasAnyInCollectionStep>()
 
             override val gasCertIssueDateStep =


### PR DESCRIPTION
## Ticket number

PDJB-718

## Goal of change

Restructure the gas safety, electrical safety, and EPC tasks to expose an inner "details" task that holds the data-collection steps without the mini-CYA step.

## Description of main change(s)

- Splits each of `GasSafetyTask`, `ElectricalSafetyTask`, and `EpcTask` into a thin wrapper task that composes a new inner `*DetailsTask` with the original mini-CYA step.
- The inner `*DetailsTask` classes contain just the data-collection steps so they can be reused as the destination of CYA edit links in a subsequent PR.
- No behaviour change: the wrapping tasks expose the same step graph as before.

## Anything you'd like to highlight to the reviewer?

This is the second of a stack of four PRs for PDJB-718. It is a pure refactor — no user-facing behaviour change. The `*DetailsTask` classes are unused outside the wrapper tasks until the wiring PR lands.

Stacked on `feat/PDJB-718-update-property-registration-cya-page`.

## Checklist

- [x] Unit tests for new logic (e.g. new service methods) have been added
- [x] Branch has been rebased onto main and run locally, with everything working as expected (both for your new feature and any related functionality)
- [x] TODO comments referencing this JIRA ticket have been searched for and removed - if a future PR will address them, mention that here
