### PR TITLE
PDJB-887: Restrict system operator pages to link to other system operator pages

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/LocalCouncilDashboardController.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/LocalCouncilDashboardController.kt
@@ -39,7 +39,10 @@ class LocalCouncilDashboardController(
                 "navLinks",
                 listOf(
                     NavigationLinkViewModel(
-                        ManageLocalCouncilUsersController.getLocalCouncilManageUsersRoute(localCouncilUser.localCouncil.id),
+                        ManageLocalCouncilUsersController.getManageUsersRoute(
+                            localCouncilUser.localCouncil.id,
+                            ManageUsersViewType.LocalAuthorityView,
+                        ),
                         "navLink.manageUsers.title",
                         false,
                     ),

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/ManageLocalCouncilUsersController.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/ManageLocalCouncilUsersController.kt
@@ -432,28 +432,57 @@ class ManageLocalCouncilUsersController(
         }
     }
 
+    private fun isSystemOperatorRequest(request: HttpServletRequest): Boolean =
+        request.requestURI.startsWith("/$SYSTEM_OPERATOR_PATH_SEGMENT/")
+
     private fun getRequestPathPrefix(request: HttpServletRequest) =
-        if (request.requestURI.startsWith("/$SYSTEM_OPERATOR_PATH_SEGMENT/")) {
+        if (isSystemOperatorRequest(request)) {
             SYSTEM_OPERATOR_PATH_SEGMENT
         } else {
             LOCAL_COUNCIL_PATH_SEGMENT
         }
 
-    private fun getManageUsersRoute(
+    private fun getSystemOperatorOrLocalCouncilRoute(
+        request: HttpServletRequest,
+        systemManagerRoute: String,
+        localCouncilRoute: String,
+    ): String =
+        if (isSystemOperatorRequest(request)) {
+            systemManagerRoute
+        } else {
+            localCouncilRoute
+        }
+
+    fun getManageUsersRoute(
         localCouncilId: Int,
         request: HttpServletRequest,
-    ): String = "/${getRequestPathPrefix(request)}/$localCouncilId/$MANAGE_USERS_PATH_SEGMENT"
+    ): String =
+        getSystemOperatorOrLocalCouncilRoute(
+            request,
+            getSystemOperatorManageUsersRoute(localCouncilId),
+            getLocalCouncilManageUsersRoute(localCouncilId),
+        )
 
     private fun getInviteNewUserRoute(
         localCouncilId: Int,
         request: HttpServletRequest,
-    ): String = "/${getRequestPathPrefix(request)}/$localCouncilId/$INVITE_NEW_USER_PATH_SEGMENT"
+    ): String =
+        getSystemOperatorOrLocalCouncilRoute(
+            request,
+            getSystemOperatorInviteNewUserRoute(localCouncilId),
+            getLocalCouncilInviteNewUserRoute(localCouncilId),
+        )
 
     private fun getDeleteUserRoute(
         localCouncilId: Int,
         localCouncilUserId: Long,
         request: HttpServletRequest,
-    ): String = "/${getRequestPathPrefix(request)}/$localCouncilId/$DELETE_USER_PATH_SEGMENT/$localCouncilUserId"
+    ): String =
+        getSystemOperatorOrLocalCouncilRoute(
+            request,
+            getSystemOperatorDeleteUserRoute(localCouncilId, localCouncilUserId),
+            getLocalCouncilDeleteUserRoute(localCouncilId, localCouncilUserId),
+        )
 
     private fun getEditUserBaseUrl(
         localCouncilId: Int,

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/ManageLocalCouncilUsersController.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/ManageLocalCouncilUsersController.kt
@@ -505,8 +505,13 @@ class ManageLocalCouncilUsersController(
         private const val SYSTEM_OPERATOR_MANAGE_USERS_ROUTE = "$SYSTEM_OPERATOR_MANAGE_COUNCIL_ROUTE/$MANAGE_USERS_PATH_SEGMENT"
         private const val SYSTEM_OPERATOR_EDIT_USER_ROUTE = "$SYSTEM_OPERATOR_MANAGE_COUNCIL_ROUTE/$EDIT_USER_ROUTE"
         private const val SYSTEM_OPERATOR_DELETE_USER_ROUTE = "$SYSTEM_OPERATOR_MANAGE_COUNCIL_ROUTE/$DELETE_USER_ROUTE"
+        private const val SYSTEM_OPERATOR_DELETE_USER_CONFIRMATION_ROUTE =
+            "$SYSTEM_OPERATOR_MANAGE_COUNCIL_ROUTE/$DELETE_USER_CONFIRMATION_ROUTE"
         private const val SYSTEM_OPERATOR_INVITE_NEW_USER_ROUTE = "$SYSTEM_OPERATOR_MANAGE_COUNCIL_ROUTE/$INVITE_NEW_USER_PATH_SEGMENT"
-        private const val SYSTEM_OPERATOR_CANCEL_INVITE_ROUTE = "$SYSTEM_OPERATOR_MANAGE_COUNCIL_ROUTE/$CANCEL_INVITE_ROUTE"
+        private const val SYSTEM_OPERATOR_INVITE_NEW_USER_CONFIRMATION_ROUTE =
+            "$SYSTEM_OPERATOR_MANAGE_COUNCIL_ROUTE/$INVITE_USER_CONFIRMATION_ROUTE"
+        private const val SYSTEM_OPERATOR_CANCEL_INVITE_CONFIRMATION_ROUTE =
+            "$SYSTEM_OPERATOR_MANAGE_COUNCIL_ROUTE/$CANCEL_INVITE_CONFIRMATION_ROUTE"
 
         fun getLocalCouncilManageUsersRoute(localCouncilId: Int): String =
             UriTemplate(LOCAL_COUNCIL_MANAGE_USERS_ROUTE).expand(localCouncilId).toASCIIString()
@@ -528,6 +533,24 @@ class ManageLocalCouncilUsersController(
             localCouncilId: Int,
             localCouncilUserId: Long,
         ): String = UriTemplate(SYSTEM_OPERATOR_DELETE_USER_ROUTE).expand(localCouncilId, localCouncilUserId).toASCIIString()
+
+        fun getSystemOperatorEditUserRoute(
+            localCouncilId: Int,
+            localCouncilUserId: Long,
+        ): String = UriTemplate(SYSTEM_OPERATOR_EDIT_USER_ROUTE).expand(localCouncilId, localCouncilUserId).toASCIIString()
+
+        fun getSystemOperatorDeleteUserSuccessRoute(
+            localCouncilId: Int,
+            deletedUserId: Long,
+        ): String = UriTemplate(SYSTEM_OPERATOR_DELETE_USER_CONFIRMATION_ROUTE).expand(localCouncilId, deletedUserId).toASCIIString()
+
+        fun getSystemOperatorInviteUserSuccessRoute(localCouncilId: Int): String =
+            UriTemplate(SYSTEM_OPERATOR_INVITE_NEW_USER_CONFIRMATION_ROUTE).expand(localCouncilId).toASCIIString()
+
+        fun getSystemOperatorCancelInviteSuccessRoute(
+            localCouncilId: Int,
+            invitationId: Long,
+        ): String = UriTemplate(SYSTEM_OPERATOR_CANCEL_INVITE_CONFIRMATION_ROUTE).expand(localCouncilId, invitationId).toASCIIString()
 
         fun getDeleteUserConfirmationRoute(deletedUserId: Long): String =
             UriTemplate(DELETE_USER_CONFIRMATION_ROUTE).expand(deletedUserId).toASCIIString()

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/ManageLocalCouncilUsersController.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/ManageLocalCouncilUsersController.kt
@@ -432,56 +432,38 @@ class ManageLocalCouncilUsersController(
         }
     }
 
+    private fun getRequestPathPrefix(request: HttpServletRequest) =
+        if (request.requestURI.startsWith("/$SYSTEM_OPERATOR_PATH_SEGMENT/")) {
+            SYSTEM_OPERATOR_PATH_SEGMENT
+        } else {
+            LOCAL_COUNCIL_PATH_SEGMENT
+        }
+
     private fun getManageUsersRoute(
         localCouncilId: Int,
         request: HttpServletRequest,
-    ): String =
-        if (request.isUserInRole(ROLE_SYSTEM_OPERATOR)) {
-            getSystemOperatorManageUsersRoute(localCouncilId)
-        } else {
-            getLocalCouncilManageUsersRoute(localCouncilId)
-        }
+    ): String = "/${getRequestPathPrefix(request)}/$localCouncilId/$MANAGE_USERS_PATH_SEGMENT"
 
     private fun getInviteNewUserRoute(
         localCouncilId: Int,
         request: HttpServletRequest,
-    ): String =
-        if (request.isUserInRole(ROLE_SYSTEM_OPERATOR)) {
-            getSystemOperatorInviteNewUserRoute(localCouncilId)
-        } else {
-            getLocalCouncilInviteNewUserRoute(localCouncilId)
-        }
+    ): String = "/${getRequestPathPrefix(request)}/$localCouncilId/$INVITE_NEW_USER_PATH_SEGMENT"
 
     private fun getDeleteUserRoute(
         localCouncilId: Int,
         localCouncilUserId: Long,
         request: HttpServletRequest,
-    ): String =
-        if (request.isUserInRole(ROLE_SYSTEM_OPERATOR)) {
-            getSystemOperatorDeleteUserRoute(localCouncilId, localCouncilUserId)
-        } else {
-            getLocalCouncilDeleteUserRoute(localCouncilId, localCouncilUserId)
-        }
+    ): String = "/${getRequestPathPrefix(request)}/$localCouncilId/$DELETE_USER_PATH_SEGMENT/$localCouncilUserId"
 
     private fun getEditUserBaseUrl(
         localCouncilId: Int,
         request: HttpServletRequest,
-    ): String =
-        if (request.isUserInRole(ROLE_SYSTEM_OPERATOR)) {
-            "/$SYSTEM_OPERATOR_PATH_SEGMENT/$localCouncilId/$EDIT_USER_PATH_SEGMENT/"
-        } else {
-            "/$LOCAL_COUNCIL_PATH_SEGMENT/$localCouncilId/$EDIT_USER_PATH_SEGMENT/"
-        }
+    ): String = "/${getRequestPathPrefix(request)}/$localCouncilId/$EDIT_USER_PATH_SEGMENT/"
 
     private fun getCancelInvitationBaseUrl(
         localCouncilId: Int,
         request: HttpServletRequest,
-    ): String =
-        if (request.isUserInRole(ROLE_SYSTEM_OPERATOR)) {
-            "/$SYSTEM_OPERATOR_PATH_SEGMENT/$localCouncilId/$CANCEL_INVITATION_PATH_SEGMENT/"
-        } else {
-            "/$LOCAL_COUNCIL_PATH_SEGMENT/$localCouncilId/$CANCEL_INVITATION_PATH_SEGMENT/"
-        }
+    ): String = "/${getRequestPathPrefix(request)}/$localCouncilId/$CANCEL_INVITATION_PATH_SEGMENT/"
 
     companion object {
         const val LOCAL_COUNCIL_ROUTE = "/$LOCAL_COUNCIL_PATH_SEGMENT/{localCouncilId}"

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/ManageLocalCouncilUsersController.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/ManageLocalCouncilUsersController.kt
@@ -84,7 +84,7 @@ class ManageLocalCouncilUsersController(
             )
 
         if (pagedUserList.totalPages != 0 && pagedUserList.totalPages < page) {
-            return "redirect:${getLocalCouncilManageUsersRoute(localCouncilId)}"
+            return "redirect:${getManageUsersRoute(localCouncilId, request)}"
         }
 
         model.addAttribute("currentUserId", loggedInLocalCouncilAdmin?.id)
@@ -98,6 +98,9 @@ class ManageLocalCouncilUsersController(
 
         // TODO: PRSD-672 - if the user is not an la admin, make this a link to the system operator dashboard
         model.addAttribute("dashboardUrl", LOCAL_COUNCIL_DASHBOARD_URL)
+        model.addAttribute("inviteNewUserUrl", getInviteNewUserRoute(localCouncilId, request))
+        model.addAttribute("editUserBaseUrl", getEditUserBaseUrl(localCouncilId, request))
+        model.addAttribute("cancelInvitationBaseUrl", getCancelInvitationBaseUrl(localCouncilId, request))
 
         return "manageLocalCouncilUsers"
     }
@@ -134,7 +137,7 @@ class ManageLocalCouncilUsersController(
                 ),
             ),
         )
-        model.addAttribute("deleteUserUrl", getLocalCouncilDeleteUserRoute(localCouncilId, localCouncilUserId))
+        model.addAttribute("deleteUserUrl", getDeleteUserRoute(localCouncilId, localCouncilUserId, request))
 
         return "editLocalCouncilUserAccess"
     }
@@ -152,7 +155,7 @@ class ManageLocalCouncilUsersController(
         localCouncilDataService.getLocalCouncilUserIfAuthorizedLocalCouncil(localCouncilUserId, localCouncilId)
 
         localCouncilDataService.updateUserAccessLevel(localCouncilUserAccessLevel, localCouncilUserId)
-        return "redirect:${getLocalCouncilManageUsersRoute(localCouncilId)}"
+        return "redirect:${getManageUsersRoute(localCouncilId, request)}"
     }
 
     @GetMapping("/$DELETE_USER_ROUTE")
@@ -215,7 +218,7 @@ class ManageLocalCouncilUsersController(
 
         model.addAttribute("localCouncil", getLocalCouncil(principal, localCouncilId, request))
 
-        model.addAttribute("returnToManageUsersUrl", getLocalCouncilManageUsersRoute(localCouncilId))
+        model.addAttribute("returnToManageUsersUrl", getManageUsersRoute(localCouncilId, request))
 
         return "deleteLocalCouncilUserSuccess"
     }
