### PR TITLE
PDJB-588: Feature-flag joint landlord sections in landlord privacy notice

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/LandlordPrivacyNoticeController.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/LandlordPrivacyNoticeController.kt
@@ -4,18 +4,22 @@ import org.springframework.ui.Model
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import uk.gov.communities.prsdb.webapp.annotations.webAnnotations.PrsdbController
+import uk.gov.communities.prsdb.webapp.config.managers.FeatureFlagManager
 import uk.gov.communities.prsdb.webapp.constants.COMPLAINTS_PROCEDURE_URL
 import uk.gov.communities.prsdb.webapp.constants.DATA_PROTECTION_COMMUNITIES_EMAILS
 import uk.gov.communities.prsdb.webapp.constants.DPO_COMMUNITIES_EMAILS
 import uk.gov.communities.prsdb.webapp.constants.INFORMATION_COMMISSIONERS_OFFICE_URL
 import uk.gov.communities.prsdb.webapp.constants.INFORMATION_COMMISSIONERS_OFFICE_URL_FOR_THE_PUBLIC
+import uk.gov.communities.prsdb.webapp.constants.JOINT_LANDLORDS
 import uk.gov.communities.prsdb.webapp.constants.LANDLORD_PATH_SEGMENT
 import uk.gov.communities.prsdb.webapp.constants.PRIVACY_NOTICE_PATH_SEGMENT
 import uk.gov.communities.prsdb.webapp.controllers.LandlordPrivacyNoticeController.Companion.LANDLORD_PRIVACY_NOTICE_ROUTE
 
 @PrsdbController
 @RequestMapping(LANDLORD_PRIVACY_NOTICE_ROUTE, "/$PRIVACY_NOTICE_PATH_SEGMENT")
