### PR TITLE
PDJB-878: Format numbers correctly on submit

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/helpers/extensions/StringExtensions.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/helpers/extensions/StringExtensions.kt
@@ -1,0 +1,9 @@
+package uk.gov.communities.prsdb.webapp.helpers.extensions
+
+class StringExtensions {
+    companion object {
+        fun String.toNormalizedDecimalString(): String = toBigDecimalOrNull()?.toPlainString() ?: this
+
+        fun String.toNormalizedIntegerString(): String = toIntOrNull()?.toString() ?: this
+    }
+}

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/helpers/extensions/StringExtensions.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/helpers/extensions/StringExtensions.kt
@@ -2,7 +2,11 @@ package uk.gov.communities.prsdb.webapp.helpers.extensions
 
 class StringExtensions {
     companion object {
-        fun String.toNormalizedDecimalString(): String = toBigDecimalOrNull()?.toPlainString() ?: this
+        fun String.toNormalizedCurrencyString(): String {
+            val decimal = toBigDecimalOrNull()?.stripTrailingZeros() ?: return this
+            val scaled = if (decimal.scale() < 2) decimal.setScale(2) else decimal
+            return scaled.toPlainString()
+        }
 
         fun String.toNormalizedIntegerString(): String = toIntOrNull()?.toString() ?: this
     }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/requestModels/formModels/NumberOfBedroomsFormModel.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/requestModels/formModels/NumberOfBedroomsFormModel.kt
@@ -1,5 +1,6 @@
 package uk.gov.communities.prsdb.webapp.models.requestModels.formModels
 
+import uk.gov.communities.prsdb.webapp.helpers.extensions.StringExtensions.Companion.toNormalizedIntegerString
 import uk.gov.communities.prsdb.webapp.validation.ConstraintDescriptor
 import uk.gov.communities.prsdb.webapp.validation.IsValidPrioritised
 import uk.gov.communities.prsdb.webapp.validation.PositiveIntegerValidator
@@ -16,4 +17,7 @@ class NumberOfBedroomsFormModel : FormModel {
         ],
     )
     var numberOfBedrooms: String = ""
+        set(value) {
+            field = value.toNormalizedIntegerString()
+        }
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/requestModels/formModels/NumberOfHouseholdsFormModel.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/requestModels/formModels/NumberOfHouseholdsFormModel.kt
@@ -1,6 +1,7 @@
 package uk.gov.communities.prsdb.webapp.models.requestModels.formModels
 
 import uk.gov.communities.prsdb.webapp.database.entity.PropertyOwnership
+import uk.gov.communities.prsdb.webapp.helpers.extensions.StringExtensions.Companion.toNormalizedIntegerString
 import uk.gov.communities.prsdb.webapp.validation.ConstraintDescriptor
 import uk.gov.communities.prsdb.webapp.validation.IsValidPrioritised
 import uk.gov.communities.prsdb.webapp.validation.PositiveIntegerValidator
@@ -17,6 +18,9 @@ class NumberOfHouseholdsFormModel : FormModel {
         ],
     )
     var numberOfHouseholds: String = ""
