### PR TITLE
chore(PDJB-595): name audit landlord web UI

### DIFF
--- a/src/main/resources/messages/deregisterLandlord.yml
+++ b/src/main/resources/messages/deregisterLandlord.yml
@@ -5,11 +5,13 @@ noProperties:
       heading: Account deleted
       body: No longer registered as a landlord
     paragraph:
-      one: We have sent you a confirmation email. You’ll need to register a new account if you become a landlord again.
+      one: We have sent you a confirmation email.
+      two: You’ll need to register a new account if you become a landlord again.
 withProperties:
   confirmation:
     banner:
       heading: Account deleted
       body: No longer registered as a landlord
     paragraph:
-      one: You have deleted your landlord information and all your properties. We have sent you an email confirming this. You’ll need to register a new account if you become a landlord again.
+      one: You have deleted your landlord information and all your properties. We have sent you an email confirming this.
+      two: You’ll need to register a new account if you become a landlord again.

--- a/src/main/resources/templates/deregisterLandlordWithNoPropertiesConfirmation.html
+++ b/src/main/resources/templates/deregisterLandlordWithNoPropertiesConfirmation.html
@@ -10,6 +10,9 @@
         <p class="govuk-body" th:text="#{deregisterLandlord.noProperties.confirmation.paragraph.one}">
             deregisterLandlord.noProperties.confirmation.paragraph.one
         </p>
+        <p class="govuk-body" th:text="#{deregisterLandlord.noProperties.confirmation.paragraph.two}">
+            deregisterLandlord.noProperties.confirmation.paragraph.two
+        </p>
     </div>
 </main>
 </html>

--- a/src/main/resources/templates/deregisterLandlordWithRegisteredPropertiesConfirmation.html
+++ b/src/main/resources/templates/deregisterLandlordWithRegisteredPropertiesConfirmation.html
@@ -10,6 +10,9 @@
         <p class="govuk-body" th:text="#{deregisterLandlord.withProperties.confirmation.paragraph.one}">
             deregisterLandlord.withProperties.confirmation.paragraph.one
         </p>
+        <p class="govuk-body" th:text="#{deregisterLandlord.withProperties.confirmation.paragraph.two}">
+            deregisterLandlord.withProperties.confirmation.paragraph.two
+        </p>
     </div>
 </main>
 </html>


### PR DESCRIPTION
## Ticket number

PDJB-595

## Goal of change

Address QA feedback on the landlord deregistration confirmation pages from the original PDJB-595 PR (#1277).

## Description of main change(s)

Restores the paragraph break on the landlord deregistration confirmation pages (both the no-properties and with-properties variants) to match the Figma. The body copy on each page is now split across two `<p>` elements rather than a single one.

## Anything you'd like to highlight to the reviewer?

Pure copy / template change – no behavioural changes. Existing integration test assertions still hold as they only check the first sentence is present in the page content.

## Checklist

- [x] Screenshots of any UI changes have been added (on the ticket)
- [x] Branch has been rebased onto main and run locally, with everything working as expected
- [x] QA instructions have been added to the ticket
