### PR TITLE
PDJB-588: Fix privacy notice QA defects

### DIFF
--- a/src/main/resources/messages/privacyNotice.yml
+++ b/src/main/resources/messages/privacyNotice.yml
@@ -76,7 +76,7 @@ section:
     heading: '3. Lawful basis for processing the data'
     paragraph:
       one: The data protection legislation sets out when we are lawfully allowed to process your personal data.
-      'two.intro': '3.1 For MHCLG, we process your personal and usage data under the lawful basis below;'
+      'two.intro': '3.1. For MHCLG, we process your personal and usage data under the lawful basis below;'
       'two.bullet.one': '<strong>UK GDPR Article 6(1)(e) - Public Task:</strong> The processing is necessary for the performance of a task carried out in the public interest. Specifically, the department is tasked with developing, securing, and testing the national digital infrastructure required for the future Private Rented Sector Database.'
       'two.bullet.two': '<strong>Domestic Legal Basis (The "Vires"):</strong> This is supported by <strong>Section 8(d) of the Data Protection Act 2018</strong> (the exercise of a function of a Minister of the Crown) and the <strong>Secretary of State’s general common law powers</strong> to undertake preparatory work incidental to their ministerial functions.'
       'two.additional': '<strong>1. UK GDPR Article 9(2)(j)</strong> - Ethnicity data (optional): We process ethnicity data for research and statistical purposes under <strong>Article 9(2)(j)</strong> and <strong>Article 89(1)</strong>. This is supported by Schedule 1, Part 2, paragraph 8 of the Data Protection Act 2018 (equality of opportunity or treatment). We request this in the feedback survey (on an optional basis) so we can check whether our service works well for people from different backgrounds.'
@@ -125,9 +125,8 @@ section:
   ten:
     heading: '10. Complaints and more information'
     paragraph:
-      one: 'When we ask you for information, we will keep to the law, including the Data Protection Act 2018 and UK General Data Protection Regulation.'
       two:
-        beforeLink: 'If you are unhappy with the way the Department has acted, you can'
+        beforeLink: 'When we ask you for information, we will keep to the law, including the Data Protection Act 2018 and UK General Data Protection Regulation. If you are unhappy with the way the Department has acted, you can'
         linkText: make a complaint
         afterLink: .
       three:

--- a/src/main/resources/templates/landlordPrivacyNotice.html
+++ b/src/main/resources/templates/landlordPrivacyNotice.html
@@ -106,7 +106,7 @@
                 <li th:utext="#{privacyNotice.section.three.paragraph.two.bullet.one}">privacyNotice.section.three.paragraph.two.bullet.one</li>
                 <li th:utext="#{privacyNotice.section.three.paragraph.two.bullet.two}">privacyNotice.section.three.paragraph.two.bullet.two</li>
             </ul>
-            <p class="govuk-body" th:utext="#{privacyNotice.section.three.paragraph.two.additional}">privacyNotice.section.three.paragraph.two.additional</p>
+            <p class="govuk-body govuk-!-padding-left-6" th:utext="#{privacyNotice.section.three.paragraph.two.additional}">privacyNotice.section.three.paragraph.two.additional</p>
         </section>
         <section>
             <h2 class="govuk-heading-m" th:text="#{privacyNotice.section.four.heading}">privacyNotice.section.four.heading</h2>
@@ -160,7 +160,6 @@
         </section>
         <section>
             <h2 class="govuk-heading-m" th:text="#{privacyNotice.section.ten.heading}">privacyNotice.section.ten.heading</h2>
-            <p class="govuk-body" th:text="#{privacyNotice.section.ten.paragraph.one}">privacyNotice.section.ten.paragraph.one</p>
             <p class="govuk-body">
                 <span th:remove="tag" th:text="#{privacyNotice.section.ten.paragraph.two.beforeLink}">privacyNotice.section.ten.paragraph.two.beforeLink</span>
                 <a class="govuk-link" th:href="${complaintsProcedureUrl}" rel="noreferrer noopener" target="_blank"


### PR DESCRIPTION
## Ticket number

PDJB-588

## Goal of change

Address three QA defects on the landlord privacy notice page.

## Description of main change(s)

- **Section 3.1**: Adds a trailing dot after `3.1` so the numbered paragraphs are punctuated consistently with the rest of the document (section 2 already uses `2.1.`, `2.2.` etc.).
- **UK GDPR Article 9(2)(j) paragraph**: Indents the paragraph so it visually aligns with the bullet list above it, matching the QA mock-up. Implemented by adding the `govuk-!-padding-left-6` GOV.UK Frontend utility class to the existing `<p>` rather than introducing bespoke CSS.
- **Section 10**: Merges the spurious paragraph break between the "...UK General Data Protection Regulation." sentence and "If you are unhappy with the way the Department has acted, you can make a complaint." so the two sentences render in a single paragraph as designed. Done by deleting `paragraph.one` from `privacyNotice.yml` and prepending its text to `paragraph.two.beforeLink`, then removing the corresponding `<p>` from the template.


## Checklist

- [x] Screenshots of any UI changes have been added
- [x] Branch has been rebased onto main and run locally, with everything working as expected (both for your new feature and any related functionality)
