### PR TITLE
PDJB-879: Fix task list back button from register page

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/RegisterPropertyController.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/RegisterPropertyController.kt
@@ -39,10 +39,10 @@ import uk.gov.communities.prsdb.webapp.journeys.NoSuchJourneyException
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.JointLandlordsPropertyRegistrationStrategy
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.PropertyRegistrationJourneyFactory
 import uk.gov.communities.prsdb.webapp.models.dataModels.RegistrationNumberDataModel
+import uk.gov.communities.prsdb.webapp.services.BackUrlStorageService
 import uk.gov.communities.prsdb.webapp.services.CollectionKeyParameterService
 import uk.gov.communities.prsdb.webapp.services.FileUploadCookieService.Companion.FILE_UPLOAD_COOKIE_NAME
 import uk.gov.communities.prsdb.webapp.services.PropertyComplianceService
-import uk.gov.communities.prsdb.webapp.services.BackUrlStorageService
 import uk.gov.communities.prsdb.webapp.services.PropertyOwnershipService
 import uk.gov.communities.prsdb.webapp.services.PropertyRegistrationConfirmationService
 import java.security.Principal

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/RegisterPropertyController.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/RegisterPropertyController.kt
@@ -19,6 +19,7 @@ import org.springframework.web.servlet.ModelAndView
 import org.springframework.web.util.UriTemplate
 import uk.gov.communities.prsdb.webapp.annotations.webAnnotations.PrsdbController
 import uk.gov.communities.prsdb.webapp.config.filters.MultipartFormDataFilter
+import uk.gov.communities.prsdb.webapp.config.interceptors.BackLinkInterceptor.Companion.overrideBackLinkForUrl
 import uk.gov.communities.prsdb.webapp.constants.CONFIRMATION_PATH_SEGMENT
 import uk.gov.communities.prsdb.webapp.constants.CONTEXT_ID_URL_PARAMETER
 import uk.gov.communities.prsdb.webapp.constants.LANDLORD_PATH_SEGMENT
@@ -41,6 +42,7 @@ import uk.gov.communities.prsdb.webapp.models.dataModels.RegistrationNumberDataM
 import uk.gov.communities.prsdb.webapp.services.CollectionKeyParameterService
 import uk.gov.communities.prsdb.webapp.services.FileUploadCookieService.Companion.FILE_UPLOAD_COOKIE_NAME
 import uk.gov.communities.prsdb.webapp.services.PropertyComplianceService
+import uk.gov.communities.prsdb.webapp.services.BackUrlStorageService
 import uk.gov.communities.prsdb.webapp.services.PropertyOwnershipService
 import uk.gov.communities.prsdb.webapp.services.PropertyRegistrationConfirmationService
 import java.security.Principal
