### PR TITLE
PDJB-868: Add uploads to per-user directory

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/helpers/PropertyComplianceJourneyHelper.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/helpers/PropertyComplianceJourneyHelper.kt
@@ -1,8 +1,11 @@
 package uk.gov.communities.prsdb.webapp.helpers
 
+import org.springframework.security.core.context.SecurityContextHolder
 import uk.gov.communities.prsdb.webapp.constants.enums.CertificateType
 import uk.gov.communities.prsdb.webapp.journeys.propertyCompliance.steps.EicrUploadStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyCompliance.steps.GasSafetyCertificateUploadStep
+import java.nio.ByteBuffer
+import java.security.MessageDigest
 
 class PropertyComplianceJourneyHelper {
     // TODO PDJB-748 Rename this helper class
@@ -18,14 +21,26 @@ class PropertyComplianceJourneyHelper {
             memberId: String?,
         ): String =
             if (memberId != null) {
-                "certificateUpload.$journeyId.$stepName.$memberId"
+                "${directory()}/certificateUpload.$journeyId.$stepName.$memberId"
             } else {
-                "certificateUpload.$journeyId.$stepName.${randomSuffix()}"
+                "${directory()}/certificateUpload.$journeyId.$stepName.${randomSuffix()}"
             }
 
         private fun randomSuffix(): String {
             val allowedChars = ('a'..'z')
             return String(CharArray(5) { allowedChars.random() })
+        }
+
+        private fun directory(): String {
+            val userName = SecurityContextHolder.getContext().authentication.name
+
+            val digest = MessageDigest.getInstance("MD5").digest(userName.toByteArray())
+
+            return ByteBuffer
+                .wrap(digest)
+                .long
+                .toULong()
+                .toString(36)
         }
 
         fun getCertFilename(

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/local/services/LocalFileUploader.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/local/services/LocalFileUploader.kt
@@ -16,7 +16,7 @@ import java.io.InputStream
 class LocalFileUploader(
     private val uploadRepository: FileUploadRepository,
 ) : FileUploader {
-    private val forbiddenFilenameCharacters = listOf(':', '<', '>', '"', '?', '*', '&', '/', '\\', ',')
+    private val forbiddenFilenameCharacters = listOf(':', '<', '>', '"', '?', '*', '&', '\\', ',')
 
     override fun uploadFile(
         objectKey: String,
@@ -26,7 +26,9 @@ class LocalFileUploader(
             objectKey
                 .map { char -> if (char in forbiddenFilenameCharacters) "" else char }
                 .joinToString("")
-        File(".local-uploads").mkdir()
+
+        makeAllDirectories(cleanObjectKey)
+
         val destinationRoute = ".local-uploads/$cleanObjectKey"
         val destinationFile = File(destinationRoute)
         destinationFile.outputStream().use { outputStream ->
@@ -40,5 +42,14 @@ class LocalFileUploader(
             eTag = objectKey,
             versionId = Clock.System.now().toString(),
         )
+    }
+
+    private fun makeAllDirectories(cleanObjectKey: String) {
+        val directories = cleanObjectKey.split('/').dropLast(1)
+        File(".local-uploads").mkdir()
+        directories.fold(".local-uploads") { a, b ->
+            File("$a/$b").mkdir()
+            "$a/$b"
+        }
     }
 }


### PR DESCRIPTION
## Ticket number
PDJB-868

## Goal of change
Puts uploads in a directory created by hashing the user name to prevent collisions.

## Anything you'd like to highlight to the reviewer?
"Long" gives us 64 bits of hash, which means that if we had 10 million users we would have approximately .0005% chance of having one collision. The chance of two users who share a user hash also sharing a journey id is therefore even lower.