### PR TITLE
PDJB-895: Remove messaging around returning to notify

### DIFF
--- a/src/main/resources/messages/forms.yml
+++ b/src/main/resources/messages/forms.yml
@@ -72,9 +72,7 @@ checkAnswers:
 identityNotVerified:
   heading: You have not proven your identity using GOV.UK One Login
   paragraph:
-    one: You can return to GOV.UK One Login at any time to prove your identity. You only need to do this once.
-    two: Proving your identity helps local councils understand who has registered on the service.
-    three: You can continue using the service as normal.
+    one: For this private beta, you can continue to use the service without proving your identity.
 confirmDetails:
   title: Confirm your details
   heading: Confirm your name and date of birth

--- a/src/main/resources/templates/forms/identityNotVerifiedForm.html
+++ b/src/main/resources/templates/forms/identityNotVerifiedForm.html
@@ -12,8 +12,6 @@
         </header>
         <section>
             <p class="govuk-body" th:text="#{forms.identityNotVerified.paragraph.one}">forms.identityNotVerified.paragraph.one</p>
-            <p class="govuk-body" th:text="#{forms.identityNotVerified.paragraph.two}">forms.identityNotVerified.paragraph.two</p>
-            <p class="govuk-body" th:text="#{forms.identityNotVerified.paragraph.three}">forms.identityNotVerified.paragraph.three</p>
         </section>
     </th:block>
     <th:block id="form-content">


### PR DESCRIPTION
## Ticket number

[PDJB-895](https://mhclgdigital.atlassian.net/browse/PDJB-895)

## Goal of change

update copy as requested

<img alt="landlord couldn't verify identity page with no reference to returning to notify" src="https://github.com/user-attachments/assets/c444ae25-ffb6-4105-a723-861fc69a40dc" />

## Checklist

Delete any that are not applicable, and add explanation below for any that are applicable but haven't been done

- [x] Screenshots of any UI changes have been added
- [x] Test suite has been run in full locally and is passing
- [x] Branch has been rebased onto main and run locally, with everything working as expected (both for your new feature
  and any related functionality)
- [x] TODO comments referencing this JIRA ticket have been searched for and removed - if a future PR will address them,
  mention that here
- [x] QA instructions have been added to the ticket (particularly if this is the last PR required to complete the ticket)