@@ -57,12 +59,14 @@ class RegisterPropertyController(
     private val certificateUploadHelper: CertificateUploadHelper,
     private val propertyComplianceService: PropertyComplianceService,
     private val jointLandlordsStrategy: JointLandlordsPropertyRegistrationStrategy,
+    private val backUrlStorageService: BackUrlStorageService,
 ) {
     @GetMapping
     fun index(model: Model): String {
+        val backUrlKey = backUrlStorageService.storeCurrentUrlReturningKey()
         model.addAttribute(
             "registerPropertyInitialStep",
-            "$PROPERTY_REGISTRATION_ROUTE/$TASK_LIST_PATH_SEGMENT",
+            "$PROPERTY_REGISTRATION_ROUTE/$TASK_LIST_PATH_SEGMENT".overrideBackLinkForUrl(backUrlKey),
         )
         model.addAttribute("backUrl", LANDLORD_DASHBOARD_URL)
         jointLandlordsStrategy.ifEnabled {

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/PropertyRegistrationJourneyFactory.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/PropertyRegistrationJourneyFactory.kt
@@ -539,6 +539,8 @@ class PropertyRegistrationJourney(
         return getMatchingAddress(submittedAddress)?.uprn
     }
 
+    override var backUrlKey: Int? by delegateProvider.nullableDelegate("backUrlKey")
+
     override val allowProvideCertificateLaterRoute: Boolean = true
 
     override fun generateJourneyId(seed: Any?): String {
@@ -575,4 +577,5 @@ interface PropertyRegistrationJourneyState :
     val confirmMissingComplianceStep: ConfirmMissingComplianceStep
     val savePropertyRegistrationDataStep: SavePropertyRegistrationDataStep
     var registrationNumberValue: Long?
+    var backUrlKey: Int?
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/PropertyRegistrationTaskListStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/PropertyRegistrationTaskListStepConfig.kt
@@ -1,6 +1,8 @@
 package uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps
 
+import jakarta.servlet.http.HttpServletRequest
 import uk.gov.communities.prsdb.webapp.annotations.webAnnotations.JourneyFrameworkComponent
+import uk.gov.communities.prsdb.webapp.constants.WITH_BACK_URL_PARAMETER_NAME
 import uk.gov.communities.prsdb.webapp.journeys.AbstractRequestableStepConfig
 import uk.gov.communities.prsdb.webapp.journeys.JourneyStep.RequestableStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.JointLandlordsPropertyRegistrationStrategy
@@ -10,10 +12,13 @@ import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.NoInputFo
 import uk.gov.communities.prsdb.webapp.models.viewModels.taskModels.TaskListItemViewModel
 import uk.gov.communities.prsdb.webapp.models.viewModels.taskModels.TaskListViewModel
 import uk.gov.communities.prsdb.webapp.models.viewModels.taskModels.TaskSectionViewModel
+import uk.gov.communities.prsdb.webapp.services.BackUrlStorageService
 
 @JourneyFrameworkComponent
 class PropertyRegistrationTaskListStepConfig(
     private val jointLandlordsStrategy: JointLandlordsPropertyRegistrationStrategy,
+    private val httpServletRequest: HttpServletRequest,
+    private val backUrlStorageService: BackUrlStorageService,
 ) : AbstractRequestableStepConfig<Complete, NoInputFormModel, PropertyRegistrationJourneyState>() {
     override val formModelClass = NoInputFormModel::class
 
@@ -21,6 +26,11 @@ class PropertyRegistrationTaskListStepConfig(
         mapOf("taskListViewModel" to getTaskListViewModel(state))
 
     fun getTaskListViewModel(state: PropertyRegistrationJourneyState): TaskListViewModel {
+        val backRequestUrl: Int? = httpServletRequest.getParameter(WITH_BACK_URL_PARAMETER_NAME)?.toIntOrNull()
+        if (backRequestUrl != null) {
+            state.backUrlKey = backRequestUrl
+        }
+
         val registerTaskItems =
             listOf(
                 TaskListItemViewModel.fromTask("registerProperty.taskList.register.addAddress", state.addressTask),
@@ -60,11 +70,17 @@ class PropertyRegistrationTaskListStepConfig(
                 ),
             )
 
+        val backUrlFromState =
+            state
+                .backUrlKey
+                ?.let { backUrlStorageService.getBackUrl(it) }
+
         return TaskListViewModel(
             "registerProperty.title",
             "registerProperty.taskList.heading",
             listOf("registerProperty.taskList.subtitle"),
             sectionViewModels,
+            backUrl = backUrlFromState,
         )
     }
 

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/BackUrlStorageService.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/BackUrlStorageService.kt
@@ -19,12 +19,18 @@ class BackUrlStorageService(
 
         val storedUrl = backUrlMap[currentUrlHash]
         return when (storedUrl) {
-            currentUrl -> currentUrlHash
+            currentUrl -> {
+                currentUrlHash
+            }
+
             null -> {
                 session.setAttribute(BACK_URL_STORAGE_SESSION_ATTRIBUTE, backUrlMap + (currentUrlHash to currentUrl))
                 currentUrlHash
             }
-            else -> storeUrlWithHashCollisionReturningKey(backUrlMap, currentUrl)
+
+            else -> {
+                storeUrlWithHashCollisionReturningKey(backUrlMap, currentUrl)
+            }
         }
     }
 

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/controllers/RegisterPropertyControllerTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/controllers/RegisterPropertyControllerTests.kt
@@ -96,7 +96,7 @@ class RegisterPropertyControllerTests(
                 model {
                     attribute(
                         "registerPropertyInitialStep",
-                        "${RegisterPropertyController.PROPERTY_REGISTRATION_ROUTE}/$TASK_LIST_PATH_SEGMENT",
+                        "${RegisterPropertyController.PROPERTY_REGISTRATION_ROUTE}/$TASK_LIST_PATH_SEGMENT?withBackUrl=0",
                     )
                     attribute("backUrl", LandlordController.LANDLORD_DASHBOARD_URL)
                 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/PropertyRegistrationJourneyTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/PropertyRegistrationJourneyTests.kt
@@ -29,6 +29,7 @@ import uk.gov.communities.prsdb.webapp.database.entity.PropertyOwnership
 import uk.gov.communities.prsdb.webapp.database.repository.JointLandlordInvitationRepository
 import uk.gov.communities.prsdb.webapp.database.repository.PropertyOwnershipRepository
 import uk.gov.communities.prsdb.webapp.helpers.DateTimeHelper
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.BackLink
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.BaseComponent.Companion.assertThat
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.LandlordDashboardPage
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages.BasePage.Companion.assertPageIs
@@ -83,6 +84,7 @@ import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyReg
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyRegistrationJourneyPages.ProvideElectricalCertLaterFormPagePropertyRegistration
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyRegistrationJourneyPages.ProvideEpcLaterFormPagePropertyRegistration
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyRegistrationJourneyPages.ProvideGasCertLaterFormPagePropertyRegistration
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyRegistrationJourneyPages.RegisterPropertyStartPage
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyRegistrationJourneyPages.RemoveElectricalCertUploadFormPagePropertyRegistration
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyRegistrationJourneyPages.RemoveGasCertUploadFormPagePropertyRegistration
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyRegistrationJourneyPages.RemoveJointLandlordAreYouSureFormPagePropertyRegistration
@@ -1370,6 +1372,33 @@ class PropertyRegistrationJourneyTests : IntegrationTestWithMutableData("data-lo
 
         // Check EPC Answers - render page
         assertThat(checkEpcAnswersPage.heading).containsText("Energy performance certificate (EPC)")
+    }
+
+    @Test
+    fun `task list back link navigates to start page after entering from start page`(page: Page) {
+        val registerPropertyStartPage = navigator.goToPropertyRegistrationStartPage()
+        registerPropertyStartPage.startButton.clickAndWait()
+        val taskListPage = assertPageIs(page, TaskListPagePropertyRegistration::class)
+
+        taskListPage.backLink.clickAndWait()
+        assertPageIs(page, RegisterPropertyStartPage::class)
+    }
+
+    @Test
+    fun `task list back link navigates to start page after entering from start page and returning from a task`(page: Page) {
+        val registerPropertyStartPage = navigator.goToPropertyRegistrationStartPage()
+        registerPropertyStartPage.startButton.clickAndWait()
+        var taskListPage = assertPageIs(page, TaskListPagePropertyRegistration::class)
+
+        taskListPage.clickRegisterTaskWithName("Property address")
+        assertPageIs(page, LookupAddressFormPagePropertyRegistration::class)
+
+        val backLink = BackLink.default(page)
+        backLink.clickAndWait()
+        taskListPage = assertPageIs(page, TaskListPagePropertyRegistration::class)
+
+        taskListPage.backLink.clickAndWait()
+        assertPageIs(page, RegisterPropertyStartPage::class)
     }
 
     companion object {

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/ResumePropertyRegistrationJourneyTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/ResumePropertyRegistrationJourneyTests.kt
@@ -2,7 +2,10 @@ package uk.gov.communities.prsdb.webapp.integration
 
 import com.microsoft.playwright.Page
 import org.junit.jupiter.api.Test
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.BackLink
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.LandlordIncompletePropertiesPage
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages.BasePage.Companion.assertPageIs
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyRegistrationJourneyPages.LookupAddressFormPagePropertyRegistration
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyRegistrationJourneyPages.TaskListPagePropertyRegistration
 import kotlin.test.assertFalse
 
@@ -19,5 +22,32 @@ class ResumePropertyRegistrationJourneyTests :
             taskListPage.taskHasStatus("Property address", "Not started"),
             "Property address task should not be 'Not started' after restoring saved journey state",
         )
+    }
+
+    @Test
+    fun `task list back link navigates to incomplete properties page after resuming registration`(page: Page) {
+        val incompletePropertiesPage = navigator.goToLandlordIncompleteProperties()
+        incompletePropertiesPage.firstSummaryCard.continueLink.clickAndWait()
+        val taskListPage = assertPageIs(page, TaskListPagePropertyRegistration::class)
+
+        taskListPage.backLink.clickAndWait()
+        assertPageIs(page, LandlordIncompletePropertiesPage::class)
+    }
+
+    @Test
+    fun `task list back link navigates to incomplete properties page after resuming registration and returning from a task`(page: Page) {
+        val incompletePropertiesPage = navigator.goToLandlordIncompleteProperties()
+        incompletePropertiesPage.firstSummaryCard.continueLink.clickAndWait()
+        var taskListPage = assertPageIs(page, TaskListPagePropertyRegistration::class)
+
+        taskListPage.clickRegisterTaskWithName("Property address")
+        assertPageIs(page, LookupAddressFormPagePropertyRegistration::class)
+
+        val backLink = BackLink.default(page)
+        backLink.clickAndWait()
+        taskListPage = assertPageIs(page, TaskListPagePropertyRegistration::class)
+
+        taskListPage.backLink.clickAndWait()
+        assertPageIs(page, LandlordIncompletePropertiesPage::class)
     }
 }


### PR DESCRIPTION
## Ticket number

[PDJB-879](https://mhclgdigital.atlassian.net/browse/PDJB-879)

## Goal of change

Fix an edge case where when navigating from the 'Register a property' flow the task list would have no back button

## Description of main change(s)

sets an appropriate back link url using `BackUrlStorageService`. this is used by the template

<img alt="task list with back url" src="https://github.com/user-attachments/assets/d4408b3a-84eb-48a4-9d30-73a918b644dc" />

## Checklist

Delete any that are not applicable, and add explanation below for any that are applicable but haven't been done

- [x] Screenshots of any UI changes have been added
- [x] Controller tests for any new endpoints, including testing the relevant permissions
- [x] Test suite has been run in full locally and is passing
- [x] Branch has been rebased onto main and run locally, with everything working as expected (both for your new feature
  and any related functionality)
- [x] TODO comments referencing this JIRA ticket have been searched for and removed - if a future PR will address them,
  mention that here
- [x] QA instructions have been added to the ticket (particularly if this is the last PR required to complete the ticket)
