### PR TITLE
PDJB-NONE: Add JVM metrics export to CloudWatch and unpin builder image

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,5 @@
 import org.gradle.internal.os.OperatingSystem
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
-import org.springframework.boot.gradle.tasks.bundling.BootBuildImage
 
 plugins {
     kotlin("jvm") version "1.9.25"
@@ -58,6 +57,10 @@ dependencies {
     // Templating
     implementation("org.springframework.boot:spring-boot-starter-thymeleaf")
     implementation("org.thymeleaf.extras:thymeleaf-extras-springsecurity6")
+
+    // Observability
+    implementation("org.springframework.boot:spring-boot-starter-actuator")
+    implementation("io.micrometer:micrometer-registry-cloudwatch2")
 
     // External service clients
     implementation("uk.gov.service.notify:notifications-java-client:5.2.1-RELEASE")
@@ -133,14 +136,6 @@ tasks.register<Copy>("copyBuiltAssets") {
 
 tasks.withType<KotlinCompile> {
     dependsOn("copyBuiltAssets")
-}
-
-tasks.named<BootBuildImage>("bootBuildImage") {
-    // Pinned to the Paketo builder that was `latest` on Friday 2026-05-01.
-    // Newer builders pulled during a rebuild (0.0.132 Sun, 0.0.133 Mon) are suspected of
-    // introducing a memory leak. Update deliberately after verification.
-    // The run image is whatever this builder references in its metadata.
-    builder.set("paketobuildpacks/builder-noble-java-tiny@sha256:360357383e19ee1d85fd245360f49e981992a959231576ea40e705188106c9e7")
 }
 
 tasks.withType<Test> {

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/config/MetricsConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/config/MetricsConfig.kt
@@ -1,0 +1,11 @@
+package uk.gov.communities.prsdb.webapp.config
+
+import io.micrometer.core.instrument.config.MeterFilter
+import org.springframework.context.annotation.Bean
+import uk.gov.communities.prsdb.webapp.annotations.webAnnotations.PrsdbWebConfiguration
+
+@PrsdbWebConfiguration
+class MetricsConfig {
+    @Bean
+    fun denyHttpServerRequestMetrics(): MeterFilter = MeterFilter.denyNameStartsWith("http.server.requests")
+}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -75,6 +75,12 @@ aws:
     quarantineBucket: ${AWS_QUARANTINE_BUCKET:prsdb-quarantine-integration}
     safeBucket: ${S3_SAFE_BUCKET_KEY:prsdb-uploaded-files-integration}
 
+management:
+  metrics:
+    export:
+      cloudwatch:
+        enabled: false
+
 plausible:
   site-id: local-no-analytics
 

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -76,6 +76,10 @@ aws:
     safeBucket: ${S3_SAFE_BUCKET_KEY:prsdb-uploaded-files-integration}
 
 management:
+  endpoints:
+    web:
+      exposure:
+        include: metrics,health,info
   metrics:
     export:
       cloudwatch:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -64,6 +64,18 @@ aws:
     quarantineBucket: ${AWS_QUARANTINE_BUCKET}
     safeBucket: ${S3_SAFE_BUCKET_KEY}
 
+management:
+  endpoints:
+    web:
+      exposure:
+        include: ""
+  metrics:
+    export:
+      cloudwatch:
+        namespace: ${METRICS_CLOUDWATCH_NAMESPACE}
+        step: 1m
+        batch-size: 20
+
 base-url:
   landlord: ${LANDLORD_BASE_URL}
   local-council: ${LOCAL_COUNCIL_BASE_URL}


### PR DESCRIPTION
## Ticket number

PDJB-NONE

## Goal of change

Add minimal JVM and process metrics export to CloudWatch so we can determine whether the ongoing memory growth in ECS is heap-internal or native (off-heap), and revert the builder pin from #1289 since it did not stop the leak.

## Description of main change(s)

- Adds `spring-boot-starter-actuator` and `micrometer-registry-cloudwatch2` dependencies
- Configures Micrometer to push metrics (JVM memory, GC, threads, classloader, process, Hikari, Tomcat, etc.) to CloudWatch every 1 minute under a namespace supplied via the `METRICS_CLOUDWATCH_NAMESPACE` env var
- Does **not** expose any actuator HTTP endpoints (`management.endpoints.web.exposure.include` is empty) — registry is push-only, no new attack surface, and the existing `HEALTHCHECK_ROUTE` controller is untouched
- Disables the CloudWatch registry in the `local` profile
- Removes the Paketo builder pin added in #1289 to allow leak to be investigated independently of the base image.

## Checklist

- [x] Branch has been rebased onto main and run locally, with everything working as expected (both for your new feature
  and any related functionality)
