### PR TITLE
PDJB-598: Update Notify email templates

### DIFF
--- a/src/main/resources/emails/LocalCouncilUserInvitationInformAdminEmail.md
+++ b/src/main/resources/emails/LocalCouncilUserInvitationInformAdminEmail.md
@@ -4,8 +4,6 @@
 
 ^ ((Local Council Name))
 
-You'll receive an email if this person accepts the invitation to register as a local council user.
-
 If the person invited does not respond, contact them directly.
 
 If you think this was a mistake, you can cancel the invite.

--- a/src/main/resources/emails/emailTemplates.json
+++ b/src/main/resources/emails/emailTemplates.json
@@ -122,10 +122,10 @@
     "bodyLocation": "/emails/LocalCouncilRegistrationConfirmation.md"
   },
   {
-    "test_id": "df6e1f82-2a36-4a83-86e1-a1c122bf81aa",
-    "prod_id": "a7de7897-0758-4e8d-823f-6c652d502045",
+    "test_id": "aafefbd6-f109-4728-ad8b-c7b0bc44ef54",
+    "prod_id": "c916a57a-4099-490b-b195-41e337530c0f",
     "enumName": "LOCAL_COUNCIL_USER_DELETION_EMAIL",
-    "subject": "You can no longer access check rental properties or landlords",
+    "subject": "You can no longer access Check a rental property or landlord",
     "bodyLocation": "/emails/LocalCouncilUserDeletion.md"
   },
   {
@@ -136,8 +136,8 @@
     "bodyLocation": "/emails/LocalCouncilUserDeletionAdminEmail.md"
   },
   {
-    "test_id": "f2de4378-b15f-437b-b1df-2cc94362a130",
-    "prod_id": "473dc4ec-b6ea-4437-ab43-eaf6ac8b60ef",
+    "test_id": "180829b1-6d2b-4346-86c0-53d65a6d0eb4",
+    "prod_id": "4ee75f0d-b182-4577-80e8-1f79184ac6ae",
     "enumName": "LOCAL_COUNCIL_USER_INVITATION_INFORM_ADMIN_EMAIL",
     "subject": "A user has been invited to register as a local council user on Check a rental property or landlord",
     "bodyLocation": "/emails/LocalCouncilUserInvitationInformAdminEmail.md"


### PR DESCRIPTION
## Ticket number

PDJB-598

## Goal of change

Apply QA feedback to two of the Notify email templates updated in #1282.

## Description of main change(s)

- Updates the `LOCAL_COUNCIL_USER_DELETION_EMAIL` subject to "You can no longer access Check a rental property or landlord"
- Removes the "You'll receive an email if this person accepts the invitation to register as a local council user." line from the local council user invitation admin email body
- Updates the test/prod template IDs for both templates to point to the revised Notify templates

## Anything you'd like to highlight to the reviewer?

The template content lives in GOV.UK Notify — this PR only updates the IDs the app references and the markdown body that is rendered locally for tests/preview.

## Checklist

- [x] Test suite has been run in full locally and is passing
- [x] QA instructions have been added to the ticket
