### PR TITLE
PDJB-877: Update copy on empty compliance actions page

### DIFF
--- a/src/main/resources/messages/complianceActions.yml
+++ b/src/main/resources/messages/complianceActions.yml
@@ -14,19 +14,4 @@ status:
   notAdded: Not added
   expired: Expired
 none:
-  hintText: You have no properties awaiting compliance information
-  paragraph:
-    one: You only need to add compliance information for properties occupied by tenants.
-updatePropertyOccupancy:
-  heading: 'To update a property from unoccupied to occupied:'
-  bullet:
-    one:
-      beforeLink: Go to ‘
-      linkText: View your property records
-      afterLink: ’
-    two: Select the property you want to update
-    three: Select ‘Edit record’
-    four: Select ‘Change’ beside the ‘Occupied by tenants’ row
-    five: Save your changes on the property record
-  paragraph:
-    one: You’ll then be asked to add compliance information for the property.
+  inset: The certificates for your occupied properties are up to date.

--- a/src/main/resources/templates/complianceActions.html
+++ b/src/main/resources/templates/complianceActions.html
@@ -4,7 +4,7 @@
     <main class="govuk-main-wrapper" id="main-content">
         <header>
             <h1 class="govuk-heading-l" th:text="#{complianceActions.heading}">complianceActions.heading</h1>
-            <p class="govuk-body-l govuk-hint" th:text="#{${#lists.isEmpty(complianceActions) ? 'complianceActions.none.hintText' : 'complianceActions.hintText'}}">complianceActions.(none.)hintText</p>
+            <p class="govuk-body-l govuk-hint" th:unless="${#lists.isEmpty(complianceActions)}" th:text="#{complianceActions.hintText}">complianceActions.hintText</p>
         </header>
 
         <th:block th:unless="${#lists.isEmpty(complianceActions)}" th:each="complianceAction: ${complianceActions}">
@@ -12,34 +12,7 @@
         </th:block>
 
         <th:block th:if="${#lists.isEmpty(complianceActions)}">
-            <p class="govuk-body" th:text="#{complianceActions.none.paragraph.one}">complianceActions.none.paragraph.one</p>
-            <section>
-                <h2 class="govuk-heading-s" th:text="#{complianceActions.updatePropertyOccupancy.heading}">complianceActions.updatePropertyOccupancy.heading</h2>
-                <ul class="govuk-list govuk-list--bullet">
-                    <li>
-                            <span th:text="#{complianceActions.updatePropertyOccupancy.bullet.one.beforeLink}">
-                                complianceActions.updatePropertyOccupancy.bullet.one.beforeLink
-                            </span><a class="govuk-link" th:text="#{complianceActions.updatePropertyOccupancy.bullet.one.linkText}" th:href="${viewRegisteredPropertiesUrl}">
-                        complianceActions.updatePropertyOccupancy.bullet.one.linkText
-                    </a><span th:text="#{complianceActions.updatePropertyOccupancy.bullet.one.afterLink}">
-                            complianceActions.updatePropertyOccupancy.bullet.one.afterLink
-                            </span>
-                    </li>
-                    <li th:text="#{complianceActions.updatePropertyOccupancy.bullet.two}">
-                        complianceActions.updatePropertyOccupancy.bullet.two
-                    </li>
-                    <li th:text="#{complianceActions.updatePropertyOccupancy.bullet.three}">
-                        complianceActions.updatePropertyOccupancy.bullet.three
-                    </li>
-                    <li th:text="#{complianceActions.updatePropertyOccupancy.bullet.four}">
-                        complianceActions.updatePropertyOccupancy.bullet.four
-                    </li>
-                    <li th:text="#{complianceActions.updatePropertyOccupancy.bullet.five}">
-                        complianceActions.updatePropertyOccupancy.bullet.five
-                    </li>
-                </ul>
-                <p class="govuk-body" th:text="#{complianceActions.updatePropertyOccupancy.paragraph.one}">complianceActions.updatePropertyOccupancy.paragraph.one</p>
-            </section>
+            <div class="govuk-inset-text" th:text="#{complianceActions.none.inset}">complianceActions.none.inset</div>
         </th:block>
 
     </main>

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/ComplianceActionsPageTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/ComplianceActionsPageTests.kt
@@ -5,7 +5,6 @@ import org.junit.jupiter.api.Nested
 import uk.gov.communities.prsdb.webapp.constants.COMPLIANCE_INFO_FRAGMENT
 import uk.gov.communities.prsdb.webapp.integration.IntegrationTestWithImmutableData.NestedIntegrationTestWithImmutableData
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.BaseComponent.Companion.assertThat
-import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.LandlordDetailsPage
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.PropertyDetailsPageLandlordView
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages.BasePage.Companion.assertPageIs
 import kotlin.test.Test