+        set(value) {
+            field = value.toNormalizedIntegerString()
+        }
 
     companion object {
         fun fromPropertyOwnership(propertyOwnership: PropertyOwnership): NumberOfHouseholdsFormModel =

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/requestModels/formModels/NumberOfPeopleFormModel.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/requestModels/formModels/NumberOfPeopleFormModel.kt
@@ -1,6 +1,7 @@
 package uk.gov.communities.prsdb.webapp.models.requestModels.formModels
 
 import uk.gov.communities.prsdb.webapp.database.entity.PropertyOwnership
+import uk.gov.communities.prsdb.webapp.helpers.extensions.StringExtensions.Companion.toNormalizedIntegerString
 import uk.gov.communities.prsdb.webapp.validation.ConstraintDescriptor
 import uk.gov.communities.prsdb.webapp.validation.DelegatedPropertyConstraintValidator
 import uk.gov.communities.prsdb.webapp.validation.IsValidPrioritised
@@ -8,7 +9,7 @@ import uk.gov.communities.prsdb.webapp.validation.PositiveIntegerValidator
 import uk.gov.communities.prsdb.webapp.validation.ValidatedBy
 
 @IsValidPrioritised
-class NumberOfPeopleFormModel(
+class NumberOfPeopleFormModel : FormModel {
     @ValidatedBy(
         constraints = [
             ConstraintDescriptor(
@@ -22,9 +23,13 @@ class NumberOfPeopleFormModel(
             ),
         ],
     )
-    var numberOfPeople: String = "",
-    var numberOfHouseholds: String = "",
-) : FormModel {
+    var numberOfPeople: String = ""
+        set(value) {
+            field = value.toNormalizedIntegerString()
+        }
+
+    var numberOfHouseholds: String = ""
+
     fun isNotLessThanNumberOfHouseholds(): Boolean = numberOfPeople.toInt() >= numberOfHouseholds.toInt()
 
     companion object {
@@ -37,7 +42,7 @@ class NumberOfPeopleFormModel(
 }
 
 @IsValidPrioritised
-class NewNumberOfPeopleFormModel(
+class NewNumberOfPeopleFormModel : FormModel {
     @ValidatedBy(
         constraints = [
             ConstraintDescriptor(
@@ -46,8 +51,11 @@ class NewNumberOfPeopleFormModel(
             ),
         ],
     )
-    var numberOfPeople: String = "",
-) : FormModel {
+    var numberOfPeople: String = ""
+        set(value) {
+            field = value.toNormalizedIntegerString()
+        }
+
     companion object {
         fun fromPropertyOwnership(propertyOwnership: PropertyOwnership): NewNumberOfPeopleFormModel =
             NewNumberOfPeopleFormModel().apply {

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/requestModels/formModels/RentAmountFormModel.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/requestModels/formModels/RentAmountFormModel.kt
@@ -1,6 +1,6 @@
 package uk.gov.communities.prsdb.webapp.models.requestModels.formModels
 
-import uk.gov.communities.prsdb.webapp.helpers.extensions.StringExtensions.Companion.toNormalizedDecimalString
+import uk.gov.communities.prsdb.webapp.helpers.extensions.StringExtensions.Companion.toNormalizedCurrencyString
 import uk.gov.communities.prsdb.webapp.validation.ConstraintDescriptor
 import uk.gov.communities.prsdb.webapp.validation.DelegatedPropertyConstraintValidator
 import uk.gov.communities.prsdb.webapp.validation.IsValidPrioritised
@@ -24,7 +24,7 @@ class RentAmountFormModel : FormModel {
     )
     var rentAmount: String = ""
         set(value) {
-            field = value.toNormalizedDecimalString()
+            field = value.toNormalizedCurrencyString()
         }
 
     fun isNotMoreThanTwoDecimalPlaces() = rentAmount.toBigDecimal().scale() <= 2

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/requestModels/formModels/RentAmountFormModel.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/requestModels/formModels/RentAmountFormModel.kt
@@ -1,5 +1,6 @@
 package uk.gov.communities.prsdb.webapp.models.requestModels.formModels
 
+import uk.gov.communities.prsdb.webapp.helpers.extensions.StringExtensions.Companion.toNormalizedDecimalString
 import uk.gov.communities.prsdb.webapp.validation.ConstraintDescriptor
 import uk.gov.communities.prsdb.webapp.validation.DelegatedPropertyConstraintValidator
 import uk.gov.communities.prsdb.webapp.validation.IsValidPrioritised
@@ -22,6 +23,9 @@ class RentAmountFormModel : FormModel {
         ],
     )
     var rentAmount: String = ""
+        set(value) {
+            field = value.toNormalizedDecimalString()
+        }
 
     fun isNotMoreThanTwoDecimalPlaces() = rentAmount.toBigDecimal().scale() <= 2
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/helpers/extensions/StringExtensionsTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/helpers/extensions/StringExtensionsTests.kt
@@ -4,7 +4,7 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.CsvSource
-import uk.gov.communities.prsdb.webapp.helpers.extensions.StringExtensions.Companion.toNormalizedDecimalString
+import uk.gov.communities.prsdb.webapp.helpers.extensions.StringExtensions.Companion.toNormalizedCurrencyString
 import uk.gov.communities.prsdb.webapp.helpers.extensions.StringExtensions.Companion.toNormalizedIntegerString
 
 class StringExtensionsTests {
@@ -15,29 +15,39 @@ class StringExtensionsTests {
         "00100, 100",
         "00100.50, 100.50",
     )
-    fun `toNormalizedDecimalString strips leading zeros`(
+    fun `toNormalizedCurrencyString strips leading zeros`(
         input: String,
         expected: String,
     ) {
-        assertEquals(expected, input.toNormalizedDecimalString())
+        assertEquals(expected, input.toNormalizedCurrencyString())
     }
 
     @ParameterizedTest
     @CsvSource(
-        "7.5, 7.5",
-        "100, 100",
-        "0.1, 0.1",
+        "7.50, 7.50",
+        "100, 100.00",
+        "0.10, 0.10",
     )
-    fun `toNormalizedDecimalString returns unchanged value when no leading zeros`(
+    fun `toNormalizedCurrencyString returns unchanged value when no leading zeros`(
         input: String,
         expected: String,
     ) {
-        assertEquals(expected, input.toNormalizedDecimalString())
+        assertEquals(expected, input.toNormalizedCurrencyString())
     }
 
     @Test
-    fun `toNormalizedDecimalString preserves trailing decimal zeros`() {
-        assertEquals("7.50", "7.50".toNormalizedDecimalString())
+    fun `toNormalizedCurrencyString adds trailing decimal zeros if less than two decimal places`() {
+        assertEquals("7.50", "7.5".toNormalizedCurrencyString())
+    }
+
+    @Test
+    fun `toNormalizedCurrencyString preserves trailing decimal if two decimal places`() {
+        assertEquals("7.50", "7.50".toNormalizedCurrencyString())
+    }
+
+    @Test
+    fun `toNormalizedCurrencyString strips trailing decimal zeros beyond the second digit`() {
+        assertEquals("7.50", "7.500".toNormalizedCurrencyString())
     }
 
     @ParameterizedTest
@@ -46,11 +56,11 @@ class StringExtensionsTests {
         "'', ''",
         "12.34.56, 12.34.56",
     )
-    fun `toNormalizedDecimalString returns original string for invalid decimal input`(
+    fun `toNormalizedCurrencyString returns original string for invalid decimal input`(
         input: String,
         expected: String,
     ) {
-        assertEquals(expected, input.toNormalizedDecimalString())
+        assertEquals(expected, input.toNormalizedCurrencyString())
     }
 
     @ParameterizedTest

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/helpers/extensions/StringExtensionsTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/helpers/extensions/StringExtensionsTests.kt
@@ -10,9 +10,9 @@ import uk.gov.communities.prsdb.webapp.helpers.extensions.StringExtensions.Compa
 class StringExtensionsTests {
     @ParameterizedTest
     @CsvSource(
-        "007.5, 7.5",
-        "0000000.1, 0.1",
-        "00100, 100",
+        "007.50, 7.50",
+        "0000000.10, 0.10",
+        "00100.00, 100.00",
         "00100.50, 100.50",
     )
     fun `toNormalizedCurrencyString strips leading zeros`(
@@ -25,7 +25,7 @@ class StringExtensionsTests {
     @ParameterizedTest
     @CsvSource(
         "7.50, 7.50",
-        "100, 100.00",
+        "100.00, 100.00",
         "0.10, 0.10",
     )
     fun `toNormalizedCurrencyString returns unchanged value when no leading zeros`(

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/helpers/extensions/StringExtensionsTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/helpers/extensions/StringExtensionsTests.kt
@@ -1,0 +1,94 @@
+package uk.gov.communities.prsdb.webapp.helpers.extensions
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.CsvSource
+import uk.gov.communities.prsdb.webapp.helpers.extensions.StringExtensions.Companion.toNormalizedDecimalString
+import uk.gov.communities.prsdb.webapp.helpers.extensions.StringExtensions.Companion.toNormalizedIntegerString
+
+class StringExtensionsTests {
+    @ParameterizedTest
+    @CsvSource(
+        "007.5, 7.5",
+        "0000000.1, 0.1",
+        "00100, 100",
+        "00100.50, 100.50",
+    )
+    fun `toNormalizedDecimalString strips leading zeros`(
+        input: String,
+        expected: String,
+    ) {
+        assertEquals(expected, input.toNormalizedDecimalString())
+    }
+
+    @ParameterizedTest
+    @CsvSource(
+        "7.5, 7.5",
+        "100, 100",
+        "0.1, 0.1",
+    )
+    fun `toNormalizedDecimalString returns unchanged value when no leading zeros`(
+        input: String,
+        expected: String,
+    ) {
+        assertEquals(expected, input.toNormalizedDecimalString())
+    }
+
+    @Test
+    fun `toNormalizedDecimalString preserves trailing decimal zeros`() {
+        assertEquals("7.50", "7.50".toNormalizedDecimalString())
+    }
+
+    @ParameterizedTest
+    @CsvSource(
+        "abc, abc",
+        "'', ''",
+        "12.34.56, 12.34.56",
+    )
+    fun `toNormalizedDecimalString returns original string for invalid decimal input`(
+        input: String,
+        expected: String,
+    ) {
+        assertEquals(expected, input.toNormalizedDecimalString())
+    }
+
+    @ParameterizedTest
+    @CsvSource(
+        "007, 7",
+        "0001, 1",
+        "00100, 100",
+    )
+    fun `toNormalizedIntegerString strips leading zeros`(
+        input: String,
+        expected: String,
+    ) {
+        assertEquals(expected, input.toNormalizedIntegerString())
+    }
+
+    @ParameterizedTest
+    @CsvSource(
+        "7, 7",
+        "100, 100",
+        "1, 1",
+    )
+    fun `toNormalizedIntegerString returns unchanged value when no leading zeros`(
+        input: String,
+        expected: String,
+    ) {
+        assertEquals(expected, input.toNormalizedIntegerString())
+    }
+
+    @ParameterizedTest
+    @CsvSource(
+        "abc, abc",
+        "'', ''",
+        "12.5, 12.5",
+    )
+    fun `toNormalizedIntegerString returns original string for invalid integer input`(
+        input: String,
+        expected: String,
+    ) {
+        assertEquals(expected, input.toNormalizedIntegerString())
+    }
+}

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/PropertyDetailsUpdateJourneyTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/PropertyDetailsUpdateJourneyTests.kt
@@ -397,6 +397,29 @@ class PropertyDetailsUpdateJourneyTests : IntegrationTestWithMutableData("data-l
                 assertThat(propertyDetailsPage.propertyDetailsSummaryList.numberOfPeopleRow.value)
                     .containsText(newNumberOfPeople.toString())
             }
+
+            @Test
+            fun `leading zeros are stripped from households and people on the CYA page`(page: Page) {
+                // Details page
+                val propertyDetailsPage = navigator.goToPropertyDetailsLandlordView(occupiedPropertyOwnershipId)
+                propertyDetailsPage.propertyDetailsSummaryList.numberOfHouseholdsRow.clickFirstActionLinkAndWait()
+                val updateNumberOfHouseholdsPage =
+                    assertPageIs(page, NumberOfHouseholdsFormPagePropertyDetailsUpdate::class, occupiedPropertyUrlArguments)
+
+                // Submit number of households with leading zeros
+                updateNumberOfHouseholdsPage.submitNumberOfHouseholds("003")
+                val updateNumberOfPeoplePage =
+                    assertPageIs(page, HouseholdsNumberOfPeopleFormPagePropertyDetailsUpdate::class, occupiedPropertyUrlArguments)
+
+                // Submit number of people with leading zeros
+                updateNumberOfPeoplePage.submitNumOfPeople("007")
+                val checkOccupancyAnswersPage =
+                    assertPageIs(page, CheckHouseholdsAnswersPagePropertyDetailsUpdate::class, occupiedPropertyUrlArguments)
+
+                // Check CYA page displays values without leading zeros
+                assertThat(checkOccupancyAnswersPage.summaryList.numberOfHouseholdsRow).containsText("3")
+                assertThat(checkOccupancyAnswersPage.summaryList.numberOfPeopleRow).containsText("7")
+            }
         }
 
         @Nested
@@ -408,7 +431,8 @@ class PropertyDetailsUpdateJourneyTests : IntegrationTestWithMutableData("data-l
                 var propertyDetailsPage = navigator.goToPropertyDetailsLandlordView(occupiedPropertyOwnershipId)
                 // Assert initial number of bedrooms is not 4
                 assertThat(propertyDetailsPage.propertyDetailsSummaryList.numberOfBedroomsRow.value)
-                    .not().containsText(newNumberOfBedrooms.toString())
+                    .not()
+                    .containsText(newNumberOfBedrooms.toString())
                 propertyDetailsPage.propertyDetailsSummaryList.numberOfBedroomsRow.clickFirstActionLinkAndWait()
                 val updateNumberOfBedroomsPage =
                     assertPageIs(page, NumberOfBedroomsFormPagePropertyDetailsUpdate::class, occupiedPropertyUrlArguments)
@@ -432,7 +456,8 @@ class PropertyDetailsUpdateJourneyTests : IntegrationTestWithMutableData("data-l
                 var propertyDetailsPage = navigator.goToPropertyDetailsLandlordView(occupiedPropertyOwnershipId)
                 // Assert initial rent includes bills status is not Yes
                 assertThat(propertyDetailsPage.propertyDetailsSummaryList.rentIncludesBillsRow.value)
-                    .not().containsText("Yes")
+                    .not()
+                    .containsText("Yes")
                 propertyDetailsPage.propertyDetailsSummaryList.rentIncludesBillsRow.clickFirstActionLinkAndWait()
                 val updateRentIncludesBillsPage =
                     assertPageIs(page, RentIncludesBillsFormPagePropertyDetailsUpdate::class, occupiedPropertyUrlArguments)
@@ -509,7 +534,8 @@ class PropertyDetailsUpdateJourneyTests : IntegrationTestWithMutableData("data-l
                 var propertyDetailsPage = navigator.goToPropertyDetailsLandlordView(occupiedPropertyOwnershipId)
                 // Assert initial furnished status is not FurnishedStatus.PART_FURNISHED
                 assertThat(propertyDetailsPage.propertyDetailsSummaryList.furnishedStatusRow.value)
-                    .not().containsText(newFurnishedStatusValue)
+                    .not()
+                    .containsText(newFurnishedStatusValue)
                 propertyDetailsPage.propertyDetailsSummaryList.furnishedStatusRow.clickFirstActionLinkAndWait()
                 val updateFurnishedStatusPage =
                     assertPageIs(page, FurnishedStatusFormPagePropertyDetailsUpdate::class, occupiedPropertyUrlArguments)
@@ -538,10 +564,12 @@ class PropertyDetailsUpdateJourneyTests : IntegrationTestWithMutableData("data-l
                 var propertyDetailsPage = navigator.goToPropertyDetailsLandlordView(occupiedPropertyOwnershipId)
                 // Assert initial rent frequency is not newRentFrequency
                 assertThat(propertyDetailsPage.propertyDetailsSummaryList.rentFrequencyRow.value)
-                    .not().containsText(newRentFrequencyDisplayName)
+                    .not()
+                    .containsText(newRentFrequencyDisplayName)
                 // Assert initial rent amount is not newRentAmount
                 assertThat(propertyDetailsPage.propertyDetailsSummaryList.rentAmountRow.value)
-                    .not().containsText(newRentAmount)
+                    .not()
+                    .containsText(newRentAmount)
                 propertyDetailsPage.propertyDetailsSummaryList.rentFrequencyRow.clickFirstActionLinkAndWait()
                 val rentFrequencyPage =
                     assertPageIs(page, RentFrequencyFormPagePropertyDetailsUpdate::class, occupiedPropertyUrlArguments)
@@ -566,6 +594,28 @@ class PropertyDetailsUpdateJourneyTests : IntegrationTestWithMutableData("data-l
 
                 assertThat(propertyDetailsPage.propertyDetailsSummaryList.rentFrequencyRow).containsText(newRentFrequencyDisplayName)
                 assertThat(propertyDetailsPage.propertyDetailsSummaryList.rentAmountRow).containsText(newRentAmount)
+            }
+
+            @Test
+            fun `leading zeros are stripped from rent amount on the CYA page`(page: Page) {
+                // Details page
+                val propertyDetailsPage = navigator.goToPropertyDetailsLandlordView(occupiedPropertyOwnershipId)
+                propertyDetailsPage.propertyDetailsSummaryList.rentFrequencyRow.clickFirstActionLinkAndWait()
+                val rentFrequencyPage =
+                    assertPageIs(page, RentFrequencyFormPagePropertyDetailsUpdate::class, occupiedPropertyUrlArguments)
+
+                // Submit any rent frequency
+                rentFrequencyPage.selectRentFrequency(RentFrequency.MONTHLY)
+                rentFrequencyPage.form.submit()
+                val rentAmountPage = assertPageIs(page, RentAmountFormPagePropertyDetailsUpdate::class, occupiedPropertyUrlArguments)
+
+                // Submit rent amount with leading zeros
+                rentAmountPage.submitRentAmount("00500.50")
+                val checkYourAnswersPage =
+                    assertPageIs(page, CheckRentFrequencyAndAmountAnswersPagePropertyDetailsUpdate::class, occupiedPropertyUrlArguments)
+
+                // Check CYA page displays value without leading zeros
+                assertThat(checkYourAnswersPage.summaryList.rentAmountRow).containsText("£500.50")
             }
         }
     }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/PropertyRegistrationJourneyTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/PropertyRegistrationJourneyTests.kt
@@ -1396,4 +1396,20 @@ class PropertyRegistrationJourneyTests : IntegrationTestWithMutableData("data-lo
 
         val uprnForSelectedAddress = 1L // This matches the uprn in data-local.sql for address 1 Fictional Road, FA1 1AA
     }
+
+    @Test
+    fun `numeric values with leading zeros are displayed without leading zeros on the CYA page`(page: Page) {
+        val checkAnswersPage =
+            navigator.skipToPropertyRegistrationCheckAnswersPageOccupied(
+                households = 2,
+                people = 4,
+                bedrooms = 3,
+                rentAmount = "0000000.1",
+            )
+
+        assertThat(checkAnswersPage.summaryList.rentAmountRow.value).containsText("£0.1")
+        assertThat(checkAnswersPage.summaryList.numberOfHouseholdsRow.value).containsText("2")
+        assertThat(checkAnswersPage.summaryList.numberOfTenantsRow.value).containsText("4")
+        assertThat(checkAnswersPage.summaryList.numberOfBedroomsRow.value).containsText("3")
+    }
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/Navigator.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/Navigator.kt
@@ -743,6 +743,25 @@ class Navigator(
         return createValidPage(page, CheckAnswersPagePropertyRegistration::class)
     }
 
+    fun skipToPropertyRegistrationCheckAnswersPageOccupied(
+        households: Int = 2,
+        people: Int = 4,
+        bedrooms: Int = 3,
+        rentAmount: String = "400",
+    ): CheckAnswersPagePropertyRegistration {
+        setJourneyStateInSession(
+            PropertyStateSessionBuilder
+                .beforePropertyRegistrationCheckAnswersOccupied(
+                    households = households,
+                    people = people,
+                    bedrooms = bedrooms,
+                    rentAmount = rentAmount,
+                ).build(),
+        )
+        navigateToPropertyRegistrationJourneyStep(PropertyRegistrationCyaStep.ROUTE_SEGMENT)
+        return createValidPage(page, CheckAnswersPagePropertyRegistration::class)
+    }
+
     fun skipToPropertyRegistrationCheckAnswersPageNoEpc(): CheckAnswersPagePropertyRegistration {
         setJourneyStateInSession(PropertyStateSessionBuilder.beforePropertyRegistrationCheckAnswersNoEpcExempt().build())
         navigateToPropertyRegistrationJourneyStep(PropertyRegistrationCyaStep.ROUTE_SEGMENT)

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/propertyRegistrationJourneyPages/CheckAnswersPagePropertyRegistration.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/propertyRegistrationJourneyPages/CheckAnswersPagePropertyRegistration.kt
@@ -44,6 +44,10 @@ class CheckAnswersPagePropertyRegistration(
     ) : SummaryList(page) {
         val ownershipRow = getRow("Ownership type")
         val licensingRow = getRow("Licensing type")
+        val numberOfHouseholdsRow = getRow("Number of households")
+        val numberOfTenantsRow = getRow("Number of tenants")
+        val numberOfBedroomsRow = getRow("Number of bedrooms")
+        val rentAmountRow = getRow("Rent amount")
     }
 
     class ComplianceSummaryList(

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/states/RentFrequencyAndAmountStateTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/states/RentFrequencyAndAmountStateTests.kt
@@ -47,7 +47,7 @@ class RentFrequencyAndAmountStateTests {
     fun `getRentAmount returns string from RentDataHelper#getRentAmount when rentFrequency`() {
         // Arrange
         val rentFrequencyValue = RentFrequency.MONTHLY
-        val rentAmountValue = "100"
+        val rentAmountValue = "100.00"
 
         val state = buildTestRentFrequencyAndAmountState(rentFrequencyValue = rentFrequencyValue, rentAmountValue = rentAmountValue)
         val expectedRentAmountString =
@@ -69,7 +69,7 @@ class RentFrequencyAndAmountStateTests {
         // Arrange
         val rentFrequencyValue = RentFrequency.OTHER
         val customRentFrequencyValue = "Daily"
-        val rentAmountValue = "100"
+        val rentAmountValue = "100.00"
 
         val state = buildTestRentFrequencyAndAmountState(rentFrequencyValue, customRentFrequencyValue, rentAmountValue)
         val expectedRentAmountString =
@@ -105,7 +105,7 @@ class RentFrequencyAndAmountStateTests {
     private fun buildTestRentFrequencyAndAmountState(
         rentFrequencyValue: RentFrequency = RentFrequency.MONTHLY,
         customRentFrequencyValue: String = "",
-        rentAmountValue: String = "100",
+        rentAmountValue: String = "100.00",
     ): RentFrequencyAndAmountState {
         val rentFrequencyFormModel =
             RentFrequencyFormModel().apply {

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/models/requestModels/formModels/NumberOfPeopleFormModelTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/models/requestModels/formModels/NumberOfPeopleFormModelTests.kt
@@ -1,5 +1,6 @@
 package uk.gov.communities.prsdb.webapp.models.requestModels.formModels
 
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
@@ -7,19 +8,38 @@ import org.junit.jupiter.api.Test
 class NumberOfPeopleFormModelTests {
     @Test
     fun `numberOfPeople is invalid if it is lower than numberOfHouseholds`() {
-        val numberOfPeopleFormModel = NumberOfPeopleFormModel(numberOfPeople = "1", numberOfHouseholds = "2")
+        val numberOfPeopleFormModel =
+            NumberOfPeopleFormModel().apply {
+                numberOfPeople = "1"
+                numberOfHouseholds = "2"
+            }
         assertFalse(numberOfPeopleFormModel.isNotLessThanNumberOfHouseholds())
     }
 
     @Test
     fun `numberOfPeople is valid if it is the same as the numberOfHouseholds`() {
-        val numberOfPeopleFormModel = NumberOfPeopleFormModel(numberOfPeople = "2", numberOfHouseholds = "2")
+        val numberOfPeopleFormModel =
+            NumberOfPeopleFormModel().apply {
+                numberOfPeople = "2"
+                numberOfHouseholds = "2"
+            }
         assertTrue(numberOfPeopleFormModel.isNotLessThanNumberOfHouseholds())
     }
 
     @Test
     fun `numberOfPeople is valid if it is higher than the numberOfHouseholds`() {
-        val numberOfPeopleFormModel = NumberOfPeopleFormModel(numberOfPeople = "3", numberOfHouseholds = "2")
+        val numberOfPeopleFormModel =
+            NumberOfPeopleFormModel().apply {
+                numberOfPeople = "3"
+                numberOfHouseholds = "2"
+            }
         assertTrue(numberOfPeopleFormModel.isNotLessThanNumberOfHouseholds())
+    }
+
+    @Test
+    fun `setting numberOfPeople with leading zeros normalizes the value`() {
+        val formModel = NumberOfPeopleFormModel()
+        formModel.numberOfPeople = "007"
+        assertEquals("7", formModel.numberOfPeople)
     }
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/models/requestModels/formModels/RentAmountFormModelTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/models/requestModels/formModels/RentAmountFormModelTests.kt
@@ -19,7 +19,7 @@ class RentAmountFormModelTests {
     @ValueSource(
         strings = ["400.12", "400.1", "400"],
     )
-    fun `rentAmount is invalid if it is two decimal places or fewer`(rentAmount: String) {
+    fun `rentAmount is valid if it is two decimal places or fewer`(rentAmount: String) {
         val rentAmountFormModel = RentAmountFormModel()
         rentAmountFormModel.rentAmount = rentAmount
         assertTrue(rentAmountFormModel.isNotMoreThanTwoDecimalPlaces())
@@ -28,7 +28,7 @@ class RentAmountFormModelTests {
     @Test
     fun `setting rentAmount with leading zeros normalizes the value`() {
         val rentAmountFormModel = RentAmountFormModel()
-        rentAmountFormModel.rentAmount = "0000000.1"
-        assertEquals("0.1", rentAmountFormModel.rentAmount)
+        rentAmountFormModel.rentAmount = "0000000.10"
+        assertEquals("0.10", rentAmountFormModel.rentAmount)
     }
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/models/requestModels/formModels/RentAmountFormModelTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/models/requestModels/formModels/RentAmountFormModelTests.kt
@@ -1,5 +1,6 @@
 package uk.gov.communities.prsdb.webapp.models.requestModels.formModels
 
+import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
@@ -22,5 +23,12 @@ class RentAmountFormModelTests {
         val rentAmountFormModel = RentAmountFormModel()
         rentAmountFormModel.rentAmount = rentAmount
         assertTrue(rentAmountFormModel.isNotMoreThanTwoDecimalPlaces())
+    }
+
+    @Test
+    fun `setting rentAmount with leading zeros normalizes the value`() {
+        val rentAmountFormModel = RentAmountFormModel()
+        rentAmountFormModel.rentAmount = "0000000.1"
+        assertEquals("0.1", rentAmountFormModel.rentAmount)
     }
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/testHelpers/builders/PropertyStateSessionBuilder.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/testHelpers/builders/PropertyStateSessionBuilder.kt
@@ -353,6 +353,18 @@ class PropertyStateSessionBuilder(
                 .withElectricalSafetyCertificateMissing()
                 .withCompliantEpc()
 
+        fun beforePropertyRegistrationCheckAnswersOccupied(
+            households: Int = 2,
+            people: Int = 4,
+            bedrooms: Int = 3,
+            rentAmount: String = "400",
+        ) = beforePropertyRegistrationOccupancy()
+            .withTenants(households = households, people = people, bedrooms = bedrooms, rentAmount = rentAmount)
+            .withHasNoJointLandlords()
+            .withGasSafetyTaskCompletedWithNoGasSupply()
+            .withElectricalSafetyCertificateMissing()
+            .withCompliantEpc()
+
         fun beforePropertyRegistrationCheckAnswersNoEpcExempt() =
             beforePropertyRegistrationOccupancy()
                 .withOccupancyStatus(false)


### PR DESCRIPTION
## Ticket number

closes [PDJB-878](https://mhclgdigital.atlassian.net/browse/PDJB-878)

## Goal of change

before saving in the database you could enter valid but odd numbers, eg with trailing zeros. these would be shown to the user on CYA pages and would only be corrected on saving to the database

<img alt="rent cya page with 00.10 rent amount" src="https://github.com/user-attachments/assets/20746004-5c05-4d6a-b446-cdeb5bf87e47" />

this should be fixed to show **0.1**

## Description of main change(s)

adds custom setters to impacted fields which call a normalisation function before setting the value

adds tests for the registration and update flows

## Anything you'd like to highlight to the reviewer?

I think this is the most sensible method vs changing CYA display logic. it means the number will be correct when displayed anywhere which reduces the likelihood of a regression occurring on another field and we keep the best values in long-lived state, though happy to hear otherwise

## Checklist

- [x] Unit tests for new logic (e.g. new service methods) have been added
- [x] Single page integration tests have been added for any unhappy-flow UI features, e.g. validation errors
- [x] A new journey integration test has been added for any new journeys
- [x] Test suite has been run in full locally and is passing
- [x] Branch has been rebased onto main and run locally, with everything working as expected (both for your new feature
  and any related functionality)
- [x] TODO comments referencing this JIRA ticket have been searched for and removed - if a future PR will address them,
  mention that here
- [x] QA instructions have been added to the ticket (particularly if this is the last PR required to complete the ticket)
