### PR TITLE
PDJB-779: update local council user registration text

### DIFF
--- a/src/main/resources/messages/registerLocalCouncilUser.yml
+++ b/src/main/resources/messages/registerLocalCouncilUser.yml
@@ -25,10 +25,7 @@ success:
   whatHappensNext:
     paragraph:
       one: You now have full access to the database.
-      two: 'Head to your dashboard to:'
-    bullet:
-      one: view property and landlord information
-      two: request compliance updates
+      two: Head to your dashboard to view property and landlord information.
 privacyNotice:
   heading: Read and agree to the privacy notice
   paragraph:

--- a/src/main/resources/templates/registerLocalCouncilUserSuccess.html
+++ b/src/main/resources/templates/registerLocalCouncilUserSuccess.html
@@ -13,14 +13,6 @@
         <p class="govuk-body" th:text="#{registerLocalCouncilUser.success.whatHappensNext.paragraph.two}">
             registerLocalCouncilUser.success.whatHappensNext.paragraph.two
         </p>
-        <ul class="govuk-list govuk-list--bullet">
-            <li th:text="#{registerLocalCouncilUser.success.whatHappensNext.bullet.one}">
-                registerLocalCouncilUser.success.whatHappensNext.bullet.one
-            </li>
-            <li th:text="#{registerLocalCouncilUser.success.whatHappensNext.bullet.two}">
-                registerLocalCouncilUser.success.whatHappensNext.bullet.two
-            </li>
-        </ul>
         <div class="govuk-button-group">
             <a th:replace="~{fragments/buttons/primaryButtonLink :: primaryButtonLink(@{${dashboardUrl}}, #{common.confirmationPage.goToDashboard})}">
                 registerLocalCouncilUser.success.goToDashboardButtonText


### PR DESCRIPTION
## Ticket number

PDJB-779

## Goal of change

Remove erroneous text from LC registration page

## Description of main change(s)

<img width="700" height="609" alt="image" src="https://github.com/user-attachments/assets/78e46e4d-5c72-4d28-8c95-d815e55b4dcc" />

Removes the 2nd bullet point and combines bullet point 1 and the start sentence

## Checklist

Delete any that are not applicable, and add explanation below for any that are applicable but haven't been done

- [x] Screenshots of any UI changes have been added
- [x] Test suite has been run in full locally and is passing
- [x] Branch has been rebased onto main and run locally, with everything working as expected (both for your new feature
  and any related functionality)
- [ ] QA instructions have been added to the ticket (particularly if this is the last PR required to complete the ticket)
