### PR TITLE
Not a PR, notes on seeding NFT

### DIFF
--- a/.run/local-nft-seeder.run.xml
+++ b/.run/local-nft-seeder.run.xml
@@ -18,7 +18,6 @@
     <method v="2">
       <option name="RunConfigurationTask" enabled="true" run_configuration_name="local_resources_up" run_configuration_type="docker-deploy" />
       <option name="Make" enabled="true" />
-      <option name="RunConfigurationTask" enabled="true" run_configuration_name="flywayClean-local-except-address" run_configuration_type="GradleRunConfiguration" />
     </method>
   </configuration>
 </component>

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/database/dao/NftDataSeederDao.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/database/dao/NftDataSeederDao.kt
@@ -104,16 +104,6 @@ class NftDataSeederDao(
         return connection.prepareStatement(query)
     }
 
-    fun prepareCertificateUploadStatement(): PreparedStatement {
-        val query =
-            """
-            INSERT INTO certificate_upload 
-            (created_date, last_modified_date, category, property_ownership_id, file_upload_id) 
-            VALUES (?, ?, ?, ?, ?)
-            """
-        return connection.prepareStatement(query)
-    }
-
     fun prepareGasSafetyFileUploadsStatement(): PreparedStatement {
         val query =
             """

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/NftDataSeeder.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/NftDataSeeder.kt
@@ -40,7 +40,7 @@ class NftDataSeeder(
 
     private val registrationNumberGenerator = RegistrationNumberGenerator()
     private val landlordAddressGenerator = AddressGenerator()
-    private val propertyOwnershipAddressGenerator = AddressGenerator(restrictToAvailable = true)
+    private val propertyOwnershipAddressGenerator = AddressGenerator(restrictToAvailable = true, PREFERRED_PROPERTY_ADDRESS_IDS)
     private val incompletePropertyAddressGenerator = AddressGenerator(restrictToAvailable = true)
 
     fun seedDatabase() {
@@ -576,17 +576,23 @@ class NftDataSeeder(
     companion object {
         const val NUM_OF_SYSTEM_OPERATORS = 0
         const val NUM_OF_LC_USERS = 0
-        const val NUM_OF_LANDLORDS = 10
-        const val NUM_OF_PROPERTIES = 20
-        const val BATCH_SIZE = 5
+        const val NUM_OF_LANDLORDS = 300
+        const val NUM_OF_PROPERTIES = 1000
+        const val BATCH_SIZE = 1000
 
-        const val REGISTRATION_NUMBERS_ALREADY_ADDED = 27
-        const val LICENCES_ALREADY_ADDED = 3
-        const val PROPERTY_OWNERSHIPS_ALREADY_ADDED = 17
-        const val COMPLIANCE_RECORDS_ALREADY_ADDED = 17
-        const val REMINDER_EMAILS_ADDED = 1
-        const val INCOMPLETE_PROPERTIES_ADDED = 3
-        const val LANDLORDS_ALREADY_ADDED = 10
+        const val REGISTRATION_NUMBERS_ALREADY_ADDED = 40
+        const val LICENCES_ALREADY_ADDED = 7
+        const val PROPERTY_OWNERSHIPS_ALREADY_ADDED = 20
+        const val COMPLIANCE_RECORDS_ALREADY_ADDED = 20
+        const val REMINDER_EMAILS_ADDED = 0
+        const val INCOMPLETE_PROPERTIES_ADDED = 1
+        const val LANDLORDS_ALREADY_ADDED = 20
+
+        val PREFERRED_PROPERTY_ADDRESS_IDS: List<Long> =
+            listOf(
+                33769665L,
+                10744667L,
+            )
     }
 
     private abstract class Generator<T> {
@@ -622,17 +628,24 @@ class NftDataSeeder(
 
     private inner class AddressGenerator(
         private val restrictToAvailable: Boolean = false,
+        preferredAddressIds: List<Long> = emptyList(),
     ) : Generator<Address>() {
+        private val preferredAddresses = ArrayDeque(preferredAddressIds)
         private val replenishmentSize = BATCH_SIZE * 5
 
         override fun replenishValues() {
             val valueSet = values.toSet()
             val newAddresses =
-                nftDataSeederDao.findAddresses(
-                    limit = replenishmentSize,
-                    offset = NftDataFaker.generateNumberLessThan(addressCount - replenishmentSize),
-                    restrictToAvailable,
-                )
+                if (preferredAddresses.isNotEmpty()) {
+                    val batch = (1..replenishmentSize).mapNotNull { preferredAddresses.removeFirstOrNull() }
+                    addressRepository.findAllById(batch)
+                } else {
+                    nftDataSeederDao.findAddresses(
+                        limit = replenishmentSize,
+                        offset = NftDataFaker.generateNumberLessThan(addressCount - replenishmentSize),
+                        restrictToAvailable,
+                    )
+                }
             values = (valueSet + newAddresses.shuffled()).toList()
         }
     }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/NftDataSeeder.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/NftDataSeeder.kt
@@ -1,11 +1,9 @@
 package uk.gov.communities.prsdb.webapp.services
 
-import kotlinx.datetime.LocalDate
 import org.hibernate.SessionFactory
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Profile
 import uk.gov.communities.prsdb.webapp.annotations.taskAnnotations.PrsdbTaskService
-import uk.gov.communities.prsdb.webapp.constants.GAS_SAFETY_CERT_VALIDITY_YEARS
 import uk.gov.communities.prsdb.webapp.constants.enums.CertificateType
 import uk.gov.communities.prsdb.webapp.constants.enums.RegistrationNumberType
 import uk.gov.communities.prsdb.webapp.database.dao.NftDataSeederDao
@@ -23,7 +21,6 @@ import uk.gov.communities.prsdb.webapp.helpers.extensions.PreparedStatementExten
 import uk.gov.communities.prsdb.webapp.helpers.extensions.PreparedStatementExtensions.Companion.setStringOrNull
 import uk.gov.communities.prsdb.webapp.models.dataModels.EpcDataModel
 import java.sql.Connection
-import java.sql.Date
 import java.sql.PreparedStatement
 import java.sql.Timestamp
 import java.time.LocalDateTime
@@ -133,9 +130,9 @@ class NftDataSeeder(
         val licenceStmt = nftDataSeederDao.prepareLicenceStatement()
         val propertyOwnershipStmt = nftDataSeederDao.preparePropertyOwnershipStatement()
 
-        val fileUploadStmt = nftDataSeederDao.prepareFileUploadStatement()
-        val gasSafetyFileUploadsStmt = nftDataSeederDao.prepareGasSafetyFileUploadsStatement()
-        val electricalSafetyFileUploadsStmt = nftDataSeederDao.prepareElectricalSafetyFileUploadsStatement()
+        //  val fileUploadStmt = nftDataSeederDao.prepareFileUploadStatement()
+        //  val gasSafetyFileUploadsStmt = nftDataSeederDao.prepareGasSafetyFileUploadsStatement()
+        //  val electricalSafetyFileUploadsStmt = nftDataSeederDao.prepareElectricalSafetyFileUploadsStatement()
         val propertyComplianceStmt = nftDataSeederDao.preparePropertyComplianceStatement()
 
         val reminderEmailSentStmt = nftDataSeederDao.prepareReminderEmailSentStatement()
@@ -143,22 +140,29 @@ class NftDataSeeder(
         val incompletePropertyStmt = nftDataSeederDao.prepareLandlordIncompletePropertyStatement()
 
         try {
-            var registrationNumbersAdded = 0
+            var registrationNumbersAdded = REGISTRATION_NUMBERS_ALREADY_ADDED
 
-            var licencesAdded = 0
-            var propertyOwnershipsAdded = 0
+            var licencesAdded = LICENCES_ALREADY_ADDED
+            var propertyOwnershipsAdded = PROPERTY_OWNERSHIPS_ALREADY_ADDED
 
-            var fileUploadsAdded = 0
-            var complianceRecordsAdded = 0
+            var fileUploadsAdded = 0 // currently not adding to this
+            var complianceRecordsAdded = COMPLIANCE_RECORDS_ALREADY_ADDED
 
-            var reminderEmailsAdded = 0
-            var incompletePropertiesAdded = 0
+            var reminderEmailsAdded = REMINDER_EMAILS_ADDED
+            var incompletePropertiesAdded = INCOMPLETE_PROPERTIES_ADDED
 
             fun propertyRegistrationsAdded() = propertyOwnershipsAdded + incompletePropertiesAdded
 
             val numOfLandlordBatches = ceil(NUM_OF_LANDLORDS.toFloat() / BATCH_SIZE).toInt()
             for (landlordBatchNum in 1..numOfLandlordBatches) {
-                val landlordIdRange = ((landlordBatchNum - 1) * BATCH_SIZE + 1)..min(landlordBatchNum * BATCH_SIZE, NUM_OF_LANDLORDS)
+                val landlordIdRange =
+                    (LANDLORDS_ALREADY_ADDED + (landlordBatchNum - 1) * BATCH_SIZE + 1)..(
+                        LANDLORDS_ALREADY_ADDED +
+                            min(
+                                landlordBatchNum * BATCH_SIZE,
+                                NUM_OF_LANDLORDS,
+                            )
+                    )
                 val coreDetailsForLandlords = NftDataFaker.generateCoreDetailsForLandlords(landlordIdRange.toList())
 
                 coreDetailsForLandlords.forEach {
@@ -207,9 +211,9 @@ class NftDataSeeder(
                                 val complianceId = (++complianceRecordsAdded).toLong()
                                 fileUploadsAdded =
                                     addPropertyComplianceToBatchReturningUpdatedFileUploadsAdded(
-                                        fileUploadStmt,
+/*                                        fileUploadStmt,
                                         gasSafetyFileUploadsStmt,
-                                        electricalSafetyFileUploadsStmt,
+                                        electricalSafetyFileUploadsStmt,*/
                                         propertyComplianceStmt,
                                         complianceId,
                                         propertyOwnershipId,
@@ -236,10 +240,10 @@ class NftDataSeeder(
                             registrationNumberGenerator.forgetUsedValues()
                             propertyOwnershipAddressGenerator.forgetUsedValues()
 
-                            fileUploadStmt.executeBatch()
+                            //                          fileUploadStmt.executeBatch()
                             propertyComplianceStmt.executeBatch()
-                            gasSafetyFileUploadsStmt.executeBatch()
-                            electricalSafetyFileUploadsStmt.executeBatch()
+                            //                           gasSafetyFileUploadsStmt.executeBatch()
+                            //                          electricalSafetyFileUploadsStmt.executeBatch()
                         }
                         if (incompletePropertiesAdded % BATCH_SIZE == 0 || propertyRegistrationsAdded() == NUM_OF_PROPERTIES) {
                             reminderEmailSentStmt.executeBatch()
@@ -262,9 +266,9 @@ class NftDataSeeder(
             licenceStmt.close()
             propertyOwnershipStmt.close()
 
-            fileUploadStmt.close()
+/*            fileUploadStmt.close()
             gasSafetyFileUploadsStmt.close()
-            electricalSafetyFileUploadsStmt.close()
+            electricalSafetyFileUploadsStmt.close()*/
             propertyComplianceStmt.close()
 
             reminderEmailSentStmt.close()
@@ -458,9 +462,9 @@ class NftDataSeeder(
     }
 
     private fun addPropertyComplianceToBatchReturningUpdatedFileUploadsAdded(
-        fileUploadStmt: PreparedStatement,
+/*        fileUploadStmt: PreparedStatement,
         gasSafetyFileUploadsStmt: PreparedStatement,
-        electricalSafetyFileUploadsStmt: PreparedStatement,
+        electricalSafetyFileUploadsStmt: PreparedStatement,*/
         propertyComplianceStmt: PreparedStatement,
         complianceId: Long,
         propertyOwnershipId: Long,
@@ -472,7 +476,7 @@ class NftDataSeeder(
 
         var updatedFileUploadCount = currentFileUploadCount
 
-        if (complianceData.gasSafetyCertIssueDate?.after(
+/*        if (complianceData.gasSafetyCertIssueDate?.after(
                 Date.valueOf(
                     java.time.LocalDate
                         .now()
@@ -505,7 +509,7 @@ class NftDataSeeder(
             electricalSafetyFileUploadsStmt.setLong(1, complianceId)
             electricalSafetyFileUploadsStmt.setLong(2, eicrUploadId)
             electricalSafetyFileUploadsStmt.addBatch()
-        }
+        }*/
 
         propertyComplianceStmt.setLong(1, complianceId)
         propertyComplianceStmt.setTimestamp(2, createdDate)
@@ -557,11 +561,19 @@ class NftDataSeeder(
     }
 
     companion object {
-        const val NUM_OF_SYSTEM_OPERATORS = 150
-        const val NUM_OF_LC_USERS = 3000
-        const val NUM_OF_LANDLORDS = 2820000
-        const val NUM_OF_PROPERTIES = 4700000
-        const val BATCH_SIZE = 10000
+        const val NUM_OF_SYSTEM_OPERATORS = 5
+        const val NUM_OF_LC_USERS = 10
+        const val NUM_OF_LANDLORDS = 10
+        const val NUM_OF_PROPERTIES = 40
+        const val BATCH_SIZE = 5
+
+        const val REGISTRATION_NUMBERS_ALREADY_ADDED = 40
+        const val LICENCES_ALREADY_ADDED = 7
+        const val PROPERTY_OWNERSHIPS_ALREADY_ADDED = 20
+        const val COMPLIANCE_RECORDS_ALREADY_ADDED = 17
+        const val REMINDER_EMAILS_ADDED = 2
+        const val INCOMPLETE_PROPERTIES_ADDED = 5
+        const val LANDLORDS_ALREADY_ADDED = 20
     }
 
     private abstract class Generator<T> {

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/NftDataSeeder.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/NftDataSeeder.kt
@@ -134,7 +134,6 @@ class NftDataSeeder(
         val propertyOwnershipStmt = nftDataSeederDao.preparePropertyOwnershipStatement()
 
         val fileUploadStmt = nftDataSeederDao.prepareFileUploadStatement()
-        val certificateUploadStmt = nftDataSeederDao.prepareCertificateUploadStatement()
         val gasSafetyFileUploadsStmt = nftDataSeederDao.prepareGasSafetyFileUploadsStatement()
         val electricalSafetyFileUploadsStmt = nftDataSeederDao.prepareElectricalSafetyFileUploadsStatement()
         val propertyComplianceStmt = nftDataSeederDao.preparePropertyComplianceStatement()
@@ -209,7 +208,6 @@ class NftDataSeeder(
                                 fileUploadsAdded =
                                     addPropertyComplianceToBatchReturningUpdatedFileUploadsAdded(
                                         fileUploadStmt,
-                                        certificateUploadStmt,
                                         gasSafetyFileUploadsStmt,
                                         electricalSafetyFileUploadsStmt,
                                         propertyComplianceStmt,
@@ -239,7 +237,6 @@ class NftDataSeeder(
                             propertyOwnershipAddressGenerator.forgetUsedValues()
 
                             fileUploadStmt.executeBatch()
-                            certificateUploadStmt.executeBatch()
                             propertyComplianceStmt.executeBatch()
                             gasSafetyFileUploadsStmt.executeBatch()
                             electricalSafetyFileUploadsStmt.executeBatch()
@@ -266,7 +263,6 @@ class NftDataSeeder(
             propertyOwnershipStmt.close()
 
             fileUploadStmt.close()
-            certificateUploadStmt.close()
             gasSafetyFileUploadsStmt.close()
             electricalSafetyFileUploadsStmt.close()
             propertyComplianceStmt.close()
@@ -463,7 +459,6 @@ class NftDataSeeder(
 
     private fun addPropertyComplianceToBatchReturningUpdatedFileUploadsAdded(
         fileUploadStmt: PreparedStatement,
-        certificateUploadStmt: PreparedStatement,
         gasSafetyFileUploadsStmt: PreparedStatement,
         electricalSafetyFileUploadsStmt: PreparedStatement,
         propertyComplianceStmt: PreparedStatement,
@@ -489,7 +484,6 @@ class NftDataSeeder(
             val gasSafetyUploadId = (++updatedFileUploadCount).toLong()
             addFileUploadToBatch(
                 fileUploadStmt,
-                certificateUploadStmt,
                 propertyOwnershipId,
                 createdDate,
                 CertificateType.GasSafetyCert,
@@ -503,7 +497,6 @@ class NftDataSeeder(
             val eicrUploadId = (++updatedFileUploadCount).toLong()
             addFileUploadToBatch(
                 fileUploadStmt,
-                certificateUploadStmt,
                 propertyOwnershipId,
                 createdDate,
                 complianceData.electricalCertType!!,
@@ -541,7 +534,6 @@ class NftDataSeeder(
     // TODO PDJB-239: Upload files to S3
     private fun addFileUploadToBatch(
         fileUploadStmt: PreparedStatement,
-        certificateUploadStmt: PreparedStatement,
         propertyOwnershipId: Long,
         createdDate: Timestamp,
         certificateType: CertificateType,
@@ -558,13 +550,6 @@ class NftDataSeeder(
         fileUploadStmt.setString(5, NftDataFaker.generateETag())
         fileUploadStmt.setString(6, "fake-certificate.png")
         fileUploadStmt.addBatch()
-
-        certificateUploadStmt.setTimestamp(1, createdDate)
-        certificateUploadStmt.setTimestamp(2, NftDataFaker.generateLastModifiedDate(createdDate))
-        certificateUploadStmt.setInt(3, certificateType.ordinal)
-        certificateUploadStmt.setLong(4, propertyOwnershipId)
-        certificateUploadStmt.setLong(5, fileUploadId)
-        certificateUploadStmt.addBatch()
     }
 
     private fun log(message: String) {

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/NftDataSeeder.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/NftDataSeeder.kt
@@ -151,7 +151,7 @@ class NftDataSeeder(
             var reminderEmailsAdded = REMINDER_EMAILS_ADDED
             var incompletePropertiesAdded = INCOMPLETE_PROPERTIES_ADDED
 
-            fun propertyRegistrationsAdded() = propertyOwnershipsAdded + incompletePropertiesAdded
+            var newPropertyRegistrations = 0
 
             val numOfLandlordBatches = ceil(NUM_OF_LANDLORDS.toFloat() / BATCH_SIZE).toInt()
             for (landlordBatchNum in 1..numOfLandlordBatches) {
@@ -181,10 +181,10 @@ class NftDataSeeder(
                 registrationNumberGenerator.forgetUsedValues()
                 landlordAddressGenerator.forgetUsedValues()
 
-                log("Seeded ${landlordIdRange.last} landlords")
+                log("Seeded ${landlordIdRange.last - LANDLORDS_ALREADY_ADDED} / $NUM_OF_LANDLORDS landlords")
 
                 coreDetailsForLandlords.forEach { landlord ->
-                    val numOfPropertiesLeft = NUM_OF_PROPERTIES - propertyRegistrationsAdded()
+                    val numOfPropertiesLeft = NUM_OF_PROPERTIES - newPropertyRegistrations
                     val numOfPropertiesForLandlord = NftDataFaker.generateNumberOfPropertiesForLandlord().coerceAtMost(numOfPropertiesLeft)
 
                     repeat(numOfPropertiesForLandlord) {
@@ -206,21 +206,18 @@ class NftDataSeeder(
                                     landlord,
                                 )
 
-                            val probabilityOfComplianceRecord = if (isOccupied) 0.9 else 0.1
-                            if (NftDataFaker.generateBoolean(probabilityTrue = probabilityOfComplianceRecord)) {
-                                val complianceId = (++complianceRecordsAdded).toLong()
-                                fileUploadsAdded =
-                                    addPropertyComplianceToBatchReturningUpdatedFileUploadsAdded(
+                            val complianceId = (++complianceRecordsAdded).toLong()
+                            fileUploadsAdded =
+                                addPropertyComplianceToBatchReturningUpdatedFileUploadsAdded(
 /*                                        fileUploadStmt,
-                                        gasSafetyFileUploadsStmt,
-                                        electricalSafetyFileUploadsStmt,*/
-                                        propertyComplianceStmt,
-                                        complianceId,
-                                        propertyOwnershipId,
-                                        propertyOwnershipCreatedDate,
-                                        fileUploadsAdded,
-                                    )
-                            }
+                                    gasSafetyFileUploadsStmt,
+                                    electricalSafetyFileUploadsStmt,*/
+                                    propertyComplianceStmt,
+                                    complianceId,
+                                    propertyOwnershipId,
+                                    propertyOwnershipCreatedDate,
+                                    fileUploadsAdded,
+                                )
                         } else {
                             val hasReminderEmailBeenSent = NftDataFaker.generateBoolean(probabilityTrue = 0.25)
                             addIncompletePropertyToBatch(
@@ -233,7 +230,11 @@ class NftDataSeeder(
                             )
                         }
 
-                        if (propertyOwnershipsAdded % BATCH_SIZE == 0 || propertyRegistrationsAdded() == NUM_OF_PROPERTIES) {
+                        newPropertyRegistrations++
+
+                        if ((propertyOwnershipsAdded - PROPERTY_OWNERSHIPS_ALREADY_ADDED) % BATCH_SIZE == 0 ||
+                            newPropertyRegistrations == NUM_OF_PROPERTIES
+                        ) {
                             registrationNumberStmt.executeBatch()
                             licenceStmt.executeBatch()
                             propertyOwnershipStmt.executeBatch()
@@ -244,20 +245,32 @@ class NftDataSeeder(
                             propertyComplianceStmt.executeBatch()
                             //                           gasSafetyFileUploadsStmt.executeBatch()
                             //                          electricalSafetyFileUploadsStmt.executeBatch()
-                        }
-                        if (incompletePropertiesAdded % BATCH_SIZE == 0 || propertyRegistrationsAdded() == NUM_OF_PROPERTIES) {
+
                             reminderEmailSentStmt.executeBatch()
                             savedJourneyStateStmt.executeBatch()
                             incompletePropertyStmt.executeBatch()
                             incompletePropertyAddressGenerator.forgetUsedValues()
                         }
 
-                        if (propertyRegistrationsAdded() % BATCH_SIZE == 0 || propertyRegistrationsAdded() == NUM_OF_PROPERTIES) {
-                            log("Seeded ${propertyRegistrationsAdded()} property ownerships/incomplete properties")
+                        if (newPropertyRegistrations % BATCH_SIZE == 0 || newPropertyRegistrations == NUM_OF_PROPERTIES) {
+                            log("Seeded $newPropertyRegistrations / $NUM_OF_PROPERTIES property registrations")
                         }
                     }
                 }
             }
+
+            // Flush any remaining batched items if we ran out of landlords before reaching NUM_OF_PROPERTIES
+            if (newPropertyRegistrations > 0 && newPropertyRegistrations % BATCH_SIZE != 0) {
+                registrationNumberStmt.executeBatch()
+                licenceStmt.executeBatch()
+                propertyOwnershipStmt.executeBatch()
+                propertyComplianceStmt.executeBatch()
+                reminderEmailSentStmt.executeBatch()
+                savedJourneyStateStmt.executeBatch()
+                incompletePropertyStmt.executeBatch()
+            }
+
+            log("Seeded $newPropertyRegistrations / $NUM_OF_PROPERTIES property registrations")
         } finally {
             prsdbUserStmt.close()
             registrationNumberStmt.close()
@@ -561,19 +574,19 @@ class NftDataSeeder(
     }
 
     companion object {
-        const val NUM_OF_SYSTEM_OPERATORS = 5
-        const val NUM_OF_LC_USERS = 10
+        const val NUM_OF_SYSTEM_OPERATORS = 0
+        const val NUM_OF_LC_USERS = 0
         const val NUM_OF_LANDLORDS = 10
-        const val NUM_OF_PROPERTIES = 40
+        const val NUM_OF_PROPERTIES = 20
         const val BATCH_SIZE = 5
 
-        const val REGISTRATION_NUMBERS_ALREADY_ADDED = 40
-        const val LICENCES_ALREADY_ADDED = 7
-        const val PROPERTY_OWNERSHIPS_ALREADY_ADDED = 20
+        const val REGISTRATION_NUMBERS_ALREADY_ADDED = 27
+        const val LICENCES_ALREADY_ADDED = 3
+        const val PROPERTY_OWNERSHIPS_ALREADY_ADDED = 17
         const val COMPLIANCE_RECORDS_ALREADY_ADDED = 17
-        const val REMINDER_EMAILS_ADDED = 2
-        const val INCOMPLETE_PROPERTIES_ADDED = 5
-        const val LANDLORDS_ALREADY_ADDED = 20
+        const val REMINDER_EMAILS_ADDED = 1
+        const val INCOMPLETE_PROPERTIES_ADDED = 3
+        const val LANDLORDS_ALREADY_ADDED = 10
     }
 
     private abstract class Generator<T> {


### PR DESCRIPTION
## Ticket number

PDJB-NONE

## Goal of change

Seed a few hundred records for pen testing, including a load in a particular LC

## Description of main change(s)

* We no longer have a certificate_uploads table, so seeded that is removed
* File uploads (gas and electric certificates) should be there but may not be correctly implemented - I removed these for this seeded but they should be implemented properly
* Some of the landlord data specifies the ids, but doesn't account for there already being data in the db. Added some constants which let the user add an offset to the ids if there are already records in the db (these might want renaming actually so it's the highest id in the db)
* PREFERRED_PROPERTY_ADDRESS_IDS lets you add ids of particular addresses you want to use - I used this to add addresses in a particular LC (once those ran out, it continued to select random address to make the rest of the property ownership records)

Running it:
* Try again the local DB using local-nft-seeder
* To run again nft, remove the "local" profile and set RDS_URL to point to where you have the nft db running
* A few environment variables then need adding to the local .env file (I added 8 - it will tell you what's missing when you try to run)

## Anything you'd like to highlight to the reviewer?

## Checklist
