### PR TITLE
PDJB-NONE: Use Spring Cloud AWS to autoconfigure CloudWatch metrics export

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -60,6 +60,8 @@ dependencies {
 
     // Observability
     implementation("org.springframework.boot:spring-boot-starter-actuator")
+    implementation(platform("io.awspring.cloud:spring-cloud-aws-dependencies:3.4.2"))
+    implementation("io.awspring.cloud:spring-cloud-aws-starter-metrics")
     implementation("io.micrometer:micrometer-registry-cloudwatch2")
 
     // External service clients

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -38,6 +38,11 @@ spring:
       ssl:
         enabled: false
 
+  cloud:
+    aws:
+      cloudwatch:
+        enabled: false
+
 one-login:
   jwt:
     # We provide a default for the keys if the env vars are missing: this allows us to keep the keys in uncommitted
@@ -80,10 +85,6 @@ management:
     web:
       exposure:
         include: metrics,health,info
-  metrics:
-    export:
-      cloudwatch:
-        enabled: false
 
 plausible:
   site-id: local-no-analytics

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -69,12 +69,11 @@ management:
     web:
       exposure:
         include: ""
-  metrics:
-    export:
-      cloudwatch:
+  cloudwatch:
+    metrics:
+      export:
         namespace: ${METRICS_CLOUDWATCH_NAMESPACE}
         step: 1m
-        batch-size: 20
 
 base-url:
   landlord: ${LANDLORD_BASE_URL}


### PR DESCRIPTION
## Ticket number

PDJB-NONE

## Goal of change

Make CloudWatch metrics export actually work — neither #1293 nor #1296 did, because Spring Boot 3.x has no built-in CloudWatch autoconfig.

## Description of main change(s)

- Adds Spring Cloud AWS BOM (3.4.2) and `spring-cloud-aws-starter-metrics`, which provides the autoconfig.
- Updates property paths in `application.yml` and `application-local.yml` to those Spring Cloud AWS actually binds.