### PR TITLE
 PDJB-795: make downloadable files show the file name in compliance tab

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/summaryModels/propertyComplianceViewModels/ComplianceUploadRowHelper.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/summaryModels/propertyComplianceViewModels/ComplianceUploadRowHelper.kt
@@ -27,6 +27,7 @@ fun MutableList<SummaryListRowViewModel>.addFileUploadRows(
                 FileUploadStatus.SCANNED ->
                     UploadedFileUrl(
                         messageKey = downloadMessageKey,
+                        displayName = displayName,
                         url = uploadService.getDownloadUrlOrNull(upload, displayName),
                     )
 

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/summaryModels/propertyComplianceViewModels/ElectricalSafetyViewModelFactory.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/summaryModels/propertyComplianceViewModels/ElectricalSafetyViewModelFactory.kt
@@ -25,7 +25,7 @@ class ElectricalSafetyViewModelFactory(
                     downloadMessageKey =
                         if (expired == true) "$certKeyPrefix.downloadExpiredCertificate" else "$certKeyPrefix.downloadCertificate",
                     noUploadMessageKey = getNonUploadStatusMessageKey(propertyCompliance),
-                    fallbackFileName = "certificate",
+                    fallbackFileName = "electrical_safety_certificate",
                     uploadService = uploadService,
                 )
                 if (propertyCompliance.electricalSafetyExpiryDate != null) {

--- a/src/main/resources/templates/fragments/uploadedFileUrl.html
+++ b/src/main/resources/templates/fragments/uploadedFileUrl.html
@@ -6,7 +6,7 @@
         <a th:href="@{${value.url}}"
            th:attr="target=${value.urlOpensNewTab} ? '_blank' : null, rel=${value.urlOpensNewTab} ? 'noreferrer noopener' : null"
            class="govuk-link"
-           th:text="${#messages.msgOrNull(value.messageKey)} ?: ${{value.messageKey}}">
+           th:text="${value.displayName != null ? value.displayName : (#messages.msgOrNull(value.messageKey) ?: value.messageKey)}">
         </a>
     </p>
     <p th:if="${value.url == null}"

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/summaryModels/propertyComplianceViewModels/ElectricalSafetyViewModelFactoryTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/summaryModels/propertyComplianceViewModels/ElectricalSafetyViewModelFactoryTests.kt
@@ -90,6 +90,7 @@ class ElectricalSafetyViewModelFactoryTests : ComplianceViewModelFactoryTests() 
                             listOf(
                                 UploadedFileUrl(
                                     messageKey = "propertyDetails.complianceInformation.electricalSafety.eicr.downloadCertificate",
+                                    displayName = "electrical_safety_certificate.pdf",
                                     url = DOWNLOAD_URL,
                                 ),
                             ),
@@ -111,6 +112,7 @@ class ElectricalSafetyViewModelFactoryTests : ComplianceViewModelFactoryTests() 
                             listOf(
                                 UploadedFileUrl(
                                     messageKey = "propertyDetails.complianceInformation.electricalSafety.eicr.downloadCertificate",
+                                    displayName = "electrical_safety_certificate.pdf",
                                     url = DOWNLOAD_URL,
                                 ),
                             ),
@@ -132,6 +134,7 @@ class ElectricalSafetyViewModelFactoryTests : ComplianceViewModelFactoryTests() 
                             listOf(
                                 UploadedFileUrl(
                                     messageKey = "propertyDetails.complianceInformation.electricalSafety.eic.downloadCertificate",
+                                    displayName = "electrical_safety_certificate.pdf",
                                     url = DOWNLOAD_URL,
                                 ),
                             ),
@@ -153,6 +156,7 @@ class ElectricalSafetyViewModelFactoryTests : ComplianceViewModelFactoryTests() 
                             listOf(
                                 UploadedFileUrl(
                                     messageKey = "propertyDetails.complianceInformation.electricalSafety.eicr.downloadCertificate",
+                                    displayName = "my_electrical_report.pdf",
                                     url = DOWNLOAD_URL,
                                 ),
                             ),
@@ -196,6 +200,7 @@ class ElectricalSafetyViewModelFactoryTests : ComplianceViewModelFactoryTests() 
                                 UploadedFileUrl(
                                     messageKey =
                                         "propertyDetails.complianceInformation.electricalSafety.eicr.downloadExpiredCertificate",
+                                    displayName = "electrical_safety_certificate.pdf",
                                     url = DOWNLOAD_URL,
                                 ),
                             ),

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/summaryModels/propertyComplianceViewModels/GasSafetyViewModelFactoryTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/summaryModels/propertyComplianceViewModels/GasSafetyViewModelFactoryTests.kt
@@ -114,6 +114,7 @@ class GasSafetyViewModelFactoryTests : ComplianceViewModelFactoryTests() {
                             listOf(
                                 UploadedFileUrl(
                                     messageKey = "propertyDetails.complianceInformation.gasSafety.downloadCertificate",
+                                    displayName = "gas_safety_certificate.pdf",
                                     url = DOWNLOAD_URL,
                                 ),
                             ),
@@ -135,6 +136,7 @@ class GasSafetyViewModelFactoryTests : ComplianceViewModelFactoryTests() {
                             listOf(
                                 UploadedFileUrl(
                                     messageKey = "propertyDetails.complianceInformation.gasSafety.downloadCertificate",
+                                    displayName = "gas_safety_certificate.pdf",
                                     url = DOWNLOAD_URL,
                                 ),
                             ),
@@ -156,6 +158,7 @@ class GasSafetyViewModelFactoryTests : ComplianceViewModelFactoryTests() {
                             listOf(
                                 UploadedFileUrl(
                                     messageKey = "propertyDetails.complianceInformation.gasSafety.downloadCertificate",
+                                    displayName = "my_gas_certificate.pdf",
                                     url = DOWNLOAD_URL,
                                 ),
                             ),
@@ -198,6 +201,7 @@ class GasSafetyViewModelFactoryTests : ComplianceViewModelFactoryTests() {
                             listOf(
                                 UploadedFileUrl(
                                     messageKey = "propertyDetails.complianceInformation.gasSafety.downloadExpiredCertificate",
+                                    displayName = "gas_safety_certificate.pdf",
                                     url = DOWNLOAD_URL,
                                 ),
                             ),


### PR DESCRIPTION
## Ticket number

PDJB-795

## Goal of change

Display downloadable files in the compliance tab with their real file name

## Description of main change(s)

<img width="942" height="275" alt="image" src="https://github.com/user-attachments/assets/c4557398-18d7-4a71-864f-4bc2f336fee6" />

## Checklist

Delete any that are not applicable, and add explanation below for any that are applicable but haven't been done

- [x] Screenshots of any UI changes have been added
- [ ] Unit tests for new logic (e.g. new service methods) have been added
- [x] Test suite has been run in full locally and is passing
- [x] Branch has been rebased onto main and run locally, with everything working as expected (both for your new feature
  and any related functionality)
- [ ] QA instructions have been added to the ticket (particularly if this is the last PR required to complete the ticket)