@@ -297,6 +300,7 @@ class ManageLocalCouncilUsersController(
         model.addAttribute("localCouncil", getLocalCouncil(principal, localCouncilId, request))
         model.addAttribute("dashboardUrl", LOCAL_COUNCIL_DASHBOARD_URL)
         model.addAttribute("invitedEmailAddress", invitedEmail)
+        model.addAttribute("inviteNewUserUrl", getInviteNewUserRoute(localCouncilId, request))
         return "inviteLocalCouncilUserSuccess"
     }
 
@@ -368,7 +372,7 @@ class ManageLocalCouncilUsersController(
         model.addAttribute("deletedEmail", invitationDeletedThisSession.invitedEmail)
 
         model.addAttribute("localCouncil", getLocalCouncil(principal, localCouncilId, request))
-        model.addAttribute("returnToManageUsersUrl", getLocalCouncilManageUsersRoute(localCouncilId))
+        model.addAttribute("returnToManageUsersUrl", getManageUsersRoute(localCouncilId, request))
 
         return "cancelLocalCouncilUserInvitationSuccess"
     }
@@ -428,6 +432,57 @@ class ManageLocalCouncilUsersController(
         }
     }
 
+    private fun getManageUsersRoute(
+        localCouncilId: Int,
+        request: HttpServletRequest,
+    ): String =
+        if (request.isUserInRole(ROLE_SYSTEM_OPERATOR)) {
+            getSystemOperatorManageUsersRoute(localCouncilId)
+        } else {
+            getLocalCouncilManageUsersRoute(localCouncilId)
+        }
+
+    private fun getInviteNewUserRoute(
+        localCouncilId: Int,
+        request: HttpServletRequest,
+    ): String =
+        if (request.isUserInRole(ROLE_SYSTEM_OPERATOR)) {
+            getSystemOperatorInviteNewUserRoute(localCouncilId)
+        } else {
+            getLocalCouncilInviteNewUserRoute(localCouncilId)
+        }
+
+    private fun getDeleteUserRoute(
+        localCouncilId: Int,
+        localCouncilUserId: Long,
+        request: HttpServletRequest,
+    ): String =
+        if (request.isUserInRole(ROLE_SYSTEM_OPERATOR)) {
+            getSystemOperatorDeleteUserRoute(localCouncilId, localCouncilUserId)
+        } else {
+            getLocalCouncilDeleteUserRoute(localCouncilId, localCouncilUserId)
+        }
+
+    private fun getEditUserBaseUrl(
+        localCouncilId: Int,
+        request: HttpServletRequest,
+    ): String =
+        if (request.isUserInRole(ROLE_SYSTEM_OPERATOR)) {
+            "/$SYSTEM_OPERATOR_PATH_SEGMENT/$localCouncilId/$EDIT_USER_PATH_SEGMENT/"
+        } else {
+            "/$LOCAL_COUNCIL_PATH_SEGMENT/$localCouncilId/$EDIT_USER_PATH_SEGMENT/"
+        }
+
+    private fun getCancelInvitationBaseUrl(
+        localCouncilId: Int,
+        request: HttpServletRequest,
+    ): String =
+        if (request.isUserInRole(ROLE_SYSTEM_OPERATOR)) {
+            "/$SYSTEM_OPERATOR_PATH_SEGMENT/$localCouncilId/$CANCEL_INVITATION_PATH_SEGMENT/"
+        } else {
+            "/$LOCAL_COUNCIL_PATH_SEGMENT/$localCouncilId/$CANCEL_INVITATION_PATH_SEGMENT/"
+        }
+
     companion object {
         const val LOCAL_COUNCIL_ROUTE = "/$LOCAL_COUNCIL_PATH_SEGMENT/{localCouncilId}"
         const val SYSTEM_OPERATOR_MANAGE_COUNCIL_ROUTE = "/$SYSTEM_OPERATOR_PATH_SEGMENT/{localCouncilId}"
@@ -447,11 +502,17 @@ class ManageLocalCouncilUsersController(
         private const val LOCAL_COUNCIL_CANCEL_INVITE_ROUTE = "$LOCAL_COUNCIL_ROUTE/$CANCEL_INVITE_ROUTE"
         private const val LOCAL_COUNCIL_CANCEL_INVITE_CONFIRMATION_ROUTE = "$LOCAL_COUNCIL_ROUTE/$CANCEL_INVITE_CONFIRMATION_ROUTE"
 
+        private const val SYSTEM_OPERATOR_MANAGE_USERS_ROUTE = "$SYSTEM_OPERATOR_MANAGE_COUNCIL_ROUTE/$MANAGE_USERS_PATH_SEGMENT"
+        private const val SYSTEM_OPERATOR_EDIT_USER_ROUTE = "$SYSTEM_OPERATOR_MANAGE_COUNCIL_ROUTE/$EDIT_USER_ROUTE"
+        private const val SYSTEM_OPERATOR_DELETE_USER_ROUTE = "$SYSTEM_OPERATOR_MANAGE_COUNCIL_ROUTE/$DELETE_USER_ROUTE"
+        private const val SYSTEM_OPERATOR_INVITE_NEW_USER_ROUTE = "$SYSTEM_OPERATOR_MANAGE_COUNCIL_ROUTE/$INVITE_NEW_USER_PATH_SEGMENT"
+        private const val SYSTEM_OPERATOR_CANCEL_INVITE_ROUTE = "$SYSTEM_OPERATOR_MANAGE_COUNCIL_ROUTE/$CANCEL_INVITE_ROUTE"
+
         fun getLocalCouncilManageUsersRoute(localCouncilId: Int): String =
             UriTemplate(LOCAL_COUNCIL_MANAGE_USERS_ROUTE).expand(localCouncilId).toASCIIString()
 
         fun getSystemOperatorManageUsersRoute(localCouncilId: Int): String =
-            UriTemplate("$SYSTEM_OPERATOR_MANAGE_COUNCIL_ROUTE/$MANAGE_USERS_PATH_SEGMENT").expand(localCouncilId).toASCIIString()
+            UriTemplate(SYSTEM_OPERATOR_MANAGE_USERS_ROUTE).expand(localCouncilId).toASCIIString()
 
         fun getLocalCouncilEditUserRoute(
             localCouncilId: Int,
@@ -462,6 +523,11 @@ class ManageLocalCouncilUsersController(
             localCouncilId: Int,
             localCouncilUserId: Long,
         ): String = UriTemplate(LOCAL_COUNCIL_DELETE_USER_ROUTE).expand(localCouncilId, localCouncilUserId).toASCIIString()
+
+        fun getSystemOperatorDeleteUserRoute(
+            localCouncilId: Int,
+            localCouncilUserId: Long,
+        ): String = UriTemplate(SYSTEM_OPERATOR_DELETE_USER_ROUTE).expand(localCouncilId, localCouncilUserId).toASCIIString()
 
         fun getDeleteUserConfirmationRoute(deletedUserId: Long): String =
             UriTemplate(DELETE_USER_CONFIRMATION_ROUTE).expand(deletedUserId).toASCIIString()
@@ -476,6 +542,9 @@ class ManageLocalCouncilUsersController(
 
         fun getLocalCouncilInviteNewUserRoute(localCouncilId: Int): String =
             UriTemplate(LOCAL_COUNCIL_INVITE_NEW_USER_ROUTE).expand(localCouncilId).toASCIIString()
+
+        fun getSystemOperatorInviteNewUserRoute(localCouncilId: Int): String =
+            UriTemplate(SYSTEM_OPERATOR_INVITE_NEW_USER_ROUTE).expand(localCouncilId).toASCIIString()
 
         fun getLocalCouncilCancelInviteRoute(
             localCouncilId: Int,

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/ManageLocalCouncilUsersController.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/ManageLocalCouncilUsersController.kt
@@ -51,6 +51,11 @@ import uk.gov.communities.prsdb.webapp.services.LocalCouncilService
 import uk.gov.communities.prsdb.webapp.services.SecurityContextService
 import java.security.Principal
 
+enum class ManageUsersViewType {
+    LocalAuthorityView,
+    SystemOperatorView,
+}
+
 @PreAuthorize("hasAnyRole('LOCAL_COUNCIL_ADMIN', 'SYSTEM_OPERATOR')")
 @PrsdbController
 @RequestMapping(LOCAL_COUNCIL_ROUTE, SYSTEM_OPERATOR_MANAGE_COUNCIL_ROUTE)
@@ -84,7 +89,7 @@ class ManageLocalCouncilUsersController(
             )
 
         if (pagedUserList.totalPages != 0 && pagedUserList.totalPages < page) {
-            return "redirect:${getManageUsersRoute(localCouncilId, request)}"
+            return "redirect:${getManageUsersRoute(localCouncilId, getRequestType(request))}"
         }
 
         model.addAttribute("currentUserId", loggedInLocalCouncilAdmin?.id)
@@ -432,67 +437,46 @@ class ManageLocalCouncilUsersController(
         }
     }
 
-    private fun isSystemOperatorRequest(request: HttpServletRequest): Boolean =
-        request.requestURI.startsWith("/$SYSTEM_OPERATOR_PATH_SEGMENT/")
-
-    private fun getRequestPathPrefix(request: HttpServletRequest) =
-        if (isSystemOperatorRequest(request)) {
-            SYSTEM_OPERATOR_PATH_SEGMENT
+    private fun getRequestType(request: HttpServletRequest): ManageUsersViewType =
+        if (request.requestURI.startsWith("/$SYSTEM_OPERATOR_PATH_SEGMENT/")) {
+            ManageUsersViewType.SystemOperatorView
         } else {
-            LOCAL_COUNCIL_PATH_SEGMENT
+            ManageUsersViewType.LocalAuthorityView
         }
 
-    private fun getSystemOperatorOrLocalCouncilRoute(
-        request: HttpServletRequest,
-        systemManagerRoute: String,
-        localCouncilRoute: String,
-    ): String =
-        if (isSystemOperatorRequest(request)) {
-            systemManagerRoute
-        } else {
-            localCouncilRoute
-        }
-
-    fun getManageUsersRoute(
+    private fun getManageUsersRoute(
         localCouncilId: Int,
         request: HttpServletRequest,
-    ): String =
-        getSystemOperatorOrLocalCouncilRoute(
-            request,
-            getSystemOperatorManageUsersRoute(localCouncilId),
-            getLocalCouncilManageUsersRoute(localCouncilId),
-        )
+    ): String = getManageUsersRoute(localCouncilId, getRequestType(request))
 
     private fun getInviteNewUserRoute(
         localCouncilId: Int,
         request: HttpServletRequest,
-    ): String =
-        getSystemOperatorOrLocalCouncilRoute(
-            request,
-            getSystemOperatorInviteNewUserRoute(localCouncilId),
-            getLocalCouncilInviteNewUserRoute(localCouncilId),
-        )
+    ): String = getInviteNewUserRoute(localCouncilId, getRequestType(request))
 
     private fun getDeleteUserRoute(
         localCouncilId: Int,
         localCouncilUserId: Long,
         request: HttpServletRequest,
-    ): String =
-        getSystemOperatorOrLocalCouncilRoute(
-            request,
-            getSystemOperatorDeleteUserRoute(localCouncilId, localCouncilUserId),
-            getLocalCouncilDeleteUserRoute(localCouncilId, localCouncilUserId),
-        )
+    ): String = getDeleteUserRoute(localCouncilId, localCouncilUserId, getRequestType(request))
 
     private fun getEditUserBaseUrl(
         localCouncilId: Int,
         request: HttpServletRequest,
-    ): String = "/${getRequestPathPrefix(request)}/$localCouncilId/$EDIT_USER_PATH_SEGMENT/"
+    ): String {
+        val viewType = getRequestType(request)
+        val prefix = if (viewType == ManageUsersViewType.SystemOperatorView) SYSTEM_OPERATOR_PATH_SEGMENT else LOCAL_COUNCIL_PATH_SEGMENT
+        return "/$prefix/$localCouncilId/$EDIT_USER_PATH_SEGMENT/"
+    }
 
     private fun getCancelInvitationBaseUrl(
         localCouncilId: Int,
         request: HttpServletRequest,
-    ): String = "/${getRequestPathPrefix(request)}/$localCouncilId/$CANCEL_INVITATION_PATH_SEGMENT/"
+    ): String {
+        val viewType = getRequestType(request)
+        val prefix = if (viewType == ManageUsersViewType.SystemOperatorView) SYSTEM_OPERATOR_PATH_SEGMENT else LOCAL_COUNCIL_PATH_SEGMENT
+        return "/$prefix/$localCouncilId/$CANCEL_INVITATION_PATH_SEGMENT/"
+    }
 
     companion object {
         const val LOCAL_COUNCIL_ROUTE = "/$LOCAL_COUNCIL_PATH_SEGMENT/{localCouncilId}"
@@ -521,76 +505,123 @@ class ManageLocalCouncilUsersController(
         private const val SYSTEM_OPERATOR_INVITE_NEW_USER_ROUTE = "$SYSTEM_OPERATOR_MANAGE_COUNCIL_ROUTE/$INVITE_NEW_USER_PATH_SEGMENT"
         private const val SYSTEM_OPERATOR_INVITE_NEW_USER_CONFIRMATION_ROUTE =
             "$SYSTEM_OPERATOR_MANAGE_COUNCIL_ROUTE/$INVITE_USER_CONFIRMATION_ROUTE"
+        private const val SYSTEM_OPERATOR_CANCEL_INVITE_ROUTE = "$SYSTEM_OPERATOR_MANAGE_COUNCIL_ROUTE/$CANCEL_INVITE_ROUTE"
         private const val SYSTEM_OPERATOR_CANCEL_INVITE_CONFIRMATION_ROUTE =
             "$SYSTEM_OPERATOR_MANAGE_COUNCIL_ROUTE/$CANCEL_INVITE_CONFIRMATION_ROUTE"
 
-        fun getLocalCouncilManageUsersRoute(localCouncilId: Int): String =
-            UriTemplate(LOCAL_COUNCIL_MANAGE_USERS_ROUTE).expand(localCouncilId).toASCIIString()
+        fun getManageUsersRoute(
+            localCouncilId: Int,
+            viewType: ManageUsersViewType,
+        ): String {
+            val route =
+                if (viewType == ManageUsersViewType.SystemOperatorView) {
+                    SYSTEM_OPERATOR_MANAGE_USERS_ROUTE
+                } else {
+                    LOCAL_COUNCIL_MANAGE_USERS_ROUTE
+                }
+            return UriTemplate(route).expand(localCouncilId).toASCIIString()
+        }
 
-        fun getSystemOperatorManageUsersRoute(localCouncilId: Int): String =
-            UriTemplate(SYSTEM_OPERATOR_MANAGE_USERS_ROUTE).expand(localCouncilId).toASCIIString()
-
-        fun getLocalCouncilEditUserRoute(
+        fun getEditUserRoute(
             localCouncilId: Int,
             localCouncilUserId: Long,
-        ): String = UriTemplate(LOCAL_COUNCIL_EDIT_USER_ROUTE).expand(localCouncilId, localCouncilUserId).toASCIIString()
+            viewType: ManageUsersViewType,
+        ): String {
+            val route =
+                if (viewType == ManageUsersViewType.SystemOperatorView) {
+                    SYSTEM_OPERATOR_EDIT_USER_ROUTE
+                } else {
+                    LOCAL_COUNCIL_EDIT_USER_ROUTE
+                }
+            return UriTemplate(route).expand(localCouncilId, localCouncilUserId).toASCIIString()
+        }
 
-        fun getLocalCouncilDeleteUserRoute(
+        fun getDeleteUserRoute(
             localCouncilId: Int,
             localCouncilUserId: Long,
-        ): String = UriTemplate(LOCAL_COUNCIL_DELETE_USER_ROUTE).expand(localCouncilId, localCouncilUserId).toASCIIString()
+            viewType: ManageUsersViewType,
+        ): String {
+            val route =
+                if (viewType == ManageUsersViewType.SystemOperatorView) {
+                    SYSTEM_OPERATOR_DELETE_USER_ROUTE
+                } else {
+                    LOCAL_COUNCIL_DELETE_USER_ROUTE
+                }
+            return UriTemplate(route).expand(localCouncilId, localCouncilUserId).toASCIIString()
+        }
 
-        fun getSystemOperatorDeleteUserRoute(
-            localCouncilId: Int,
-            localCouncilUserId: Long,
-        ): String = UriTemplate(SYSTEM_OPERATOR_DELETE_USER_ROUTE).expand(localCouncilId, localCouncilUserId).toASCIIString()
-
-        fun getSystemOperatorEditUserRoute(
-            localCouncilId: Int,
-            localCouncilUserId: Long,
-        ): String = UriTemplate(SYSTEM_OPERATOR_EDIT_USER_ROUTE).expand(localCouncilId, localCouncilUserId).toASCIIString()
-
-        fun getSystemOperatorDeleteUserSuccessRoute(
+        fun getDeleteUserSuccessRoute(
             localCouncilId: Int,
             deletedUserId: Long,
-        ): String = UriTemplate(SYSTEM_OPERATOR_DELETE_USER_CONFIRMATION_ROUTE).expand(localCouncilId, deletedUserId).toASCIIString()
+            viewType: ManageUsersViewType,
+        ): String {
+            val route =
+                if (viewType == ManageUsersViewType.SystemOperatorView) {
+                    SYSTEM_OPERATOR_DELETE_USER_CONFIRMATION_ROUTE
+                } else {
+                    LOCAL_COUNCIL_DELETE_USER_CONFIRMATION_ROUTE
+                }
+            return UriTemplate(route).expand(localCouncilId, deletedUserId).toASCIIString()
+        }
 
-        fun getSystemOperatorInviteUserSuccessRoute(localCouncilId: Int): String =
-            UriTemplate(SYSTEM_OPERATOR_INVITE_NEW_USER_CONFIRMATION_ROUTE).expand(localCouncilId).toASCIIString()
+        fun getInviteNewUserRoute(
+            localCouncilId: Int,
+            viewType: ManageUsersViewType,
+        ): String {
+            val route =
+                if (viewType == ManageUsersViewType.SystemOperatorView) {
+                    SYSTEM_OPERATOR_INVITE_NEW_USER_ROUTE
+                } else {
+                    LOCAL_COUNCIL_INVITE_NEW_USER_ROUTE
+                }
+            return UriTemplate(route).expand(localCouncilId).toASCIIString()
+        }
 
-        fun getSystemOperatorCancelInviteSuccessRoute(
+        fun getInviteUserSuccessRoute(
+            localCouncilId: Int,
+            viewType: ManageUsersViewType,
+        ): String {
+            val route =
+                if (viewType == ManageUsersViewType.SystemOperatorView) {
+                    SYSTEM_OPERATOR_INVITE_NEW_USER_CONFIRMATION_ROUTE
+                } else {
+                    LOCAL_COUNCIL_INVITE_NEW_USER_CONFIRMATION_ROUTE
+                }
+            return UriTemplate(route).expand(localCouncilId).toASCIIString()
+        }
+
+        fun getCancelInviteRoute(
             localCouncilId: Int,
             invitationId: Long,
-        ): String = UriTemplate(SYSTEM_OPERATOR_CANCEL_INVITE_CONFIRMATION_ROUTE).expand(localCouncilId, invitationId).toASCIIString()
+            viewType: ManageUsersViewType,
+        ): String {
+            val route =
+                if (viewType == ManageUsersViewType.SystemOperatorView) {
+                    SYSTEM_OPERATOR_CANCEL_INVITE_ROUTE
+                } else {
+                    LOCAL_COUNCIL_CANCEL_INVITE_ROUTE
+                }
+            return UriTemplate(route).expand(localCouncilId, invitationId).toASCIIString()
+        }
+
+        fun getCancelInviteSuccessRoute(
+            localCouncilId: Int,
+            invitationId: Long,
+            viewType: ManageUsersViewType,
+        ): String {
+            val route =
+                if (viewType == ManageUsersViewType.SystemOperatorView) {
+                    SYSTEM_OPERATOR_CANCEL_INVITE_CONFIRMATION_ROUTE
+                } else {
+                    LOCAL_COUNCIL_CANCEL_INVITE_CONFIRMATION_ROUTE
+                }
+            return UriTemplate(route).expand(localCouncilId, invitationId).toASCIIString()
+        }
 
         fun getDeleteUserConfirmationRoute(deletedUserId: Long): String =
             UriTemplate(DELETE_USER_CONFIRMATION_ROUTE).expand(deletedUserId).toASCIIString()
 
-        fun getLocalCouncilDeleteUserSuccessRoute(
-            localCouncilId: Int,
-            deletedUserId: Long,
-        ): String = UriTemplate(LOCAL_COUNCIL_DELETE_USER_CONFIRMATION_ROUTE).expand(localCouncilId, deletedUserId).toASCIIString()
-
-        fun getLocalCouncilInviteUserSuccessRoute(localCouncilId: Int): String =
-            UriTemplate(LOCAL_COUNCIL_INVITE_NEW_USER_CONFIRMATION_ROUTE).expand(localCouncilId).toASCIIString()
-
-        fun getLocalCouncilInviteNewUserRoute(localCouncilId: Int): String =
-            UriTemplate(LOCAL_COUNCIL_INVITE_NEW_USER_ROUTE).expand(localCouncilId).toASCIIString()
-
-        fun getSystemOperatorInviteNewUserRoute(localCouncilId: Int): String =
-            UriTemplate(SYSTEM_OPERATOR_INVITE_NEW_USER_ROUTE).expand(localCouncilId).toASCIIString()
-
-        fun getLocalCouncilCancelInviteRoute(
-            localCouncilId: Int,
-            localCouncilUserId: Long,
-        ): String = UriTemplate(LOCAL_COUNCIL_CANCEL_INVITE_ROUTE).expand(localCouncilId, localCouncilUserId).toASCIIString()
-
         fun getCancelInviteConfirmationRoute(invitationId: Long): String =
             UriTemplate(CANCEL_INVITE_CONFIRMATION_ROUTE).expand(invitationId).toASCIIString()
-
-        fun getLocalCouncilCancelInviteSuccessRoute(
-            localCouncilId: Int,
-            invitationId: Long,
-        ): String = UriTemplate(LOCAL_COUNCIL_CANCEL_INVITE_CONFIRMATION_ROUTE).expand(localCouncilId, invitationId).toASCIIString()
     }
 }

--- a/src/main/resources/templates/inviteLocalCouncilUserSuccess.html
+++ b/src/main/resources/templates/inviteLocalCouncilUserSuccess.html
@@ -15,7 +15,7 @@
             addLocalCouncilUserSuccess.whatHappensNext.para2
         </p>
         <div class="govuk-button-group">
-            <a th:replace="~{fragments/buttons/primaryButtonLink :: primaryButtonLink(@{/local-council/{id}/invite-new-user(id=${localCouncil.id})}, #{addLocalCouncilUserSuccess.inviteAnother})}">
+            <a th:replace="~{fragments/buttons/primaryButtonLink :: primaryButtonLink(@{${inviteNewUserUrl}}, #{addLocalCouncilUserSuccess.inviteAnother})}">
                 addLocalCouncilUserSuccess.inviteAnother
             </a>
             <a th:replace="~{fragments/buttons/secondaryButtonLink :: secondaryButtonLink(@{${dashboardUrl}}, #{addLocalCouncilUserSuccess.returnToDashboard})}">

--- a/src/main/resources/templates/manageLocalCouncilUsers.html
+++ b/src/main/resources/templates/manageLocalCouncilUsers.html
@@ -29,7 +29,7 @@
                                 </span>
                     </td>
                     <td class="govuk-table__cell">
-                        <a th:href="@{${user.pending ? 'cancel-invitation/' + user.id : 'edit-user/' + user.id}}"
+                        <a th:href="@{${user.pending ? cancelInvitationBaseUrl + user.id : editUserBaseUrl + user.id}}"
                            class="govuk-link"
                            th:text="#{forms.links.change}"
                            th:if="(${currentUserId} != ${user.id}) or ${user.pending} or ${userCanEditTheirOwnAccount}"
@@ -46,7 +46,7 @@
                 <h2 class="govuk-heading-m" th:text="#{manageLocalCouncilUsers.noUsersText}"></h2>
             </div>
             <div class="govuk-button-group" id="action-buttons">
-                <a th:replace="~{fragments/buttons/primaryButtonLink :: primaryButtonLink(@{/local-council/{id}/invite-new-user(id=${localCouncil.id})}, #{manageLocalCouncilUsers.inviteAnotherUserButtonText})}">
+                <a th:replace="~{fragments/buttons/primaryButtonLink :: primaryButtonLink(@{${inviteNewUserUrl}}, #{manageLocalCouncilUsers.inviteAnotherUserButtonText})}">
                     manageLocalCouncilUsers.inviteAnotherUserButtonText
                 </a>
                 <button th:replace="~{fragments/buttons/secondaryButtonLink :: secondaryButtonLink(@{${dashboardUrl}},#{manageLocalCouncilUsers.returnToDashboardButton})}"></button>

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/controllers/ManageLocalCouncilUsersControllerTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/controllers/ManageLocalCouncilUsersControllerTests.kt
@@ -27,22 +27,15 @@ import uk.gov.communities.prsdb.webapp.constants.LOCAL_COUNCIL_PATH_SEGMENT
 import uk.gov.communities.prsdb.webapp.constants.SYSTEM_OPERATOR_PATH_SEGMENT
 import uk.gov.communities.prsdb.webapp.controllers.ManageLocalCouncilUsersController.Companion.INVITE_USER_CONFIRMATION_ROUTE
 import uk.gov.communities.prsdb.webapp.controllers.ManageLocalCouncilUsersController.Companion.getCancelInviteConfirmationRoute
+import uk.gov.communities.prsdb.webapp.controllers.ManageLocalCouncilUsersController.Companion.getCancelInviteRoute
+import uk.gov.communities.prsdb.webapp.controllers.ManageLocalCouncilUsersController.Companion.getCancelInviteSuccessRoute
 import uk.gov.communities.prsdb.webapp.controllers.ManageLocalCouncilUsersController.Companion.getDeleteUserConfirmationRoute
-import uk.gov.communities.prsdb.webapp.controllers.ManageLocalCouncilUsersController.Companion.getLocalCouncilCancelInviteRoute
-import uk.gov.communities.prsdb.webapp.controllers.ManageLocalCouncilUsersController.Companion.getLocalCouncilCancelInviteSuccessRoute
-import uk.gov.communities.prsdb.webapp.controllers.ManageLocalCouncilUsersController.Companion.getLocalCouncilDeleteUserRoute
-import uk.gov.communities.prsdb.webapp.controllers.ManageLocalCouncilUsersController.Companion.getLocalCouncilDeleteUserSuccessRoute
-import uk.gov.communities.prsdb.webapp.controllers.ManageLocalCouncilUsersController.Companion.getLocalCouncilEditUserRoute
-import uk.gov.communities.prsdb.webapp.controllers.ManageLocalCouncilUsersController.Companion.getLocalCouncilInviteNewUserRoute
-import uk.gov.communities.prsdb.webapp.controllers.ManageLocalCouncilUsersController.Companion.getLocalCouncilInviteUserSuccessRoute
-import uk.gov.communities.prsdb.webapp.controllers.ManageLocalCouncilUsersController.Companion.getLocalCouncilManageUsersRoute
-import uk.gov.communities.prsdb.webapp.controllers.ManageLocalCouncilUsersController.Companion.getSystemOperatorCancelInviteSuccessRoute
-import uk.gov.communities.prsdb.webapp.controllers.ManageLocalCouncilUsersController.Companion.getSystemOperatorDeleteUserRoute
-import uk.gov.communities.prsdb.webapp.controllers.ManageLocalCouncilUsersController.Companion.getSystemOperatorDeleteUserSuccessRoute
-import uk.gov.communities.prsdb.webapp.controllers.ManageLocalCouncilUsersController.Companion.getSystemOperatorEditUserRoute
-import uk.gov.communities.prsdb.webapp.controllers.ManageLocalCouncilUsersController.Companion.getSystemOperatorInviteNewUserRoute
-import uk.gov.communities.prsdb.webapp.controllers.ManageLocalCouncilUsersController.Companion.getSystemOperatorInviteUserSuccessRoute
-import uk.gov.communities.prsdb.webapp.controllers.ManageLocalCouncilUsersController.Companion.getSystemOperatorManageUsersRoute
+import uk.gov.communities.prsdb.webapp.controllers.ManageLocalCouncilUsersController.Companion.getDeleteUserRoute
+import uk.gov.communities.prsdb.webapp.controllers.ManageLocalCouncilUsersController.Companion.getDeleteUserSuccessRoute
+import uk.gov.communities.prsdb.webapp.controllers.ManageLocalCouncilUsersController.Companion.getEditUserRoute
+import uk.gov.communities.prsdb.webapp.controllers.ManageLocalCouncilUsersController.Companion.getInviteNewUserRoute
+import uk.gov.communities.prsdb.webapp.controllers.ManageLocalCouncilUsersController.Companion.getInviteUserSuccessRoute
+import uk.gov.communities.prsdb.webapp.controllers.ManageLocalCouncilUsersController.Companion.getManageUsersRoute
 import uk.gov.communities.prsdb.webapp.database.entity.LocalCouncil
 import uk.gov.communities.prsdb.webapp.database.entity.LocalCouncilUser
 import uk.gov.communities.prsdb.webapp.models.dataModels.LocalCouncilUserDataModel
@@ -97,7 +90,7 @@ class ManageLocalCouncilUsersControllerTests(
     inner class ManageUsersPage {
         @Test
         fun `index returns a redirect for unauthenticated user`() {
-            mvc.get(getLocalCouncilManageUsersRoute(DEFAULT_LOCAL_COUNCIL_ID)).andExpect {
+            mvc.get(getManageUsersRoute(DEFAULT_LOCAL_COUNCIL_ID, ManageUsersViewType.LocalAuthorityView)).andExpect {
                 status { is3xxRedirection() }
             }
         }
@@ -106,7 +99,7 @@ class ManageLocalCouncilUsersControllerTests(
         @WithMockUser
         fun `index returns 403 for unauthorized user`() {
             mvc
-                .get(getLocalCouncilManageUsersRoute(DEFAULT_LOCAL_COUNCIL_ID))
+                .get(getManageUsersRoute(DEFAULT_LOCAL_COUNCIL_ID, ManageUsersViewType.LocalAuthorityView))
                 .andExpect {
                     status { isForbidden() }
                 }
@@ -116,7 +109,7 @@ class ManageLocalCouncilUsersControllerTests(
         @WithMockUser(roles = ["LOCAL_COUNCIL_USER"])
         fun `index returns 403 for a local council (non-admin) user`() {
             mvc
-                .get(getLocalCouncilManageUsersRoute(DEFAULT_LOCAL_COUNCIL_ID))
+                .get(getManageUsersRoute(DEFAULT_LOCAL_COUNCIL_ID, ManageUsersViewType.LocalAuthorityView))
                 .andExpect {
                     status { isForbidden() }
                 }
@@ -135,7 +128,7 @@ class ManageLocalCouncilUsersControllerTests(
                 .thenReturn(PageImpl(listOf(), PageRequest.of(0, 10), 1))
 
             mvc
-                .get(getLocalCouncilManageUsersRoute(DEFAULT_LOCAL_COUNCIL_ID))
+                .get(getManageUsersRoute(DEFAULT_LOCAL_COUNCIL_ID, ManageUsersViewType.LocalAuthorityView))
                 .andExpect {
                     status { isOk() }
                     model {
@@ -152,7 +145,7 @@ class ManageLocalCouncilUsersControllerTests(
                 .thenThrow(AccessDeniedException(""))
 
             mvc
-                .get(getLocalCouncilManageUsersRoute(DEFAULT_LOCAL_COUNCIL_ID))
+                .get(getManageUsersRoute(DEFAULT_LOCAL_COUNCIL_ID, ManageUsersViewType.LocalAuthorityView))
                 .andExpect {
                     status { isForbidden() }
                 }
@@ -165,7 +158,7 @@ class ManageLocalCouncilUsersControllerTests(
             whenever(localCouncilDataService.getPaginatedUsersAndInvitations(eq(localCouncil), eq(0), anyOrNull(), anyOrNull()))
                 .thenReturn(PageImpl(listOf(), PageRequest.of(0, 10), 1))
             mvc
-                .get(getLocalCouncilManageUsersRoute(NON_ADMIN_LOCAL_COUNCIL_ID))
+                .get(getManageUsersRoute(NON_ADMIN_LOCAL_COUNCIL_ID, ManageUsersViewType.LocalAuthorityView))
                 .andExpect {
                     status { isOk() }
                     model {
@@ -181,11 +174,14 @@ class ManageLocalCouncilUsersControllerTests(
             whenever(localCouncilDataService.getPaginatedUsersAndInvitations(eq(localCouncil), eq(0), anyOrNull(), anyOrNull()))
                 .thenReturn(PageImpl(listOf(), PageRequest.of(0, 10), 1))
             mvc
-                .get(getSystemOperatorManageUsersRoute(NON_ADMIN_LOCAL_COUNCIL_ID))
+                .get(getManageUsersRoute(NON_ADMIN_LOCAL_COUNCIL_ID, ManageUsersViewType.SystemOperatorView))
                 .andExpect {
                     status { isOk() }
                     model {
-                        attribute("inviteNewUserUrl", getSystemOperatorInviteNewUserRoute(NON_ADMIN_LOCAL_COUNCIL_ID))
+                        attribute(
+                            "inviteNewUserUrl",
+                            getInviteNewUserRoute(NON_ADMIN_LOCAL_COUNCIL_ID, ManageUsersViewType.SystemOperatorView),
+                        )
                         attribute(
                             "editUserBaseUrl",
                             "/$SYSTEM_OPERATOR_PATH_SEGMENT/$NON_ADMIN_LOCAL_COUNCIL_ID/$EDIT_USER_PATH_SEGMENT/",
@@ -209,11 +205,14 @@ class ManageLocalCouncilUsersControllerTests(
                 .thenReturn(PageImpl(listOf(), PageRequest.of(0, 10), 1))
 
             mvc
-                .get(getLocalCouncilManageUsersRoute(DEFAULT_LOCAL_COUNCIL_ID))
+                .get(getManageUsersRoute(DEFAULT_LOCAL_COUNCIL_ID, ManageUsersViewType.LocalAuthorityView))
                 .andExpect {
                     status { isOk() }
                     model {
-                        attribute("inviteNewUserUrl", getLocalCouncilInviteNewUserRoute(DEFAULT_LOCAL_COUNCIL_ID))
+                        attribute(
+                            "inviteNewUserUrl",
+                            getInviteNewUserRoute(DEFAULT_LOCAL_COUNCIL_ID, ManageUsersViewType.LocalAuthorityView),
+                        )
                         attribute(
                             "editUserBaseUrl",
                             "/$LOCAL_COUNCIL_PATH_SEGMENT/$DEFAULT_LOCAL_COUNCIL_ID/$EDIT_USER_PATH_SEGMENT/",
@@ -237,7 +236,7 @@ class ManageLocalCouncilUsersControllerTests(
                 .thenReturn(PageImpl(listOf(), PageRequest.of(0, 10), 1))
 
             mvc
-                .get("${getLocalCouncilManageUsersRoute(DEFAULT_LOCAL_COUNCIL_ID)}?page=0")
+                .get("${getManageUsersRoute(DEFAULT_LOCAL_COUNCIL_ID, ManageUsersViewType.LocalAuthorityView)}?page=0")
                 .andExpect {
                     status { isNotFound() }
                 }
@@ -352,7 +351,7 @@ class ManageLocalCouncilUsersControllerTests(
             whenever((localCouncilDataService.getLastLocalCouncilUserInvitedThisSession(DEFAULT_LOCAL_COUNCIL_ID)))
                 .thenReturn("invited.email@example.com")
 
-            mvc.get(getLocalCouncilInviteUserSuccessRoute(DEFAULT_LOCAL_COUNCIL_ID)).andExpect {
+            mvc.get(getInviteUserSuccessRoute(DEFAULT_LOCAL_COUNCIL_ID, ManageUsersViewType.LocalAuthorityView)).andExpect {
                 status { isOk() }
             }
         }
@@ -364,10 +363,10 @@ class ManageLocalCouncilUsersControllerTests(
             whenever((localCouncilDataService.getLastLocalCouncilUserInvitedThisSession(NON_ADMIN_LOCAL_COUNCIL_ID)))
                 .thenReturn("invited.email@example.com")
 
-            mvc.get(getSystemOperatorInviteUserSuccessRoute(NON_ADMIN_LOCAL_COUNCIL_ID)).andExpect {
+            mvc.get(getInviteUserSuccessRoute(NON_ADMIN_LOCAL_COUNCIL_ID, ManageUsersViewType.SystemOperatorView)).andExpect {
                 status { isOk() }
                 model {
-                    attribute("inviteNewUserUrl", getSystemOperatorInviteNewUserRoute(NON_ADMIN_LOCAL_COUNCIL_ID))
+                    attribute("inviteNewUserUrl", getInviteNewUserRoute(NON_ADMIN_LOCAL_COUNCIL_ID, ManageUsersViewType.SystemOperatorView))
                 }
             }
         }
@@ -377,7 +376,7 @@ class ManageLocalCouncilUsersControllerTests(
         fun `inviteNewUserConfirmation returns 404 if no user was invited to the requested local council this session`() {
             whenever((localCouncilDataService.getLastUserIdRegisteredThisSession())).thenReturn(null)
 
-            mvc.get(getLocalCouncilInviteUserSuccessRoute(DEFAULT_LOCAL_COUNCIL_ID)).andExpect {
+            mvc.get(getInviteUserSuccessRoute(DEFAULT_LOCAL_COUNCIL_ID, ManageUsersViewType.LocalAuthorityView)).andExpect {
                 status { isNotFound() }
             }
         }
@@ -403,7 +402,7 @@ class ManageLocalCouncilUsersControllerTests(
             invitedEmail: String,
         ) {
             mvc
-                .post(getLocalCouncilInviteNewUserRoute(localCouncilId)) {
+                .post(getInviteNewUserRoute(localCouncilId, ManageUsersViewType.LocalAuthorityView)) {
                     contentType = MediaType.APPLICATION_FORM_URLENCODED
                     content = urlEncodedConfirmedEmailDataModel(invitedEmail)
                     with(csrf())
@@ -431,7 +430,7 @@ class ManageLocalCouncilUsersControllerTests(
                 .thenThrow(AccessDeniedException(""))
 
             mvc
-                .get(getLocalCouncilEditUserRoute(DEFAULT_LOCAL_COUNCIL_ID, 1))
+                .get(getEditUserRoute(DEFAULT_LOCAL_COUNCIL_ID, 1, ManageUsersViewType.LocalAuthorityView))
                 .andExpect {
                     status { isForbidden() }
                 }
@@ -449,7 +448,7 @@ class ManageLocalCouncilUsersControllerTests(
             ).thenThrow(ResponseStatusException(HttpStatus.NOT_FOUND))
 
             mvc
-                .get(getLocalCouncilEditUserRoute(DEFAULT_LOCAL_COUNCIL_ID, DEFAULT_LOCAL_COUNCIL_USER_ID))
+                .get(getEditUserRoute(DEFAULT_LOCAL_COUNCIL_ID, DEFAULT_LOCAL_COUNCIL_USER_ID, ManageUsersViewType.LocalAuthorityView))
                 .andExpect {
                     status { isNotFound() }
                 }
@@ -477,7 +476,7 @@ class ManageLocalCouncilUsersControllerTests(
                 .thenReturn(loggedInUser)
 
             mvc
-                .get(getLocalCouncilEditUserRoute(DEFAULT_LOCAL_COUNCIL_ID, loggedInUserModel.id))
+                .get(getEditUserRoute(DEFAULT_LOCAL_COUNCIL_ID, loggedInUserModel.id, ManageUsersViewType.LocalAuthorityView))
                 .andExpect {
                     status { isForbidden() }
                 }
@@ -491,7 +490,7 @@ class ManageLocalCouncilUsersControllerTests(
             setupLocalCouncilUserToEdit(localCouncil)
 
             mvc
-                .get(getLocalCouncilEditUserRoute(DEFAULT_LOCAL_COUNCIL_ID, DEFAULT_LOCAL_COUNCIL_USER_ID))
+                .get(getEditUserRoute(DEFAULT_LOCAL_COUNCIL_ID, DEFAULT_LOCAL_COUNCIL_USER_ID, ManageUsersViewType.LocalAuthorityView))
                 .andExpect {
                     status { isOk() }
                     model { attributeExists("localCouncilUser", "options") }
@@ -506,7 +505,7 @@ class ManageLocalCouncilUsersControllerTests(
             setupLocalCouncilUserToEdit(localCouncil)
 
             mvc
-                .get(getLocalCouncilEditUserRoute(NON_ADMIN_LOCAL_COUNCIL_ID, DEFAULT_LOCAL_COUNCIL_USER_ID))
+                .get(getEditUserRoute(NON_ADMIN_LOCAL_COUNCIL_ID, DEFAULT_LOCAL_COUNCIL_USER_ID, ManageUsersViewType.LocalAuthorityView))
                 .andExpect {
                     status { isOk() }
                     model { attributeExists("localCouncilUser", "options") }
@@ -521,13 +520,17 @@ class ManageLocalCouncilUsersControllerTests(
             setupLocalCouncilUserToEdit(localCouncil)
 
             mvc
-                .get(getSystemOperatorEditUserRoute(NON_ADMIN_LOCAL_COUNCIL_ID, DEFAULT_LOCAL_COUNCIL_USER_ID))
+                .get(getEditUserRoute(NON_ADMIN_LOCAL_COUNCIL_ID, DEFAULT_LOCAL_COUNCIL_USER_ID, ManageUsersViewType.SystemOperatorView))
                 .andExpect {
                     status { isOk() }
                     model {
                         attribute(
                             "deleteUserUrl",
-                            getSystemOperatorDeleteUserRoute(NON_ADMIN_LOCAL_COUNCIL_ID, DEFAULT_LOCAL_COUNCIL_USER_ID),
+                            getDeleteUserRoute(
+                                NON_ADMIN_LOCAL_COUNCIL_ID,
+                                DEFAULT_LOCAL_COUNCIL_USER_ID,
+                                ManageUsersViewType.SystemOperatorView,
+                            ),
                         )
                     }
                 }
@@ -541,13 +544,17 @@ class ManageLocalCouncilUsersControllerTests(
             setupLocalCouncilUserToEdit(localCouncil)
 
             mvc
-                .get(getLocalCouncilEditUserRoute(DEFAULT_LOCAL_COUNCIL_ID, DEFAULT_LOCAL_COUNCIL_USER_ID))
+                .get(getEditUserRoute(DEFAULT_LOCAL_COUNCIL_ID, DEFAULT_LOCAL_COUNCIL_USER_ID, ManageUsersViewType.LocalAuthorityView))
                 .andExpect {
                     status { isOk() }
                     model {
                         attribute(
                             "deleteUserUrl",
-                            getLocalCouncilDeleteUserRoute(DEFAULT_LOCAL_COUNCIL_ID, DEFAULT_LOCAL_COUNCIL_USER_ID),
+                            getDeleteUserRoute(
+                                DEFAULT_LOCAL_COUNCIL_ID,
+                                DEFAULT_LOCAL_COUNCIL_USER_ID,
+                                ManageUsersViewType.LocalAuthorityView,
+                            ),
                         )
                     }
                 }
@@ -562,7 +569,7 @@ class ManageLocalCouncilUsersControllerTests(
                 .thenReturn(Pair(loggedInUserModel, localCouncil))
 
             mvc
-                .post(getLocalCouncilEditUserRoute(DEFAULT_LOCAL_COUNCIL_ID, loggedInUserModel.id)) {
+                .post(getEditUserRoute(DEFAULT_LOCAL_COUNCIL_ID, loggedInUserModel.id, ManageUsersViewType.LocalAuthorityView)) {
                     contentType = MediaType.APPLICATION_FORM_URLENCODED
                     content = "isManager=false"
                     with(csrf())
@@ -577,8 +584,8 @@ class ManageLocalCouncilUsersControllerTests(
             setupDefaultLocalCouncilForLocalCouncilAdmin()
 
             postUpdateUserAccessLevelAndAssertSuccess(
-                getLocalCouncilEditUserRoute(DEFAULT_LOCAL_COUNCIL_ID, DEFAULT_LOCAL_COUNCIL_USER_ID),
-                getLocalCouncilManageUsersRoute(DEFAULT_LOCAL_COUNCIL_ID),
+                getEditUserRoute(DEFAULT_LOCAL_COUNCIL_ID, DEFAULT_LOCAL_COUNCIL_USER_ID, ManageUsersViewType.LocalAuthorityView),
+                getManageUsersRoute(DEFAULT_LOCAL_COUNCIL_ID, ManageUsersViewType.LocalAuthorityView),
             )
         }
 
@@ -588,8 +595,8 @@ class ManageLocalCouncilUsersControllerTests(
             setupLocalCouncilForSystemOperator(NON_ADMIN_LOCAL_COUNCIL_ID)
 
             postUpdateUserAccessLevelAndAssertSuccess(
-                getSystemOperatorEditUserRoute(DEFAULT_LOCAL_COUNCIL_ID, DEFAULT_LOCAL_COUNCIL_USER_ID),
-                getSystemOperatorManageUsersRoute(DEFAULT_LOCAL_COUNCIL_ID),
+                getEditUserRoute(DEFAULT_LOCAL_COUNCIL_ID, DEFAULT_LOCAL_COUNCIL_USER_ID, ManageUsersViewType.SystemOperatorView),
+                getManageUsersRoute(DEFAULT_LOCAL_COUNCIL_ID, ManageUsersViewType.SystemOperatorView),
             )
         }
 
@@ -625,7 +632,7 @@ class ManageLocalCouncilUsersControllerTests(
             setupLocalCouncilUserToEdit(localCouncil)
 
             mvc
-                .get(getLocalCouncilDeleteUserRoute(DEFAULT_LOCAL_COUNCIL_ID, DEFAULT_LOCAL_COUNCIL_USER_ID))
+                .get(getDeleteUserRoute(DEFAULT_LOCAL_COUNCIL_ID, DEFAULT_LOCAL_COUNCIL_USER_ID, ManageUsersViewType.LocalAuthorityView))
                 .andExpect {
                     status { isOk() }
                     model { attributeExists("user") }
@@ -639,7 +646,7 @@ class ManageLocalCouncilUsersControllerTests(
             setupLocalCouncilUserToEdit(localCouncil)
 
             mvc
-                .get(getLocalCouncilDeleteUserRoute(NON_ADMIN_LOCAL_COUNCIL_ID, DEFAULT_LOCAL_COUNCIL_USER_ID))
+                .get(getDeleteUserRoute(NON_ADMIN_LOCAL_COUNCIL_ID, DEFAULT_LOCAL_COUNCIL_USER_ID, ManageUsersViewType.LocalAuthorityView))
                 .andExpect {
                     status { isOk() }
                     model { attributeExists("user") }
@@ -655,7 +662,7 @@ class ManageLocalCouncilUsersControllerTests(
                 .thenReturn(Pair(loggedInUserModel, localCouncil))
 
             mvc
-                .post(getLocalCouncilDeleteUserRoute(DEFAULT_LOCAL_COUNCIL_ID, loggedInUserModel.id)) {
+                .post(getDeleteUserRoute(DEFAULT_LOCAL_COUNCIL_ID, loggedInUserModel.id, ManageUsersViewType.LocalAuthorityView)) {
                     contentType = MediaType.APPLICATION_FORM_URLENCODED
                     content = "isManager=false"
                     with(csrf())
@@ -697,7 +704,7 @@ class ManageLocalCouncilUsersControllerTests(
                 .thenReturn(Pair(loggedInUserModel, localCouncil))
 
             mvc
-                .post(getLocalCouncilDeleteUserRoute(DEFAULT_LOCAL_COUNCIL_ID, loggedInUserModel.id)) {
+                .post(getDeleteUserRoute(DEFAULT_LOCAL_COUNCIL_ID, loggedInUserModel.id, ManageUsersViewType.LocalAuthorityView)) {
                     contentType = MediaType.APPLICATION_FORM_URLENCODED
                     with(csrf())
                 }.andExpect {
@@ -738,7 +745,13 @@ class ManageLocalCouncilUsersControllerTests(
             whenever(localCouncilDataService.getUserDeletedThisSessionById(localCouncilUser.id))
                 .thenReturn(localCouncilUser)
             mvc
-                .get(getLocalCouncilDeleteUserSuccessRoute(DEFAULT_LOCAL_COUNCIL_ID, DEFAULT_LOCAL_COUNCIL_USER_ID))
+                .get(
+                    getDeleteUserSuccessRoute(
+                        DEFAULT_LOCAL_COUNCIL_ID,
+                        DEFAULT_LOCAL_COUNCIL_USER_ID,
+                        ManageUsersViewType.LocalAuthorityView,
+                    ),
+                )
                 .andExpect {
                     status { isOk() }
                 }
@@ -752,11 +765,20 @@ class ManageLocalCouncilUsersControllerTests(
             whenever(localCouncilDataService.getUserDeletedThisSessionById(localCouncilUser.id))
                 .thenReturn(localCouncilUser)
             mvc
-                .get(getSystemOperatorDeleteUserSuccessRoute(NON_ADMIN_LOCAL_COUNCIL_ID, DEFAULT_LOCAL_COUNCIL_USER_ID))
+                .get(
+                    getDeleteUserSuccessRoute(
+                        NON_ADMIN_LOCAL_COUNCIL_ID,
+                        DEFAULT_LOCAL_COUNCIL_USER_ID,
+                        ManageUsersViewType.SystemOperatorView,
+                    ),
+                )
                 .andExpect {
                     status { isOk() }
                     model {
-                        attribute("returnToManageUsersUrl", getSystemOperatorManageUsersRoute(NON_ADMIN_LOCAL_COUNCIL_ID))
+                        attribute(
+                            "returnToManageUsersUrl",
+                            getManageUsersRoute(NON_ADMIN_LOCAL_COUNCIL_ID, ManageUsersViewType.SystemOperatorView),
+                        )
                     }
                 }
         }
@@ -769,11 +791,20 @@ class ManageLocalCouncilUsersControllerTests(
             whenever(localCouncilDataService.getUserDeletedThisSessionById(localCouncilUser.id))
                 .thenReturn(localCouncilUser)
             mvc
-                .get(getLocalCouncilDeleteUserSuccessRoute(DEFAULT_LOCAL_COUNCIL_ID, DEFAULT_LOCAL_COUNCIL_USER_ID))
+                .get(
+                    getDeleteUserSuccessRoute(
+                        DEFAULT_LOCAL_COUNCIL_ID,
+                        DEFAULT_LOCAL_COUNCIL_USER_ID,
+                        ManageUsersViewType.LocalAuthorityView,
+                    ),
+                )
                 .andExpect {
                     status { isOk() }
                     model {
-                        attribute("returnToManageUsersUrl", getLocalCouncilManageUsersRoute(DEFAULT_LOCAL_COUNCIL_ID))
+                        attribute(
+                            "returnToManageUsersUrl",
+                            getManageUsersRoute(DEFAULT_LOCAL_COUNCIL_ID, ManageUsersViewType.LocalAuthorityView),
+                        )
                     }
                 }
         }
@@ -784,7 +815,13 @@ class ManageLocalCouncilUsersControllerTests(
             whenever(localCouncilDataService.getUserDeletedThisSessionById(DEFAULT_LOCAL_COUNCIL_USER_ID))
                 .thenThrow(ResponseStatusException(HttpStatus.NOT_FOUND))
             mvc
-                .get(getLocalCouncilDeleteUserSuccessRoute(DEFAULT_LOCAL_COUNCIL_ID, DEFAULT_LOCAL_COUNCIL_USER_ID))
+                .get(
+                    getDeleteUserSuccessRoute(
+                        DEFAULT_LOCAL_COUNCIL_ID,
+                        DEFAULT_LOCAL_COUNCIL_USER_ID,
+                        ManageUsersViewType.LocalAuthorityView,
+                    ),
+                )
                 .andExpect {
                     status { isNotFound() }
                 }
@@ -797,7 +834,13 @@ class ManageLocalCouncilUsersControllerTests(
                 .thenThrow(ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR))
 
             mvc
-                .get(getLocalCouncilDeleteUserSuccessRoute(DEFAULT_LOCAL_COUNCIL_ID, DEFAULT_LOCAL_COUNCIL_USER_ID))
+                .get(
+                    getDeleteUserSuccessRoute(
+                        DEFAULT_LOCAL_COUNCIL_ID,
+                        DEFAULT_LOCAL_COUNCIL_USER_ID,
+                        ManageUsersViewType.LocalAuthorityView,
+                    ),
+                )
                 .andExpect {
                     status { is5xxServerError() }
                 }
@@ -811,7 +854,7 @@ class ManageLocalCouncilUsersControllerTests(
                 .thenReturn(userBeingDeleted)
 
             mvc
-                .post(getLocalCouncilDeleteUserRoute(localCouncilId, userBeingDeleted.id)) {
+                .post(getDeleteUserRoute(localCouncilId, userBeingDeleted.id, ManageUsersViewType.LocalAuthorityView)) {
                     contentType = MediaType.APPLICATION_FORM_URLENCODED
                     with(csrf())
                 }.andExpect {
@@ -838,7 +881,13 @@ class ManageLocalCouncilUsersControllerTests(
             whenever(localCouncilInvitationService.getInvitationByIdOrNull(DEFAULT_LOCAL_COUNCIL_INVITATION_ID)).thenReturn(invitation)
 
             mvc
-                .get(getLocalCouncilCancelInviteRoute(DEFAULT_LOCAL_COUNCIL_ID, DEFAULT_LOCAL_COUNCIL_INVITATION_ID))
+                .get(
+                    getCancelInviteRoute(
+                        DEFAULT_LOCAL_COUNCIL_ID,
+                        DEFAULT_LOCAL_COUNCIL_INVITATION_ID,
+                        ManageUsersViewType.LocalAuthorityView,
+                    ),
+                )
                 .andExpect {
                     status { isOk() }
                     model { attribute("email", invitation.invitedEmail) }
@@ -854,7 +903,13 @@ class ManageLocalCouncilUsersControllerTests(
             whenever(localCouncilInvitationService.getInvitationByIdOrNull(DEFAULT_LOCAL_COUNCIL_INVITATION_ID)).thenReturn(invitation)
 
             mvc
-                .get(getLocalCouncilCancelInviteRoute(NON_ADMIN_LOCAL_COUNCIL_ID, DEFAULT_LOCAL_COUNCIL_INVITATION_ID))
+                .get(
+                    getCancelInviteRoute(
+                        NON_ADMIN_LOCAL_COUNCIL_ID,
+                        DEFAULT_LOCAL_COUNCIL_INVITATION_ID,
+                        ManageUsersViewType.LocalAuthorityView,
+                    ),
+                )
                 .andExpect {
                     status { isOk() }
                     model { attribute("email", invitation.invitedEmail) }
@@ -871,7 +926,13 @@ class ManageLocalCouncilUsersControllerTests(
             whenever(localCouncilInvitationService.getInvitationByIdOrNull(DEFAULT_LOCAL_COUNCIL_INVITATION_ID)).thenReturn(invitation)
 
             mvc
-                .get(getLocalCouncilCancelInviteRoute(DEFAULT_LOCAL_COUNCIL_ID, DEFAULT_LOCAL_COUNCIL_INVITATION_ID))
+                .get(
+                    getCancelInviteRoute(
+                        DEFAULT_LOCAL_COUNCIL_ID,
+                        DEFAULT_LOCAL_COUNCIL_INVITATION_ID,
+                        ManageUsersViewType.LocalAuthorityView,
+                    ),
+                )
                 .andExpect {
                     status { isForbidden() }
                 }
@@ -886,7 +947,13 @@ class ManageLocalCouncilUsersControllerTests(
             whenever(localCouncilInvitationService.getInvitationByIdOrNull(DEFAULT_LOCAL_COUNCIL_INVITATION_ID)).thenReturn(invitation)
 
             mvc
-                .get(getLocalCouncilCancelInviteRoute(DEFAULT_LOCAL_COUNCIL_ID, DEFAULT_LOCAL_COUNCIL_INVITATION_ID))
+                .get(
+                    getCancelInviteRoute(
+                        DEFAULT_LOCAL_COUNCIL_ID,
+                        DEFAULT_LOCAL_COUNCIL_INVITATION_ID,
+                        ManageUsersViewType.LocalAuthorityView,
+                    ),
+                )
                 .andExpect {
                     status { isForbidden() }
                 }
@@ -898,7 +965,13 @@ class ManageLocalCouncilUsersControllerTests(
             whenever(localCouncilInvitationService.getInvitationByIdOrNull(DEFAULT_LOCAL_COUNCIL_INVITATION_ID)).thenReturn(null)
 
             mvc
-                .post(getLocalCouncilCancelInviteRoute(DEFAULT_LOCAL_COUNCIL_ID, DEFAULT_LOCAL_COUNCIL_INVITATION_ID)) {
+                .post(
+                    getCancelInviteRoute(
+                        DEFAULT_LOCAL_COUNCIL_ID,
+                        DEFAULT_LOCAL_COUNCIL_INVITATION_ID,
+                        ManageUsersViewType.LocalAuthorityView,
+                    ),
+                ) {
                     contentType = MediaType.APPLICATION_FORM_URLENCODED
                     with(csrf())
                 }.andExpect {
@@ -925,7 +998,13 @@ class ManageLocalCouncilUsersControllerTests(
             whenever(localCouncilInvitationService.getInvitationByIdOrNull(DEFAULT_LOCAL_COUNCIL_INVITATION_ID)).thenReturn(invitation)
 
             mvc
-                .post(getLocalCouncilCancelInviteRoute(DEFAULT_LOCAL_COUNCIL_ID, DEFAULT_LOCAL_COUNCIL_INVITATION_ID)) {
+                .post(
+                    getCancelInviteRoute(
+                        DEFAULT_LOCAL_COUNCIL_ID,
+                        DEFAULT_LOCAL_COUNCIL_INVITATION_ID,
+                        ManageUsersViewType.LocalAuthorityView,
+                    ),
+                ) {
                     contentType = MediaType.APPLICATION_FORM_URLENCODED
                     with(csrf())
                 }.andExpect {
@@ -944,7 +1023,13 @@ class ManageLocalCouncilUsersControllerTests(
         fun `cancelInvitation returns 404 if the invite is not in the database`() {
             whenever(localCouncilInvitationService.getInvitationByIdOrNull(DEFAULT_LOCAL_COUNCIL_INVITATION_ID)).thenReturn(null)
             mvc
-                .get(getLocalCouncilCancelInviteRoute(DEFAULT_LOCAL_COUNCIL_ID, DEFAULT_LOCAL_COUNCIL_INVITATION_ID))
+                .get(
+                    getCancelInviteRoute(
+                        DEFAULT_LOCAL_COUNCIL_ID,
+                        DEFAULT_LOCAL_COUNCIL_INVITATION_ID,
+                        ManageUsersViewType.LocalAuthorityView,
+                    ),
+                )
                 .andExpect { status { isNotFound() } }
         }
 
@@ -959,7 +1044,13 @@ class ManageLocalCouncilUsersControllerTests(
             setupDefaultLocalCouncilForLocalCouncilAdmin()
 
             mvc
-                .get(getLocalCouncilCancelInviteSuccessRoute(DEFAULT_LOCAL_COUNCIL_ID, DEFAULT_LOCAL_COUNCIL_INVITATION_ID))
+                .get(
+                    getCancelInviteSuccessRoute(
+                        DEFAULT_LOCAL_COUNCIL_ID,
+                        DEFAULT_LOCAL_COUNCIL_INVITATION_ID,
+                        ManageUsersViewType.LocalAuthorityView,
+                    ),
+                )
                 .andExpect { status { isOk() } }
         }
 
@@ -974,11 +1065,20 @@ class ManageLocalCouncilUsersControllerTests(
             setupLocalCouncilForSystemOperator(NON_ADMIN_LOCAL_COUNCIL_ID)
 
             mvc
-                .get(getSystemOperatorCancelInviteSuccessRoute(NON_ADMIN_LOCAL_COUNCIL_ID, DEFAULT_LOCAL_COUNCIL_INVITATION_ID))
+                .get(
+                    getCancelInviteSuccessRoute(
+                        NON_ADMIN_LOCAL_COUNCIL_ID,
+                        DEFAULT_LOCAL_COUNCIL_INVITATION_ID,
+                        ManageUsersViewType.SystemOperatorView,
+                    ),
+                )
                 .andExpect {
                     status { isOk() }
                     model {
-                        attribute("returnToManageUsersUrl", getSystemOperatorManageUsersRoute(NON_ADMIN_LOCAL_COUNCIL_ID))
+                        attribute(
+                            "returnToManageUsersUrl",
+                            getManageUsersRoute(NON_ADMIN_LOCAL_COUNCIL_ID, ManageUsersViewType.SystemOperatorView),
+                        )
                     }
                 }
         }
@@ -989,7 +1089,13 @@ class ManageLocalCouncilUsersControllerTests(
             whenever(localCouncilDataService.getInvitationCancelledThisSessionById(DEFAULT_LOCAL_COUNCIL_INVITATION_ID))
                 .thenThrow(ResponseStatusException(HttpStatus.NOT_FOUND))
 
-            mvc.get(getLocalCouncilCancelInviteSuccessRoute(DEFAULT_LOCAL_COUNCIL_ID, DEFAULT_LOCAL_COUNCIL_INVITATION_ID)).andExpect {
+            mvc.get(
+                getCancelInviteSuccessRoute(
+                    DEFAULT_LOCAL_COUNCIL_ID,
+                    DEFAULT_LOCAL_COUNCIL_INVITATION_ID,
+                    ManageUsersViewType.LocalAuthorityView,
+                ),
+            ).andExpect {
                 status { isNotFound() }
             }
         }
@@ -1000,7 +1106,13 @@ class ManageLocalCouncilUsersControllerTests(
             whenever(localCouncilDataService.getInvitationCancelledThisSessionById(DEFAULT_LOCAL_COUNCIL_INVITATION_ID))
                 .thenThrow(ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR))
 
-            mvc.get(getLocalCouncilCancelInviteSuccessRoute(DEFAULT_LOCAL_COUNCIL_ID, DEFAULT_LOCAL_COUNCIL_INVITATION_ID)).andExpect {
+            mvc.get(
+                getCancelInviteSuccessRoute(
+                    DEFAULT_LOCAL_COUNCIL_ID,
+                    DEFAULT_LOCAL_COUNCIL_INVITATION_ID,
+                    ManageUsersViewType.LocalAuthorityView,
+                ),
+            ).andExpect {
                 status { isInternalServerError() }
             }
         }
@@ -1010,7 +1122,13 @@ class ManageLocalCouncilUsersControllerTests(
             whenever(localCouncilInvitationService.getInvitationByIdOrNull(DEFAULT_LOCAL_COUNCIL_INVITATION_ID)).thenReturn(invitation)
 
             mvc
-                .post(getLocalCouncilCancelInviteRoute(DEFAULT_LOCAL_COUNCIL_ID, DEFAULT_LOCAL_COUNCIL_INVITATION_ID)) {
+                .post(
+                    getCancelInviteRoute(
+                        DEFAULT_LOCAL_COUNCIL_ID,
+                        DEFAULT_LOCAL_COUNCIL_INVITATION_ID,
+                        ManageUsersViewType.LocalAuthorityView,
+                    ),
+                ) {
                     contentType = MediaType.APPLICATION_FORM_URLENCODED
                     with(csrf())
                 }.andExpect {

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/controllers/ManageLocalCouncilUsersControllerTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/controllers/ManageLocalCouncilUsersControllerTests.kt
@@ -21,8 +21,10 @@ import org.springframework.test.web.servlet.get
 import org.springframework.test.web.servlet.post
 import org.springframework.web.context.WebApplicationContext
 import org.springframework.web.server.ResponseStatusException
+import uk.gov.communities.prsdb.webapp.constants.CANCEL_INVITATION_PATH_SEGMENT
 import uk.gov.communities.prsdb.webapp.constants.EDIT_USER_PATH_SEGMENT
 import uk.gov.communities.prsdb.webapp.constants.LOCAL_COUNCIL_PATH_SEGMENT
+import uk.gov.communities.prsdb.webapp.constants.SYSTEM_OPERATOR_PATH_SEGMENT
 import uk.gov.communities.prsdb.webapp.controllers.ManageLocalCouncilUsersController.Companion.INVITE_USER_CONFIRMATION_ROUTE
 import uk.gov.communities.prsdb.webapp.controllers.ManageLocalCouncilUsersController.Companion.getCancelInviteConfirmationRoute
 import uk.gov.communities.prsdb.webapp.controllers.ManageLocalCouncilUsersController.Companion.getDeleteUserConfirmationRoute
@@ -34,6 +36,13 @@ import uk.gov.communities.prsdb.webapp.controllers.ManageLocalCouncilUsersContro
 import uk.gov.communities.prsdb.webapp.controllers.ManageLocalCouncilUsersController.Companion.getLocalCouncilInviteNewUserRoute
 import uk.gov.communities.prsdb.webapp.controllers.ManageLocalCouncilUsersController.Companion.getLocalCouncilInviteUserSuccessRoute
 import uk.gov.communities.prsdb.webapp.controllers.ManageLocalCouncilUsersController.Companion.getLocalCouncilManageUsersRoute
+import uk.gov.communities.prsdb.webapp.controllers.ManageLocalCouncilUsersController.Companion.getSystemOperatorCancelInviteSuccessRoute
+import uk.gov.communities.prsdb.webapp.controllers.ManageLocalCouncilUsersController.Companion.getSystemOperatorDeleteUserRoute
+import uk.gov.communities.prsdb.webapp.controllers.ManageLocalCouncilUsersController.Companion.getSystemOperatorDeleteUserSuccessRoute
+import uk.gov.communities.prsdb.webapp.controllers.ManageLocalCouncilUsersController.Companion.getSystemOperatorEditUserRoute
+import uk.gov.communities.prsdb.webapp.controllers.ManageLocalCouncilUsersController.Companion.getSystemOperatorInviteNewUserRoute
+import uk.gov.communities.prsdb.webapp.controllers.ManageLocalCouncilUsersController.Companion.getSystemOperatorInviteUserSuccessRoute
+import uk.gov.communities.prsdb.webapp.controllers.ManageLocalCouncilUsersController.Companion.getSystemOperatorManageUsersRoute
 import uk.gov.communities.prsdb.webapp.database.entity.LocalCouncil
 import uk.gov.communities.prsdb.webapp.database.entity.LocalCouncilUser
 import uk.gov.communities.prsdb.webapp.models.dataModels.LocalCouncilUserDataModel
@@ -166,6 +175,58 @@ class ManageLocalCouncilUsersControllerTests(
         }
 
         @Test
+        @WithMockUser(roles = ["SYSTEM_OPERATOR"])
+        fun `index adds system-operator URLs for system operators`() {
+            val localCouncil = setupLocalCouncilForSystemOperator(NON_ADMIN_LOCAL_COUNCIL_ID)
+            whenever(localCouncilDataService.getPaginatedUsersAndInvitations(eq(localCouncil), eq(0), anyOrNull(), anyOrNull()))
+                .thenReturn(PageImpl(listOf(), PageRequest.of(0, 10), 1))
+            mvc
+                .get(getSystemOperatorManageUsersRoute(NON_ADMIN_LOCAL_COUNCIL_ID))
+                .andExpect {
+                    status { isOk() }
+                    model {
+                        attribute("inviteNewUserUrl", getSystemOperatorInviteNewUserRoute(NON_ADMIN_LOCAL_COUNCIL_ID))
+                        attribute(
+                            "editUserBaseUrl",
+                            "/$SYSTEM_OPERATOR_PATH_SEGMENT/$NON_ADMIN_LOCAL_COUNCIL_ID/$EDIT_USER_PATH_SEGMENT/",
+                        )
+                        attribute(
+                            "cancelInvitationBaseUrl",
+                            "/$SYSTEM_OPERATOR_PATH_SEGMENT/$NON_ADMIN_LOCAL_COUNCIL_ID/$CANCEL_INVITATION_PATH_SEGMENT/",
+                        )
+                    }
+                }
+        }
+
+        @Test
+        @WithMockUser(roles = ["LOCAL_COUNCIL_ADMIN"])
+        fun `index adds local-council URLs for LC admins`() {
+            val loggedInUserModel = createdLoggedInUserModel()
+            val localCouncil = LocalCouncil(DEFAULT_LOCAL_COUNCIL_ID, "Test Local Council", "custodianCode")
+            whenever(localCouncilDataService.getUserAndLocalCouncilIfAuthorizedUser(DEFAULT_LOCAL_COUNCIL_ID, "user"))
+                .thenReturn(Pair(loggedInUserModel, localCouncil))
+            whenever(localCouncilDataService.getPaginatedUsersAndInvitations(localCouncil, 0))
+                .thenReturn(PageImpl(listOf(), PageRequest.of(0, 10), 1))
+
+            mvc
+                .get(getLocalCouncilManageUsersRoute(DEFAULT_LOCAL_COUNCIL_ID))
+                .andExpect {
+                    status { isOk() }
+                    model {
+                        attribute("inviteNewUserUrl", getLocalCouncilInviteNewUserRoute(DEFAULT_LOCAL_COUNCIL_ID))
+                        attribute(
+                            "editUserBaseUrl",
+                            "/$LOCAL_COUNCIL_PATH_SEGMENT/$DEFAULT_LOCAL_COUNCIL_ID/$EDIT_USER_PATH_SEGMENT/",
+                        )
+                        attribute(
+                            "cancelInvitationBaseUrl",
+                            "/$LOCAL_COUNCIL_PATH_SEGMENT/$DEFAULT_LOCAL_COUNCIL_ID/$CANCEL_INVITATION_PATH_SEGMENT/",
+                        )
+                    }
+                }
+        }
+
+        @Test
         @WithMockUser(roles = ["LOCAL_COUNCIL_ADMIN"])
         fun `index returns 404 for authorized user accessing a page less than 1`() {
             val loggedInUserModel = createdLoggedInUserModel()
@@ -293,6 +354,21 @@ class ManageLocalCouncilUsersControllerTests(
 
             mvc.get(getLocalCouncilInviteUserSuccessRoute(DEFAULT_LOCAL_COUNCIL_ID)).andExpect {
                 status { isOk() }
+            }
+        }
+
+        @Test
+        @WithMockUser(roles = ["SYSTEM_OPERATOR"])
+        fun `inviteNewUserConfirmation adds system-operator inviteNewUserUrl for system operators`() {
+            setupLocalCouncilForSystemOperator(NON_ADMIN_LOCAL_COUNCIL_ID)
+            whenever((localCouncilDataService.getLastLocalCouncilUserInvitedThisSession(NON_ADMIN_LOCAL_COUNCIL_ID)))
+                .thenReturn("invited.email@example.com")
+
+            mvc.get(getSystemOperatorInviteUserSuccessRoute(NON_ADMIN_LOCAL_COUNCIL_ID)).andExpect {
+                status { isOk() }
+                model {
+                    attribute("inviteNewUserUrl", getSystemOperatorInviteNewUserRoute(NON_ADMIN_LOCAL_COUNCIL_ID))
+                }
             }
         }
 
@@ -438,6 +514,46 @@ class ManageLocalCouncilUsersControllerTests(
         }
 
         @Test
+        @WithMockUser(roles = ["SYSTEM_OPERATOR"])
+        fun `getEditUserAccessLevelPage adds system-operator deleteUserUrl for system operators`() {
+            val localCouncil = setupLocalCouncilForSystemOperator(NON_ADMIN_LOCAL_COUNCIL_ID)
+
+            setupLocalCouncilUserToEdit(localCouncil)
+
+            mvc
+                .get(getSystemOperatorEditUserRoute(NON_ADMIN_LOCAL_COUNCIL_ID, DEFAULT_LOCAL_COUNCIL_USER_ID))
+                .andExpect {
+                    status { isOk() }
+                    model {
+                        attribute(
+                            "deleteUserUrl",
+                            getSystemOperatorDeleteUserRoute(NON_ADMIN_LOCAL_COUNCIL_ID, DEFAULT_LOCAL_COUNCIL_USER_ID),
+                        )
+                    }
+                }
+        }
+
+        @Test
+        @WithMockUser(roles = ["LOCAL_COUNCIL_ADMIN"])
+        fun `getEditUserAccessLevelPage adds local-council deleteUserUrl for LC admins`() {
+            val localCouncil = setupDefaultLocalCouncilForLocalCouncilAdmin()
+
+            setupLocalCouncilUserToEdit(localCouncil)
+
+            mvc
+                .get(getLocalCouncilEditUserRoute(DEFAULT_LOCAL_COUNCIL_ID, DEFAULT_LOCAL_COUNCIL_USER_ID))
+                .andExpect {
+                    status { isOk() }
+                    model {
+                        attribute(
+                            "deleteUserUrl",
+                            getLocalCouncilDeleteUserRoute(DEFAULT_LOCAL_COUNCIL_ID, DEFAULT_LOCAL_COUNCIL_USER_ID),
+                        )
+                    }
+                }
+        }
+
+        @Test
         @WithMockUser(roles = ["LOCAL_COUNCIL_ADMIN"])
         fun `updateUserAccessLevel gives a 403 when trying to update currently logged in user`() {
             val loggedInUserModel = createdLoggedInUserModel()
@@ -460,7 +576,7 @@ class ManageLocalCouncilUsersControllerTests(
         fun `updateUserAccessLevel updates the given user's access level when called by a local council admin`() {
             setupDefaultLocalCouncilForLocalCouncilAdmin()
 
-            postUpdateUserAccessLevelAndAssertSuccess(DEFAULT_LOCAL_COUNCIL_ID)
+            postUpdateUserAccessLevelAndAssertSuccess(getLocalCouncilManageUsersRoute(DEFAULT_LOCAL_COUNCIL_ID))
         }
 
         @Test
@@ -468,19 +584,19 @@ class ManageLocalCouncilUsersControllerTests(
         fun `updateUserAccessLevel updates the given user's access level when called by a system operator`() {
             setupLocalCouncilForSystemOperator(NON_ADMIN_LOCAL_COUNCIL_ID)
 
-            postUpdateUserAccessLevelAndAssertSuccess()
+            postUpdateUserAccessLevelAndAssertSuccess(getSystemOperatorManageUsersRoute(DEFAULT_LOCAL_COUNCIL_ID))
         }
 
-        private fun postUpdateUserAccessLevelAndAssertSuccess(localCouncilId: Int = DEFAULT_LOCAL_COUNCIL_ID) {
+        private fun postUpdateUserAccessLevelAndAssertSuccess(expectedRedirectUrl: String) {
             mvc
-                .post(getLocalCouncilEditUserRoute(localCouncilId, DEFAULT_LOCAL_COUNCIL_USER_ID)) {
+                .post(getLocalCouncilEditUserRoute(DEFAULT_LOCAL_COUNCIL_ID, DEFAULT_LOCAL_COUNCIL_USER_ID)) {
                     contentType = MediaType.APPLICATION_FORM_URLENCODED
                     content = "isManager=true"
                     with(csrf())
                 }.andExpect {
                     status {
                         is3xxRedirection()
-                        redirectedUrl(getLocalCouncilManageUsersRoute(DEFAULT_LOCAL_COUNCIL_ID))
+                        redirectedUrl(expectedRedirectUrl)
                     }
                 }
 
@@ -616,6 +732,40 @@ class ManageLocalCouncilUsersControllerTests(
                 .get(getLocalCouncilDeleteUserSuccessRoute(DEFAULT_LOCAL_COUNCIL_ID, DEFAULT_LOCAL_COUNCIL_USER_ID))
                 .andExpect {
                     status { isOk() }
+                }
+        }
+
+        @Test
+        @WithMockUser(roles = ["SYSTEM_OPERATOR"])
+        fun `deleteUserSuccess adds system-operator returnToManageUsersUrl for system operators`() {
+            setupLocalCouncilForSystemOperator(NON_ADMIN_LOCAL_COUNCIL_ID)
+            val localCouncilUser = createLocalCouncilUser(id = DEFAULT_LOCAL_COUNCIL_USER_ID)
+            whenever(localCouncilDataService.getUserDeletedThisSessionById(localCouncilUser.id))
+                .thenReturn(localCouncilUser)
+            mvc
+                .get(getSystemOperatorDeleteUserSuccessRoute(NON_ADMIN_LOCAL_COUNCIL_ID, DEFAULT_LOCAL_COUNCIL_USER_ID))
+                .andExpect {
+                    status { isOk() }
+                    model {
+                        attribute("returnToManageUsersUrl", getSystemOperatorManageUsersRoute(NON_ADMIN_LOCAL_COUNCIL_ID))
+                    }
+                }
+        }
+
+        @Test
+        @WithMockUser(roles = ["LOCAL_COUNCIL_ADMIN"])
+        fun `deleteUserSuccess adds local-council returnToManageUsersUrl for LC admins`() {
+            setupDefaultLocalCouncilForLocalCouncilAdmin()
+            val localCouncilUser = createLocalCouncilUser(id = DEFAULT_LOCAL_COUNCIL_USER_ID)
+            whenever(localCouncilDataService.getUserDeletedThisSessionById(localCouncilUser.id))
+                .thenReturn(localCouncilUser)
+            mvc
+                .get(getLocalCouncilDeleteUserSuccessRoute(DEFAULT_LOCAL_COUNCIL_ID, DEFAULT_LOCAL_COUNCIL_USER_ID))
+                .andExpect {
+                    status { isOk() }
+                    model {
+                        attribute("returnToManageUsersUrl", getLocalCouncilManageUsersRoute(DEFAULT_LOCAL_COUNCIL_ID))
+                    }
                 }
         }
 
@@ -802,6 +952,26 @@ class ManageLocalCouncilUsersControllerTests(
             mvc
                 .get(getLocalCouncilCancelInviteSuccessRoute(DEFAULT_LOCAL_COUNCIL_ID, DEFAULT_LOCAL_COUNCIL_INVITATION_ID))
                 .andExpect { status { isOk() } }
+        }
+
+        @Test
+        @WithMockUser(roles = ["SYSTEM_OPERATOR"])
+        fun `cancelInvitationSuccess adds system-operator returnToManageUsersUrl for system operators`() {
+            val deletedInvitation = createLocalCouncilInvitation(DEFAULT_LOCAL_COUNCIL_INVITATION_ID)
+
+            whenever(localCouncilDataService.getInvitationCancelledThisSessionById(deletedInvitation.id))
+                .thenReturn(deletedInvitation)
+
+            setupLocalCouncilForSystemOperator(NON_ADMIN_LOCAL_COUNCIL_ID)
+
+            mvc
+                .get(getSystemOperatorCancelInviteSuccessRoute(NON_ADMIN_LOCAL_COUNCIL_ID, DEFAULT_LOCAL_COUNCIL_INVITATION_ID))
+                .andExpect {
+                    status { isOk() }
+                    model {
+                        attribute("returnToManageUsersUrl", getSystemOperatorManageUsersRoute(NON_ADMIN_LOCAL_COUNCIL_ID))
+                    }
+                }
         }
 
         @Test

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/controllers/ManageLocalCouncilUsersControllerTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/controllers/ManageLocalCouncilUsersControllerTests.kt
@@ -576,7 +576,10 @@ class ManageLocalCouncilUsersControllerTests(
         fun `updateUserAccessLevel updates the given user's access level when called by a local council admin`() {
             setupDefaultLocalCouncilForLocalCouncilAdmin()
 
-            postUpdateUserAccessLevelAndAssertSuccess(getLocalCouncilManageUsersRoute(DEFAULT_LOCAL_COUNCIL_ID))
+            postUpdateUserAccessLevelAndAssertSuccess(
+                getLocalCouncilEditUserRoute(DEFAULT_LOCAL_COUNCIL_ID, DEFAULT_LOCAL_COUNCIL_USER_ID),
+                getLocalCouncilManageUsersRoute(DEFAULT_LOCAL_COUNCIL_ID),
+            )
         }
 
         @Test
@@ -584,12 +587,18 @@ class ManageLocalCouncilUsersControllerTests(
         fun `updateUserAccessLevel updates the given user's access level when called by a system operator`() {
             setupLocalCouncilForSystemOperator(NON_ADMIN_LOCAL_COUNCIL_ID)
 
-            postUpdateUserAccessLevelAndAssertSuccess(getSystemOperatorManageUsersRoute(DEFAULT_LOCAL_COUNCIL_ID))
+            postUpdateUserAccessLevelAndAssertSuccess(
+                getSystemOperatorEditUserRoute(DEFAULT_LOCAL_COUNCIL_ID, DEFAULT_LOCAL_COUNCIL_USER_ID),
+                getSystemOperatorManageUsersRoute(DEFAULT_LOCAL_COUNCIL_ID),
+            )
         }
 
-        private fun postUpdateUserAccessLevelAndAssertSuccess(expectedRedirectUrl: String) {
+        private fun postUpdateUserAccessLevelAndAssertSuccess(
+            postUrl: String,
+            expectedRedirectUrl: String,
+        ) {
             mvc
-                .post(getLocalCouncilEditUserRoute(DEFAULT_LOCAL_COUNCIL_ID, DEFAULT_LOCAL_COUNCIL_USER_ID)) {
+                .post(postUrl) {
                     contentType = MediaType.APPLICATION_FORM_URLENCODED
                     content = "isManager=true"
                     with(csrf())

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/EditLocalCouncilUserTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/EditLocalCouncilUserTests.kt
@@ -13,6 +13,7 @@ import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.ManageLocal
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.ManageLocalCouncilUsersPage.Companion.USERNAME_COL_INDEX
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages.BasePage.Companion.assertPageIs
 import java.net.URI
+import kotlin.test.assertContains
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
@@ -76,5 +77,45 @@ class EditLocalCouncilUserTests : IntegrationTestWithMutableData("data-local.sql
 
         // The user is no longer in the table
         assertThat(manageUsersPage.table.getCell(0, USERNAME_COL_INDEX)).not().containsText("Arthur Dent")
+    }
+
+    @Test
+    fun `a user's access level can be updated via system-operator path`(page: Page) {
+        // Navigate via system operator path
+        var manageUsersPage = navigator.goToSystemOperatorManageLocalCouncilUsers(1)
+        assertThat(manageUsersPage.table.getCell(0, USERNAME_COL_INDEX)).containsText("Arthur Dent")
+        assertThat(manageUsersPage.table.getCell(0, ACCESS_LEVEL_COL_INDEX)).containsText("Basic")
+
+        // Editing the user stays on the system-operator path
+        manageUsersPage.getChangeLink(rowIndex = 0).clickAndWait()
+        val editUserPage = assertPageIs(page, EditLocalCouncilUserPage::class)
+        assertContains(page.url(), "/system-operator/")
+
+        // Saving redirects back to manage users on the system-operator path
+        editUserPage.selectManagerRadio()
+        editUserPage.form.submit()
+        manageUsersPage = assertPageIs(page, ManageLocalCouncilUsersPage::class)
+        assertContains(page.url(), "/system-operator/")
+        assertThat(manageUsersPage.table.getCell(0, ACCESS_LEVEL_COL_INDEX)).containsText("Admin")
+    }
+
+    @Test
+    fun `a user can be deleted via system-operator path`(page: Page) {
+        // Navigate via system operator path
+        val manageUsersPage = navigator.goToSystemOperatorManageLocalCouncilUsers(1)
+        assertThat(manageUsersPage.table.getCell(0, USERNAME_COL_INDEX)).containsText("Arthur Dent")
+        manageUsersPage.getChangeLink(rowIndex = 0).clickAndWait()
+        val editUserPage = assertPageIs(page, EditLocalCouncilUserPage::class)
+        assertContains(page.url(), "/system-operator/")
+
+        // Delete button stays on system-operator path
+        editUserPage.removeAccountButton.clickAndWait()
+        val confirmDeletePage = assertPageIs(page, ConfirmDeleteLocalCouncilUserPage::class)
+        assertContains(page.url(), "/system-operator/")
+
+        // Confirming deletion stays on system-operator path
+        confirmDeletePage.form.submit()
+        assertContains(page.url(), "/system-operator/")
+        assertContains(page.url(), "/confirmation")
     }
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/ManageLocalCouncilUsersTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/ManageLocalCouncilUsersTests.kt
@@ -12,6 +12,7 @@ import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.ManageLocal
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.ManageLocalCouncilUsersPage.Companion.USERNAME_COL_INDEX
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages.BasePage.Companion.assertPageIs
 import kotlin.test.Test
+import kotlin.test.assertContains
 import kotlin.test.assertEquals
 
 class ManageLocalCouncilUsersTests : IntegrationTestWithImmutableData("data-local.sql") {
@@ -115,5 +116,13 @@ class ManageLocalCouncilUsersTests : IntegrationTestWithImmutableData("data-loca
         }
 
         // TODO: PRSD-672 - add tests for Return To Dashboard button going to System Operator dashboard
+
+        @Test
+        fun `invite button goes to invite new user page via system-operator path`(page: Page) {
+            val managePage = navigator.goToSystemOperatorManageLocalCouncilUsers(localCouncilId)
+            managePage.inviteAnotherUserButton.clickAndWait()
+            assertPageIs(page, InviteNewLocalCouncilUserPage::class)
+            assertContains(page.url(), "/system-operator/")
+        }
     }
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/ManageLocalCouncilUsersTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/ManageLocalCouncilUsersTests.kt
@@ -3,6 +3,7 @@ package uk.gov.communities.prsdb.webapp.integration
 import com.microsoft.playwright.Page
 import org.junit.jupiter.api.Nested
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.BaseComponent.Companion.assertThat
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.EditLocalCouncilUserPage
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.InviteNewLocalCouncilUserPage
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.LocalCouncilDashboardPage
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.ManageLocalCouncilUsersPage
@@ -122,6 +123,21 @@ class ManageLocalCouncilUsersTests : IntegrationTestWithImmutableData("data-loca
             val managePage = navigator.goToSystemOperatorManageLocalCouncilUsers(localCouncilId)
             managePage.inviteAnotherUserButton.clickAndWait()
             assertPageIs(page, InviteNewLocalCouncilUserPage::class)
+            assertContains(page.url(), "/system-operator/")
+        }
+
+        @Test
+        fun `change link for active user goes to edit page via system-operator path`(page: Page) {
+            val managePage = navigator.goToSystemOperatorManageLocalCouncilUsers(localCouncilId)
+            managePage.getChangeLink(rowIndex = 0).clickAndWait()
+            assertPageIs(page, EditLocalCouncilUserPage::class)
+            assertContains(page.url(), "/system-operator/")
+        }
+
+        @Test
+        fun `change link for pending user goes to cancel invitation page via system-operator path`(page: Page) {
+            val managePage = navigator.goToSystemOperatorManageLocalCouncilUsers(localCouncilId)
+            managePage.getChangeLink(rowIndex = 2).clickAndWait()
             assertContains(page.url(), "/system-operator/")
         }
     }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/Navigator.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/Navigator.kt
@@ -27,9 +27,9 @@ import uk.gov.communities.prsdb.webapp.controllers.LandlordPrivacyNoticeControll
 import uk.gov.communities.prsdb.webapp.controllers.LocalCouncilDashboardController.Companion.LOCAL_COUNCIL_DASHBOARD_URL
 import uk.gov.communities.prsdb.webapp.controllers.ManageLocalCouncilAdminsController
 import uk.gov.communities.prsdb.webapp.controllers.ManageLocalCouncilAdminsController.Companion.SYSTEM_OPERATOR_ROUTE
-import uk.gov.communities.prsdb.webapp.controllers.ManageLocalCouncilUsersController.Companion.getLocalCouncilInviteNewUserRoute
-import uk.gov.communities.prsdb.webapp.controllers.ManageLocalCouncilUsersController.Companion.getLocalCouncilManageUsersRoute
-import uk.gov.communities.prsdb.webapp.controllers.ManageLocalCouncilUsersController.Companion.getSystemOperatorManageUsersRoute
+import uk.gov.communities.prsdb.webapp.controllers.ManageLocalCouncilUsersController.Companion.getInviteNewUserRoute
+import uk.gov.communities.prsdb.webapp.controllers.ManageLocalCouncilUsersController.Companion.getManageUsersRoute
+import uk.gov.communities.prsdb.webapp.controllers.ManageUsersViewType
 import uk.gov.communities.prsdb.webapp.controllers.PasscodeEntryController.Companion.INVALID_PASSCODE_ROUTE
 import uk.gov.communities.prsdb.webapp.controllers.PasscodeEntryController.Companion.PASSCODE_ENTRY_ROUTE
 import uk.gov.communities.prsdb.webapp.controllers.PropertyDetailsController
@@ -212,17 +212,17 @@ class Navigator(
     private val port: Int,
 ) {
     fun goToManageLocalCouncilUsers(councilId: Int): ManageLocalCouncilUsersPage {
-        navigate(getLocalCouncilManageUsersRoute(councilId))
+        navigate(getManageUsersRoute(councilId, ManageUsersViewType.LocalAuthorityView))
         return createValidPage(page, ManageLocalCouncilUsersPage::class)
     }
 
     fun goToSystemOperatorManageLocalCouncilUsers(councilId: Int): ManageLocalCouncilUsersPage {
-        navigate(getSystemOperatorManageUsersRoute(councilId))
+        navigate(getManageUsersRoute(councilId, ManageUsersViewType.SystemOperatorView))
         return createValidPage(page, ManageLocalCouncilUsersPage::class)
     }
 
     fun goToInviteNewLocalCouncilUser(councilId: Int): InviteNewLocalCouncilUserPage {
-        navigate(getLocalCouncilInviteNewUserRoute(councilId))
+        navigate(getInviteNewUserRoute(councilId, ManageUsersViewType.LocalAuthorityView))
         return createValidPage(page, InviteNewLocalCouncilUserPage::class)
     }
 

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/DeleteLocalCouncilUserSuccessPage.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/DeleteLocalCouncilUserSuccessPage.kt
@@ -2,6 +2,7 @@ package uk.gov.communities.prsdb.webapp.integration.pageObjects.pages
 
 import com.microsoft.playwright.Page
 import uk.gov.communities.prsdb.webapp.controllers.ManageLocalCouncilUsersController
+import uk.gov.communities.prsdb.webapp.controllers.ManageUsersViewType
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages.DeleteLocalCouncilUserSuccessBasePage
 
 class DeleteLocalCouncilUserSuccessPage(
@@ -9,8 +10,9 @@ class DeleteLocalCouncilUserSuccessPage(
     urlArguments: Map<String, String>,
 ) : DeleteLocalCouncilUserSuccessBasePage(
         page,
-        ManageLocalCouncilUsersController.getLocalCouncilDeleteUserSuccessRoute(
+        ManageLocalCouncilUsersController.getDeleteUserSuccessRoute(
             urlArguments["localCouncilId"]!!.toInt(),
             urlArguments["deleteeId"]!!.toLong(),
+            ManageUsersViewType.LocalAuthorityView,
         ),
     )

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/InviteNewLocalCouncilUserSuccessPage.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/InviteNewLocalCouncilUserSuccessPage.kt
@@ -2,6 +2,7 @@ package uk.gov.communities.prsdb.webapp.integration.pageObjects.pages
 
 import com.microsoft.playwright.Page
 import uk.gov.communities.prsdb.webapp.controllers.ManageLocalCouncilUsersController
+import uk.gov.communities.prsdb.webapp.controllers.ManageUsersViewType
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.Button
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.ConfirmationBanner
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages.BasePage
@@ -9,7 +10,13 @@ import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages.B
 class InviteNewLocalCouncilUserSuccessPage(
     page: Page,
     urlArguments: Map<String, String>,
-) : BasePage(page, ManageLocalCouncilUsersController.getLocalCouncilInviteUserSuccessRoute(urlArguments["localCouncilId"]!!.toInt())) {
+) : BasePage(
+        page,
+        ManageLocalCouncilUsersController.getInviteUserSuccessRoute(
+            urlArguments["localCouncilId"]!!.toInt(),
+            ManageUsersViewType.LocalAuthorityView,
+        ),
+    ) {
     val confirmationBanner = ConfirmationBanner(page)
     val returnToDashboardButton = Button.byText(page, "Return to dashboard")
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/urlProviders/InvitationUrlTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/urlProviders/InvitationUrlTests.kt
@@ -19,7 +19,8 @@ import org.springframework.web.context.WebApplicationContext
 import uk.gov.communities.prsdb.webapp.constants.LOCAL_COUNCIL_PATH_SEGMENT
 import uk.gov.communities.prsdb.webapp.controllers.ControllerTest
 import uk.gov.communities.prsdb.webapp.controllers.ManageLocalCouncilUsersController
-import uk.gov.communities.prsdb.webapp.controllers.ManageLocalCouncilUsersController.Companion.getLocalCouncilInviteNewUserRoute
+import uk.gov.communities.prsdb.webapp.controllers.ManageLocalCouncilUsersController.Companion.getInviteNewUserRoute
+import uk.gov.communities.prsdb.webapp.controllers.ManageUsersViewType
 import uk.gov.communities.prsdb.webapp.controllers.RegisterLocalCouncilUserController
 import uk.gov.communities.prsdb.webapp.database.entity.LocalCouncil
 import uk.gov.communities.prsdb.webapp.journeys.localCouncilUserRegistration.LocalCouncilUserRegistrationJourney
@@ -96,7 +97,7 @@ class InvitationUrlTests(
 
         // Act
         mvc
-            .post(getLocalCouncilInviteNewUserRoute(123)) {
+            .post(getInviteNewUserRoute(123, ManageUsersViewType.LocalAuthorityView)) {
                 contentType = MediaType.APPLICATION_FORM_URLENCODED
                 content = encodedConfirmedEmailContent
                 with(csrf())


### PR DESCRIPTION
## Ticket number

[PDJB-887](https://mhclgdigital.atlassian.net/browse/PDJB-887)

## Goal of change

makes it so links in /system-operatorr still direct to /system-operator and not the local authority pages

## Description of main change(s)

add needed handlers to ManageLocalAuthorityCouncilUsersController

make needed changes on templates to use these methods

## Anything you'd like to highlight to the reviewer?

all the routes existed already, just weren't linked to

the dashboard button wasn't touched, it's waiting for the system operator dashboard to be created

<img alt="user list system operator view" src="https://github.com/user-attachments/assets/dfa736be-58c3-4806-b8e7-7d54e714b723" />

## Checklist

Delete any that are not applicable, and add explanation below for any that are applicable but haven't been done

- [x] Screenshots of any UI changes have been added
- [x] Unit tests for new logic (e.g. new service methods) have been added
- [x] A new journey integration test has been added for any new journeys
- [x] Test suite has been run in full locally and is passing
- [x] Branch has been rebased onto main and run locally, with everything working as expected (both for your new feature
  and any related functionality)
- [x] TODO comments referencing this JIRA ticket have been searched for and removed - if a future PR will address them,
  mention that here
- [x] QA instructions have been added to the ticket (particularly if this is the last PR required to complete the ticket)
