### PR TITLE
PDJB-821: update occupied tag design

### DIFF
--- a/src/main/resources/templates/fragments/tag.html
+++ b/src/main/resources/templates/fragments/tag.html
@@ -1,5 +1,5 @@
-<th:block th:fragment="tag(text)" th:with="greyBackground=${greyBackground}">
-    <strong class="govuk-tag" th:classappend="${greyBackground == true ? 'govuk-tag--grey' : ''}"
+<th:block th:fragment="tag(text)" th:with="tagColour=${tagColour}">
+    <strong class="govuk-tag" th:classappend="${tagColour != null ? 'govuk-tag--' + tagColour : ''}"
     th:text="${text}">
     </strong>
 </th:block>

--- a/src/main/resources/templates/propertyDetailsView.html
+++ b/src/main/resources/templates/propertyDetailsView.html
@@ -33,7 +33,7 @@
             <span class="govuk-caption-l" th:text="#{propertyDetails.heading}">propertyDetails.heading</span>
             <h1 class="govuk-heading-l" th:text="${propertyDetails.address}">propertyDetails.address</h1>
             <p class="govuk-body">
-                <div th:replace="~{fragments/tag :: tag(text= #{${propertyDetails.isOccupiedKey()}}, greyBackground = ${!propertyDetails.isOccupied()})}"></div>
+                <div th:replace="~{fragments/tag :: tag(text= #{${propertyDetails.isOccupiedKey()}}, tagColour = ${propertyDetails.isOccupied() ? 'turquoise' : 'grey'})}"></div>
             </p>
             <div th:replace="~{fragments/lastModifiedInsetText :: lastModifiedInsetText(${lastModifiedBy}, ${lastModifiedDate})}"></div>
 


### PR DESCRIPTION
## Ticket number

PDJB-821

## Goal of change

Makes the occupied tag green

## Description of main change(s)

It's green (technically turquoise) now
<img width="708" height="349" alt="image" src="https://github.com/user-attachments/assets/8dc2d31a-ce5f-4cda-84a3-ad29e5e1fdca" />

## Checklist

Delete any that are not applicable, and add explanation below for any that are applicable but haven't been done

- [x] Screenshots of any UI changes have been added
- [x] Test suite has been run in full locally and is passing
- [x] Branch has been rebased onto main and run locally, with everything working as expected (both for your new feature
  and any related functionality)
- [ ] QA instructions have been added to the ticket (particularly if this is the last PR required to complete the ticket)
