### PR TITLE
PDJB-NONE: Correct CloudWatch metrics property path for Spring Boot 3.x

### DIFF
--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -80,9 +80,9 @@ management:
     web:
       exposure:
         include: metrics,health,info
-  metrics:
-    export:
-      cloudwatch:
+  cloudwatch:
+    metrics:
+      export:
         enabled: false
 
 plausible:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -69,9 +69,9 @@ management:
     web:
       exposure:
         include: ""
-  metrics:
-    export:
-      cloudwatch:
+  cloudwatch:
+    metrics:
+      export:
         namespace: ${METRICS_CLOUDWATCH_NAMESPACE}
         step: 1m
         batch-size: 20


### PR DESCRIPTION
## Ticket number

PDJB-NONE

## Goal of change

Fix CloudWatch metrics export, which silently failed to publish anything after #1293 was deployed.

## Description of main change(s)

- Moves the CloudWatch registry config from `management.metrics.export.cloudwatch.*` to `management.cloudwatch.metrics.export.*` in both `application.yml` and `application-local.yml`.