### PR TITLE
PDJB-595: Name audit landlord web UI

### DIFF
--- a/src/main/resources/messages/deregisterLandlord.yml
+++ b/src/main/resources/messages/deregisterLandlord.yml
@@ -2,15 +2,14 @@ title: Deregister Landlord
 noProperties:
   confirmation:
     banner:
-      heading: You have deleted your account from the database
+      heading: Account deleted
+      body: No longer registered as a landlord
     paragraph:
-      one: You have deleted your account from the database. You can no longer use the database.
-      two: We’ve sent a confirmation to your email address.
+      one: We have sent you a confirmation email. You’ll need to register a new account if you become a landlord again.
 withProperties:
   confirmation:
     banner:
-      heading: You have deleted your account from the database
+      heading: Account deleted
+      body: No longer registered as a landlord
     paragraph:
-      one: You have deleted your landlord information and all your properties from the database.
-      two: You can no longer use the database.
-      three: We’ve sent a confirmation to your email address.
+      one: You have deleted your landlord information and all your properties. We have sent you an email confirming this. You’ll need to register a new account if you become a landlord again.

--- a/src/main/resources/messages/forms.yml
+++ b/src/main/resources/messages/forms.yml
@@ -648,7 +648,7 @@ update:
       summaryName: You have updated whether the property is occupied by tenants
     numberOfHouseholds:
       fieldSetHeading: Households in your property
-  warning: 'You must not provide any false or misleading information on the database. By submitting this information, you agree it’s accurate to the best of your knowledge at the time of updating.'
+  warning: 'You must not provide any false or misleading information. By submitting this information, you agree it’s accurate to the best of your knowledge at the time of updating.'
   gasSafetyType:
     fieldSetHeading: Do you want to add a new gas safety certificate or add an exemption?
     certificate: Add a new gas safety certificate
@@ -684,13 +684,13 @@ areYouSure:
         missing: Select whether you want to delete this property from the database
   landlordDeregistration:
     noProperties:
-      fieldSetHeading: Are you sure you want to delete your account from the database?
+      fieldSetHeading: Are you sure you want to delete your account?
       radios:
         error:
-          missing: Select whether you want to delete your account from the database
+          missing: Select whether you want to delete your account
     hasProperties:
-      fieldSetHeading: Are you sure you want to delete your account and all your properties on the database?
-      fieldSetHint: 'By deleting your account, you are also deleting your properties on the database.'
+      fieldSetHeading: Are you sure you want to delete your account and all your properties?
+      fieldSetHint: 'By deleting your account, you are also deleting your properties.'
     withProperties:
       radios:
         error:

--- a/src/main/resources/messages/landlordDetails.yml
+++ b/src/main/resources/messages/landlordDetails.yml
@@ -4,7 +4,7 @@ removeRecord: Delete account
 personalDetails:
   heading: Personal details
   lrn: Landlord Registration Number
-  registrationDate: Database registration date
+  registrationDate: Registration date
   name: Name
   dateOfBirth: Date of birth
   oneLoginVerified: Verified by GOV.UK One Login

--- a/src/main/resources/templates/deregisterLandlordWithNoPropertiesConfirmation.html
+++ b/src/main/resources/templates/deregisterLandlordWithNoPropertiesConfirmation.html
@@ -4,14 +4,11 @@
     <div id="page-contents"
          th:replace="~{fragments/layouts/twoThirdsLayout :: twoThirdsLayout(~{::#page-contents/content()})}">
         <div id="confirmation-banner"
-             th:replace="~{fragments/banners/confirmationPageBanner :: confirmationPageBanner(#{deregisterLandlord.noProperties.confirmation.banner.heading}, null)}">
+             th:replace="~{fragments/banners/confirmationPageBanner :: confirmationPageBanner(#{deregisterLandlord.noProperties.confirmation.banner.heading}, ~{::#confirmation-banner/content()})}">
+            <span th:text="#{deregisterLandlord.noProperties.confirmation.banner.body}">Body</span>
         </div>
-        <h1 class="govuk-heading-l" th:text="#{common.confirmationPage.whatHappensNext}">common.whatHappensNext</h1>
         <p class="govuk-body" th:text="#{deregisterLandlord.noProperties.confirmation.paragraph.one}">
             deregisterLandlord.noProperties.confirmation.paragraph.one
-        </p>
-        <p class="govuk-body" th:text="#{deregisterLandlord.noProperties.confirmation.paragraph.two}">
-            deregisterLandlord.noProperties.confirmation.paragraph.two
         </p>
     </div>
 </main>

--- a/src/main/resources/templates/deregisterLandlordWithRegisteredPropertiesConfirmation.html
+++ b/src/main/resources/templates/deregisterLandlordWithRegisteredPropertiesConfirmation.html
@@ -4,17 +4,11 @@
     <div id="page-contents"
          th:replace="~{fragments/layouts/twoThirdsLayout :: twoThirdsLayout(~{::#page-contents/content()})}">
         <div id="confirmation-banner"
-             th:replace="~{fragments/banners/confirmationPageBanner :: confirmationPageBanner(#{deregisterLandlord.withProperties.confirmation.banner.heading}, null)}">
+             th:replace="~{fragments/banners/confirmationPageBanner :: confirmationPageBanner(#{deregisterLandlord.withProperties.confirmation.banner.heading}, ~{::#confirmation-banner/content()})}">
+            <span th:text="#{deregisterLandlord.withProperties.confirmation.banner.body}">Body</span>
         </div>
