### PR TITLE
PDJB-NONE: Restrict CloudWatch metrics to JVM and process diagnostics

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/config/MetricsConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/config/MetricsConfig.kt
@@ -8,4 +8,14 @@ import uk.gov.communities.prsdb.webapp.annotations.webAnnotations.PrsdbWebConfig
 class MetricsConfig {
     @Bean
     fun denyHttpServerRequestMetrics(): MeterFilter = MeterFilter.denyNameStartsWith("http.server.requests")
+
+    @Bean
+    fun allowOnlyDiagnosticMetrics(): MeterFilter =
+        MeterFilter.denyUnless { id ->
+            val name = id.name
+            name.startsWith("jvm.") ||
+                name.startsWith("process.") ||
+                name.startsWith("system.cpu") ||
+                name.startsWith("system.load")
+        }
 }


### PR DESCRIPTION
## Ticket number

PDJB-NONE

## Goal of change

Reduce the volume of metrics published to CloudWatch to keep custom metric costs and namespace clutter under control.

## Description of main change(s)

- Adds an additional `MeterFilter` bean that allow-lists only metrics relevant to JVM and process diagnostics
- Allowed prefixes: `jvm.`, `process.`, `system.cpu`, `system.load`
- Drops Tomcat, Hikari, Logback, executor, disk space, file descriptor and Spring Cloud AWS internal SDK metrics from the export

The retained metrics cover everything currently used to diagnose memory and GC behaviour (heap, non-heap pool committed/used, classes loaded/unloaded, threads, direct buffers, GC pauses, CPU). Additional categories can be allow-listed back in if a future investigation needs them.

Expected reduction is roughly 75% of the current published metric count.

## Anything you'd like to highlight to the reviewer?

The existing `http.server.requests` deny filter is left in place. Both filters apply (Micrometer ANDs `MeterFilter` beans).

## Checklist

- [ ] No special release instructions