### PR TITLE
PDJB-769: exclude provide later from invalid cases for compliance

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/PropertyRegistrationJourneyFactory.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/PropertyRegistrationJourneyFactory.kt
@@ -336,11 +336,11 @@ class PropertyRegistrationJourneyFactory(
                     parents { journey.cyaStep.isComplete() }
                     nextStep { mode ->
                         when (mode) {
-                            ConfirmMissingComplianceCheckResult.OCCUPIED_AND_HAS_MISSING_CERTIFICATES -> {
+                            ConfirmMissingComplianceCheckResult.OCCUPIED_AND_HAS_INVALID_CERTIFICATES -> {
                                 journey.confirmMissingComplianceStep
                             }
 
-                            ConfirmMissingComplianceCheckResult.UNOCCUPIED_OR_ALL_CERTIFICATES -> {
+                            ConfirmMissingComplianceCheckResult.UNOCCUPIED_OR_VALID_CERTIFICATES -> {
                                 journey.savePropertyRegistrationDataStep
                             }
                         }
@@ -350,7 +350,7 @@ class PropertyRegistrationJourneyFactory(
                     routeSegment(ConfirmMissingComplianceStep.ROUTE_SEGMENT)
                     parents {
                         journey.hasMissingComplianceStep.hasOutcome(
-                            ConfirmMissingComplianceCheckResult.OCCUPIED_AND_HAS_MISSING_CERTIFICATES,
+                            ConfirmMissingComplianceCheckResult.OCCUPIED_AND_HAS_INVALID_CERTIFICATES,
                         )
                     }
                     nextDestination { mode ->
@@ -369,7 +369,7 @@ class PropertyRegistrationJourneyFactory(
                     parents {
                         OrParents(
                             journey.hasMissingComplianceStep.hasOutcome(
-                                ConfirmMissingComplianceCheckResult.UNOCCUPIED_OR_ALL_CERTIFICATES,
+                                ConfirmMissingComplianceCheckResult.UNOCCUPIED_OR_VALID_CERTIFICATES,
                             ),
                             journey.confirmMissingComplianceStep.hasOutcome(ConfirmMissingComplianceMode.CONFIRMED),
                         )

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/ConfirmMissingComplianceStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/ConfirmMissingComplianceStepConfig.kt
@@ -15,9 +15,9 @@ class ConfirmMissingComplianceStepConfig :
     override fun getStepSpecificContent(state: PropertyRegistrationJourneyState) =
         mapOf(
             "title" to "registerProperty.confirmMissingCompliance.heading",
-            "isGasMissing" to HasMissingComplianceStepConfig.isGasCertMissingOrExpired(state),
-            "isElectricalMissing" to HasMissingComplianceStepConfig.isElectricalCertMissingOrExpired(state),
-            "isEpcMissing" to HasMissingComplianceStepConfig.isEpcMissingOrInvalid(state),
+            "isGasMissing" to HasMissingComplianceStepConfig.isGasCertInvalid(state),
+            "isElectricalMissing" to HasMissingComplianceStepConfig.isElectricalCertInvalid(state),
+            "isEpcMissing" to HasMissingComplianceStepConfig.isEpcInvalid(state),
             "radioOptions" to
                 listOf(
                     RadiosButtonViewModel(

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/HasMissingComplianceStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/HasMissingComplianceStepConfig.kt
@@ -11,27 +11,30 @@ import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.GasS
 @JourneyFrameworkComponent
 class HasMissingComplianceStepConfig : AbstractInternalStepConfig<ConfirmMissingComplianceCheckResult, CombinedComplianceCheckState>() {
     override fun mode(state: CombinedComplianceCheckState): ConfirmMissingComplianceCheckResult {
-        val anyMissing = isGasCertMissingOrExpired(state) || isElectricalCertMissingOrExpired(state) || isEpcMissingOrInvalid(state)
-        return if (state.isOccupied && anyMissing) {
-            ConfirmMissingComplianceCheckResult.OCCUPIED_AND_HAS_MISSING_CERTIFICATES
+        val anyInvalid = isGasCertInvalid(state) || isElectricalCertInvalid(state) || isEpcInvalid(state)
+        return if (state.isOccupied && anyInvalid) {
+            ConfirmMissingComplianceCheckResult.OCCUPIED_AND_HAS_INVALID_CERTIFICATES
         } else {
-            ConfirmMissingComplianceCheckResult.UNOCCUPIED_OR_ALL_CERTIFICATES
+            ConfirmMissingComplianceCheckResult.UNOCCUPIED_OR_VALID_CERTIFICATES
         }
     }
 
     companion object {
-        fun isGasCertMissingOrExpired(state: GasSafetyState): Boolean {
+        fun isGasCertInvalid(state: GasSafetyState): Boolean {
             if (state.hasGasSupplyStep.formModelIfReachableOrNull?.hasGasSupply != true) return false
+            if (state.hasGasCertStep.outcome == HasGasCertMode.PROVIDE_THIS_LATER) return false
             val isOutdated = state.getGasSafetyCertificateIsOutdated()
             return isOutdated == null || isOutdated
         }
 
-        fun isElectricalCertMissingOrExpired(state: ElectricalSafetyState): Boolean {
+        fun isElectricalCertInvalid(state: ElectricalSafetyState): Boolean {
+            if (state.hasElectricalCertStep.outcome == HasElectricalCertMode.PROVIDE_THIS_LATER) return false
             val isOutdated = state.getElectricalCertificateIsOutdated()
             return isOutdated == null || isOutdated
         }
 
-        fun isEpcMissingOrInvalid(state: EpcState): Boolean {
+        fun isEpcInvalid(state: EpcState): Boolean {
+            if (state.hasEpcStep.outcome == HasEpcMode.PROVIDE_LATER) return false
             val acceptedEpc =
                 state.acceptedEpcIfReachable
                     ?: return state.epcExemptionStep.formModelIfReachableOrNull?.exemptionReason == null
@@ -50,6 +53,6 @@ class HasMissingComplianceStep(
 ) : JourneyStep.InternalStep<ConfirmMissingComplianceCheckResult, CombinedComplianceCheckState>(stepConfig)
 
 enum class ConfirmMissingComplianceCheckResult {
-    UNOCCUPIED_OR_ALL_CERTIFICATES,
-    OCCUPIED_AND_HAS_MISSING_CERTIFICATES,
+    UNOCCUPIED_OR_VALID_CERTIFICATES,
+    OCCUPIED_AND_HAS_INVALID_CERTIFICATES,
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/HasMissingComplianceStepConfigTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/HasMissingComplianceStepConfigTests.kt
@@ -37,7 +37,7 @@ class HasMissingComplianceStepConfigTests {
             val result = stepConfig.mode(mockState)
 
             // Assert
-            assertEquals(ConfirmMissingComplianceCheckResult.UNOCCUPIED_OR_ALL_CERTIFICATES, result)
+            assertEquals(ConfirmMissingComplianceCheckResult.UNOCCUPIED_OR_VALID_CERTIFICATES, result)
         }
 
         @Test
@@ -50,7 +50,7 @@ class HasMissingComplianceStepConfigTests {
             val result = stepConfig.mode(mockState)
 
             // Assert
-            assertEquals(ConfirmMissingComplianceCheckResult.OCCUPIED_AND_HAS_MISSING_CERTIFICATES, result)
+            assertEquals(ConfirmMissingComplianceCheckResult.OCCUPIED_AND_HAS_INVALID_CERTIFICATES, result)
         }
 
         @Test
@@ -64,7 +64,7 @@ class HasMissingComplianceStepConfigTests {
             val result = stepConfig.mode(mockState)
 
             // Assert
-            assertEquals(ConfirmMissingComplianceCheckResult.OCCUPIED_AND_HAS_MISSING_CERTIFICATES, result)
+            assertEquals(ConfirmMissingComplianceCheckResult.OCCUPIED_AND_HAS_INVALID_CERTIFICATES, result)
         }
 
         @Test
@@ -79,7 +79,7 @@ class HasMissingComplianceStepConfigTests {
             val result = stepConfig.mode(mockState)
 
             // Assert
-            assertEquals(ConfirmMissingComplianceCheckResult.OCCUPIED_AND_HAS_MISSING_CERTIFICATES, result)
+            assertEquals(ConfirmMissingComplianceCheckResult.OCCUPIED_AND_HAS_INVALID_CERTIFICATES, result)
         }
 
         @Test
@@ -94,7 +94,7 @@ class HasMissingComplianceStepConfigTests {
             val result = stepConfig.mode(mockState)
 
             // Assert
-            assertEquals(ConfirmMissingComplianceCheckResult.UNOCCUPIED_OR_ALL_CERTIFICATES, result)
+            assertEquals(ConfirmMissingComplianceCheckResult.UNOCCUPIED_OR_VALID_CERTIFICATES, result)
         }
 
         private fun setupGasCertMissing() {
@@ -144,7 +144,7 @@ class HasMissingComplianceStepConfigTests {
             whenever(mockHasGasSupplyStep.formModelIfReachableOrNull).thenReturn(null)
             whenever(mockState.hasGasSupplyStep).thenReturn(mockHasGasSupplyStep)
 
-            assertFalse(HasMissingComplianceStepConfig.isGasCertMissingOrExpired(mockState))
+            assertFalse(HasMissingComplianceStepConfig.isGasCertInvalid(mockState))
         }
 
         @Test
@@ -154,7 +154,7 @@ class HasMissingComplianceStepConfigTests {
             whenever(mockHasGasSupplyStep.formModelIfReachableOrNull).thenReturn(formModel)
             whenever(mockState.hasGasSupplyStep).thenReturn(mockHasGasSupplyStep)
 
-            assertFalse(HasMissingComplianceStepConfig.isGasCertMissingOrExpired(mockState))
+            assertFalse(HasMissingComplianceStepConfig.isGasCertInvalid(mockState))
         }
 
         @Test
@@ -165,7 +165,7 @@ class HasMissingComplianceStepConfigTests {
             whenever(mockState.hasGasSupplyStep).thenReturn(mockHasGasSupplyStep)
             whenever(mockState.getGasSafetyCertificateIsOutdated()).thenReturn(null)
 
-            assertTrue(HasMissingComplianceStepConfig.isGasCertMissingOrExpired(mockState))
+            assertTrue(HasMissingComplianceStepConfig.isGasCertInvalid(mockState))
         }
 
         @Test
@@ -176,7 +176,7 @@ class HasMissingComplianceStepConfigTests {
             whenever(mockState.hasGasSupplyStep).thenReturn(mockHasGasSupplyStep)
             whenever(mockState.getGasSafetyCertificateIsOutdated()).thenReturn(true)
 
-            assertTrue(HasMissingComplianceStepConfig.isGasCertMissingOrExpired(mockState))
+            assertTrue(HasMissingComplianceStepConfig.isGasCertInvalid(mockState))
         }
 
         @Test
@@ -187,7 +187,7 @@ class HasMissingComplianceStepConfigTests {
             whenever(mockState.hasGasSupplyStep).thenReturn(mockHasGasSupplyStep)
             whenever(mockState.getGasSafetyCertificateIsOutdated()).thenReturn(false)
 
-            assertFalse(HasMissingComplianceStepConfig.isGasCertMissingOrExpired(mockState))
+            assertFalse(HasMissingComplianceStepConfig.isGasCertInvalid(mockState))
         }
     }
 
@@ -197,21 +197,21 @@ class HasMissingComplianceStepConfigTests {
         fun `returns true when cert is missing`() {
             whenever(mockState.getElectricalCertificateIsOutdated()).thenReturn(null)
 
-            assertTrue(HasMissingComplianceStepConfig.isElectricalCertMissingOrExpired(mockState))
+            assertTrue(HasMissingComplianceStepConfig.isElectricalCertInvalid(mockState))
         }
 
         @Test
         fun `returns true when cert is outdated`() {
             whenever(mockState.getElectricalCertificateIsOutdated()).thenReturn(true)
 
-            assertTrue(HasMissingComplianceStepConfig.isElectricalCertMissingOrExpired(mockState))
+            assertTrue(HasMissingComplianceStepConfig.isElectricalCertInvalid(mockState))
         }
 
         @Test
         fun `returns false when cert is valid`() {
             whenever(mockState.getElectricalCertificateIsOutdated()).thenReturn(false)
 
-            assertFalse(HasMissingComplianceStepConfig.isElectricalCertMissingOrExpired(mockState))
+            assertFalse(HasMissingComplianceStepConfig.isElectricalCertInvalid(mockState))
         }
     }
 
@@ -224,7 +224,7 @@ class HasMissingComplianceStepConfigTests {
             whenever(mockEpc.isEnergyRatingEOrBetter()).thenReturn(true)
             whenever(mockState.acceptedEpcIfReachable).thenReturn(mockEpc)
 
-            assertFalse(HasMissingComplianceStepConfig.isEpcMissingOrInvalid(mockState))
+            assertFalse(HasMissingComplianceStepConfig.isEpcInvalid(mockState))
         }
 
         @Test
@@ -233,7 +233,7 @@ class HasMissingComplianceStepConfigTests {
             whenever(mockEpc.isPastExpiryDate()).thenReturn(true)
             whenever(mockState.acceptedEpcIfReachable).thenReturn(mockEpc)
 
-            assertTrue(HasMissingComplianceStepConfig.isEpcMissingOrInvalid(mockState))
+            assertTrue(HasMissingComplianceStepConfig.isEpcInvalid(mockState))
         }
 
         @Test
@@ -246,7 +246,7 @@ class HasMissingComplianceStepConfigTests {
             whenever(mockMeesExemptionStep.formModelIfReachableOrNull).thenReturn(null)
             whenever(mockState.meesExemptionStep).thenReturn(mockMeesExemptionStep)
 
-            assertTrue(HasMissingComplianceStepConfig.isEpcMissingOrInvalid(mockState))
+            assertTrue(HasMissingComplianceStepConfig.isEpcInvalid(mockState))
         }
 
         @Test
@@ -263,7 +263,7 @@ class HasMissingComplianceStepConfigTests {
             whenever(mockMeesExemptionStep.formModelIfReachableOrNull).thenReturn(formModel)
             whenever(mockState.meesExemptionStep).thenReturn(mockMeesExemptionStep)
 
-            assertFalse(HasMissingComplianceStepConfig.isEpcMissingOrInvalid(mockState))
+            assertFalse(HasMissingComplianceStepConfig.isEpcInvalid(mockState))
         }
 
         @Test
@@ -273,7 +273,7 @@ class HasMissingComplianceStepConfigTests {
             whenever(mockEpcExemptionStep.formModelIfReachableOrNull).thenReturn(null)
             whenever(mockState.epcExemptionStep).thenReturn(mockEpcExemptionStep)
 
-            assertTrue(HasMissingComplianceStepConfig.isEpcMissingOrInvalid(mockState))
+            assertTrue(HasMissingComplianceStepConfig.isEpcInvalid(mockState))
         }
 
         @Test
@@ -287,7 +287,7 @@ class HasMissingComplianceStepConfigTests {
             whenever(mockEpcExemptionStep.formModelIfReachableOrNull).thenReturn(formModel)
             whenever(mockState.epcExemptionStep).thenReturn(mockEpcExemptionStep)
 
-            assertFalse(HasMissingComplianceStepConfig.isEpcMissingOrInvalid(mockState))
+            assertFalse(HasMissingComplianceStepConfig.isEpcInvalid(mockState))
         }
 
         @Test
@@ -298,7 +298,7 @@ class HasMissingComplianceStepConfigTests {
             whenever(mockEpcExemptionStep.formModelIfReachableOrNull).thenReturn(formModel)
             whenever(mockState.epcExemptionStep).thenReturn(mockEpcExemptionStep)
 
-            assertTrue(HasMissingComplianceStepConfig.isEpcMissingOrInvalid(mockState))
+            assertTrue(HasMissingComplianceStepConfig.isEpcInvalid(mockState))
         }
     }
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/HasMissingComplianceStepConfigTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/HasMissingComplianceStepConfigTests.kt
@@ -97,11 +97,27 @@ class HasMissingComplianceStepConfigTests {
             assertEquals(ConfirmMissingComplianceCheckResult.UNOCCUPIED_OR_VALID_CERTIFICATES, result)
         }
 
+        @Test
+        fun `returns UNOCCUPIED_OR_VALID_CERTIFICATES when occupied but all certs are provide later`() {
+            // Arrange
+            whenever(mockState.isOccupied).thenReturn(true)
+            setupGasCertProvideLater()
+            setupElectricalCertProvideLater()
+            setupEpcProvideLater()
+
+            // Act
+            val result = stepConfig.mode(mockState)
+
+            // Assert
+            assertEquals(ConfirmMissingComplianceCheckResult.UNOCCUPIED_OR_VALID_CERTIFICATES, result)
+        }
+
         private fun setupGasCertMissing() {
             val mockHasGasSupplyStep = mock<HasGasSupplyStep>()
             val gasFormModel = GasSupplyFormModel().apply { hasGasSupply = true }
             whenever(mockHasGasSupplyStep.formModelIfReachableOrNull).thenReturn(gasFormModel)
             whenever(mockState.hasGasSupplyStep).thenReturn(mockHasGasSupplyStep)
+            whenever(mockState.hasGasCertStep).thenReturn(mock<HasGasCertStep>())
             whenever(mockState.getGasSafetyCertificateIsOutdated()).thenReturn(null)
         }
 
@@ -110,18 +126,22 @@ class HasMissingComplianceStepConfigTests {
             val gasFormModel = GasSupplyFormModel().apply { hasGasSupply = true }
             whenever(mockHasGasSupplyStep.formModelIfReachableOrNull).thenReturn(gasFormModel)
             whenever(mockState.hasGasSupplyStep).thenReturn(mockHasGasSupplyStep)
+            whenever(mockState.hasGasCertStep).thenReturn(mock<HasGasCertStep>())
             whenever(mockState.getGasSafetyCertificateIsOutdated()).thenReturn(false)
         }
 
         private fun setupElectricalCertMissing() {
+            whenever(mockState.hasElectricalCertStep).thenReturn(mock<HasElectricalCertStep>())
             whenever(mockState.getElectricalCertificateIsOutdated()).thenReturn(null)
         }
 
         private fun setupElectricalCertPresent() {
+            whenever(mockState.hasElectricalCertStep).thenReturn(mock<HasElectricalCertStep>())
             whenever(mockState.getElectricalCertificateIsOutdated()).thenReturn(false)
         }
 
         private fun setupEpcMissing() {
+            whenever(mockState.hasEpcStep).thenReturn(mock<HasEpcStep>())
             whenever(mockState.acceptedEpcIfReachable).thenReturn(null)
             val mockEpcExemptionStep = mock<EpcExemptionStep>()
             whenever(mockEpcExemptionStep.formModelIfReachableOrNull).thenReturn(null)
@@ -129,15 +149,51 @@ class HasMissingComplianceStepConfigTests {
         }
 
         private fun setupEpcPresent() {
+            whenever(mockState.hasEpcStep).thenReturn(mock<HasEpcStep>())
             val mockEpc = mock<EpcDataModel>()
             whenever(mockEpc.isPastExpiryDate()).thenReturn(false)
             whenever(mockEpc.isEnergyRatingEOrBetter()).thenReturn(true)
             whenever(mockState.acceptedEpcIfReachable).thenReturn(mockEpc)
         }
+
+        private fun setupGasCertProvideLater() {
+            val mockHasGasSupplyStep = mock<HasGasSupplyStep>()
+            val gasFormModel = GasSupplyFormModel().apply { hasGasSupply = true }
+            whenever(mockHasGasSupplyStep.formModelIfReachableOrNull).thenReturn(gasFormModel)
+            whenever(mockState.hasGasSupplyStep).thenReturn(mockHasGasSupplyStep)
+            val mockHasGasCertStep = mock<HasGasCertStep>()
+            whenever(mockHasGasCertStep.outcome).thenReturn(HasGasCertMode.PROVIDE_THIS_LATER)
+            whenever(mockState.hasGasCertStep).thenReturn(mockHasGasCertStep)
+        }
+
+        private fun setupElectricalCertProvideLater() {
+            val mockHasElectricalCertStep = mock<HasElectricalCertStep>()
+            whenever(mockHasElectricalCertStep.outcome).thenReturn(HasElectricalCertMode.PROVIDE_THIS_LATER)
+            whenever(mockState.hasElectricalCertStep).thenReturn(mockHasElectricalCertStep)
+        }
+
+        private fun setupEpcProvideLater() {
+            val mockHasEpcStep = mock<HasEpcStep>()
+            whenever(mockHasEpcStep.outcome).thenReturn(HasEpcMode.PROVIDE_LATER)
+            whenever(mockState.hasEpcStep).thenReturn(mockHasEpcStep)
+        }
     }
 
     @Nested
     inner class IsGasCertMissingOrExpired {
+        @Test
+        fun `returns false when user chose provide this later`() {
+            val mockHasGasSupplyStep = mock<HasGasSupplyStep>()
+            val formModel = GasSupplyFormModel().apply { hasGasSupply = true }
+            whenever(mockHasGasSupplyStep.formModelIfReachableOrNull).thenReturn(formModel)
+            whenever(mockState.hasGasSupplyStep).thenReturn(mockHasGasSupplyStep)
+            val mockHasGasCertStep = mock<HasGasCertStep>()
+            whenever(mockHasGasCertStep.outcome).thenReturn(HasGasCertMode.PROVIDE_THIS_LATER)
+            whenever(mockState.hasGasCertStep).thenReturn(mockHasGasCertStep)
+
+            assertFalse(HasMissingComplianceStepConfig.isGasCertInvalid(mockState))
+        }
+
         @Test
         fun `returns false when gas supply step not reachable`() {
             val mockHasGasSupplyStep = mock<HasGasSupplyStep>()
@@ -163,6 +219,7 @@ class HasMissingComplianceStepConfigTests {
             val formModel = GasSupplyFormModel().apply { hasGasSupply = true }
             whenever(mockHasGasSupplyStep.formModelIfReachableOrNull).thenReturn(formModel)
             whenever(mockState.hasGasSupplyStep).thenReturn(mockHasGasSupplyStep)
+            whenever(mockState.hasGasCertStep).thenReturn(mock<HasGasCertStep>())
             whenever(mockState.getGasSafetyCertificateIsOutdated()).thenReturn(null)
 
             assertTrue(HasMissingComplianceStepConfig.isGasCertInvalid(mockState))
@@ -174,6 +231,7 @@ class HasMissingComplianceStepConfigTests {
             val formModel = GasSupplyFormModel().apply { hasGasSupply = true }
             whenever(mockHasGasSupplyStep.formModelIfReachableOrNull).thenReturn(formModel)
             whenever(mockState.hasGasSupplyStep).thenReturn(mockHasGasSupplyStep)
+            whenever(mockState.hasGasCertStep).thenReturn(mock<HasGasCertStep>())
             whenever(mockState.getGasSafetyCertificateIsOutdated()).thenReturn(true)
 
             assertTrue(HasMissingComplianceStepConfig.isGasCertInvalid(mockState))
@@ -185,6 +243,7 @@ class HasMissingComplianceStepConfigTests {
             val formModel = GasSupplyFormModel().apply { hasGasSupply = true }
             whenever(mockHasGasSupplyStep.formModelIfReachableOrNull).thenReturn(formModel)
             whenever(mockState.hasGasSupplyStep).thenReturn(mockHasGasSupplyStep)
+            whenever(mockState.hasGasCertStep).thenReturn(mock<HasGasCertStep>())
             whenever(mockState.getGasSafetyCertificateIsOutdated()).thenReturn(false)
 
             assertFalse(HasMissingComplianceStepConfig.isGasCertInvalid(mockState))
@@ -194,7 +253,17 @@ class HasMissingComplianceStepConfigTests {
     @Nested
     inner class IsElectricalCertMissingOrExpired {
         @Test
+        fun `returns false when user chose provide this later`() {
+            val mockHasElectricalCertStep = mock<HasElectricalCertStep>()
+            whenever(mockHasElectricalCertStep.outcome).thenReturn(HasElectricalCertMode.PROVIDE_THIS_LATER)
+            whenever(mockState.hasElectricalCertStep).thenReturn(mockHasElectricalCertStep)
+
+            assertFalse(HasMissingComplianceStepConfig.isElectricalCertInvalid(mockState))
+        }
+
+        @Test
         fun `returns true when cert is missing`() {
+            whenever(mockState.hasElectricalCertStep).thenReturn(mock<HasElectricalCertStep>())
             whenever(mockState.getElectricalCertificateIsOutdated()).thenReturn(null)
 
             assertTrue(HasMissingComplianceStepConfig.isElectricalCertInvalid(mockState))
@@ -202,6 +271,7 @@ class HasMissingComplianceStepConfigTests {
 
         @Test
         fun `returns true when cert is outdated`() {
+            whenever(mockState.hasElectricalCertStep).thenReturn(mock<HasElectricalCertStep>())
             whenever(mockState.getElectricalCertificateIsOutdated()).thenReturn(true)
 
             assertTrue(HasMissingComplianceStepConfig.isElectricalCertInvalid(mockState))
@@ -209,6 +279,7 @@ class HasMissingComplianceStepConfigTests {
 
         @Test
         fun `returns false when cert is valid`() {
+            whenever(mockState.hasElectricalCertStep).thenReturn(mock<HasElectricalCertStep>())
             whenever(mockState.getElectricalCertificateIsOutdated()).thenReturn(false)
 
             assertFalse(HasMissingComplianceStepConfig.isElectricalCertInvalid(mockState))
@@ -218,7 +289,17 @@ class HasMissingComplianceStepConfigTests {
     @Nested
     inner class IsEpcMissingOrExpired {
         @Test
+        fun `returns false when user chose provide later`() {
+            val mockHasEpcStep = mock<HasEpcStep>()
+            whenever(mockHasEpcStep.outcome).thenReturn(HasEpcMode.PROVIDE_LATER)
+            whenever(mockState.hasEpcStep).thenReturn(mockHasEpcStep)
+
+            assertFalse(HasMissingComplianceStepConfig.isEpcInvalid(mockState))
+        }
+
+        @Test
         fun `returns false when accepted epc present and not expired and good rating`() {
+            whenever(mockState.hasEpcStep).thenReturn(mock<HasEpcStep>())
             val mockEpc = mock<EpcDataModel>()
             whenever(mockEpc.isPastExpiryDate()).thenReturn(false)
             whenever(mockEpc.isEnergyRatingEOrBetter()).thenReturn(true)
@@ -229,6 +310,7 @@ class HasMissingComplianceStepConfigTests {
 
         @Test
         fun `returns true when accepted epc present but expired`() {
+            whenever(mockState.hasEpcStep).thenReturn(mock<HasEpcStep>())
             val mockEpc = mock<EpcDataModel>()
             whenever(mockEpc.isPastExpiryDate()).thenReturn(true)
             whenever(mockState.acceptedEpcIfReachable).thenReturn(mockEpc)
@@ -238,6 +320,7 @@ class HasMissingComplianceStepConfigTests {
 
         @Test
         fun `returns true when accepted epc has low rating and no mees exemption`() {
+            whenever(mockState.hasEpcStep).thenReturn(mock<HasEpcStep>())
             val mockEpc = mock<EpcDataModel>()
             whenever(mockEpc.isPastExpiryDate()).thenReturn(false)
             whenever(mockEpc.isEnergyRatingEOrBetter()).thenReturn(false)
@@ -251,6 +334,7 @@ class HasMissingComplianceStepConfigTests {
 
         @Test
         fun `returns false when accepted epc has low rating but has mees exemption`() {
+            whenever(mockState.hasEpcStep).thenReturn(mock<HasEpcStep>())
             val mockEpc = mock<EpcDataModel>()
             whenever(mockEpc.isPastExpiryDate()).thenReturn(false)
             whenever(mockEpc.isEnergyRatingEOrBetter()).thenReturn(false)
@@ -268,6 +352,7 @@ class HasMissingComplianceStepConfigTests {
 
         @Test
         fun `returns true when no accepted epc and no exemption`() {
+            whenever(mockState.hasEpcStep).thenReturn(mock<HasEpcStep>())
             whenever(mockState.acceptedEpcIfReachable).thenReturn(null)
             val mockEpcExemptionStep = mock<EpcExemptionStep>()
             whenever(mockEpcExemptionStep.formModelIfReachableOrNull).thenReturn(null)
@@ -278,6 +363,7 @@ class HasMissingComplianceStepConfigTests {
 
         @Test
         fun `returns false when no accepted epc but exemption present`() {
+            whenever(mockState.hasEpcStep).thenReturn(mock<HasEpcStep>())
             whenever(mockState.acceptedEpcIfReachable).thenReturn(null)
             val mockEpcExemptionStep = mock<EpcExemptionStep>()
             val formModel =
@@ -292,6 +378,7 @@ class HasMissingComplianceStepConfigTests {
 
         @Test
         fun `returns true when no accepted epc and exemption reason is null`() {
+            whenever(mockState.hasEpcStep).thenReturn(mock<HasEpcStep>())
             whenever(mockState.acceptedEpcIfReachable).thenReturn(null)
             val mockEpcExemptionStep = mock<EpcExemptionStep>()
             val formModel = EpcExemptionFormModel()


### PR DESCRIPTION
## Ticket number

PDJB-769

## Goal of change

Makes the invalid compliance page no longer show when a user has selected PROVIDE_THIS_LATER

## Description of main change(s)

Adds an early return for provide this later in the rendering logic for the page.
Renames to make the names make more sense now

## Checklist

Delete any that are not applicable, and add explanation below for any that are applicable but haven't been done

- [ ] Unit tests for new logic (e.g. new service methods) have been added
- [ ] Test suite has been run in full locally and is passing
- [ ] Branch has been rebased onto main and run locally, with everything working as expected (both for your new feature
  and any related functionality)
- [ ] QA instructions have been added to the ticket (particularly if this is the last PR required to complete the ticket)