-        <h1 class="govuk-heading-l" th:text="#{common.confirmationPage.whatHappensNext}">common.whatHappensNext</h1>
         <p class="govuk-body" th:text="#{deregisterLandlord.withProperties.confirmation.paragraph.one}">
             deregisterLandlord.withProperties.confirmation.paragraph.one
-        </p>
-        <p class="govuk-body" th:text="#{deregisterLandlord.withProperties.confirmation.paragraph.two}">
-            deregisterLandlord.withProperties.confirmation.paragraph.two
-        </p>
-        <p class="govuk-body" th:text="#{deregisterLandlord.withProperties.confirmation.paragraph.three}">
-            deregisterLandlord.withProperties.confirmation.paragraph.three
         </p>
     </div>
 </main>

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/LandlordDeregistrationJourneyTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/LandlordDeregistrationJourneyTests.kt
@@ -21,7 +21,7 @@ class LandlordDeregistrationJourneyTests : IntegrationTest() {
             landlordDetailsPage.deleteAccountButton.clickAndWait()
             val areYouSurePage = assertPageIs(page, AreYouSureFormPageLandlordDeregistration::class)
             assertThat(areYouSurePage.form.fieldsetHeading)
-                .containsText("Are you sure you want to delete your account and all your properties on the database?")
+                .containsText("Are you sure you want to delete your account and all your properties?")
             areYouSurePage.submitWantsToProceed()
 
             val reasonPage = assertPageIs(page, ReasonFormPageLandlordDeregistration::class)
@@ -30,11 +30,13 @@ class LandlordDeregistrationJourneyTests : IntegrationTest() {
             reasonPage.form.submit()
 
             val confirmationPage = assertPageIs(page, ConfirmationPageLandlordDeregistration::class)
-            assertThat(confirmationPage.confirmationBanner).containsText("You have deleted your account from the database")
+            assertThat(confirmationPage.confirmationBanner).containsText("Account deleted")
             assertTrue(
                 confirmationPage.page
                     .content()
-                    .contains("You have deleted your landlord information and all your properties from the database"),
+                    .contains(
+                        "You have deleted your landlord information and all your properties. We have sent you an email confirming this.",
+                    ),
             )
 
             // Check they can no longer access the landlord dashboard
@@ -50,12 +52,12 @@ class LandlordDeregistrationJourneyTests : IntegrationTest() {
             val landlordDetailsPage = navigator.goToLandlordDetails()
             landlordDetailsPage.deleteAccountButton.clickAndWait()
             val areYouSurePage = assertPageIs(page, AreYouSureFormPageLandlordDeregistration::class)
-            assertThat(areYouSurePage.form.fieldsetHeading).containsText("Are you sure you want to delete your account from the database?")
+            assertThat(areYouSurePage.form.fieldsetHeading).containsText("Are you sure you want to delete your account?")
             areYouSurePage.submitWantsToProceed()
 
             val confirmationPage = assertPageIs(page, ConfirmationPageLandlordDeregistration::class)
-            assertThat(confirmationPage.confirmationBanner).containsText("You have deleted your account from the database")
-            assertTrue(confirmationPage.page.content().contains("You have deleted your account from the database"))
+            assertThat(confirmationPage.confirmationBanner).containsText("Account deleted")
+            assertTrue(confirmationPage.page.content().contains("We have sent you a confirmation email."))
 
             // Check they can no longer access the landlord dashboard
             val landlordDashboard = navigator.goToLandlordDashboard()

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/LandlordDeregistrationSinglePageTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/LandlordDeregistrationSinglePageTests.kt
@@ -43,7 +43,7 @@ class LandlordDeregistrationSinglePageTests : IntegrationTest() {
             val areYouSurePage = navigator.goToLandlordDeregistrationAreYouSurePage()
             areYouSurePage.form.submit()
             assertThat(areYouSurePage.form.getErrorMessage("wantsToProceed"))
-                .containsText("Select whether you want to delete your account from the database")
+                .containsText("Select whether you want to delete your account")
         }
     }
 }


### PR DESCRIPTION
## Ticket number

PDJB-595

## Goal of change

Remove legacy "database" terminology from specific landlord-facing pages, per the Figma name audit.

## Description of main change(s)

Content-only changes (i18n YAML + a small Thymeleaf restructure of two confirmation pages); no controller, service, route, or behaviour changes.

- Landlord record page: rename "Database registration date" → "Registration date".
- Update landlord record warning: drop "on the database" from the warning sentence.
- Delete-account "Are you sure" page (with-properties + no-properties variants): drop "from/on the database" from the heading and hint, and from the no-properties radio error message (for consistency with the new heading).
- Delete-account confirmation pages (with-properties + no-properties): restructure to match Figma — the panel now shows heading + body ("Account deleted" / "No longer registered as a landlord"), the "What happens next" h1 is removed, and the body collapses to a single paragraph plus the existing email-confirmation line.
- Updates the affected integration / single-page test assertions to the new strings.

## Anything you'd like to highlight to the reviewer?

There will likely be more references found during smoke testing however.

## Checklist

- [x] New journey steps have been added to the appropriate journey integration test(s)
- [x] Test suite has been run in full locally and is passing (targeted: `LandlordDeregistrationJourneyTests`, `LandlordDeregistrationSinglePageTests`)
- [x] Branch has been rebased onto main and run locally, with everything working as expected
- [x] QA instructions have been added to the ticket
