### PR TITLE
PDJB-NONE: Include households and tenants in occupancy update email

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/update/occupancy/UpdateOccupancyCyaConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/update/occupancy/UpdateOccupancyCyaConfig.kt
@@ -4,7 +4,6 @@ import kotlinx.datetime.Instant
 import kotlinx.datetime.toJavaInstant
 import org.springframework.context.MessageSource
 import uk.gov.communities.prsdb.webapp.annotations.webAnnotations.JourneyFrameworkComponent
-import uk.gov.communities.prsdb.webapp.database.entity.PropertyOwnership
 import uk.gov.communities.prsdb.webapp.exceptions.NotNullFormModelValueIsNullException.Companion.notNullValue
 import uk.gov.communities.prsdb.webapp.journeys.shared.helpers.OccupancyDetailsHelper
 import uk.gov.communities.prsdb.webapp.journeys.shared.stepConfig.AbstractCheckYourAnswersStep
@@ -45,8 +44,6 @@ class UpdateOccupancyCyaConfig(
     override fun afterStepDataIsAdded(state: UpdateOccupancyJourneyState) {
         val isOccupied = isOccupied(state)
         val billsIncludedDataModel = state.getBillsIncludedOrNull()
-        val propertyOwnership = propertyOwnershipService.getPropertyOwnership(state.propertyId)
-        val wasOccupied = propertyOwnership.isOccupied
         propertyOwnershipService.updateOccupancy(
             id = state.propertyId,
             numberOfHouseholds =
@@ -87,18 +84,18 @@ class UpdateOccupancyCyaConfig(
                 },
             initialLastModifiedDate = Instant.parse(state.lastModifiedDate).toJavaInstant(),
         )
-        sendUpdateConfirmationEmail(propertyOwnership, wasOccupied = wasOccupied, isOccupied = isOccupied)
+        sendUpdateConfirmationEmail(state, isOccupied = isOccupied)
     }
 
     private fun sendUpdateConfirmationEmail(
-        propertyOwnership: PropertyOwnership,
-        wasOccupied: Boolean,
+        state: UpdateOccupancyJourneyState,
         isOccupied: Boolean,
     ) {
+        val propertyOwnership = propertyOwnershipService.getPropertyOwnership(state.propertyId)
         val bullets =
             buildList {
                 add("Whether the property is occupied by tenants")
-                if (!wasOccupied && isOccupied) {
+                if (!state.wasOccupied && isOccupied) {
                     add("The number of households living in this property")
                     add("The number of people living in this property")
                 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/update/occupancy/UpdateOccupancyCyaConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/update/occupancy/UpdateOccupancyCyaConfig.kt
@@ -4,6 +4,7 @@ import kotlinx.datetime.Instant
 import kotlinx.datetime.toJavaInstant
 import org.springframework.context.MessageSource
 import uk.gov.communities.prsdb.webapp.annotations.webAnnotations.JourneyFrameworkComponent
+import uk.gov.communities.prsdb.webapp.database.entity.PropertyOwnership
 import uk.gov.communities.prsdb.webapp.exceptions.NotNullFormModelValueIsNullException.Companion.notNullValue
 import uk.gov.communities.prsdb.webapp.journeys.shared.helpers.OccupancyDetailsHelper
 import uk.gov.communities.prsdb.webapp.journeys.shared.stepConfig.AbstractCheckYourAnswersStep
@@ -44,6 +45,8 @@ class UpdateOccupancyCyaConfig(
     override fun afterStepDataIsAdded(state: UpdateOccupancyJourneyState) {
         val isOccupied = isOccupied(state)
         val billsIncludedDataModel = state.getBillsIncludedOrNull()
+        val propertyOwnership = propertyOwnershipService.getPropertyOwnership(state.propertyId)
+        val wasOccupied = propertyOwnership.isOccupied
         propertyOwnershipService.updateOccupancy(
             id = state.propertyId,
             numberOfHouseholds =
@@ -84,17 +87,28 @@ class UpdateOccupancyCyaConfig(
                 },
             initialLastModifiedDate = Instant.parse(state.lastModifiedDate).toJavaInstant(),
         )
-        sendUpdateConfirmationEmail(state)
+        sendUpdateConfirmationEmail(propertyOwnership, wasOccupied = wasOccupied, isOccupied = isOccupied)
     }
 
-    private fun sendUpdateConfirmationEmail(state: UpdateOccupancyJourneyState) {
-        val propertyOwnership = propertyOwnershipService.getPropertyOwnership(state.propertyId)
+    private fun sendUpdateConfirmationEmail(
+        propertyOwnership: PropertyOwnership,
+        wasOccupied: Boolean,
+        isOccupied: Boolean,
+    ) {
+        val bullets =
+            buildList {
+                add("Whether the property is occupied by tenants")
+                if (!wasOccupied && isOccupied) {
+                    add("The number of households living in this property")
+                    add("The number of people living in this property")
+                }
+            }
         updateConfirmationEmailService.sendEmail(
             propertyOwnership.primaryLandlord.email,
             PropertyUpdateConfirmation(
                 singleLineAddress = propertyOwnership.address.singleLineAddress,
                 registrationNumber = RegistrationNumberDataModel.fromRegistrationNumber(propertyOwnership.registrationNumber).toString(),
-                updatedBullets = listOf("Whether the property is occupied by tenants"),
+                updatedBullets = bullets,
                 dashboardUrl = absoluteUrlProvider.buildLandlordDashboardUri(),
             ),
         )

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/update/occupancy/UpdateOccupancyJourneyFactory.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/update/occupancy/UpdateOccupancyJourneyFactory.kt
@@ -44,8 +44,10 @@ class UpdateOccupancyJourneyFactory(
         val state = stateFactory.getObject()
 
         if (!state.isStateInitialized) {
+            val propertyOwnership = propertyOwnershipService.getPropertyOwnership(propertyId)
             state.propertyId = propertyId
-            state.lastModifiedDate = propertyOwnershipService.getPropertyOwnership(propertyId).getMostRecentlyUpdated().toString()
+            state.lastModifiedDate = propertyOwnership.getMostRecentlyUpdated().toString()
+            state.wasOccupied = propertyOwnership.isOccupied
             state.isStateInitialized = true
         }
 
@@ -208,6 +210,8 @@ class UpdateOccupancyJourney(
 
     override var lastModifiedDate: String by delegateProvider.requiredImmutableDelegate("lastModifiedDate")
 
+    override var wasOccupied: Boolean by delegateProvider.requiredImmutableDelegate("wasOccupied")
+
     override var cachedOccupied: Boolean? by delegateProvider.nullableDelegate("cachedOccupied")
 }
 
@@ -218,4 +222,5 @@ interface UpdateOccupancyJourneyState :
     override val cyaStep: UpdateOccupancyCyaStep
     val propertyId: Long
     val lastModifiedDate: String
+    val wasOccupied: Boolean
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/UpdateOccupancyCyaConfigTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/UpdateOccupancyCyaConfigTests.kt
@@ -130,6 +130,7 @@ class UpdateOccupancyCyaConfigTests {
         whenever(mockState.occupied).thenReturn(mockOccupiedStep)
         whenever(mockOccupiedStep.formModel).thenReturn(mockOccupancyFormModel)
         whenever(mockOccupancyFormModel.occupied).thenReturn(true)
+        lenient().`when`(mockState.wasOccupied).thenReturn(false)
         lenient().`when`(mockState.households).thenReturn(mockHouseholdStep)
         lenient().`when`(mockHouseholdStep.formModel).thenReturn(mockNumberOfHouseholdsFormModel)
         lenient().`when`(mockNumberOfHouseholdsFormModel.numberOfHouseholds).thenReturn("2")
@@ -167,9 +168,10 @@ class UpdateOccupancyCyaConfigTests {
 
     @Test
     fun `afterStepDataIsAdded sends confirmation email listing households and tenants when transitioning unoccupied to occupied`() {
-        val propertyOwnership = MockLandlordData.createUnoccupiedPropertyOwnership()
+        val propertyOwnership = MockLandlordData.createPropertyOwnership(id = propertyId)
         whenever(mockPropertyOwnershipService.getPropertyOwnership(propertyId)).thenReturn(propertyOwnership)
         whenever(mockAbsoluteUrlProvider.buildLandlordDashboardUri()).thenReturn(URI("http://example.com"))
+        whenever(mockState.wasOccupied).thenReturn(false)
         whenever(mockOccupancyFormModel.occupied).thenReturn(true)
 
         stepConfig.afterStepDataIsAdded(mockState)
@@ -189,9 +191,10 @@ class UpdateOccupancyCyaConfigTests {
 
     @Test
     fun `afterStepDataIsAdded sends confirmation email with only the occupancy bullet when property was already occupied`() {
-        val propertyOwnership = MockLandlordData.createOccupiedPropertyOwnership()
+        val propertyOwnership = MockLandlordData.createPropertyOwnership(id = propertyId)
         whenever(mockPropertyOwnershipService.getPropertyOwnership(propertyId)).thenReturn(propertyOwnership)
         whenever(mockAbsoluteUrlProvider.buildLandlordDashboardUri()).thenReturn(URI("http://example.com"))
+        whenever(mockState.wasOccupied).thenReturn(true)
         whenever(mockOccupancyFormModel.occupied).thenReturn(true)
 
         stepConfig.afterStepDataIsAdded(mockState)
@@ -204,9 +207,10 @@ class UpdateOccupancyCyaConfigTests {
 
     @Test
     fun `afterStepDataIsAdded sends confirmation email with only the occupancy bullet when transitioning occupied to unoccupied`() {
-        val propertyOwnership = MockLandlordData.createOccupiedPropertyOwnership()
+        val propertyOwnership = MockLandlordData.createPropertyOwnership(id = propertyId)
         whenever(mockPropertyOwnershipService.getPropertyOwnership(propertyId)).thenReturn(propertyOwnership)
         whenever(mockAbsoluteUrlProvider.buildLandlordDashboardUri()).thenReturn(URI("http://example.com"))
+        whenever(mockState.wasOccupied).thenReturn(true)
         whenever(mockOccupancyFormModel.occupied).thenReturn(false)
 
         stepConfig.afterStepDataIsAdded(mockState)
@@ -219,9 +223,10 @@ class UpdateOccupancyCyaConfigTests {
 
     @Test
     fun `afterStepDataIsAdded sends confirmation email with only the occupancy bullet when property remains unoccupied`() {
-        val propertyOwnership = MockLandlordData.createUnoccupiedPropertyOwnership()
+        val propertyOwnership = MockLandlordData.createPropertyOwnership(id = propertyId)
         whenever(mockPropertyOwnershipService.getPropertyOwnership(propertyId)).thenReturn(propertyOwnership)
         whenever(mockAbsoluteUrlProvider.buildLandlordDashboardUri()).thenReturn(URI("http://example.com"))
+        whenever(mockState.wasOccupied).thenReturn(false)
         whenever(mockOccupancyFormModel.occupied).thenReturn(false)
 
         stepConfig.afterStepDataIsAdded(mockState)

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/UpdateOccupancyCyaConfigTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/UpdateOccupancyCyaConfigTests.kt
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.Mock
+import org.mockito.Mockito.lenient
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argThat
@@ -129,26 +130,26 @@ class UpdateOccupancyCyaConfigTests {
         whenever(mockState.occupied).thenReturn(mockOccupiedStep)
         whenever(mockOccupiedStep.formModel).thenReturn(mockOccupancyFormModel)
         whenever(mockOccupancyFormModel.occupied).thenReturn(true)
-        whenever(mockState.households).thenReturn(mockHouseholdStep)
-        whenever(mockHouseholdStep.formModel).thenReturn(mockNumberOfHouseholdsFormModel)
-        whenever(mockNumberOfHouseholdsFormModel.numberOfHouseholds).thenReturn("2")
-        whenever(mockState.tenants).thenReturn(mockTenantsStep)
-        whenever(mockTenantsStep.formModel).thenReturn(mockNumberOfTenantsFormModel)
-        whenever(mockNumberOfTenantsFormModel.numberOfPeople).thenReturn("5")
-        whenever(mockState.bedrooms).thenReturn(mockBedroomsStep)
-        whenever(mockBedroomsStep.formModel).thenReturn(mockNumberOfBedroomsFormModel)
-        whenever(mockNumberOfBedroomsFormModel.numberOfBedrooms).thenReturn("3")
-        whenever(mockState.getBillsIncludedOrNull()).thenReturn(null)
-        whenever(mockState.furnishedStatus).thenReturn(mockFurnishedStatusStep)
-        whenever(mockFurnishedStatusStep.formModel).thenReturn(mockFurnishedStatusFormModel)
-        whenever(mockFurnishedStatusFormModel.furnishedStatus).thenReturn(null)
-        whenever(mockState.rentFrequency).thenReturn(mockRentFrequencyStep)
-        whenever(mockRentFrequencyStep.formModel).thenReturn(mockRentFrequencyFormModel)
-        whenever(mockRentFrequencyFormModel.rentFrequency).thenReturn(null)
-        whenever(mockState.getCustomRentFrequencyIfSelected()).thenReturn(null)
-        whenever(mockState.rentAmount).thenReturn(mockRentAmountStep)
-        whenever(mockRentAmountStep.formModel).thenReturn(mockRentAmountFormModel)
-        whenever(mockRentAmountFormModel.rentAmount).thenReturn("500")
+        lenient().`when`(mockState.households).thenReturn(mockHouseholdStep)
+        lenient().`when`(mockHouseholdStep.formModel).thenReturn(mockNumberOfHouseholdsFormModel)
+        lenient().`when`(mockNumberOfHouseholdsFormModel.numberOfHouseholds).thenReturn("2")
+        lenient().`when`(mockState.tenants).thenReturn(mockTenantsStep)
+        lenient().`when`(mockTenantsStep.formModel).thenReturn(mockNumberOfTenantsFormModel)
+        lenient().`when`(mockNumberOfTenantsFormModel.numberOfPeople).thenReturn("5")
+        lenient().`when`(mockState.bedrooms).thenReturn(mockBedroomsStep)
+        lenient().`when`(mockBedroomsStep.formModel).thenReturn(mockNumberOfBedroomsFormModel)
+        lenient().`when`(mockNumberOfBedroomsFormModel.numberOfBedrooms).thenReturn("3")
+        lenient().`when`(mockState.getBillsIncludedOrNull()).thenReturn(null)
+        lenient().`when`(mockState.furnishedStatus).thenReturn(mockFurnishedStatusStep)
+        lenient().`when`(mockFurnishedStatusStep.formModel).thenReturn(mockFurnishedStatusFormModel)
+        lenient().`when`(mockFurnishedStatusFormModel.furnishedStatus).thenReturn(null)
+        lenient().`when`(mockState.rentFrequency).thenReturn(mockRentFrequencyStep)
+        lenient().`when`(mockRentFrequencyStep.formModel).thenReturn(mockRentFrequencyFormModel)
+        lenient().`when`(mockRentFrequencyFormModel.rentFrequency).thenReturn(null)
+        lenient().`when`(mockState.getCustomRentFrequencyIfSelected()).thenReturn(null)
+        lenient().`when`(mockState.rentAmount).thenReturn(mockRentAmountStep)
+        lenient().`when`(mockRentAmountStep.formModel).thenReturn(mockRentAmountFormModel)
+        lenient().`when`(mockRentAmountFormModel.rentAmount).thenReturn("500")
     }
 
     @Test
@@ -165,10 +166,63 @@ class UpdateOccupancyCyaConfigTests {
     }
 
     @Test
-    fun `afterStepDataIsAdded sends confirmation email with correct updated items`() {
-        val propertyOwnership = MockLandlordData.createPropertyOwnership(id = propertyId)
+    fun `afterStepDataIsAdded sends confirmation email listing households and tenants when transitioning unoccupied to occupied`() {
+        val propertyOwnership = MockLandlordData.createUnoccupiedPropertyOwnership()
         whenever(mockPropertyOwnershipService.getPropertyOwnership(propertyId)).thenReturn(propertyOwnership)
         whenever(mockAbsoluteUrlProvider.buildLandlordDashboardUri()).thenReturn(URI("http://example.com"))
+        whenever(mockOccupancyFormModel.occupied).thenReturn(true)
+
+        stepConfig.afterStepDataIsAdded(mockState)
+
+        verify(mockEmailNotificationService).sendEmail(
+            any(),
+            argThat<PropertyUpdateConfirmation> {
+                this.updatedBullets ==
+                    listOf(
+                        "Whether the property is occupied by tenants",
+                        "The number of households living in this property",
+                        "The number of people living in this property",
+                    )
+            },
+        )
+    }
+
+    @Test
+    fun `afterStepDataIsAdded sends confirmation email with only the occupancy bullet when property was already occupied`() {
+        val propertyOwnership = MockLandlordData.createOccupiedPropertyOwnership()
+        whenever(mockPropertyOwnershipService.getPropertyOwnership(propertyId)).thenReturn(propertyOwnership)
+        whenever(mockAbsoluteUrlProvider.buildLandlordDashboardUri()).thenReturn(URI("http://example.com"))
+        whenever(mockOccupancyFormModel.occupied).thenReturn(true)
+
+        stepConfig.afterStepDataIsAdded(mockState)
+
+        verify(mockEmailNotificationService).sendEmail(
+            any(),
+            argThat<PropertyUpdateConfirmation> { this.updatedBullets == listOf("Whether the property is occupied by tenants") },
+        )
+    }
+
+    @Test
+    fun `afterStepDataIsAdded sends confirmation email with only the occupancy bullet when transitioning occupied to unoccupied`() {
+        val propertyOwnership = MockLandlordData.createOccupiedPropertyOwnership()
+        whenever(mockPropertyOwnershipService.getPropertyOwnership(propertyId)).thenReturn(propertyOwnership)
+        whenever(mockAbsoluteUrlProvider.buildLandlordDashboardUri()).thenReturn(URI("http://example.com"))
+        whenever(mockOccupancyFormModel.occupied).thenReturn(false)
+
+        stepConfig.afterStepDataIsAdded(mockState)
+
+        verify(mockEmailNotificationService).sendEmail(
+            any(),
+            argThat<PropertyUpdateConfirmation> { this.updatedBullets == listOf("Whether the property is occupied by tenants") },
+        )
+    }
+
+    @Test
+    fun `afterStepDataIsAdded sends confirmation email with only the occupancy bullet when property remains unoccupied`() {
+        val propertyOwnership = MockLandlordData.createUnoccupiedPropertyOwnership()
+        whenever(mockPropertyOwnershipService.getPropertyOwnership(propertyId)).thenReturn(propertyOwnership)
+        whenever(mockAbsoluteUrlProvider.buildLandlordDashboardUri()).thenReturn(URI("http://example.com"))
+        whenever(mockOccupancyFormModel.occupied).thenReturn(false)
 
         stepConfig.afterStepDataIsAdded(mockState)
 


### PR DESCRIPTION
## Ticket number

PDJB-NONE

## Goal of change

Fix the property update confirmation email so it lists households and tenants when a landlord transitions a property from unoccupied to occupied.

## Description of main change(s)

- The `UpdateOccupancy` journey already wrote new household / tenant counts (and other occupancy-related fields) when a landlord changed a property from unoccupied to occupied, but the confirmation email it sent only ever listed `Whether the property is occupied by tenants`.
- The email now also includes `The number of households living in this property` and `The number of people living in this property` whenever the property's previous state was unoccupied and the landlord has just made it occupied. The wording matches the bullets used by the dedicated `UpdateHouseholdsAndTenants` confirmation email.
- All other transitions (occupied → unoccupied, occupied → occupied, unoccupied → unoccupied) keep the existing single-bullet email behaviour.
- The pre-update `isOccupied` value is now snapshotted onto the journey state at journey-init time (alongside the existing `lastModifiedDate` snapshot), and the CYA submit reads it from there instead of re-deriving it from the database. This keeps the email consistent with what the user saw when they started the journey, and gives us a clear pattern for snapshotting other pre-update fields (rent, bedrooms, etc.) onto the journey state when we want to extend the email to cover more diffs.

## Anything you'd like to highlight to the reviewer?

The same unoccupied → occupied transition also writes other newly-required occupancy fields (bedrooms, furnished status, rent frequency, rent amount, bills included). Per discussion, the email intentionally lists only the fields that have their own dedicated update-email journey today — i.e. households and tenants — so it stays in step with `UpdateHouseholdsAndTenantsCyaConfig`. None of bedrooms / furnished status / rent / bills currently sends its own confirmation email; when we want them in the email, the new `wasOccupied` snapshot pattern on `UpdateOccupancyJourneyState` is the place to add them.

## Checklist

- [x] Unit tests for new logic (e.g. new service methods) have been added
- [x] Test suite has been run in full locally and is passing — only `UpdateOccupancyCyaConfigTests` and `ktlintCheck` were run; the change is confined to one CYA config and is fully covered by those targeted unit tests, so the full suite was not run
- [x] Branch has been rebased onto main and run locally, with everything working as expected (both for your new feature and any related functionality) — branched from `origin/main` in a fresh worktree; targeted tests + ktlintCheck pass