-class LandlordPrivacyNoticeController {
+class LandlordPrivacyNoticeController(
+    private val featureFlagManager: FeatureFlagManager,
+) {
     @GetMapping
     fun getPrivacyNoticePage(model: Model): String {
         model.addAttribute("complaintsProcedureUrl", COMPLAINTS_PROCEDURE_URL)
@@ -26,6 +30,7 @@ class LandlordPrivacyNoticeController {
             INFORMATION_COMMISSIONERS_OFFICE_URL_FOR_THE_PUBLIC,
         )
         model.addAttribute("dpoEmail", DPO_COMMUNITIES_EMAILS)
+        model.addAttribute("jointLandlordsEnabled", featureFlagManager.checkFeature(JOINT_LANDLORDS))
         return "landlordPrivacyNotice"
     }
 

--- a/src/main/resources/templates/landlordPrivacyNotice.html
+++ b/src/main/resources/templates/landlordPrivacyNotice.html
@@ -31,13 +31,15 @@
                 <li th:text="#{privacyNotice.section.two.paragraph.one.bullet.six}">privacyNotice.section.two.paragraph.one.bullet.six</li>
                 <li th:text="#{privacyNotice.section.two.paragraph.one.bullet.seven}">privacyNotice.section.two.paragraph.one.bullet.seven</li>
             </ul>
-            <h3 class="govuk-heading-s" th:text="#{privacyNotice.section.two.paragraph.two.heading}">privacyNotice.section.two.paragraph.two.heading</h3>
-            <p class="govuk-body" th:text="#{privacyNotice.section.two.paragraph.two}">privacyNotice.section.two.paragraph.two</p>
-            <ul class="govuk-list govuk-list--bullet">
-                <li th:text="#{privacyNotice.section.two.paragraph.two.bullet.one}">privacyNotice.section.two.paragraph.two.bullet.one</li>
-                <li th:text="#{privacyNotice.section.two.paragraph.two.bullet.two}">privacyNotice.section.two.paragraph.two.bullet.two</li>
-                <li th:text="#{privacyNotice.section.two.paragraph.two.bullet.three}">privacyNotice.section.two.paragraph.two.bullet.three</li>
-            </ul>
+            <th:block th:if="${jointLandlordsEnabled}">
+                <h3 class="govuk-heading-s" th:text="#{privacyNotice.section.two.paragraph.two.heading}">privacyNotice.section.two.paragraph.two.heading</h3>
+                <p class="govuk-body" th:text="#{privacyNotice.section.two.paragraph.two}">privacyNotice.section.two.paragraph.two</p>
+                <ul class="govuk-list govuk-list--bullet">
+                    <li th:text="#{privacyNotice.section.two.paragraph.two.bullet.one}">privacyNotice.section.two.paragraph.two.bullet.one</li>
+                    <li th:text="#{privacyNotice.section.two.paragraph.two.bullet.two}">privacyNotice.section.two.paragraph.two.bullet.two</li>
+                    <li th:text="#{privacyNotice.section.two.paragraph.two.bullet.three}">privacyNotice.section.two.paragraph.two.bullet.three</li>
+                </ul>
+            </th:block>
             <h3 class="govuk-heading-s" th:text="#{privacyNotice.section.two.paragraph.three.heading}">privacyNotice.section.two.paragraph.three.heading</h3>
             <p class="govuk-body" th:text="#{privacyNotice.section.two.paragraph.three}">privacyNotice.section.two.paragraph.three</p>
             <ul class="govuk-list govuk-list--bullet">
@@ -115,12 +117,14 @@
             <p class="govuk-body" th:text="#{privacyNotice.section.four.paragraph.five}">privacyNotice.section.four.paragraph.five</p>
             <p class="govuk-body" th:text="#{privacyNotice.section.four.paragraph.six}">privacyNotice.section.four.paragraph.six</p>
             <p class="govuk-body" th:text="#{privacyNotice.section.four.paragraph.seven}">privacyNotice.section.four.paragraph.seven</p>
-            <p class="govuk-body" th:text="#{privacyNotice.section.four.paragraph.eight}">privacyNotice.section.four.paragraph.eight</p>
-            <ul class="govuk-list govuk-list--bullet">
-                <li th:text="#{privacyNotice.section.four.paragraph.eight.bullet.one}">privacyNotice.section.four.paragraph.eight.bullet.one</li>
-                <li th:text="#{privacyNotice.section.four.paragraph.eight.bullet.two}">privacyNotice.section.four.paragraph.eight.bullet.two</li>
-                <li th:text="#{privacyNotice.section.four.paragraph.eight.bullet.three}">privacyNotice.section.four.paragraph.eight.bullet.three</li>
-            </ul>
+            <th:block th:if="${jointLandlordsEnabled}">
+                <p class="govuk-body" th:text="#{privacyNotice.section.four.paragraph.eight}">privacyNotice.section.four.paragraph.eight</p>
+                <ul class="govuk-list govuk-list--bullet">
+                    <li th:text="#{privacyNotice.section.four.paragraph.eight.bullet.one}">privacyNotice.section.four.paragraph.eight.bullet.one</li>
+                    <li th:text="#{privacyNotice.section.four.paragraph.eight.bullet.two}">privacyNotice.section.four.paragraph.eight.bullet.two</li>
+                    <li th:text="#{privacyNotice.section.four.paragraph.eight.bullet.three}">privacyNotice.section.four.paragraph.eight.bullet.three</li>
+                </ul>
+            </th:block>
         </section>
         <section>
             <h2 class="govuk-heading-m" th:text="#{privacyNotice.section.five.heading}">privacyNotice.section.five.heading</h2>

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/controllers/LandlordPrivacyNoticeControllerTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/controllers/LandlordPrivacyNoticeControllerTests.kt
@@ -1,16 +1,23 @@
 package uk.gov.communities.prsdb.webapp.controllers
 
 import org.junit.jupiter.api.Test
+import org.mockito.kotlin.whenever
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
 import org.springframework.security.test.context.support.WithMockUser
+import org.springframework.test.context.bean.override.mockito.MockitoBean
 import org.springframework.test.web.servlet.get
 import org.springframework.web.context.WebApplicationContext
+import uk.gov.communities.prsdb.webapp.config.managers.FeatureFlagManager
+import uk.gov.communities.prsdb.webapp.constants.JOINT_LANDLORDS
 
 @WebMvcTest(LandlordPrivacyNoticeController::class)
 class LandlordPrivacyNoticeControllerTests(
     @Autowired val webContext: WebApplicationContext,
 ) : ControllerTest(webContext) {
+    @MockitoBean
+    lateinit var featureFlagManager: FeatureFlagManager
+
     @Test
     fun `LandlordPrivacyNoticeController returns 200 for unauthenticated user`() {
         mvc.get(LandlordPrivacyNoticeController.LANDLORD_PRIVACY_NOTICE_ROUTE).andExpect {
@@ -30,6 +37,24 @@ class LandlordPrivacyNoticeControllerTests(
     fun `LandlordPrivacyNoticeController returns 200 for authenticated user`() {
         mvc.get(LandlordPrivacyNoticeController.LANDLORD_PRIVACY_NOTICE_ROUTE).andExpect {
             status { isOk() }
+        }
+    }
+
+    @Test
+    fun `LandlordPrivacyNoticeController sets jointLandlordsEnabled to true when JOINT_LANDLORDS is enabled`() {
+        whenever(featureFlagManager.checkFeature(JOINT_LANDLORDS)).thenReturn(true)
+        mvc.get(LandlordPrivacyNoticeController.LANDLORD_PRIVACY_NOTICE_ROUTE).andExpect {
+            status { isOk() }
+            model { attribute("jointLandlordsEnabled", true) }
+        }
+    }
+
+    @Test
+    fun `LandlordPrivacyNoticeController sets jointLandlordsEnabled to false when JOINT_LANDLORDS is disabled`() {
+        whenever(featureFlagManager.checkFeature(JOINT_LANDLORDS)).thenReturn(false)
+        mvc.get(LandlordPrivacyNoticeController.LANDLORD_PRIVACY_NOTICE_ROUTE).andExpect {
+            status { isOk() }
+            model { attribute("jointLandlordsEnabled", false) }
         }
     }
 }


### PR DESCRIPTION
## Ticket number

PDJB-588

## Goal of change

Hide the joint-landlord-specific sections of the landlord privacy notice while the joint-landlords feature is not yet released.

## Description of main change(s)

- Section 2.1.1 (Joint Landlord personal data) and section 4.7 (Specific Requirement for Joint Landlords) of the landlord privacy notice are now only shown when the existing `joint-landlords` feature flag is enabled.
- `LandlordPrivacyNoticeController` now adds a `jointLandlordsEnabled` model attribute derived from `FeatureFlagManager.checkFeature(JOINT_LANDLORDS)`, and the template wraps each affected section in a `<th:block th:if="""">`.

## Anything you'd like to highlight to the reviewer?

- Used `FeatureFlagManager.checkFeature` directly in the controller (rather than `@AvailableWhenFeatureEnabled` or `@PrsdbFlip`) because the flag only toggles the visibility of two sub-sections within an otherwise unchanged page.
- Smoke-tested locally with the flag both on and off; the sections appear/disappear as expected and the rest of the notice is unaffected.

## Checklist

- [x] Controller tests for any new endpoints, including testing the relevant permissions
- [x] Branch has been rebased onto main and run locally, with everything working as expected (both for your new feature and any related functionality)

Other checklist items are not applicable: no UI screenshots (text-only conditional render), no new endpoints, no journey/integration changes, no email templates, no schema/seed data changes, no full test suite run (targeted tests only as agreed), no TODO comments added.