@@ -65,18 +64,11 @@ class ComplianceActionsPageTests : IntegrationTest() {
     @Nested
     inner class LandlordsWithoutComplianceActions : NestedIntegrationTestWithImmutableData("data-mockuser-landlord-with-properties.sql") {
         @Test
-        fun `the page loads with heading and page text`() {
+        fun `the page loads with heading and inset text`() {
             val complianceActionsPage = navigator.goToComplianceActions()
             assertThat(complianceActionsPage.heading).containsText("Compliance actions")
-            assertThat(complianceActionsPage.hintText).containsText("You have no properties awaiting compliance information")
-        }
-
-        @Test
-        fun `the view registered properties link goes to the property records tab on the landlord details page`(page: Page) {
-            val complianceActionsPage = navigator.goToComplianceActions()
-            complianceActionsPage.viewRegisteredPropertiesLink.clickAndWait()
-            val detailsPage = assertPageIs(page, LandlordDetailsPage::class)
-            assertEquals("registered-properties", detailsPage.tabs.activeTabPanelId)
+            assertThat(complianceActionsPage.hintText).isHidden()
+            assertThat(complianceActionsPage.insetText).containsText("The certificates for your occupied properties are up to date.")
         }
     }
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/ComplianceActionsPage.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/ComplianceActionsPage.kt
@@ -4,7 +4,7 @@ import com.microsoft.playwright.Locator
 import com.microsoft.playwright.Page
 import uk.gov.communities.prsdb.webapp.controllers.LandlordController.Companion.COMPLIANCE_ACTIONS_URL
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.Heading
-import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.Link
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.InsetText
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.SummaryCard
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.SummaryList
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages.BasePage
@@ -14,7 +14,7 @@ class ComplianceActionsPage(
 ) : BasePage(page, COMPLIANCE_ACTIONS_URL) {
     val heading = Heading.default(page)
     val hintText = Heading(page.locator("p.govuk-hint"))
-    val viewRegisteredPropertiesLink = Link.byText(page, "View your property records")
+    val insetText = InsetText(page)
 
     fun getSummaryCard(propertyAddress: String) = ComplianceActionSummaryCard(page, propertyAddress)
 


### PR DESCRIPTION
## Ticket number

[PDJB-877](https://mhclgdigital.atlassian.net/browse/PDJB-877)

## Goal of change

update copy on no compliance page to match required copy

<img alt="no compliance page" src="https://github.com/user-attachments/assets/05976381-6fce-4073-aa53-9d494ad19ef1" />

## Description of main change(s)

updates the template

adds needed new strings and removes unneeded ones

updates tests

## Anything you'd like to highlight to the reviewer?

the hint text is now conditional rather than using a ternary since it now isn't used on the no compliance page

there shouldn't be any unused strings in the yml

## Checklist

Delete any that are not applicable, and add explanation below for any that are applicable but haven't been done

- [x] Screenshots of any UI changes have been added
- [x] Single page integration tests have been added for any unhappy-flow UI features, e.g. validation errors
- [x] Test suite has been run in full locally and is passing
- [x] Branch has been rebased onto main and run locally, with everything working as expected (both for your new feature
  and any related functionality)
- [x] TODO comments referencing this JIRA ticket have been searched for and removed - if a future PR will address them,
  mention that here
- [ ] QA instructions have been added to the ticket (particularly if this is the last PR required to complete the ticket)
