### PR TITLE
PDJB-891: Fix 500 when changing bills included from rent includes bills CYA page

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/update/rentIncludesBills/UpdateRentIncludesBillsJourneyFactory.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/update/rentIncludesBills/UpdateRentIncludesBillsJourneyFactory.kt
@@ -100,7 +100,7 @@ class UpdateRentIncludesBillsJourneyFactory(
                 else -> throw IllegalStateException("Unknown step being checked: $checkingAnswersFor")
             }
             step(journey.finishCyaStep) {
-                parents { journey.rentIncludesBillsTask.isComplete() }
+                initialStep()
                 nextDestination { Destination.Nowhere() }
             }
             configureStep(journey.rentIncludesBills) {

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/PropertyDetailsUpdateJourneyTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/PropertyDetailsUpdateJourneyTests.kt
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.whenever
+import uk.gov.communities.prsdb.webapp.constants.enums.BillsIncluded
 import uk.gov.communities.prsdb.webapp.constants.enums.FurnishedStatus
 import uk.gov.communities.prsdb.webapp.constants.enums.LicensingType
 import uk.gov.communities.prsdb.webapp.constants.enums.OwnershipType
@@ -522,6 +523,42 @@ class PropertyDetailsUpdateJourneyTests : IntegrationTestWithMutableData("data-l
                 assertThat(propertyDetailsPage.propertyDetailsSummaryList.rentIncludesBillsRow.value)
                     .containsText("No")
                 assertThat(propertyDetailsPage.propertyDetailsSummaryList.billsIncludedRow).isHidden()
+            }
+
+            @Test
+            fun `Changing the bills included answer from the CYA page updates the property with the correct values`(page: Page) {
+                // Start update journey and reach the CYA page with bills included set
+                val propertyDetailsPage = navigator.goToPropertyDetailsLandlordView(occupiedPropertyOwnershipId)
+                propertyDetailsPage.propertyDetailsSummaryList.rentIncludesBillsRow.clickFirstActionLinkAndWait()
+                val updateRentIncludesBillsPage =
+                    assertPageIs(page, RentIncludesBillsFormPagePropertyDetailsUpdate::class, occupiedPropertyUrlArguments)
+                updateRentIncludesBillsPage.submitIsIncluded()
+                val initialBillsIncludedPage =
+                    assertPageIs(page, BillsIncludedFormPagePropertyDetailsUpdate::class, occupiedPropertyUrlArguments)
+                initialBillsIncludedPage.selectGasElectricityWater()
+                initialBillsIncludedPage.form.submit()
+                var checkYourAnswersPage =
+                    assertPageIs(page, CheckRentIncludesBillsAnswersPagePropertyDetailsUpdate::class, occupiedPropertyUrlArguments)
+
+                // Click the change link on the bills included row
+                checkYourAnswersPage.summaryList.billsIncludedRow.clickFirstActionLinkAndWait()
+                val billsIncludedPage =
+                    assertPageIs(page, BillsIncludedFormPagePropertyDetailsUpdate::class, occupiedPropertyUrlArguments)
+
+                // Change the selection and submit
+                billsIncludedPage.form.billsIncludedCheckboxes.checkCheckbox(BillsIncluded.COUNCIL_TAX.toString())
+                billsIncludedPage.form.submit()
+                checkYourAnswersPage =
+                    assertPageIs(page, CheckRentIncludesBillsAnswersPagePropertyDetailsUpdate::class, occupiedPropertyUrlArguments)
+
+                // Confirm new value shown on CYA and persisted to property details
+                val expectedBillsIncluded = "Gas, Electricity, Water, Council Tax"
+                assertThat(checkYourAnswersPage.summaryList.billsIncludedRow).containsText(expectedBillsIncluded)
+                checkYourAnswersPage.confirm()
+                val updatedPropertyDetailsPage =
+                    assertPageIs(page, PropertyDetailsPageLandlordView::class, occupiedPropertyUrlArguments)
+                assertThat(updatedPropertyDetailsPage.propertyDetailsSummaryList.billsIncludedRow)
+                    .containsText(expectedBillsIncluded)
             }
         }
 


### PR DESCRIPTION
## Ticket number

PDJB-891

## Goal of change

Fix a 500 error when clicking the "Change" link next to "Which bills are included" on the rent-includes-bills update Check Your Answers page.

## Description of main change(s)

- The `finishCyaStep` in `UpdateRentIncludesBillsJourneyFactory.checkYourAnswersJourneyMap` previously gated its parents on `rentIncludesBillsTask.isComplete()`. `Task.isComplete()` reads a `lateinit` `subJourneyBuilder` that is only initialised when `Task.makeSubJourney()` runs (via `checkAnswerTask`). The `BillsIncludedStep` branch of the CYA journey map uses `checkAnswerStep` instead, so the task was never initialised and the parents predicate threw `UninitializedPropertyAccessException` → 500.
- Changed that step to `initialStep()`, matching the pattern used in `UpdateOccupancyJourneyFactory.checkYourAnswersJourneyMap` (the other update journey that mixes `checkAnswerTask` and `checkAnswerStep` branches).
- Added a regression integration test that drives the bug repro (CYA → Change "Which bills are included" → update selection → submit) and asserts the new value is persisted.

## Anything you'd like to highlight to the reviewer?

- This is a one-line behavioural fix. The other three update journey factories that still use `parents { task.isComplete() }` (`UpdatePropertyLicensingJourneyFactory`, `UpdateRentFrequencyAndAmountJourneyFactory`, `UpdateHouseholdsAndTenantsJourneyFactory`) only have `checkAnswerTask` branches, so they don't hit the lateinit and don't need changing.
- Possible follow-up (not in scope here): defensively guarding `Task.isComplete()` to return `false` when `subJourneyBuilder` is uninitialised would prevent any future occurrence of this class of bug.

## Checklist

- [x] New journey steps have been added to the appropriate journey integration test(s)
- [x] Test suite has been run in full locally and is passing (RentIncludesBills nested class — 3/3, plus local smoke test against bootRun)
- [x] Branch has been rebased onto main and run locally, with everything working as expected