### PR TITLE
PDJB-768: Route compliance tasks back to task list after completion

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/UpdateEpcController.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/UpdateEpcController.kt
@@ -17,7 +17,7 @@ import uk.gov.communities.prsdb.webapp.controllers.UpdateEpcController.Companion
 import uk.gov.communities.prsdb.webapp.journeys.FormData
 import uk.gov.communities.prsdb.webapp.journeys.JourneyStateService
 import uk.gov.communities.prsdb.webapp.journeys.NoSuchJourneyException
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.update.epc.StartEpcUpdateStep
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.StartEpcStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.update.epc.UpdateEpcJourneyFactory
 import uk.gov.communities.prsdb.webapp.services.PropertyOwnershipService
 import java.security.Principal
@@ -86,6 +86,6 @@ class UpdateEpcController(
             UPDATE_EPC_ROUTE.replace("{propertyOwnershipId}", propertyOwnershipId.toString())
 
         fun getUpdateEpcRouteFirstStep(propertyOwnershipId: Long): String =
-            getUpdateEpcRoute(propertyOwnershipId) + "/${StartEpcUpdateStep.ROUTE_SEGMENT}"
+            getUpdateEpcRoute(propertyOwnershipId) + "/${StartEpcStep.ROUTE_SEGMENT}"
     }
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/PropertyRegistrationJourneyFactory.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/PropertyRegistrationJourneyFactory.kt
@@ -310,11 +310,13 @@ class PropertyRegistrationJourneyFactory(
                 }
                 task(journey.electricalSafetyTask) {
                     parents { journey.gasSafetyTask.isComplete() }
+                    backStep { journey.taskListStep }
                     nextStep { journey.taskListStep }
                     saveProgress()
                 }
                 task(journey.epcTask) {
                     parents { journey.electricalSafetyTask.isComplete() }
+                    backStep { journey.taskListStep }
                     nextStep { journey.taskListStep }
                     saveProgress()
                 }
@@ -323,6 +325,7 @@ class PropertyRegistrationJourneyFactory(
                 withHeadingMessageKey("registerProperty.taskList.checkAndSubmit.heading")
                 step(journey.cyaStep) {
                     routeSegment(PropertyRegistrationCyaStep.ROUTE_SEGMENT)
+                    backStep { journey.taskListStep }
                     parents {
                         journey.epcTask.isComplete()
                     }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/PropertyRegistrationJourneyFactory.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/PropertyRegistrationJourneyFactory.kt
@@ -91,6 +91,7 @@ import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.RentF
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.RentIncludesBillsStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.SavePropertyRegistrationDataStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.SelectiveLicenceStep
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.StartEpcStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.TenantsStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.UploadElectricalCertStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.UploadGasCertStep
@@ -457,6 +458,7 @@ class PropertyRegistrationJourney(
     // EPC task
     override val epcTask: EpcTask,
     override val epcDetailsTask: EpcDetailsTask,
+    override val startEpcStep: StartEpcStep,
     override val epcLookupByUprnStep: EpcLookupByUprnStep,
     override val hasEpcStep: HasEpcStep,
     override val checkUprnMatchedEpcStep: ConfirmEpcRetrievedByUprnStep,

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/PropertyRegistrationJourneyFactory.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/PropertyRegistrationJourneyFactory.kt
@@ -305,17 +305,17 @@ class PropertyRegistrationJourneyFactory(
                             ifDisabled { journey.occupationTask.isComplete() }
                         }
                     }
-                    nextStep { journey.electricalSafetyTask.firstStep }
+                    nextStep { journey.taskListStep }
                     saveProgress()
                 }
                 task(journey.electricalSafetyTask) {
                     parents { journey.gasSafetyTask.isComplete() }
-                    nextStep { journey.epcTask.firstStep }
+                    nextStep { journey.taskListStep }
                     saveProgress()
                 }
                 task(journey.epcTask) {
                     parents { journey.electricalSafetyTask.isComplete() }
-                    nextStep { journey.cyaStep }
+                    nextStep { journey.taskListStep }
                     saveProgress()
                 }
             }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/states/EpcState.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/states/EpcState.kt
@@ -22,6 +22,7 @@ import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.LowEn
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.MeesExemptionStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.PropertyOccupiedCheckStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.ProvideEpcLaterStep
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.StartEpcStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.EpcDetailsTask
 import uk.gov.communities.prsdb.webapp.models.dataModels.EpcDataModel
 
