### PR TITLE
PDJB-880: Ensure all numeric fields have an appropriate max

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/validation/PositiveBigDecimalValidator.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/validation/PositiveBigDecimalValidator.kt
@@ -5,6 +5,7 @@ import org.hibernate.validator.internal.constraintvalidators.bv.number.sign.Posi
 class PositiveBigDecimalValidator : PropertyConstraintValidator {
     override fun isValid(value: Any?): Boolean {
         val bigDecimalValue = value.toString().toBigDecimalOrNull() ?: return false
-        return PositiveValidatorForBigDecimal().isValid(bigDecimalValue, null)
+        return PositiveValidatorForBigDecimal().isValid(bigDecimalValue, null) &&
+            bigDecimalValue < 10000000.toBigDecimal() // numbers 10000000 and above cannot be stored in the DECIMAL(9, 2) col
     }
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/PropertyRegistrationSinglePageTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/PropertyRegistrationSinglePageTests.kt
@@ -608,6 +608,15 @@ class PropertyRegistrationSinglePageTests : IntegrationTestWithImmutableData("da
             ).containsText("Rent amount must only include numbers (and a decimal point), like 600 or 193.54")
         }
 
+        @Test
+        fun `Submitting a rentAmount of 10000000 or above returns an error`(page: Page) {
+            val rentAmountPage = navigator.skipToPropertyRegistrationRentAmountPage()
+            rentAmountPage.submitRentAmount("10000000")
+            assertThat(
+                rentAmountPage.form.getErrorMessage(),
+            ).containsText("Rent amount must only include numbers (and a decimal point), like 600 or 193.54")
+        }
+
         @Nested
         inner class ConditionalContentPerRentFrequency {
             @Test

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/validation/PositiveBigDecimalValidatorTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/validation/PositiveBigDecimalValidatorTests.kt
@@ -1,0 +1,45 @@
+package uk.gov.communities.prsdb.webapp.validation
+
+import org.junit.jupiter.api.Named
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.MethodSource
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class PositiveBigDecimalValidatorTests {
+    companion object {
+        @JvmStatic
+        fun provideValidValues() =
+            arrayOf(
+                Named.of("integer", "600"),
+                Named.of("decimal", "193.54"),
+                Named.of("small value", "0.01"),
+                Named.of("just below max", "9999999.99"),
+                Named.of("large integer below max", "9999999"),
+            )
+
+        @JvmStatic
+        fun provideInvalidValues() =
+            arrayOf(
+                Named.of("exactly 10000000", "10000000"),
+                Named.of("above 10000000", "10000001"),
+                Named.of("large number above max", "99999999.99"),
+                Named.of("zero", "0"),
+                Named.of("negative", "-1"),
+                Named.of("non-numeric", "abc"),
+                Named.of("null value", null),
+            )
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("provideValidValues")
+    fun `isValid returns true for valid positive values below 10000000`(input: String) {
+        assertTrue(PositiveBigDecimalValidator().isValid(input))
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("provideInvalidValues")
+    fun `isValid returns false for invalid values`(input: String?) {
+        assertFalse(PositiveBigDecimalValidator().isValid(input))
+    }
+}


### PR DESCRIPTION
## Ticket number

[PDJB-880](https://mhclgdigital.atlassian.net/browse/PDJB-880)

## Goal of change

ensures all numeric fields have an appropriate max

## Description of main change(s)

the database has limits on data sizes. if we try to enter a number too large for the col we will get a service error

in most cases the 'is it a number' validators were handling this implicitly, it would class a number too large as not a number. this was not the case for decimals however which use BigDecimal for the parsing logic which accepts very very large numbers

so, introduce a maximum allowable decimal number into the app. specific questions can impose their own maximum

## Anything you'd like to highlight to the reviewer?

rentAmount is the only decimal input I could find

## Checklist

Delete any that are not applicable, and add explanation below for any that are applicable but haven't been done

- [x] Screenshots of any UI changes have been added
- [x] Unit tests for new logic (e.g. new service methods) have been added
- [x] Single page integration tests have been added for any unhappy-flow UI features, e.g. validation errors
- [x] Test suite has been run in full locally and is passing
- [x] Branch has been rebased onto main and run locally, with everything working as expected (both for your new feature
  and any related functionality)
- [x] TODO comments referencing this JIRA ticket have been searched for and removed - if a future PR will address them,
  mention that here
- [x] QA instructions have been added to the ticket (particularly if this is the last PR required to complete the ticket)
