### PR TITLE
PDJB-851: Show CYA certificate filenames as download links once scanned

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/ElectricalSafetyRegistrationCyaSummaryRowsFactory.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/ElectricalSafetyRegistrationCyaSummaryRowsFactory.kt
@@ -1,6 +1,5 @@
 package uk.gov.communities.prsdb.webapp.journeys.propertyRegistration
 
-import uk.gov.communities.prsdb.webapp.constants.enums.FileUploadStatus
 import uk.gov.communities.prsdb.webapp.constants.enums.HasElectricalSafetyCertificate
 import uk.gov.communities.prsdb.webapp.journeys.Destination
 import uk.gov.communities.prsdb.webapp.journeys.JourneyStep
@@ -8,10 +7,8 @@ import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.Elec
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.ElectricalSafetyScenario
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.HasElectricalCertMode
 import uk.gov.communities.prsdb.webapp.models.viewModels.summaryModels.SummaryListRowViewModel
-import uk.gov.communities.prsdb.webapp.models.viewModels.summaryModels.UploadedFileUrl
+import uk.gov.communities.prsdb.webapp.models.viewModels.summaryModels.propertyComplianceViewModels.toUploadedFileUrls
 import uk.gov.communities.prsdb.webapp.services.UploadService
-
-private const val VIRUS_SCAN_PENDING_WITH_NAME_KEY = "propertyCompliance.uploadedFile.virusScanPendingWithName"
 
 class ElectricalSafetyRegistrationCyaSummaryRowsFactory(
     private val state: ElectricalSafetyState,
@@ -45,26 +42,8 @@ class ElectricalSafetyRegistrationCyaSummaryRowsFactory(
             state.electricalUploadMap
                 .toList()
                 .sortedBy { it.first }
-                .mapNotNull { (_, upload) ->
-                    val fileUpload = uploadService.getFileUploadById(upload.fileUploadId)
-                    when (fileUpload.status) {
-                        FileUploadStatus.SCANNED ->
-                            UploadedFileUrl(
-                                messageKey = downloadMessageKey,
-                                displayName = upload.fileName,
-                                url = uploadService.getDownloadUrlOrNull(fileUpload, upload.fileName),
-                            )
-
-                        FileUploadStatus.QUARANTINED ->
-                            UploadedFileUrl(
-                                messageKey = VIRUS_SCAN_PENDING_WITH_NAME_KEY,
-                                displayName = upload.fileName,
-                                url = null,
-                            )
-
-                        FileUploadStatus.DELETED -> null
-                    }
-                }
+                .map { (_, upload) -> uploadService.getFileUploadById(upload.fileUploadId) to upload.fileName }
+                .toUploadedFileUrls(downloadMessageKey, uploadService)
 
         return listOf(
             SummaryListRowViewModel.forCheckYourAnswersPage(

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/ElectricalSafetyRegistrationCyaSummaryRowsFactory.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/ElectricalSafetyRegistrationCyaSummaryRowsFactory.kt
@@ -1,5 +1,6 @@
 package uk.gov.communities.prsdb.webapp.journeys.propertyRegistration
 
+import uk.gov.communities.prsdb.webapp.constants.enums.FileUploadStatus
 import uk.gov.communities.prsdb.webapp.constants.enums.HasElectricalSafetyCertificate
 import uk.gov.communities.prsdb.webapp.journeys.Destination
 import uk.gov.communities.prsdb.webapp.journeys.JourneyStep
@@ -7,9 +8,14 @@ import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.Elec
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.ElectricalSafetyScenario
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.HasElectricalCertMode
 import uk.gov.communities.prsdb.webapp.models.viewModels.summaryModels.SummaryListRowViewModel
+import uk.gov.communities.prsdb.webapp.models.viewModels.summaryModels.UploadedFileUrl
+import uk.gov.communities.prsdb.webapp.services.UploadService
+
+private const val VIRUS_SCAN_PENDING_WITH_NAME_KEY = "propertyCompliance.uploadedFile.virusScanPendingWithName"
 
 class ElectricalSafetyRegistrationCyaSummaryRowsFactory(
     private val state: ElectricalSafetyState,
+    private val uploadService: UploadService,
     private val destinationProvider: (JourneyStep.RequestableStep<*, *, *>) -> Destination = { Destination(it) },
 ) {
     private val scenario: ElectricalSafetyScenario = determineScenario(state)
@@ -33,16 +39,37 @@ class ElectricalSafetyRegistrationCyaSummaryRowsFactory(
         }
 
     private fun getCertUploadedRows(): List<SummaryListRowViewModel> {
-        val uploadFileNames =
+        val certType = state.getElectricalCertificateType()
+        val downloadMessageKey = getDownloadMessageKey(certType)
+        val uploadedFiles =
             state.electricalUploadMap
                 .toList()
                 .sortedBy { it.first }
-                .map { (_, upload) -> upload.fileName }
+                .mapNotNull { (_, upload) ->
+                    val fileUpload = uploadService.getFileUploadById(upload.fileUploadId)
+                    when (fileUpload.status) {
+                        FileUploadStatus.SCANNED ->
+                            UploadedFileUrl(
+                                messageKey = downloadMessageKey,
+                                displayName = upload.fileName,
+                                url = uploadService.getDownloadUrlOrNull(fileUpload, upload.fileName),
+                            )
+
+                        FileUploadStatus.QUARANTINED ->
+                            UploadedFileUrl(
+                                messageKey = VIRUS_SCAN_PENDING_WITH_NAME_KEY,
+                                displayName = upload.fileName,
+                                url = null,
+                            )
+
+                        FileUploadStatus.DELETED -> null
+                    }
+                }
 
         return listOf(
             SummaryListRowViewModel.forCheckYourAnswersPage(
                 fieldHeading = "checkElectricalSafety.electricalCert.fieldHeading",
-                fieldValue = getCertTypeLabel(state.getElectricalCertificateType()),
+                fieldValue = getCertTypeLabel(certType),
                 destination = destinationProvider(state.hasElectricalCertStep),
             ),
             SummaryListRowViewModel.forCheckYourAnswersPage(
@@ -52,11 +79,24 @@ class ElectricalSafetyRegistrationCyaSummaryRowsFactory(
             ),
             SummaryListRowViewModel.forCheckYourAnswersPage(
                 fieldHeading = "checkElectricalSafety.yourCertificate.fieldHeading",
-                fieldValue = uploadFileNames,
+                fieldValue = uploadedFiles,
                 destination = destinationProvider(state.checkElectricalCertUploadsStep),
             ),
         )
     }
+
+    private fun getDownloadMessageKey(certType: HasElectricalSafetyCertificate?): String =
+        when (certType) {
+            HasElectricalSafetyCertificate.HAS_EIC ->
+                "propertyDetails.complianceInformation.electricalSafety.eic.downloadCertificate"
+
+            HasElectricalSafetyCertificate.HAS_EICR ->
+                "propertyDetails.complianceInformation.electricalSafety.eicr.downloadCertificate"
+
+            HasElectricalSafetyCertificate.NO_CERTIFICATE, null -> throw IllegalStateException(
+                "Cert uploaded scenario requires a certificate type",
+            )
+        }
 
     private fun getCertTypeLabel(certType: HasElectricalSafetyCertificate?): String =
         when (certType) {

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/GasSafetyRegistrationCyaSummaryRowsFactory.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/GasSafetyRegistrationCyaSummaryRowsFactory.kt
@@ -1,6 +1,5 @@
 package uk.gov.communities.prsdb.webapp.journeys.propertyRegistration
 
-import uk.gov.communities.prsdb.webapp.constants.enums.FileUploadStatus
 import uk.gov.communities.prsdb.webapp.journeys.Destination
 import uk.gov.communities.prsdb.webapp.journeys.JourneyStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.GasSafetyState
@@ -8,10 +7,8 @@ import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.GasSa
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.HasGasCertMode
 import uk.gov.communities.prsdb.webapp.journeys.shared.YesOrNo
 import uk.gov.communities.prsdb.webapp.models.viewModels.summaryModels.SummaryListRowViewModel
-import uk.gov.communities.prsdb.webapp.models.viewModels.summaryModels.UploadedFileUrl
+import uk.gov.communities.prsdb.webapp.models.viewModels.summaryModels.propertyComplianceViewModels.toUploadedFileUrls
 import uk.gov.communities.prsdb.webapp.services.UploadService
-
-private const val VIRUS_SCAN_PENDING_WITH_NAME_KEY = "propertyCompliance.uploadedFile.virusScanPendingWithName"
 
 class GasSafetyRegistrationCyaSummaryRowsFactory(
     private val state: GasSafetyState,
@@ -68,26 +65,11 @@ class GasSafetyRegistrationCyaSummaryRowsFactory(
             state.gasUploadMap
                 .toList()
                 .sortedBy { it.first }
-                .mapNotNull { (_, upload) ->
-                    val fileUpload = uploadService.getFileUploadById(upload.fileUploadId)
-                    when (fileUpload.status) {
-                        FileUploadStatus.SCANNED ->
-                            UploadedFileUrl(
-                                messageKey = "propertyDetails.complianceInformation.gasSafety.downloadCertificate",
-                                displayName = upload.fileName,
-                                url = uploadService.getDownloadUrlOrNull(fileUpload, upload.fileName),
-                            )
-
-                        FileUploadStatus.QUARANTINED ->
-                            UploadedFileUrl(
-                                messageKey = VIRUS_SCAN_PENDING_WITH_NAME_KEY,
-                                displayName = upload.fileName,
-                                url = null,
-                            )
-
-                        FileUploadStatus.DELETED -> null
-                    }
-                }
+                .map { (_, upload) -> uploadService.getFileUploadById(upload.fileUploadId) to upload.fileName }
+                .toUploadedFileUrls(
+                    downloadMessageKey = "propertyDetails.complianceInformation.gasSafety.downloadCertificate",
+                    uploadService = uploadService,
+                )
 
         return listOf(
             SummaryListRowViewModel.forCheckYourAnswersPage(

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/GasSafetyRegistrationCyaSummaryRowsFactory.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/GasSafetyRegistrationCyaSummaryRowsFactory.kt
@@ -1,5 +1,6 @@
 package uk.gov.communities.prsdb.webapp.journeys.propertyRegistration
 
+import uk.gov.communities.prsdb.webapp.constants.enums.FileUploadStatus
 import uk.gov.communities.prsdb.webapp.journeys.Destination
 import uk.gov.communities.prsdb.webapp.journeys.JourneyStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.GasSafetyState
@@ -7,9 +8,14 @@ import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.GasSa
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.HasGasCertMode
 import uk.gov.communities.prsdb.webapp.journeys.shared.YesOrNo
 import uk.gov.communities.prsdb.webapp.models.viewModels.summaryModels.SummaryListRowViewModel
+import uk.gov.communities.prsdb.webapp.models.viewModels.summaryModels.UploadedFileUrl
+import uk.gov.communities.prsdb.webapp.services.UploadService
+
+private const val VIRUS_SCAN_PENDING_WITH_NAME_KEY = "propertyCompliance.uploadedFile.virusScanPendingWithName"
 
 class GasSafetyRegistrationCyaSummaryRowsFactory(
     private val state: GasSafetyState,
+    private val uploadService: UploadService,
     private val destinationProvider: (JourneyStep.RequestableStep<*, *, *>) -> Destination = { Destination(it) },
 ) {
     private val scenario: GasSafetyScenario = determineScenario(state)
@@ -58,11 +64,30 @@ class GasSafetyRegistrationCyaSummaryRowsFactory(
         }
 
     private fun getUploadedCertRows(): List<SummaryListRowViewModel> {
-        val uploadFileNames =
+        val uploadedFiles =
             state.gasUploadMap
                 .toList()
                 .sortedBy { it.first }
-                .map { (_, upload) -> upload.fileName }
+                .mapNotNull { (_, upload) ->
+                    val fileUpload = uploadService.getFileUploadById(upload.fileUploadId)
+                    when (fileUpload.status) {
+                        FileUploadStatus.SCANNED ->
+                            UploadedFileUrl(
+                                messageKey = "propertyDetails.complianceInformation.gasSafety.downloadCertificate",
+                                displayName = upload.fileName,
+                                url = uploadService.getDownloadUrlOrNull(fileUpload, upload.fileName),
+                            )
+
+                        FileUploadStatus.QUARANTINED ->
+                            UploadedFileUrl(
+                                messageKey = VIRUS_SCAN_PENDING_WITH_NAME_KEY,
+                                displayName = upload.fileName,
+                                url = null,
+                            )
+
+                        FileUploadStatus.DELETED -> null
+                    }
+                }
 
         return listOf(
             SummaryListRowViewModel.forCheckYourAnswersPage(
@@ -77,7 +102,7 @@ class GasSafetyRegistrationCyaSummaryRowsFactory(
             ),
             SummaryListRowViewModel.forCheckYourAnswersPage(
                 fieldHeading = "checkGasSafety.yourCertificate.fieldHeading",
-                fieldValue = uploadFileNames,
+                fieldValue = uploadedFiles,
                 destination = destinationProvider(state.checkGasCertUploadsStep),
             ),
         )

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/CheckElectricalSafetyAnswersStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/CheckElectricalSafetyAnswersStepConfig.kt
@@ -7,13 +7,16 @@ import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.ElectricalS
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.ElectricalSafetyState
 import uk.gov.communities.prsdb.webapp.journeys.shared.Complete
 import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.NoInputFormModel
+import uk.gov.communities.prsdb.webapp.services.UploadService
 
 @JourneyFrameworkComponent
-class CheckElectricalSafetyAnswersStepConfig : AbstractRequestableStepConfig<Complete, NoInputFormModel, ElectricalSafetyState>() {
+class CheckElectricalSafetyAnswersStepConfig(
+    private val uploadService: UploadService,
+) : AbstractRequestableStepConfig<Complete, NoInputFormModel, ElectricalSafetyState>() {
     override val formModelClass = NoInputFormModel::class
 
     override fun getStepSpecificContent(state: ElectricalSafetyState): Map<String, Any?> {
-        val factory = ElectricalSafetyRegistrationCyaSummaryRowsFactory(state)
+        val factory = ElectricalSafetyRegistrationCyaSummaryRowsFactory(state, uploadService)
         return mapOf(
             "rows" to factory.createRows(),
             "insetTextKey" to factory.getInsetTextKey(),

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/CheckGasSafetyAnswersStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/CheckGasSafetyAnswersStepConfig.kt
@@ -7,13 +7,16 @@ import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.GasSafetyRe
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.GasSafetyState
 import uk.gov.communities.prsdb.webapp.journeys.shared.Complete
 import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.NoInputFormModel
+import uk.gov.communities.prsdb.webapp.services.UploadService
 
 @JourneyFrameworkComponent
-class CheckGasSafetyAnswersStepConfig : AbstractRequestableStepConfig<Complete, NoInputFormModel, GasSafetyState>() {
+class CheckGasSafetyAnswersStepConfig(
+    private val uploadService: UploadService,
+) : AbstractRequestableStepConfig<Complete, NoInputFormModel, GasSafetyState>() {
     override val formModelClass = NoInputFormModel::class
 
     override fun getStepSpecificContent(state: GasSafetyState): Map<String, Any?> {
-        val factory = GasSafetyRegistrationCyaSummaryRowsFactory(state)
+        val factory = GasSafetyRegistrationCyaSummaryRowsFactory(state, uploadService)
         return mapOf(
             "gasSupplyRows" to factory.createGasSupplyRows(),
             "certRows" to factory.createCertRows(),

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/update/electricalSafety/UpdateCheckElectricalSafetyAnswersStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/update/electricalSafety/UpdateCheckElectricalSafetyAnswersStepConfig.kt
@@ -7,15 +7,17 @@ import uk.gov.communities.prsdb.webapp.journeys.JourneyStep.RequestableStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.ElectricalSafetyRegistrationCyaSummaryRowsFactory
 import uk.gov.communities.prsdb.webapp.journeys.shared.Complete
 import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.NoInputFormModel
+import uk.gov.communities.prsdb.webapp.services.UploadService
 
 @JourneyFrameworkComponent
-class UpdateCheckElectricalSafetyAnswersStepConfig :
-    AbstractRequestableStepConfig<Complete, NoInputFormModel, UpdateElectricalSafetyJourneyState>() {
+class UpdateCheckElectricalSafetyAnswersStepConfig(
+    private val uploadService: UploadService,
+) : AbstractRequestableStepConfig<Complete, NoInputFormModel, UpdateElectricalSafetyJourneyState>() {
     override val formModelClass = NoInputFormModel::class
 
     override fun getStepSpecificContent(state: UpdateElectricalSafetyJourneyState): Map<String, Any?> {
         val factory =
-            ElectricalSafetyRegistrationCyaSummaryRowsFactory(state) { step ->
+            ElectricalSafetyRegistrationCyaSummaryRowsFactory(state, uploadService) { step ->
                 Destination.VisitableStep(step, state.getCyaJourneyId(step))
             }
         return mapOf(

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/update/gasSafety/UpdateCheckGasSafetyAnswersStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/update/gasSafety/UpdateCheckGasSafetyAnswersStepConfig.kt
@@ -7,14 +7,17 @@ import uk.gov.communities.prsdb.webapp.journeys.JourneyStep.RequestableStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.GasSafetyRegistrationCyaSummaryRowsFactory
 import uk.gov.communities.prsdb.webapp.journeys.shared.Complete
 import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.NoInputFormModel
+import uk.gov.communities.prsdb.webapp.services.UploadService
 
 @JourneyFrameworkComponent
-class UpdateCheckGasSafetyAnswersStepConfig : AbstractRequestableStepConfig<Complete, NoInputFormModel, UpdateGasSafetyJourneyState>() {
+class UpdateCheckGasSafetyAnswersStepConfig(
+    private val uploadService: UploadService,
+) : AbstractRequestableStepConfig<Complete, NoInputFormModel, UpdateGasSafetyJourneyState>() {
     override val formModelClass = NoInputFormModel::class
 
     override fun getStepSpecificContent(state: UpdateGasSafetyJourneyState): Map<String, Any?> {
         val factory =
-            GasSafetyRegistrationCyaSummaryRowsFactory(state) { step ->
+            GasSafetyRegistrationCyaSummaryRowsFactory(state, uploadService) { step ->
                 Destination.VisitableStep(step, state.getCyaJourneyId(step))
             }
         return mapOf(

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/shared/helpers/ComplianceDetailsHelper.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/shared/helpers/ComplianceDetailsHelper.kt
@@ -10,14 +10,16 @@ import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.EpcS
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.GasSafetyState
 import uk.gov.communities.prsdb.webapp.journeys.shared.states.CheckYourAnswersJourneyState
 import uk.gov.communities.prsdb.webapp.services.EpcCertificateUrlProvider
+import uk.gov.communities.prsdb.webapp.services.UploadService
 
 @PrsdbWebService
 class ComplianceDetailsHelper(
     private val epcCertificateUrlProvider: EpcCertificateUrlProvider,
+    private val uploadService: UploadService,
 ) {
     fun <T> getGasSafetyCyaContent(state: T): Map<String, Any?> where T : GasSafetyState, T : CheckYourAnswersJourneyState {
         val factory =
-            GasSafetyRegistrationCyaSummaryRowsFactory(state) { step ->
+            GasSafetyRegistrationCyaSummaryRowsFactory(state, uploadService) { step ->
                 Destination.VisitableStep(step, state.getCyaJourneyId(step))
             }
         return mapOf(
@@ -29,7 +31,7 @@ class ComplianceDetailsHelper(
 
     fun <T> getElectricalSafetyCyaContent(state: T): Map<String, Any?> where T : ElectricalSafetyState, T : CheckYourAnswersJourneyState {
         val factory =
-            ElectricalSafetyRegistrationCyaSummaryRowsFactory(state) { step ->
+            ElectricalSafetyRegistrationCyaSummaryRowsFactory(state, uploadService) { step ->
                 Destination.VisitableStep(step, state.getCyaJourneyId(step))
             }
         return mapOf(

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/summaryModels/propertyComplianceViewModels/ComplianceUploadRowHelper.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/summaryModels/propertyComplianceViewModels/ComplianceUploadRowHelper.kt
@@ -21,29 +21,36 @@ fun MutableList<SummaryListRowViewModel>.addFileUploadRows(
     }
 
     val values =
-        visibleUploads.mapNotNull { upload ->
-            val displayName = upload.fileName ?: "$fallbackFileName.${upload.extension}"
-            when (upload.status) {
-                FileUploadStatus.SCANNED ->
-                    UploadedFileUrl(
-                        messageKey = downloadMessageKey,
-                        displayName = displayName,
-                        url = uploadService.getDownloadUrlOrNull(upload, displayName),
-                    )
-
-                FileUploadStatus.QUARANTINED ->
-                    UploadedFileUrl(
-                        messageKey = VIRUS_SCAN_PENDING_WITH_NAME_KEY,
-                        displayName = displayName,
-                    )
-
-                else -> null
-            }
-        }
+        visibleUploads
+            .map { upload -> upload to (upload.fileName ?: "$fallbackFileName.${upload.extension}") }
+            .toUploadedFileUrls(downloadMessageKey, uploadService)
 
     if (values.isNotEmpty()) {
         add(SummaryListRowViewModel(certificateKey, values))
     }
 }
+
+fun List<Pair<FileUpload, String>>.toUploadedFileUrls(
+    downloadMessageKey: String,
+    uploadService: UploadService,
+): List<UploadedFileUrl> =
+    mapNotNull { (upload, displayName) ->
+        when (upload.status) {
+            FileUploadStatus.SCANNED ->
+                UploadedFileUrl(
+                    messageKey = downloadMessageKey,
+                    displayName = displayName,
+                    url = uploadService.getDownloadUrlOrNull(upload, displayName),
+                )
+
+            FileUploadStatus.QUARANTINED ->
+                UploadedFileUrl(
+                    messageKey = VIRUS_SCAN_PENDING_WITH_NAME_KEY,
+                    displayName = displayName,
+                )
+
+            FileUploadStatus.DELETED -> null
+        }
+    }
 
 private const val VIRUS_SCAN_PENDING_WITH_NAME_KEY = "propertyCompliance.uploadedFile.virusScanPendingWithName"

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/ElectricalSafetyRegistrationCyaSummaryRowsFactoryTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/ElectricalSafetyRegistrationCyaSummaryRowsFactoryTests.kt
@@ -8,15 +8,21 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
+import uk.gov.communities.prsdb.webapp.constants.enums.FileUploadStatus
 import uk.gov.communities.prsdb.webapp.constants.enums.HasElectricalSafetyCertificate
+import uk.gov.communities.prsdb.webapp.database.entity.FileUpload
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.CertificateUpload
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.ElectricalSafetyState
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.CheckElectricalCertUploadsStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.ElectricalCertExpiryDateStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.HasElectricalCertMode
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.HasElectricalCertStep
+import uk.gov.communities.prsdb.webapp.models.viewModels.summaryModels.UploadedFileUrl
+import uk.gov.communities.prsdb.webapp.services.UploadService
 
 @ExtendWith(MockitoExtension::class)
 class ElectricalSafetyRegistrationCyaSummaryRowsFactoryTests {
@@ -26,6 +32,20 @@ class ElectricalSafetyRegistrationCyaSummaryRowsFactoryTests {
     private val mockHasElectricalCertStep: HasElectricalCertStep = mock()
     private val mockElectricalCertExpiryDateStep: ElectricalCertExpiryDateStep = mock()
     private val mockCheckElectricalCertUploadsStep: CheckElectricalCertUploadsStep = mock()
+    private val mockUploadService: UploadService = mock()
+
+    private fun fileUploadWithStatus(status: FileUploadStatus): FileUpload =
+        mock<FileUpload>().also { whenever(it.status).thenReturn(status) }
+
+    private fun stubUpload(
+        fileUploadId: Long,
+        status: FileUploadStatus,
+        downloadUrl: String? = null,
+    ) {
+        val fileUpload = fileUploadWithStatus(status)
+        whenever(mockUploadService.getFileUploadById(fileUploadId)).thenReturn(fileUpload)
+        whenever(mockUploadService.getDownloadUrlOrNull(eq(fileUpload), any())).thenReturn(downloadUrl)
+    }
 
     private fun setupCommonStateMocks() {
         whenever(mockState.hasElectricalCertStep).thenReturn(mockHasElectricalCertStep)
@@ -35,7 +55,7 @@ class ElectricalSafetyRegistrationCyaSummaryRowsFactoryTests {
     @Nested
     inner class CertUploaded {
         @Test
-        fun `factory returns correct content for EIC with uploads`() {
+        fun `factory returns scanned EIC uploads as UploadedFileUrl with eic download messageKey and link`() {
             setupCommonStateMocks()
             whenever(mockHasElectricalCertStep.outcome).thenReturn(HasElectricalCertMode.HAS_EIC)
             whenever(mockState.getElectricalCertificateIsOutdated()).thenReturn(false)
@@ -51,20 +71,30 @@ class ElectricalSafetyRegistrationCyaSummaryRowsFactoryTests {
             whenever(mockState.electricalUploadMap).thenReturn(
                 mapOf(1 to CertificateUpload(1L, "cert.pdf")),
             )
+            stubUpload(1L, FileUploadStatus.SCANNED, downloadUrl = "/download/cert.pdf")
 
-            val factory = ElectricalSafetyRegistrationCyaSummaryRowsFactory(mockState)
+            val factory = ElectricalSafetyRegistrationCyaSummaryRowsFactory(mockState, mockUploadService)
 
             val rows = factory.createRows()
             assertEquals(3, rows.size)
             assertEquals("checkElectricalSafety.eicLabel", rows[0].fieldValue)
             assertEquals(expiryDate, rows[1].fieldValue)
-            assertEquals(listOf("cert.pdf"), rows[2].fieldValue)
+            assertEquals(
+                listOf(
+                    UploadedFileUrl(
+                        messageKey = "propertyDetails.complianceInformation.electricalSafety.eic.downloadCertificate",
+                        displayName = "cert.pdf",
+                        url = "/download/cert.pdf",
+                    ),
+                ),
+                rows[2].fieldValue,
+            )
 
             assertNull(factory.getInsetTextKey())
         }
 
         @Test
-        fun `factory returns correct content for EICR with uploads`() {
+        fun `factory returns scanned EICR uploads with eicr download messageKey`() {
             setupCommonStateMocks()
             whenever(mockHasElectricalCertStep.outcome).thenReturn(HasElectricalCertMode.HAS_EICR)
             whenever(mockState.getElectricalCertificateIsOutdated()).thenReturn(false)
@@ -80,24 +110,93 @@ class ElectricalSafetyRegistrationCyaSummaryRowsFactoryTests {
             whenever(mockState.electricalUploadMap).thenReturn(
                 mapOf(1 to CertificateUpload(1L, "cert.pdf")),
             )
+            stubUpload(1L, FileUploadStatus.SCANNED, downloadUrl = "/download/cert.pdf")
 
-            val factory = ElectricalSafetyRegistrationCyaSummaryRowsFactory(mockState)
+            val factory = ElectricalSafetyRegistrationCyaSummaryRowsFactory(mockState, mockUploadService)
 
             val rows = factory.createRows()
             assertEquals(3, rows.size)
             assertEquals("checkElectricalSafety.eicrLabel", rows[0].fieldValue)
+            assertEquals(
+                listOf(
+                    UploadedFileUrl(
+                        messageKey = "propertyDetails.complianceInformation.electricalSafety.eicr.downloadCertificate",
+                        displayName = "cert.pdf",
+                        url = "/download/cert.pdf",
+                    ),
+                ),
+                rows[2].fieldValue,
+            )
 
             assertNull(factory.getInsetTextKey())
         }
 
         @Test
-        fun `factory sorts uploads by map key and returns file names`() {
+        fun `factory returns quarantined uploads with pending scan messageKey and no url`() {
             setupCommonStateMocks()
             whenever(mockHasElectricalCertStep.outcome).thenReturn(HasElectricalCertMode.HAS_EIC)
             whenever(mockState.getElectricalCertificateIsOutdated()).thenReturn(false)
             whenever(mockState.getElectricalCertificateType()).thenReturn(HasElectricalSafetyCertificate.HAS_EIC)
             whenever(mockState.getElectricalCertificateExpiryDateIfReachable()).thenReturn(LocalDate(2026, 6, 15))
+            whenever(mockState.electricalCertExpiryDateStep).thenReturn(mockElectricalCertExpiryDateStep)
+            whenever(mockState.checkElectricalCertUploadsStep).thenReturn(mockCheckElectricalCertUploadsStep)
+            whenever(mockElectricalCertExpiryDateStep.currentJourneyId).thenReturn("test-journey-id")
+            whenever(mockCheckElectricalCertUploadsStep.currentJourneyId).thenReturn("test-journey-id")
+            whenever(mockState.electricalUploadMap).thenReturn(
+                mapOf(1 to CertificateUpload(1L, "cert.pdf")),
+            )
+            stubUpload(1L, FileUploadStatus.QUARANTINED)
 
+            val factory = ElectricalSafetyRegistrationCyaSummaryRowsFactory(mockState, mockUploadService)
+
+            val rows = factory.createRows()
+            assertEquals(
+                listOf(
+                    UploadedFileUrl(
+                        messageKey = "propertyCompliance.uploadedFile.virusScanPendingWithName",
+                        displayName = "cert.pdf",
+                        url = null,
+                    ),
+                ),
+                rows[2].fieldValue,
+            )
+        }
+
+        @Test
+        fun `factory filters out deleted uploads`() {
+            setupCommonStateMocks()
+            whenever(mockHasElectricalCertStep.outcome).thenReturn(HasElectricalCertMode.HAS_EIC)
+            whenever(mockState.getElectricalCertificateIsOutdated()).thenReturn(false)
+            whenever(mockState.getElectricalCertificateType()).thenReturn(HasElectricalSafetyCertificate.HAS_EIC)
+            whenever(mockState.getElectricalCertificateExpiryDateIfReachable()).thenReturn(LocalDate(2026, 6, 15))
+            whenever(mockState.electricalCertExpiryDateStep).thenReturn(mockElectricalCertExpiryDateStep)
+            whenever(mockState.checkElectricalCertUploadsStep).thenReturn(mockCheckElectricalCertUploadsStep)
+            whenever(mockElectricalCertExpiryDateStep.currentJourneyId).thenReturn("test-journey-id")
+            whenever(mockCheckElectricalCertUploadsStep.currentJourneyId).thenReturn("test-journey-id")
+            whenever(mockState.electricalUploadMap).thenReturn(
+                mapOf(
+                    1 to CertificateUpload(1L, "scanned.pdf"),
+                    2 to CertificateUpload(2L, "deleted.pdf"),
+                ),
+            )
+            stubUpload(1L, FileUploadStatus.SCANNED, downloadUrl = "/download/scanned.pdf")
+            stubUpload(2L, FileUploadStatus.DELETED)
+
+            val factory = ElectricalSafetyRegistrationCyaSummaryRowsFactory(mockState, mockUploadService)
+
+            val rows = factory.createRows()
+            val files = rows[2].fieldValue as List<*>
+            assertEquals(1, files.size)
+            assertEquals("scanned.pdf", (files[0] as UploadedFileUrl).displayName)
+        }
+
+        @Test
+        fun `factory preserves map index ordering across mixed status uploads`() {
+            setupCommonStateMocks()
+            whenever(mockHasElectricalCertStep.outcome).thenReturn(HasElectricalCertMode.HAS_EIC)
+            whenever(mockState.getElectricalCertificateIsOutdated()).thenReturn(false)
+            whenever(mockState.getElectricalCertificateType()).thenReturn(HasElectricalSafetyCertificate.HAS_EIC)
+            whenever(mockState.getElectricalCertificateExpiryDateIfReachable()).thenReturn(LocalDate(2026, 6, 15))
             whenever(mockState.electricalCertExpiryDateStep).thenReturn(mockElectricalCertExpiryDateStep)
             whenever(mockState.checkElectricalCertUploadsStep).thenReturn(mockCheckElectricalCertUploadsStep)
             whenever(mockElectricalCertExpiryDateStep.currentJourneyId).thenReturn("test-journey-id")
@@ -109,11 +208,18 @@ class ElectricalSafetyRegistrationCyaSummaryRowsFactoryTests {
                     2 to CertificateUpload(2L, "second.pdf"),
                 ),
             )
+            stubUpload(1L, FileUploadStatus.SCANNED, downloadUrl = "/download/first.pdf")
+            stubUpload(2L, FileUploadStatus.QUARANTINED)
+            stubUpload(3L, FileUploadStatus.SCANNED, downloadUrl = "/download/third.pdf")
 
-            val factory = ElectricalSafetyRegistrationCyaSummaryRowsFactory(mockState)
+            val factory = ElectricalSafetyRegistrationCyaSummaryRowsFactory(mockState, mockUploadService)
 
             val rows = factory.createRows()
-            assertEquals(listOf("first.pdf", "second.pdf", "third.pdf"), rows[2].fieldValue)
+            val files = rows[2].fieldValue as List<*>
+            assertEquals(listOf("first.pdf", "second.pdf", "third.pdf"), files.map { (it as UploadedFileUrl).displayName })
+            assertEquals("/download/first.pdf", (files[0] as UploadedFileUrl).url)
+            assertNull((files[1] as UploadedFileUrl).url)
+            assertEquals("/download/third.pdf", (files[2] as UploadedFileUrl).url)
         }
     }
 
@@ -125,7 +231,7 @@ class ElectricalSafetyRegistrationCyaSummaryRowsFactoryTests {
             whenever(mockHasElectricalCertStep.outcome).thenReturn(HasElectricalCertMode.PROVIDE_THIS_LATER)
             whenever(mockState.isOccupied).thenReturn(true)
 
-            val factory = ElectricalSafetyRegistrationCyaSummaryRowsFactory(mockState)
+            val factory = ElectricalSafetyRegistrationCyaSummaryRowsFactory(mockState, mockUploadService)
 
             val rows = factory.createRows()
             assertEquals(1, rows.size)
@@ -140,7 +246,7 @@ class ElectricalSafetyRegistrationCyaSummaryRowsFactoryTests {
             whenever(mockHasElectricalCertStep.outcome).thenReturn(HasElectricalCertMode.PROVIDE_THIS_LATER)
             whenever(mockState.isOccupied).thenReturn(false)
 
-            val factory = ElectricalSafetyRegistrationCyaSummaryRowsFactory(mockState)
+            val factory = ElectricalSafetyRegistrationCyaSummaryRowsFactory(mockState, mockUploadService)
 
             val rows = factory.createRows()
             assertEquals(1, rows.size)
@@ -158,7 +264,7 @@ class ElectricalSafetyRegistrationCyaSummaryRowsFactoryTests {
             whenever(mockHasElectricalCertStep.outcome).thenReturn(HasElectricalCertMode.NO_CERTIFICATE)
             whenever(mockState.isOccupied).thenReturn(true)
 
-            val factory = ElectricalSafetyRegistrationCyaSummaryRowsFactory(mockState)
+            val factory = ElectricalSafetyRegistrationCyaSummaryRowsFactory(mockState, mockUploadService)
 
             val rows = factory.createRows()
             assertEquals(1, rows.size)
@@ -173,7 +279,7 @@ class ElectricalSafetyRegistrationCyaSummaryRowsFactoryTests {
             whenever(mockHasElectricalCertStep.outcome).thenReturn(HasElectricalCertMode.NO_CERTIFICATE)
             whenever(mockState.isOccupied).thenReturn(false)
 
-            val factory = ElectricalSafetyRegistrationCyaSummaryRowsFactory(mockState)
+            val factory = ElectricalSafetyRegistrationCyaSummaryRowsFactory(mockState, mockUploadService)
 
             val rows = factory.createRows()
             assertEquals(1, rows.size)
@@ -192,7 +298,7 @@ class ElectricalSafetyRegistrationCyaSummaryRowsFactoryTests {
             whenever(mockState.getElectricalCertificateIsOutdated()).thenReturn(true)
             whenever(mockState.isOccupied).thenReturn(true)
 
-            val factory = ElectricalSafetyRegistrationCyaSummaryRowsFactory(mockState)
+            val factory = ElectricalSafetyRegistrationCyaSummaryRowsFactory(mockState, mockUploadService)
 
             val rows = factory.createRows()
             assertEquals(1, rows.size)
@@ -208,7 +314,7 @@ class ElectricalSafetyRegistrationCyaSummaryRowsFactoryTests {
             whenever(mockState.getElectricalCertificateIsOutdated()).thenReturn(true)
             whenever(mockState.isOccupied).thenReturn(false)
 
-            val factory = ElectricalSafetyRegistrationCyaSummaryRowsFactory(mockState)
+            val factory = ElectricalSafetyRegistrationCyaSummaryRowsFactory(mockState, mockUploadService)
 
             val rows = factory.createRows()
             assertEquals(1, rows.size)

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/ElectricalSafetyRegistrationCyaSummaryRowsFactoryTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/ElectricalSafetyRegistrationCyaSummaryRowsFactoryTests.kt
@@ -55,7 +55,7 @@ class ElectricalSafetyRegistrationCyaSummaryRowsFactoryTests {
     @Nested
     inner class CertUploaded {
         @Test
-        fun `factory returns scanned EIC uploads as UploadedFileUrl with eic download messageKey and link`() {
+        fun `factory wires up EIC download messageKey and sorts uploads by map index`() {
             setupCommonStateMocks()
             whenever(mockHasElectricalCertStep.outcome).thenReturn(HasElectricalCertMode.HAS_EIC)
             whenever(mockState.getElectricalCertificateIsOutdated()).thenReturn(false)
@@ -69,9 +69,13 @@ class ElectricalSafetyRegistrationCyaSummaryRowsFactoryTests {
             whenever(mockElectricalCertExpiryDateStep.currentJourneyId).thenReturn("test-journey-id")
             whenever(mockCheckElectricalCertUploadsStep.currentJourneyId).thenReturn("test-journey-id")
             whenever(mockState.electricalUploadMap).thenReturn(
-                mapOf(1 to CertificateUpload(1L, "cert.pdf")),
+                mapOf(
+                    2 to CertificateUpload(2L, "second.pdf"),
+                    1 to CertificateUpload(1L, "first.pdf"),
+                ),
             )
-            stubUpload(1L, FileUploadStatus.SCANNED, downloadUrl = "/download/cert.pdf")
+            stubUpload(1L, FileUploadStatus.SCANNED, downloadUrl = "/download/first.pdf")
+            stubUpload(2L, FileUploadStatus.SCANNED, downloadUrl = "/download/second.pdf")
 
             val factory = ElectricalSafetyRegistrationCyaSummaryRowsFactory(mockState, mockUploadService)
 
@@ -83,8 +87,13 @@ class ElectricalSafetyRegistrationCyaSummaryRowsFactoryTests {
                 listOf(
                     UploadedFileUrl(
                         messageKey = "propertyDetails.complianceInformation.electricalSafety.eic.downloadCertificate",
-                        displayName = "cert.pdf",
-                        url = "/download/cert.pdf",
+                        displayName = "first.pdf",
+                        url = "/download/first.pdf",
+                    ),
+                    UploadedFileUrl(
+                        messageKey = "propertyDetails.complianceInformation.electricalSafety.eic.downloadCertificate",
+                        displayName = "second.pdf",
+                        url = "/download/second.pdf",
                     ),
                 ),
                 rows[2].fieldValue,
@@ -94,14 +103,13 @@ class ElectricalSafetyRegistrationCyaSummaryRowsFactoryTests {
         }
 
         @Test
-        fun `factory returns scanned EICR uploads with eicr download messageKey`() {
+        fun `factory wires up EICR download messageKey`() {
             setupCommonStateMocks()
             whenever(mockHasElectricalCertStep.outcome).thenReturn(HasElectricalCertMode.HAS_EICR)
             whenever(mockState.getElectricalCertificateIsOutdated()).thenReturn(false)
             whenever(mockState.getElectricalCertificateType()).thenReturn(HasElectricalSafetyCertificate.HAS_EICR)
 
-            val expiryDate = LocalDate(2026, 6, 15)
-            whenever(mockState.getElectricalCertificateExpiryDateIfReachable()).thenReturn(expiryDate)
+            whenever(mockState.getElectricalCertificateExpiryDateIfReachable()).thenReturn(LocalDate(2026, 6, 15))
 
             whenever(mockState.electricalCertExpiryDateStep).thenReturn(mockElectricalCertExpiryDateStep)
             whenever(mockState.checkElectricalCertUploadsStep).thenReturn(mockCheckElectricalCertUploadsStep)
@@ -127,99 +135,6 @@ class ElectricalSafetyRegistrationCyaSummaryRowsFactoryTests {
                 ),
                 rows[2].fieldValue,
             )
-
-            assertNull(factory.getInsetTextKey())
-        }
-
-        @Test
-        fun `factory returns quarantined uploads with pending scan messageKey and no url`() {
-            setupCommonStateMocks()
-            whenever(mockHasElectricalCertStep.outcome).thenReturn(HasElectricalCertMode.HAS_EIC)
-            whenever(mockState.getElectricalCertificateIsOutdated()).thenReturn(false)
-            whenever(mockState.getElectricalCertificateType()).thenReturn(HasElectricalSafetyCertificate.HAS_EIC)
-            whenever(mockState.getElectricalCertificateExpiryDateIfReachable()).thenReturn(LocalDate(2026, 6, 15))
-            whenever(mockState.electricalCertExpiryDateStep).thenReturn(mockElectricalCertExpiryDateStep)
-            whenever(mockState.checkElectricalCertUploadsStep).thenReturn(mockCheckElectricalCertUploadsStep)
-            whenever(mockElectricalCertExpiryDateStep.currentJourneyId).thenReturn("test-journey-id")
-            whenever(mockCheckElectricalCertUploadsStep.currentJourneyId).thenReturn("test-journey-id")
-            whenever(mockState.electricalUploadMap).thenReturn(
-                mapOf(1 to CertificateUpload(1L, "cert.pdf")),
-            )
-            stubUpload(1L, FileUploadStatus.QUARANTINED)
-
-            val factory = ElectricalSafetyRegistrationCyaSummaryRowsFactory(mockState, mockUploadService)
-
-            val rows = factory.createRows()
-            assertEquals(
-                listOf(
-                    UploadedFileUrl(
-                        messageKey = "propertyCompliance.uploadedFile.virusScanPendingWithName",
-                        displayName = "cert.pdf",
-                        url = null,
-                    ),
-                ),
-                rows[2].fieldValue,
-            )
-        }
-
-        @Test
-        fun `factory filters out deleted uploads`() {
-            setupCommonStateMocks()
-            whenever(mockHasElectricalCertStep.outcome).thenReturn(HasElectricalCertMode.HAS_EIC)
-            whenever(mockState.getElectricalCertificateIsOutdated()).thenReturn(false)
-            whenever(mockState.getElectricalCertificateType()).thenReturn(HasElectricalSafetyCertificate.HAS_EIC)
-            whenever(mockState.getElectricalCertificateExpiryDateIfReachable()).thenReturn(LocalDate(2026, 6, 15))
-            whenever(mockState.electricalCertExpiryDateStep).thenReturn(mockElectricalCertExpiryDateStep)
-            whenever(mockState.checkElectricalCertUploadsStep).thenReturn(mockCheckElectricalCertUploadsStep)
-            whenever(mockElectricalCertExpiryDateStep.currentJourneyId).thenReturn("test-journey-id")
-            whenever(mockCheckElectricalCertUploadsStep.currentJourneyId).thenReturn("test-journey-id")
-            whenever(mockState.electricalUploadMap).thenReturn(
-                mapOf(
-                    1 to CertificateUpload(1L, "scanned.pdf"),
-                    2 to CertificateUpload(2L, "deleted.pdf"),
-                ),
-            )
-            stubUpload(1L, FileUploadStatus.SCANNED, downloadUrl = "/download/scanned.pdf")
-            stubUpload(2L, FileUploadStatus.DELETED)
-
-            val factory = ElectricalSafetyRegistrationCyaSummaryRowsFactory(mockState, mockUploadService)
-
-            val rows = factory.createRows()
-            val files = rows[2].fieldValue as List<*>
-            assertEquals(1, files.size)
-            assertEquals("scanned.pdf", (files[0] as UploadedFileUrl).displayName)
-        }
-
-        @Test
-        fun `factory preserves map index ordering across mixed status uploads`() {
-            setupCommonStateMocks()
-            whenever(mockHasElectricalCertStep.outcome).thenReturn(HasElectricalCertMode.HAS_EIC)
-            whenever(mockState.getElectricalCertificateIsOutdated()).thenReturn(false)
-            whenever(mockState.getElectricalCertificateType()).thenReturn(HasElectricalSafetyCertificate.HAS_EIC)
-            whenever(mockState.getElectricalCertificateExpiryDateIfReachable()).thenReturn(LocalDate(2026, 6, 15))
-            whenever(mockState.electricalCertExpiryDateStep).thenReturn(mockElectricalCertExpiryDateStep)
-            whenever(mockState.checkElectricalCertUploadsStep).thenReturn(mockCheckElectricalCertUploadsStep)
-            whenever(mockElectricalCertExpiryDateStep.currentJourneyId).thenReturn("test-journey-id")
-            whenever(mockCheckElectricalCertUploadsStep.currentJourneyId).thenReturn("test-journey-id")
-            whenever(mockState.electricalUploadMap).thenReturn(
-                mapOf(
-                    3 to CertificateUpload(3L, "third.pdf"),
-                    1 to CertificateUpload(1L, "first.pdf"),
-                    2 to CertificateUpload(2L, "second.pdf"),
-                ),
-            )
-            stubUpload(1L, FileUploadStatus.SCANNED, downloadUrl = "/download/first.pdf")
-            stubUpload(2L, FileUploadStatus.QUARANTINED)
-            stubUpload(3L, FileUploadStatus.SCANNED, downloadUrl = "/download/third.pdf")
-
-            val factory = ElectricalSafetyRegistrationCyaSummaryRowsFactory(mockState, mockUploadService)
-
-            val rows = factory.createRows()
-            val files = rows[2].fieldValue as List<*>
-            assertEquals(listOf("first.pdf", "second.pdf", "third.pdf"), files.map { (it as UploadedFileUrl).displayName })
-            assertEquals("/download/first.pdf", (files[0] as UploadedFileUrl).url)
-            assertNull((files[1] as UploadedFileUrl).url)
-            assertEquals("/download/third.pdf", (files[2] as UploadedFileUrl).url)
         }
     }
 

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/GasSafetyRegistrationCyaSummaryRowsFactoryTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/GasSafetyRegistrationCyaSummaryRowsFactoryTests.kt
@@ -8,8 +8,12 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
+import uk.gov.communities.prsdb.webapp.constants.enums.FileUploadStatus
+import uk.gov.communities.prsdb.webapp.database.entity.FileUpload
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.CertificateUpload
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.GasSafetyState
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.CheckGasCertUploadsStep
@@ -19,6 +23,8 @@ import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.HasGa
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.HasGasSupplyStep
 import uk.gov.communities.prsdb.webapp.journeys.shared.YesOrNo
 import uk.gov.communities.prsdb.webapp.models.viewModels.summaryModels.SummaryListRowViewModel
+import uk.gov.communities.prsdb.webapp.models.viewModels.summaryModels.UploadedFileUrl
+import uk.gov.communities.prsdb.webapp.services.UploadService
 
 @ExtendWith(MockitoExtension::class)
 class GasSafetyRegistrationCyaSummaryRowsFactoryTests {
@@ -29,6 +35,20 @@ class GasSafetyRegistrationCyaSummaryRowsFactoryTests {
     private val mockHasGasCertStep: HasGasCertStep = mock()
     private val mockGasCertIssueDateStep: GasCertIssueDateStep = mock()
     private val mockCheckGasCertUploadsStep: CheckGasCertUploadsStep = mock()
+    private val mockUploadService: UploadService = mock()
+
+    private fun fileUploadWithStatus(status: FileUploadStatus): FileUpload =
+        mock<FileUpload>().also { whenever(it.status).thenReturn(status) }
+
+    private fun stubUpload(
+        fileUploadId: Long,
+        status: FileUploadStatus,
+        downloadUrl: String? = null,
+    ) {
+        val fileUpload = fileUploadWithStatus(status)
+        whenever(mockUploadService.getFileUploadById(fileUploadId)).thenReturn(fileUpload)
+        whenever(mockUploadService.getDownloadUrlOrNull(eq(fileUpload), any())).thenReturn(downloadUrl)
+    }
 
     private fun setupCommonStateMocks() {
         whenever(mockState.hasGasSupplyStep).thenReturn(mockHasGasSupplyStep)
@@ -45,7 +65,7 @@ class GasSafetyRegistrationCyaSummaryRowsFactoryTests {
             whenever(mockHasGasSupplyStep.currentJourneyId).thenReturn("test-journey-id")
             whenever(mockHasGasSupplyStep.outcome).thenReturn(YesOrNo.NO)
 
-            val factory = GasSafetyRegistrationCyaSummaryRowsFactory(mockState)
+            val factory = GasSafetyRegistrationCyaSummaryRowsFactory(mockState, mockUploadService)
 
             val gasSupplyRows = factory.createGasSupplyRows()
             assertEquals(1, gasSupplyRows.size)
@@ -61,7 +81,7 @@ class GasSafetyRegistrationCyaSummaryRowsFactoryTests {
     @Nested
     inner class UploadedCertificate {
         @Test
-        fun `factory returns correct content for valid cert with uploads`() {
+        fun `factory returns scanned uploads as UploadedFileUrl with download link`() {
             setupCommonStateMocks()
             whenever(mockHasGasSupplyStep.outcome).thenReturn(YesOrNo.YES)
             whenever(mockHasGasCertStep.outcome).thenReturn(HasGasCertMode.HAS_CERTIFICATE)
@@ -77,8 +97,9 @@ class GasSafetyRegistrationCyaSummaryRowsFactoryTests {
             whenever(mockState.gasUploadMap).thenReturn(
                 mapOf(1 to CertificateUpload(1L, "cert.pdf")),
             )
+            stubUpload(1L, FileUploadStatus.SCANNED, downloadUrl = "/download/cert.pdf")
 
-            val factory = GasSafetyRegistrationCyaSummaryRowsFactory(mockState)
+            val factory = GasSafetyRegistrationCyaSummaryRowsFactory(mockState, mockUploadService)
 
             val gasSupplyRows = factory.createGasSupplyRows()
             assertEquals(1, gasSupplyRows.size)
@@ -88,13 +109,81 @@ class GasSafetyRegistrationCyaSummaryRowsFactoryTests {
             assertEquals(3, certRows.size)
             assertEquals(true, certRows[0].fieldValue)
             assertEquals(issueDate, certRows[1].fieldValue)
-            assertEquals(listOf("cert.pdf"), certRows[2].fieldValue)
+            assertEquals(
+                listOf(
+                    UploadedFileUrl(
+                        messageKey = "propertyDetails.complianceInformation.gasSafety.downloadCertificate",
+                        displayName = "cert.pdf",
+                        url = "/download/cert.pdf",
+                    ),
+                ),
+                certRows[2].fieldValue,
+            )
 
             assertNull(factory.getInsetTextKey())
         }
 
         @Test
-        fun `factory sorts uploads by map key and returns file names`() {
+        fun `factory returns quarantined uploads as UploadedFileUrl with pending scan messageKey and no url`() {
+            setupCommonStateMocks()
+            whenever(mockHasGasSupplyStep.outcome).thenReturn(YesOrNo.YES)
+            whenever(mockHasGasCertStep.outcome).thenReturn(HasGasCertMode.HAS_CERTIFICATE)
+            whenever(mockState.getGasSafetyCertificateIsOutdated()).thenReturn(false)
+            whenever(mockState.getGasSafetyCertificateIssueDateIfReachable()).thenReturn(LocalDate(2024, 6, 15))
+            whenever(mockState.gasCertIssueDateStep).thenReturn(mockGasCertIssueDateStep)
+            whenever(mockState.checkGasCertUploadsStep).thenReturn(mockCheckGasCertUploadsStep)
+            whenever(mockGasCertIssueDateStep.currentJourneyId).thenReturn("test-journey-id")
+            whenever(mockCheckGasCertUploadsStep.currentJourneyId).thenReturn("test-journey-id")
+            whenever(mockState.gasUploadMap).thenReturn(
+                mapOf(1 to CertificateUpload(1L, "cert.pdf")),
+            )
+            stubUpload(1L, FileUploadStatus.QUARANTINED)
+
+            val factory = GasSafetyRegistrationCyaSummaryRowsFactory(mockState, mockUploadService)
+
+            val certRows = factory.createCertRows()
+            assertEquals(
+                listOf(
+                    UploadedFileUrl(
+                        messageKey = "propertyCompliance.uploadedFile.virusScanPendingWithName",
+                        displayName = "cert.pdf",
+                        url = null,
+                    ),
+                ),
+                certRows[2].fieldValue,
+            )
+        }
+
+        @Test
+        fun `factory filters out deleted uploads`() {
+            setupCommonStateMocks()
+            whenever(mockHasGasSupplyStep.outcome).thenReturn(YesOrNo.YES)
+            whenever(mockHasGasCertStep.outcome).thenReturn(HasGasCertMode.HAS_CERTIFICATE)
+            whenever(mockState.getGasSafetyCertificateIsOutdated()).thenReturn(false)
+            whenever(mockState.getGasSafetyCertificateIssueDateIfReachable()).thenReturn(LocalDate(2024, 6, 15))
+            whenever(mockState.gasCertIssueDateStep).thenReturn(mockGasCertIssueDateStep)
+            whenever(mockState.checkGasCertUploadsStep).thenReturn(mockCheckGasCertUploadsStep)
+            whenever(mockGasCertIssueDateStep.currentJourneyId).thenReturn("test-journey-id")
+            whenever(mockCheckGasCertUploadsStep.currentJourneyId).thenReturn("test-journey-id")
+            whenever(mockState.gasUploadMap).thenReturn(
+                mapOf(
+                    1 to CertificateUpload(1L, "scanned.pdf"),
+                    2 to CertificateUpload(2L, "deleted.pdf"),
+                ),
+            )
+            stubUpload(1L, FileUploadStatus.SCANNED, downloadUrl = "/download/scanned.pdf")
+            stubUpload(2L, FileUploadStatus.DELETED)
+
+            val factory = GasSafetyRegistrationCyaSummaryRowsFactory(mockState, mockUploadService)
+
+            val certRows = factory.createCertRows()
+            val files = certRows[2].fieldValue as List<*>
+            assertEquals(1, files.size)
+            assertEquals("scanned.pdf", (files[0] as UploadedFileUrl).displayName)
+        }
+
+        @Test
+        fun `factory preserves map index ordering across mixed status uploads`() {
             setupCommonStateMocks()
             whenever(mockHasGasSupplyStep.outcome).thenReturn(YesOrNo.YES)
             whenever(mockHasGasCertStep.outcome).thenReturn(HasGasCertMode.HAS_CERTIFICATE)
@@ -111,11 +200,18 @@ class GasSafetyRegistrationCyaSummaryRowsFactoryTests {
                     2 to CertificateUpload(2L, "second.pdf"),
                 ),
             )
+            stubUpload(1L, FileUploadStatus.SCANNED, downloadUrl = "/download/first.pdf")
+            stubUpload(2L, FileUploadStatus.QUARANTINED)
+            stubUpload(3L, FileUploadStatus.SCANNED, downloadUrl = "/download/third.pdf")
 
-            val factory = GasSafetyRegistrationCyaSummaryRowsFactory(mockState)
+            val factory = GasSafetyRegistrationCyaSummaryRowsFactory(mockState, mockUploadService)
 
             val certRows = factory.createCertRows()
-            assertEquals(listOf("first.pdf", "second.pdf", "third.pdf"), certRows[2].fieldValue)
+            val files = certRows[2].fieldValue as List<*>
+            assertEquals(listOf("first.pdf", "second.pdf", "third.pdf"), files.map { (it as UploadedFileUrl).displayName })
+            assertEquals("/download/first.pdf", (files[0] as UploadedFileUrl).url)
+            assertNull((files[1] as UploadedFileUrl).url)
+            assertEquals("/download/third.pdf", (files[2] as UploadedFileUrl).url)
         }
     }
 
@@ -128,7 +224,7 @@ class GasSafetyRegistrationCyaSummaryRowsFactoryTests {
             whenever(mockHasGasCertStep.outcome).thenReturn(HasGasCertMode.PROVIDE_THIS_LATER)
             whenever(mockState.isOccupied).thenReturn(true)
 
-            val factory = GasSafetyRegistrationCyaSummaryRowsFactory(mockState)
+            val factory = GasSafetyRegistrationCyaSummaryRowsFactory(mockState, mockUploadService)
 
             val gasSupplyRows = factory.createGasSupplyRows()
             assertEquals(2, gasSupplyRows.size)
@@ -148,7 +244,7 @@ class GasSafetyRegistrationCyaSummaryRowsFactoryTests {
             whenever(mockHasGasCertStep.outcome).thenReturn(HasGasCertMode.PROVIDE_THIS_LATER)
             whenever(mockState.isOccupied).thenReturn(false)
 
-            val factory = GasSafetyRegistrationCyaSummaryRowsFactory(mockState)
+            val factory = GasSafetyRegistrationCyaSummaryRowsFactory(mockState, mockUploadService)
 
             val gasSupplyRows = factory.createGasSupplyRows()
             assertEquals(2, gasSupplyRows.size)
@@ -171,7 +267,7 @@ class GasSafetyRegistrationCyaSummaryRowsFactoryTests {
             whenever(mockHasGasCertStep.outcome).thenReturn(HasGasCertMode.NO_CERTIFICATE)
             whenever(mockState.isOccupied).thenReturn(true)
 
-            val factory = GasSafetyRegistrationCyaSummaryRowsFactory(mockState)
+            val factory = GasSafetyRegistrationCyaSummaryRowsFactory(mockState, mockUploadService)
 
             val gasSupplyRows = factory.createGasSupplyRows()
             assertEquals(2, gasSupplyRows.size)
@@ -191,7 +287,7 @@ class GasSafetyRegistrationCyaSummaryRowsFactoryTests {
             whenever(mockHasGasCertStep.outcome).thenReturn(HasGasCertMode.NO_CERTIFICATE)
             whenever(mockState.isOccupied).thenReturn(false)
 
-            val factory = GasSafetyRegistrationCyaSummaryRowsFactory(mockState)
+            val factory = GasSafetyRegistrationCyaSummaryRowsFactory(mockState, mockUploadService)
 
             val gasSupplyRows = factory.createGasSupplyRows()
             assertEquals(2, gasSupplyRows.size)
@@ -215,7 +311,7 @@ class GasSafetyRegistrationCyaSummaryRowsFactoryTests {
             whenever(mockState.getGasSafetyCertificateIsOutdated()).thenReturn(true)
             whenever(mockState.isOccupied).thenReturn(true)
 
-            val factory = GasSafetyRegistrationCyaSummaryRowsFactory(mockState)
+            val factory = GasSafetyRegistrationCyaSummaryRowsFactory(mockState, mockUploadService)
 
             val gasSupplyRows = factory.createGasSupplyRows()
             assertEquals(2, gasSupplyRows.size)
@@ -236,7 +332,7 @@ class GasSafetyRegistrationCyaSummaryRowsFactoryTests {
             whenever(mockState.getGasSafetyCertificateIsOutdated()).thenReturn(true)
             whenever(mockState.isOccupied).thenReturn(false)
 
-            val factory = GasSafetyRegistrationCyaSummaryRowsFactory(mockState)
+            val factory = GasSafetyRegistrationCyaSummaryRowsFactory(mockState, mockUploadService)
 
             val gasSupplyRows = factory.createGasSupplyRows()
             assertEquals(2, gasSupplyRows.size)

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/GasSafetyRegistrationCyaSummaryRowsFactoryTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/GasSafetyRegistrationCyaSummaryRowsFactoryTests.kt
@@ -81,7 +81,7 @@ class GasSafetyRegistrationCyaSummaryRowsFactoryTests {
     @Nested
     inner class UploadedCertificate {
         @Test
-        fun `factory returns scanned uploads as UploadedFileUrl with download link`() {
+        fun `factory wires up gas download messageKey and sorts uploads by map index`() {
             setupCommonStateMocks()
             whenever(mockHasGasSupplyStep.outcome).thenReturn(YesOrNo.YES)
             whenever(mockHasGasCertStep.outcome).thenReturn(HasGasCertMode.HAS_CERTIFICATE)
@@ -95,9 +95,13 @@ class GasSafetyRegistrationCyaSummaryRowsFactoryTests {
             whenever(mockGasCertIssueDateStep.currentJourneyId).thenReturn("test-journey-id")
             whenever(mockCheckGasCertUploadsStep.currentJourneyId).thenReturn("test-journey-id")
             whenever(mockState.gasUploadMap).thenReturn(
-                mapOf(1 to CertificateUpload(1L, "cert.pdf")),
+                mapOf(
+                    2 to CertificateUpload(2L, "second.pdf"),
+                    1 to CertificateUpload(1L, "first.pdf"),
+                ),
             )
-            stubUpload(1L, FileUploadStatus.SCANNED, downloadUrl = "/download/cert.pdf")
+            stubUpload(1L, FileUploadStatus.SCANNED, downloadUrl = "/download/first.pdf")
+            stubUpload(2L, FileUploadStatus.SCANNED, downloadUrl = "/download/second.pdf")
 
             val factory = GasSafetyRegistrationCyaSummaryRowsFactory(mockState, mockUploadService)
 
@@ -113,105 +117,19 @@ class GasSafetyRegistrationCyaSummaryRowsFactoryTests {
                 listOf(
                     UploadedFileUrl(
                         messageKey = "propertyDetails.complianceInformation.gasSafety.downloadCertificate",
-                        displayName = "cert.pdf",
-                        url = "/download/cert.pdf",
+                        displayName = "first.pdf",
+                        url = "/download/first.pdf",
+                    ),
+                    UploadedFileUrl(
+                        messageKey = "propertyDetails.complianceInformation.gasSafety.downloadCertificate",
+                        displayName = "second.pdf",
+                        url = "/download/second.pdf",
                     ),
                 ),
                 certRows[2].fieldValue,
             )
 
             assertNull(factory.getInsetTextKey())
-        }
-
-        @Test
-        fun `factory returns quarantined uploads as UploadedFileUrl with pending scan messageKey and no url`() {
-            setupCommonStateMocks()
-            whenever(mockHasGasSupplyStep.outcome).thenReturn(YesOrNo.YES)
-            whenever(mockHasGasCertStep.outcome).thenReturn(HasGasCertMode.HAS_CERTIFICATE)
-            whenever(mockState.getGasSafetyCertificateIsOutdated()).thenReturn(false)
-            whenever(mockState.getGasSafetyCertificateIssueDateIfReachable()).thenReturn(LocalDate(2024, 6, 15))
-            whenever(mockState.gasCertIssueDateStep).thenReturn(mockGasCertIssueDateStep)
-            whenever(mockState.checkGasCertUploadsStep).thenReturn(mockCheckGasCertUploadsStep)
-            whenever(mockGasCertIssueDateStep.currentJourneyId).thenReturn("test-journey-id")
-            whenever(mockCheckGasCertUploadsStep.currentJourneyId).thenReturn("test-journey-id")
-            whenever(mockState.gasUploadMap).thenReturn(
-                mapOf(1 to CertificateUpload(1L, "cert.pdf")),
-            )
-            stubUpload(1L, FileUploadStatus.QUARANTINED)
-
-            val factory = GasSafetyRegistrationCyaSummaryRowsFactory(mockState, mockUploadService)
-
-            val certRows = factory.createCertRows()
-            assertEquals(
-                listOf(
-                    UploadedFileUrl(
-                        messageKey = "propertyCompliance.uploadedFile.virusScanPendingWithName",
-                        displayName = "cert.pdf",
-                        url = null,
-                    ),
-                ),
-                certRows[2].fieldValue,
-            )
-        }
-
-        @Test
-        fun `factory filters out deleted uploads`() {
-            setupCommonStateMocks()
-            whenever(mockHasGasSupplyStep.outcome).thenReturn(YesOrNo.YES)
-            whenever(mockHasGasCertStep.outcome).thenReturn(HasGasCertMode.HAS_CERTIFICATE)
-            whenever(mockState.getGasSafetyCertificateIsOutdated()).thenReturn(false)
-            whenever(mockState.getGasSafetyCertificateIssueDateIfReachable()).thenReturn(LocalDate(2024, 6, 15))
-            whenever(mockState.gasCertIssueDateStep).thenReturn(mockGasCertIssueDateStep)
-            whenever(mockState.checkGasCertUploadsStep).thenReturn(mockCheckGasCertUploadsStep)
-            whenever(mockGasCertIssueDateStep.currentJourneyId).thenReturn("test-journey-id")
-            whenever(mockCheckGasCertUploadsStep.currentJourneyId).thenReturn("test-journey-id")
-            whenever(mockState.gasUploadMap).thenReturn(
-                mapOf(
-                    1 to CertificateUpload(1L, "scanned.pdf"),
-                    2 to CertificateUpload(2L, "deleted.pdf"),
-                ),
-            )
-            stubUpload(1L, FileUploadStatus.SCANNED, downloadUrl = "/download/scanned.pdf")
-            stubUpload(2L, FileUploadStatus.DELETED)
-
-            val factory = GasSafetyRegistrationCyaSummaryRowsFactory(mockState, mockUploadService)
-
-            val certRows = factory.createCertRows()
-            val files = certRows[2].fieldValue as List<*>
-            assertEquals(1, files.size)
-            assertEquals("scanned.pdf", (files[0] as UploadedFileUrl).displayName)
-        }
-
-        @Test
-        fun `factory preserves map index ordering across mixed status uploads`() {
-            setupCommonStateMocks()
-            whenever(mockHasGasSupplyStep.outcome).thenReturn(YesOrNo.YES)
-            whenever(mockHasGasCertStep.outcome).thenReturn(HasGasCertMode.HAS_CERTIFICATE)
-            whenever(mockState.getGasSafetyCertificateIsOutdated()).thenReturn(false)
-            whenever(mockState.getGasSafetyCertificateIssueDateIfReachable()).thenReturn(LocalDate(2024, 6, 15))
-            whenever(mockState.gasCertIssueDateStep).thenReturn(mockGasCertIssueDateStep)
-            whenever(mockState.checkGasCertUploadsStep).thenReturn(mockCheckGasCertUploadsStep)
-            whenever(mockGasCertIssueDateStep.currentJourneyId).thenReturn("test-journey-id")
-            whenever(mockCheckGasCertUploadsStep.currentJourneyId).thenReturn("test-journey-id")
-            whenever(mockState.gasUploadMap).thenReturn(
-                mapOf(
-                    3 to CertificateUpload(3L, "third.pdf"),
-                    1 to CertificateUpload(1L, "first.pdf"),
-                    2 to CertificateUpload(2L, "second.pdf"),
-                ),
-            )
-            stubUpload(1L, FileUploadStatus.SCANNED, downloadUrl = "/download/first.pdf")
-            stubUpload(2L, FileUploadStatus.QUARANTINED)
-            stubUpload(3L, FileUploadStatus.SCANNED, downloadUrl = "/download/third.pdf")
-
-            val factory = GasSafetyRegistrationCyaSummaryRowsFactory(mockState, mockUploadService)
-
-            val certRows = factory.createCertRows()
-            val files = certRows[2].fieldValue as List<*>
-            assertEquals(listOf("first.pdf", "second.pdf", "third.pdf"), files.map { (it as UploadedFileUrl).displayName })
-            assertEquals("/download/first.pdf", (files[0] as UploadedFileUrl).url)
-            assertNull((files[1] as UploadedFileUrl).url)
-            assertEquals("/download/third.pdf", (files[2] as UploadedFileUrl).url)
         }
     }
 

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/CheckElectricalSafetyAnswersStepConfigTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/CheckElectricalSafetyAnswersStepConfigTests.kt
@@ -6,9 +6,11 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.ElectricalSafetyState
 import uk.gov.communities.prsdb.webapp.journeys.shared.Complete
+import uk.gov.communities.prsdb.webapp.services.UploadService
 import uk.gov.communities.prsdb.webapp.testHelpers.mockObjects.AlwaysTrueValidator
 
 @ExtendWith(MockitoExtension::class)
@@ -16,8 +18,10 @@ class CheckElectricalSafetyAnswersStepConfigTests {
     @Mock
     lateinit var mockState: ElectricalSafetyState
 
+    private val mockUploadService: UploadService = mock()
+
     private fun setupStepConfig(): CheckElectricalSafetyAnswersStepConfig {
-        val stepConfig = CheckElectricalSafetyAnswersStepConfig()
+        val stepConfig = CheckElectricalSafetyAnswersStepConfig(mockUploadService)
         stepConfig.routeSegment = CheckElectricalSafetyAnswersStep.ROUTE_SEGMENT
         stepConfig.validator = AlwaysTrueValidator()
         return stepConfig

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/CheckGasSafetyAnswersStepConfigTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/CheckGasSafetyAnswersStepConfigTests.kt
@@ -6,9 +6,11 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.GasSafetyState
 import uk.gov.communities.prsdb.webapp.journeys.shared.Complete
+import uk.gov.communities.prsdb.webapp.services.UploadService
 import uk.gov.communities.prsdb.webapp.testHelpers.mockObjects.AlwaysTrueValidator
 
 @ExtendWith(MockitoExtension::class)
@@ -16,8 +18,10 @@ class CheckGasSafetyAnswersStepConfigTests {
     @Mock
     lateinit var mockState: GasSafetyState
 
+    private val mockUploadService: UploadService = mock()
+
     private fun setupStepConfig(): CheckGasSafetyAnswersStepConfig {
-        val stepConfig = CheckGasSafetyAnswersStepConfig()
+        val stepConfig = CheckGasSafetyAnswersStepConfig(mockUploadService)
         stepConfig.routeSegment = CheckGasSafetyAnswersStep.ROUTE_SEGMENT
         stepConfig.validator = AlwaysTrueValidator()
         return stepConfig

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/shared/helpers/ComplianceDetailsHelperTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/shared/helpers/ComplianceDetailsHelperTests.kt
@@ -12,6 +12,8 @@ import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
+import uk.gov.communities.prsdb.webapp.constants.enums.FileUploadStatus
+import uk.gov.communities.prsdb.webapp.database.entity.FileUpload
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.CertificateUpload
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.ElectricalSafetyState
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.EpcState
@@ -29,6 +31,7 @@ import uk.gov.communities.prsdb.webapp.journeys.shared.YesOrNo
 import uk.gov.communities.prsdb.webapp.journeys.shared.states.CheckYourAnswersJourneyState
 import uk.gov.communities.prsdb.webapp.models.viewModels.summaryModels.SummaryListRowViewModel
 import uk.gov.communities.prsdb.webapp.services.EpcCertificateUrlProvider
+import uk.gov.communities.prsdb.webapp.services.UploadService
 
 internal interface TestableGasSafetyState : GasSafetyState, CheckYourAnswersJourneyState
 
@@ -41,7 +44,9 @@ class ComplianceDetailsHelperTests {
     @Mock
     lateinit var mockEpcCertificateUrlProvider: EpcCertificateUrlProvider
 
-    private val helper by lazy { ComplianceDetailsHelper(mockEpcCertificateUrlProvider) }
+    private val mockUploadService: UploadService = mock()
+
+    private val helper by lazy { ComplianceDetailsHelper(mockEpcCertificateUrlProvider, mockUploadService) }
 
     @Nested
     inner class GetGasSafetyCyaContent {
@@ -86,6 +91,10 @@ class ComplianceDetailsHelperTests {
             whenever(mockState.gasCertIssueDateStep).thenReturn(mockGasCertIssueDateStep)
             whenever(mockState.checkGasCertUploadsStep).thenReturn(mockCheckGasCertUploadsStep)
             whenever(mockState.gasUploadMap).thenReturn(mapOf(1 to CertificateUpload(1L, "cert.pdf")))
+            val mockFileUpload: FileUpload = mock()
+            whenever(mockFileUpload.status).thenReturn(FileUploadStatus.SCANNED)
+            whenever(mockUploadService.getFileUploadById(1L)).thenReturn(mockFileUpload)
+            whenever(mockUploadService.getDownloadUrlOrNull(any(), any())).thenReturn("/download/cert.pdf")
 
             val content = helper.getGasSafetyCyaContent(mockState)
 

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/summaryModels/propertyComplianceViewModels/ComplianceUploadRowHelperTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/summaryModels/propertyComplianceViewModels/ComplianceUploadRowHelperTests.kt
@@ -1,0 +1,123 @@
+package uk.gov.communities.prsdb.webapp.models.viewModels.summaryModels.propertyComplianceViewModels
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import uk.gov.communities.prsdb.webapp.constants.enums.FileUploadStatus
+import uk.gov.communities.prsdb.webapp.database.entity.FileUpload
+import uk.gov.communities.prsdb.webapp.models.viewModels.summaryModels.UploadedFileUrl
+import uk.gov.communities.prsdb.webapp.services.UploadService
+
+@ExtendWith(MockitoExtension::class)
+class ComplianceUploadRowHelperTests {
+    private val mockUploadService: UploadService = mock()
+
+    private fun fileUploadWithStatus(status: FileUploadStatus): FileUpload =
+        mock<FileUpload>().also { whenever(it.status).thenReturn(status) }
+
+    private fun scannedUpload(
+        displayName: String,
+        downloadUrl: String?,
+    ): Pair<FileUpload, String> {
+        val fileUpload = fileUploadWithStatus(FileUploadStatus.SCANNED)
+        whenever(mockUploadService.getDownloadUrlOrNull(eq(fileUpload), any())).thenReturn(downloadUrl)
+        return fileUpload to displayName
+    }
+
+    private fun quarantinedUpload(displayName: String): Pair<FileUpload, String> =
+        fileUploadWithStatus(FileUploadStatus.QUARANTINED) to displayName
+
+    private fun deletedUpload(displayName: String): Pair<FileUpload, String> = fileUploadWithStatus(FileUploadStatus.DELETED) to displayName
+
+    @Test
+    fun `toUploadedFileUrls maps scanned uploads to UploadedFileUrl with download messageKey and url`() {
+        val uploads = listOf(scannedUpload("cert.pdf", "/download/cert.pdf"))
+
+        val result = uploads.toUploadedFileUrls("download.messageKey", mockUploadService)
+
+        assertEquals(
+            listOf(
+                UploadedFileUrl(
+                    messageKey = "download.messageKey",
+                    displayName = "cert.pdf",
+                    url = "/download/cert.pdf",
+                ),
+            ),
+            result,
+        )
+    }
+
+    @Test
+    fun `toUploadedFileUrls maps scanned uploads with no download url to UploadedFileUrl with null url`() {
+        val uploads = listOf(scannedUpload("cert.pdf", null))
+
+        val result = uploads.toUploadedFileUrls("download.messageKey", mockUploadService)
+
+        assertEquals(1, result.size)
+        assertEquals("download.messageKey", result[0].messageKey)
+        assertEquals("cert.pdf", result[0].displayName)
+        assertNull(result[0].url)
+    }
+
+    @Test
+    fun `toUploadedFileUrls maps quarantined uploads to UploadedFileUrl with pending scan messageKey and no url`() {
+        val uploads = listOf(quarantinedUpload("cert.pdf"))
+
+        val result = uploads.toUploadedFileUrls("download.messageKey", mockUploadService)
+
+        assertEquals(
+            listOf(
+                UploadedFileUrl(
+                    messageKey = "propertyCompliance.uploadedFile.virusScanPendingWithName",
+                    displayName = "cert.pdf",
+                    url = null,
+                ),
+            ),
+            result,
+        )
+    }
+
+    @Test
+    fun `toUploadedFileUrls filters out deleted uploads`() {
+        val uploads =
+            listOf(
+                scannedUpload("scanned.pdf", "/download/scanned.pdf"),
+                deletedUpload("deleted.pdf"),
+            )
+
+        val result = uploads.toUploadedFileUrls("download.messageKey", mockUploadService)
+
+        assertEquals(1, result.size)
+        assertEquals("scanned.pdf", result[0].displayName)
+    }
+
+    @Test
+    fun `toUploadedFileUrls preserves input ordering across mixed status uploads`() {
+        val uploads =
+            listOf(
+                scannedUpload("first.pdf", "/download/first.pdf"),
+                quarantinedUpload("second.pdf"),
+                scannedUpload("third.pdf", "/download/third.pdf"),
+            )
+
+        val result = uploads.toUploadedFileUrls("download.messageKey", mockUploadService)
+
+        assertEquals(listOf("first.pdf", "second.pdf", "third.pdf"), result.map { it.displayName })
+        assertEquals("/download/first.pdf", result[0].url)
+        assertNull(result[1].url)
+        assertEquals("/download/third.pdf", result[2].url)
+    }
+
+    @Test
+    fun `toUploadedFileUrls returns empty list when given empty input`() {
+        val result = emptyList<Pair<FileUpload, String>>().toUploadedFileUrls("download.messageKey", mockUploadService)
+
+        assertEquals(emptyList<UploadedFileUrl>(), result)
+    }
+}


### PR DESCRIPTION
## Ticket number

PDJB-851

## Goal of change

Fix the property registration Check Your Answers pages so uploaded gas/electrical safety certificates appear as download links once virus scanning completes, instead of always being shown as plain filename text.

## Description of main change(s)

- On the Gas Safety and Electrical Safety registration CYA pages, uploaded certificate rows now render as a download link once the file is scanned, mirroring the behaviour already used on the property compliance journey.
- Files still being virus-scanned show the filename followed by "(Pending virus scan)" rather than appearing as a plain (non-functional) link.
- Files that have been deleted (e.g. flagged as infected) are filtered out of the CYA row instead of leaving a stale entry.
- The same fix is applied to the property compliance journey's compliance details summary, because it builds its summary via the same two factory classes (via ComplianceDetailsHelper).

## Anything you'd like to highlight to the reviewer?

The fix touches both the registration CYA pages and the compliance details summary used after registration, because both call into the same row factories. If you would prefer the compliance-journey change split into a separate PR, happy to do that.

## Checklist

- [x] Unit tests for new logic (e.g. new service methods) have been added
- [x] Test suite has been run in full locally and is passing
- [x] Branch has been rebased onto main and run locally, with everything working as expected (both for your new feature and any related functionality)