@@ -47,6 +48,7 @@ interface EpcState : JourneyState {
                 null
             }
 
+    val startEpcStep: StartEpcStep
     val epcLookupByUprnStep: EpcLookupByUprnStep
     val hasEpcStep: HasEpcStep
     val checkUprnMatchedEpcStep: ConfirmEpcRetrievedByUprnStep

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/StartEpcStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/StartEpcStepConfig.kt
@@ -1,4 +1,4 @@
-package uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.update.epc
+package uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps
 
 import uk.gov.communities.prsdb.webapp.annotations.webAnnotations.JourneyFrameworkComponent
 import uk.gov.communities.prsdb.webapp.journeys.AbstractRequestableStepConfig
@@ -9,7 +9,7 @@ import uk.gov.communities.prsdb.webapp.journeys.shared.Complete
 import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.NoInputFormModel
 
 @JourneyFrameworkComponent
-class StartEpcUpdateStepConfig : AbstractRequestableStepConfig<Complete, NoInputFormModel, JourneyState>() {
+class StartEpcStepConfig : AbstractRequestableStepConfig<Complete, NoInputFormModel, JourneyState>() {
     override val formModelClass = NoInputFormModel::class
 
     override fun getStepLifecycleOrchestrator(journeyStep: JourneyStep<*, *, *>) = RedirectingStepLifecycleOrchestrator(journeyStep)
@@ -22,8 +22,8 @@ class StartEpcUpdateStepConfig : AbstractRequestableStepConfig<Complete, NoInput
 }
 
 @JourneyFrameworkComponent
-final class StartEpcUpdateStep(
-    stepConfig: StartEpcUpdateStepConfig,
+final class StartEpcStep(
+    stepConfig: StartEpcStepConfig,
 ) : JourneyStep.RequestableStep<Complete, NoInputFormModel, JourneyState>(stepConfig) {
     companion object {
         const val ROUTE_SEGMENT = "start"

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/tasks/EpcDetailsTask.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/tasks/EpcDetailsTask.kt
@@ -3,6 +3,7 @@ package uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks
 import uk.gov.communities.prsdb.webapp.annotations.webAnnotations.JourneyFrameworkComponent
 import uk.gov.communities.prsdb.webapp.journeys.OrParents
 import uk.gov.communities.prsdb.webapp.journeys.Task
+import uk.gov.communities.prsdb.webapp.journeys.always
 import uk.gov.communities.prsdb.webapp.journeys.hasOutcome
 import uk.gov.communities.prsdb.webapp.journeys.isComplete
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.EpcState
@@ -30,13 +31,19 @@ import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.IsEpc
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.LowEnergyRatingStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.MeesExemptionStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.ProvideEpcLaterStep
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.StartEpcStep
 import uk.gov.communities.prsdb.webapp.journeys.shared.YesOrNo
 
 @JourneyFrameworkComponent("propertyRegistrationEpcDetailsTask")
 class EpcDetailsTask : Task<EpcState>() {
     override fun makeSubJourney(state: EpcState) =
         subJourney(state) {
+            step(journey.startEpcStep) {
+                routeSegment(StartEpcStep.ROUTE_SEGMENT)
+                nextStep { journey.epcLookupByUprnStep }
+            }
             step(journey.epcLookupByUprnStep) {
+                parents { journey.startEpcStep.always() }
                 nextStep { mode ->
                     when (mode) {
                         EpcLookupByUprnMode.EPC_FOUND -> journey.checkUprnMatchedEpcStep

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/tasks/EpcTask.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/tasks/EpcTask.kt
@@ -16,7 +16,7 @@ class EpcTask : Task<EpcState>() {
                     exitStep.isStepReachable -> TaskStatus.COMPLETED
                     journey.checkUprnMatchedEpcStep.outcome != null -> TaskStatus.IN_PROGRESS
                     journey.hasEpcStep.outcome != null -> TaskStatus.IN_PROGRESS
-                    journey.epcLookupByUprnStep.isStepReachable -> TaskStatus.NOT_STARTED
+                    journey.startEpcStep.isStepReachable -> TaskStatus.NOT_STARTED
                     else -> TaskStatus.CANNOT_START
                 }
             }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/update/epc/UpdateEpcJourneyFactory.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/update/epc/UpdateEpcJourneyFactory.kt
@@ -33,6 +33,7 @@ import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.LowEn
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.MeesExemptionStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.PropertyOccupiedCheckStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.ProvideEpcLaterStep
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.StartEpcStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.EpcDetailsTask
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.EpcTask
 import uk.gov.communities.prsdb.webapp.models.dataModels.EpcDataModel
@@ -68,14 +69,9 @@ class UpdateEpcJourneyFactory(
 
         return journey(state) {
             unreachableStepUrl { propertyComplianceRoute }
-            step(journey.startEpcUpdateStep) {
-                routeSegment(StartEpcUpdateStep.ROUTE_SEGMENT)
-                initialStep()
-                nextStep { journey.epcTask.firstStep }
-            }
             task(journey.epcTask) {
                 backUrl { propertyComplianceRoute }
-                parents { journey.startEpcUpdateStep.isComplete() }
+                initialStep()
                 nextStep { journey.completeEpcUpdateStep }
                 withAdditionalContentProperties {
                     mapOf(
@@ -124,7 +120,7 @@ class UpdateEpcJourney(
     override val checkEpcAnswersStep: CheckEpcAnswersStep,
     override val epcDetailsTask: EpcDetailsTask,
     override val completeEpcUpdateStep: CompleteEpcUpdateStep,
-    override val startEpcUpdateStep: StartEpcUpdateStep,
+    override val startEpcStep: StartEpcStep,
 ) : AbstractPropertyOwnershipUpdateJourneyState(journeyStateService, journeyName),
     UpdateEpcJourneyState {
     private val delegateProvider = JourneyStateDelegateProvider(journeyStateService)
@@ -144,10 +140,11 @@ class UpdateEpcJourney(
     override val allowProvideCertificateLaterRoute: Boolean = false
 }
 
-interface UpdateEpcJourneyState : JourneyState, EpcState {
+interface UpdateEpcJourneyState :
+    JourneyState,
+    EpcState {
     val propertyId: Long
     val lastModifiedDate: String
     val epcTask: EpcTask
     val completeEpcUpdateStep: CompleteEpcUpdateStep
-    val startEpcUpdateStep: StartEpcUpdateStep
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/PropertyRegistrationJourneyTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/PropertyRegistrationJourneyTests.kt
@@ -361,6 +361,8 @@ class PropertyRegistrationJourneyTests : IntegrationTestWithMutableData("data-lo
         assertThat(checkGasSafetyAnswersPage.sectionHeader).containsText(propertyRegistrationSectionHeader)
         assertThat(checkGasSafetyAnswersPage.heading).containsText("Gas safety certificate")
         checkGasSafetyAnswersPage.form.submit()
+        val taskListPageAfterGasSafety = assertPageIs(page, TaskListPagePropertyRegistration::class)
+        taskListPageAfterGasSafety.clickRegisterTaskWithName("Electrical safety certificate")
         val hasElectricalCertPage = assertPageIs(page, HasElectricalCertFormPagePropertyRegistration::class)
 
         // Has Electrical Cert - render page
@@ -422,8 +424,10 @@ class PropertyRegistrationJourneyTests : IntegrationTestWithMutableData("data-lo
         assertThat(checkElectricalSafetyAnswersPage.sectionHeader).containsText(propertyRegistrationSectionHeader)
         assertThat(checkElectricalSafetyAnswersPage.heading).containsText("Electrical safety certificate")
         checkElectricalSafetyAnswersPage.form.submit()
+        val taskListPageAfterElectricalSafety = assertPageIs(page, TaskListPagePropertyRegistration::class)
 
         // EpcLookupByUprnStep finds the EPC, so redirects to Check UPRN matched EPC
+        taskListPageAfterElectricalSafety.clickRegisterTaskWithName("Energy performance certificate (EPC)")
         val confirmUprnMatchedEpcDetailsPage = assertPageIs(page, ConfirmEpcDetailsRetrievedByUprnFormPagePropertyRegistration::class)
 
         // Confirm UPRN matched EPC - submit No (don't use this EPC)
@@ -466,6 +470,8 @@ class PropertyRegistrationJourneyTests : IntegrationTestWithMutableData("data-lo
         assertThat(checkEpcAnswersPage.sectionHeader).containsText(propertyRegistrationSectionHeader)
         assertThat(checkEpcAnswersPage.heading).containsText("Energy performance certificate (EPC)")
         checkEpcAnswersPage.form.submit()
+        val taskListPageAfterEpc = assertPageIs(page, TaskListPagePropertyRegistration::class)
+        taskListPageAfterEpc.clickCheckAndSubmitTaskWithName("Check and submit your answers")
         val checkAnswersPage = assertPageIs(page, CheckAnswersPagePropertyRegistration::class)
 
         // Check answers - render page
@@ -607,6 +613,8 @@ class PropertyRegistrationJourneyTests : IntegrationTestWithMutableData("data-lo
         // Check Gas Safety Answers - render page
         assertThat(checkGasSafetyAnswersPage.heading).containsText("Gas safety certificate")
         checkGasSafetyAnswersPage.form.submit()
+        val taskListPageAfterGasSafety = assertPageIs(page, TaskListPagePropertyRegistration::class)
+        taskListPageAfterGasSafety.clickRegisterTaskWithName("Electrical safety certificate")
         val hasElectricalCertPage = assertPageIs(page, HasElectricalCertFormPagePropertyRegistration::class)
 
         // Has Electrical Cert - render page
@@ -626,9 +634,11 @@ class PropertyRegistrationJourneyTests : IntegrationTestWithMutableData("data-lo
         // Check Electrical Safety Answers - render page
         assertThat(checkElectricalSafetyAnswersPage.heading).containsText("Electrical safety certificate")
         checkElectricalSafetyAnswersPage.form.submit()
+        val taskListPageAfterElectricalSafety = assertPageIs(page, TaskListPagePropertyRegistration::class)
 
         // We use a manual address, uprn will be null.
         // The internal EpcLookupByUprnStep at the start of the EpcTask will not find an EPC
+        taskListPageAfterElectricalSafety.clickRegisterTaskWithName("Energy performance certificate (EPC)")
         val hasEpcPage = assertPageIs(page, HasEpcFormPagePropertyRegistration::class)
 
         // Has EPC - render page
@@ -653,6 +663,8 @@ class PropertyRegistrationJourneyTests : IntegrationTestWithMutableData("data-lo
         // Check EPC Answers - render page
         assertThat(checkEpcAnswersPage.heading).containsText("Energy performance certificate (EPC)")
         checkEpcAnswersPage.form.submit()
+        val taskListPageAfterEpc = assertPageIs(page, TaskListPagePropertyRegistration::class)
+        taskListPageAfterEpc.clickCheckAndSubmitTaskWithName("Check and submit your answers")
         val checkAnswersPage = assertPageIs(page, CheckAnswersPagePropertyRegistration::class)
 
         // Check answers - render page
@@ -708,6 +720,8 @@ class PropertyRegistrationJourneyTests : IntegrationTestWithMutableData("data-lo
         // Check Gas Safety Answers - render page
         assertThat(checkGasSafetyAnswersPage.heading).containsText("Gas safety certificate")
         checkGasSafetyAnswersPage.form.submit()
+        val taskListPageAfterGasSafety = assertPageIs(page, TaskListPagePropertyRegistration::class)
+        taskListPageAfterGasSafety.clickRegisterTaskWithName("Electrical safety certificate")
         val hasElectricalCertPage = assertPageIs(page, HasElectricalCertFormPagePropertyRegistration::class)
 
         // Has Electrical Cert - render page
@@ -729,7 +743,10 @@ class PropertyRegistrationJourneyTests : IntegrationTestWithMutableData("data-lo
         // Check Electrical Safety Answers - render page
         assertThat(checkElectricalSafetyAnswersPage.heading).containsText("Electrical safety certificate")
         checkElectricalSafetyAnswersPage.form.submit()
+        val taskListPageAfterElectricalSafety = assertPageIs(page, TaskListPagePropertyRegistration::class)
+
         // The internal EpcLookupByUprnStep at the start of the EpcTask does not find an EPC
+        taskListPageAfterElectricalSafety.clickRegisterTaskWithName("Energy performance certificate (EPC)")
         val hasEpcPage = assertPageIs(page, HasEpcFormPagePropertyRegistration::class)
 
         // Has EPC - render page
@@ -750,6 +767,7 @@ class PropertyRegistrationJourneyTests : IntegrationTestWithMutableData("data-lo
         // Check EPC Answers - render page
         assertThat(checkEpcAnswersPage.heading).containsText("Energy performance certificate (EPC)")
         checkEpcAnswersPage.form.submit()
+        assertPageIs(page, TaskListPagePropertyRegistration::class)
     }
 
     @Test
@@ -778,6 +796,8 @@ class PropertyRegistrationJourneyTests : IntegrationTestWithMutableData("data-lo
         // Check Gas Safety Answers - render page
         assertThat(checkGasSafetyAnswersPage.heading).containsText("Gas safety certificate")
         checkGasSafetyAnswersPage.form.submit()
+        val taskListPageAfterGasSafety = assertPageIs(page, TaskListPagePropertyRegistration::class)
+        taskListPageAfterGasSafety.clickRegisterTaskWithName("Electrical safety certificate")
         val hasElectricalCertPage = assertPageIs(page, HasElectricalCertFormPagePropertyRegistration::class)
 
         // Has Electrical Cert - render page
@@ -803,7 +823,10 @@ class PropertyRegistrationJourneyTests : IntegrationTestWithMutableData("data-lo
         // Check Electrical Safety Answers - render page
         assertThat(checkElectricalSafetyAnswersPage.heading).containsText("Electrical safety certificate")
         checkElectricalSafetyAnswersPage.form.submit()
+        val taskListPageAfterElectricalSafety = assertPageIs(page, TaskListPagePropertyRegistration::class)
+
         // The internal EpcLookupByUprnStep at the start of the EpcTask does not find an EPC
+        taskListPageAfterElectricalSafety.clickRegisterTaskWithName("Energy performance certificate (EPC)")
         val hasEpcPage = assertPageIs(page, HasEpcFormPagePropertyRegistration::class)
 
         // Has EPC - render page
@@ -822,6 +845,7 @@ class PropertyRegistrationJourneyTests : IntegrationTestWithMutableData("data-lo
         // Check EPC Answers - render page
         assertThat(checkEpcAnswersPage.heading).containsText("Energy performance certificate (EPC)")
         checkEpcAnswersPage.form.submit()
+        assertPageIs(page, TaskListPagePropertyRegistration::class)
     }
 
     @Test
@@ -849,6 +873,8 @@ class PropertyRegistrationJourneyTests : IntegrationTestWithMutableData("data-lo
         // Check Gas Safety Answers - render page
         assertThat(checkGasSafetyAnswersPage.heading).containsText("Gas safety certificate")
         checkGasSafetyAnswersPage.form.submit()
+        val taskListPageAfterGasSafety = assertPageIs(page, TaskListPagePropertyRegistration::class)
+        taskListPageAfterGasSafety.clickRegisterTaskWithName("Electrical safety certificate")
         val hasElectricalCertPage = assertPageIs(page, HasElectricalCertFormPagePropertyRegistration::class)
 
         // Has Electrical Cert - render page
@@ -871,7 +897,10 @@ class PropertyRegistrationJourneyTests : IntegrationTestWithMutableData("data-lo
         // Check Electrical Safety Answers - render page
         assertThat(checkElectricalSafetyAnswersPage.heading).containsText("Electrical safety certificate")
         checkElectricalSafetyAnswersPage.form.submit()
+        val taskListPageAfterElectricalSafety = assertPageIs(page, TaskListPagePropertyRegistration::class)
+
         // The internal EpcLookupByUprnStep at the start of the EpcTask does not find an EPC
+        taskListPageAfterElectricalSafety.clickRegisterTaskWithName("Energy performance certificate (EPC)")
         val hasEpcPage = assertPageIs(page, HasEpcFormPagePropertyRegistration::class)
 
         // Has EPC - render page
@@ -898,6 +927,8 @@ class PropertyRegistrationJourneyTests : IntegrationTestWithMutableData("data-lo
         // Check EPC Answers - render page
         assertThat(checkEpcAnswersPage.heading).containsText("Energy performance certificate (EPC)")
         checkEpcAnswersPage.form.submit()
+        val taskListPageAfterEpc = assertPageIs(page, TaskListPagePropertyRegistration::class)
+        taskListPageAfterEpc.clickCheckAndSubmitTaskWithName("Check and submit your answers")
         val checkAnswersPage = assertPageIs(page, CheckAnswersPagePropertyRegistration::class)
         assertThat(checkAnswersPage.sectionHeader).containsText("Section 2 of 2 — Check and submit your property details")
 
@@ -967,6 +998,8 @@ class PropertyRegistrationJourneyTests : IntegrationTestWithMutableData("data-lo
         assertThat(checkGasSafetyAnswersPage.heading).containsText("Gas safety certificate")
 
         checkGasSafetyAnswersPage.form.submit()
+        val taskListPageAfterGasSafety = assertPageIs(page, TaskListPagePropertyRegistration::class)
+        taskListPageAfterGasSafety.clickRegisterTaskWithName("Electrical safety certificate")
         val hasElectricalCertPage = assertPageIs(page, HasElectricalCertFormPagePropertyRegistration::class)
 
         // Has Electrical Cert - render page
@@ -1010,8 +1043,10 @@ class PropertyRegistrationJourneyTests : IntegrationTestWithMutableData("data-lo
         // Check Electrical Safety Answers - render page
         assertThat(checkElectricalSafetyAnswersPage.heading).containsText("Electrical safety certificate")
         checkElectricalSafetyAnswersPage.form.submit()
+        val taskListPageAfterElectricalSafety = assertPageIs(page, TaskListPagePropertyRegistration::class)
 
         // EpcLookupByUprnStep finds the EPC, so redirects to Check UPRN matched EPCe
+        taskListPageAfterElectricalSafety.clickRegisterTaskWithName("Energy performance certificate (EPC)")
         val confirmUprnMatchedEpcDetailsPage = assertPageIs(page, ConfirmEpcDetailsRetrievedByUprnFormPagePropertyRegistration::class)
 
         // Check UPRN matched EPC - submit Yes (accept this expired EPC, which triggers age/rating check internally)
@@ -1034,6 +1069,8 @@ class PropertyRegistrationJourneyTests : IntegrationTestWithMutableData("data-lo
         // Check EPC Answers - render page
         assertThat(checkEpcAnswersPage.heading).containsText("Energy performance certificate (EPC)")
         checkEpcAnswersPage.form.submit()
+        val taskListPageAfterEpc = assertPageIs(page, TaskListPagePropertyRegistration::class)
+        taskListPageAfterEpc.clickCheckAndSubmitTaskWithName("Check and submit your answers")
         val checkAnswersPage = assertPageIs(page, CheckAnswersPagePropertyRegistration::class)
         assertThat(checkAnswersPage.sectionHeader).containsText("Section 2 of 2 — Check and submit your property details")
     }
@@ -1083,6 +1120,8 @@ class PropertyRegistrationJourneyTests : IntegrationTestWithMutableData("data-lo
         assertThat(checkGasSafetyAnswersPage.heading).containsText("Gas safety certificate")
 
         checkGasSafetyAnswersPage.form.submit()
+        val taskListPageAfterGasSafety = assertPageIs(page, TaskListPagePropertyRegistration::class)
+        taskListPageAfterGasSafety.clickRegisterTaskWithName("Electrical safety certificate")
         val hasElectricalCertPage = assertPageIs(page, HasElectricalCertFormPagePropertyRegistration::class)
 
         // Has Electrical Cert - render page
@@ -1120,7 +1159,10 @@ class PropertyRegistrationJourneyTests : IntegrationTestWithMutableData("data-lo
         // Check Electrical Safety Answers - render page
         assertThat(checkElectricalSafetyAnswersPage.heading).containsText("Electrical safety certificate")
         checkElectricalSafetyAnswersPage.form.submit()
+        val taskListPageAfterElectricalSafety = assertPageIs(page, TaskListPagePropertyRegistration::class)
+
         // The internal EpcLookupByUprnStep at the start of the EpcTask does not find an EPC
+        taskListPageAfterElectricalSafety.clickRegisterTaskWithName("Energy performance certificate (EPC)")
         val hasEpcPage = assertPageIs(page, HasEpcFormPagePropertyRegistration::class)
 
         // Has EPC - render page
@@ -1167,6 +1209,8 @@ class PropertyRegistrationJourneyTests : IntegrationTestWithMutableData("data-lo
         // Check EPC Answers - render page
         assertThat(checkEpcAnswersPage.heading).containsText("Energy performance certificate (EPC)")
         checkEpcAnswersPage.form.submit()
+        val taskListPageAfterEpc = assertPageIs(page, TaskListPagePropertyRegistration::class)
+        taskListPageAfterEpc.clickCheckAndSubmitTaskWithName("Check and submit your answers")
         val checkAnswersPage = assertPageIs(page, CheckAnswersPagePropertyRegistration::class)
         assertThat(checkAnswersPage.sectionHeader).containsText("Section 2 of 2 — Check and submit your property details")
     }
@@ -1223,8 +1267,7 @@ class PropertyRegistrationJourneyTests : IntegrationTestWithMutableData("data-lo
         // Check EPC Answers - render page
         assertThat(checkEpcAnswersPage.heading).containsText("Energy performance certificate (EPC)")
         checkEpcAnswersPage.form.submit()
-        val checkAnswersPage = assertPageIs(page, CheckAnswersPagePropertyRegistration::class)
-        assertThat(checkAnswersPage.sectionHeader).containsText("Section 2 of 2 — Check and submit your property details")
+        assertPageIs(page, TaskListPagePropertyRegistration::class)
     }
 
     @Test
@@ -1275,8 +1318,7 @@ class PropertyRegistrationJourneyTests : IntegrationTestWithMutableData("data-lo
         // Check EPC Answers - render page
         assertThat(checkEpcAnswersPage.heading).containsText("Energy performance certificate (EPC)")
         checkEpcAnswersPage.form.submit()
-        val checkAnswersPage = assertPageIs(page, CheckAnswersPagePropertyRegistration::class)
-        assertThat(checkAnswersPage.sectionHeader).containsText("Section 2 of 2 — Check and submit your property details")
+        assertPageIs(page, TaskListPagePropertyRegistration::class)
     }
 
     @Test

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/propertyRegistrationJourneyPages/TaskListPagePropertyRegistration.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/propertyRegistrationJourneyPages/TaskListPagePropertyRegistration.kt
@@ -19,6 +19,8 @@ class TaskListPagePropertyRegistration(
 
     fun clickRegisterTaskWithName(name: String) = registerTasks.getTask(name).clickAndWait()
 
+    fun clickCheckAndSubmitTaskWithName(name: String) = checkAndSubmitTasks.getTask(name).clickAndWait()
+
     fun getRegisterTask(name: String): TaskList.Task = registerTasks.getTask(name)
 
     fun taskHasStatus(

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/states/EpcStateTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/states/EpcStateTests.kt
@@ -26,6 +26,7 @@ import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.LowEn
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.MeesExemptionStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.PropertyOccupiedCheckStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.ProvideEpcLaterStep
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.StartEpcStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.EpcDetailsTask
 import uk.gov.communities.prsdb.webapp.models.dataModels.EpcDataModel
 
@@ -85,6 +86,11 @@ class EpcStateTests {
             override var epcRetrievedByCertificateNumberUpdatedSinceUserReview: Boolean? = null
             override var updatedEpcRetrievedByCertificateNumber: EpcDataModel? = null
             override var acceptedEpc: EpcDataModel? = acceptedEpc
+
+            override val startEpcStep =
+                mock<StartEpcStep>().apply {
+                    whenever(this.isStepReachable).thenReturn(true)
+                }
 
             override val checkUprnMatchedEpcStep =
                 mock<ConfirmEpcRetrievedByUprnStep>().apply {


### PR DESCRIPTION
## Ticket number

PDJB-768

## Goal of change

Update the property registration journey so each compliance task (gas safety, electrical safety, EPC) routes back to the task list after completion, rather than chaining directly to the next task.

## Description of main change(s)

- sets the next steps for gas safety, electrical safety and epc sections to the task list step
- sets the previous steps for electrical safety, epc and cya to the task list step
- adds the StartEpcStep to the main journey, this is needed so that the task list can link to the EPC page without running the UPRN calculations yet. navigating to the epc start page will run the UPRN EPC lookup. otherwise it'll always link to the no epc flow

## Anything you'd like to highlight to the reviewer?

StartEpcUpdateStep was renamed to StartEpcStep as it is now used across both journeys

## Checklist

- [x] Controller tests for any new endpoints, including testing the relevant permissions
- [x] New journey steps have been added to the appropriate journey integration test(s)
- [x] Test suite has been run in full locally and is passing
- [x] Branch has been rebased onto main and run locally, with everything working as expected (both for your new feature and any related functionality)
- [x] TODO comments referencing this JIRA ticket have been searched for and removed - if a future PR will address them, mention that here
- [x] QA instructions have been added to the ticket (particularly if this is the last PR required to complete the ticket)