### PR TITLE
PDJB-770: fix incorrect link on epc expired email

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/emailModels/ComplianceUpdateConfirmationEmail.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/emailModels/ComplianceUpdateConfirmationEmail.kt
@@ -1,6 +1,6 @@
 package uk.gov.communities.prsdb.webapp.models.viewModels.emailModels
 
-import uk.gov.communities.prsdb.webapp.constants.EPC_GUIDE_URL
+import uk.gov.communities.prsdb.webapp.constants.GET_NEW_EPC_URL
 import uk.gov.communities.prsdb.webapp.models.dataModels.RegistrationNumberDataModel
 import java.net.URI
 
@@ -31,7 +31,7 @@ data class ComplianceUpdateConfirmationEmail(
             "registration number" to registrationNumber.toString(),
             "dashboard url" to dashboardUrl.toString(),
             "new certificate url" to newCertificateUrl.toString(),
-            "epc guide url" to EPC_GUIDE_URL,
+            "new epc url" to GET_NEW_EPC_URL,
             "certificate type" to certificateType,
             "certificate type label" to certificateTypeLabel,
             // These default to an empty string as not all compliance templates use them, and some EPC's may not have an expiry date

--- a/src/main/resources/emails/ComplianceExpiredOccupiedEpcConfirmation.md
+++ b/src/main/resources/emails/ComplianceExpiredOccupiedEpcConfirmation.md
@@ -14,7 +14,7 @@ The energy performance certificate (EPC) for this property has expired.
 
 You've told us this property is occupied. If the EPC was valid when the current tenancy started, you do not need to get a new EPC immediately.
 
-If you advertise this property or start a new tenancy, you must [get a new EPC](((epc guide url))).
+If you advertise this property or start a new tenancy, you must [get a new EPC](((new epc url))).
 
 [Add a new EPC to this property registration](((new certificate url)))
 

--- a/src/main/resources/emails/emailTemplates.json
+++ b/src/main/resources/emails/emailTemplates.json
@@ -107,8 +107,8 @@
     "bodyLocation": "/emails/ComplianceExpiredOccupiedConfirmation.md"
   },
   {
-    "test_id": "990f7a4c-e083-46e3-9833-b1cff567cbf3",
-    "prod_id": "b864ad23-c7c1-4ea6-907f-621df2d59d36",
+    "test_id": "12229e5f-b97f-4b6a-8bab-c8b94ee873e3",
+    "prod_id": "e4aca42a-eaaf-4990-9aff-d9cacd57c876",
     "enumName": "COMPLIANCE_EXPIRED_OCCUPIED_EPC_CONFIRMATION_EMAIL",
     "subject": "A property's energy performance certificate (EPC) has expired",
     "bodyLocation": "/emails/ComplianceExpiredOccupiedEpcConfirmation.md"


### PR DESCRIPTION
## Ticket number

PDJB-770

## Goal of change

Fixes a link going to the wrong place on the occupied EPC expired email

## Description of main change(s)

Stupidly just forgot to change this from the old email.

## Checklist

Delete any that are not applicable, and add explanation below for any that are applicable but haven't been done

- [ ] New email templates have been added to `/src/main/kotlin/resources/emails/emailTemplates.json`
- [ ] Test suite has been run in full locally and is passing
- [ ] Branch has been rebased onto main and run locally, with everything working as expected (both for your new feature
  and any related functionality)
- [ ] QA instructions have been added to the ticket (particularly if this is the last PR required to complete the ticket)
