### PR TITLE
PDJB-909: Add missing license steps to CYA map

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/PropertyRegistrationJourneyFactory.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/PropertyRegistrationJourneyFactory.kt
@@ -165,7 +165,11 @@ class PropertyRegistrationJourneyFactory(
                     checkAnswerStep(journey.ownershipTypeStep, OwnershipTypeStep.ROUTE_SEGMENT)
                 }
 
-                LicensingTypeStep.ROUTE_SEGMENT -> {
+                LicensingTypeStep.ROUTE_SEGMENT,
+                SelectiveLicenceStep.ROUTE_SEGMENT,
+                HmoMandatoryLicenceStep.ROUTE_SEGMENT,
+                HmoAdditionalLicenceStep.ROUTE_SEGMENT,
+                -> {
                     checkAnswerTask(journey.licensingTask)
                 }
 

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/PropertyRegistrationSinglePageTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/PropertyRegistrationSinglePageTests.kt
@@ -47,6 +47,7 @@ import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyReg
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyRegistrationJourneyPages.OccupancyFormPagePropertyRegistration
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyRegistrationJourneyPages.OwnershipTypeFormPagePropertyRegistration
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyRegistrationJourneyPages.RemoveJointLandlordAreYouSureFormPagePropertyRegistration
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyRegistrationJourneyPages.SelectiveLicenceFormPagePropertyRegistration
 import uk.gov.communities.prsdb.webapp.models.dataModels.AddressDataModel
 import uk.gov.communities.prsdb.webapp.testHelpers.builders.PropertyStateSessionBuilder
 import kotlin.test.assertTrue
@@ -1315,6 +1316,15 @@ class PropertyRegistrationSinglePageTests : IntegrationTestWithImmutableData("da
             val checkAnswersPage = navigator.skipToPropertyRegistrationCheckAnswersPageNoEpc()
             checkAnswersPage.complianceSummaryList.hasEpcRow.clickFirstActionLinkAndWait()
             assertPageIs(page, HasEpcFormPagePropertyRegistration::class)
+        }
+
+        @Test
+        fun `the licensing number change link navigates to the licensing page`(page: Page) {
+            val checkAnswersPage = navigator.skipToPropertyRegistrationCheckAnswersPageWithSelectiveLicence()
+            checkAnswersPage.summaryList.licensingNumberRow.clickFirstActionLinkAndWait()
+            val selectiveLicencePage = assertPageIs(page, SelectiveLicenceFormPagePropertyRegistration::class)
+            selectiveLicencePage.submitLicenseNumber("SL-99999")
+            assertPageIs(page, CheckAnswersPagePropertyRegistration::class)
         }
     }
 

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/Navigator.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/Navigator.kt
@@ -743,6 +743,12 @@ class Navigator(
         return createValidPage(page, CheckAnswersPagePropertyRegistration::class)
     }
 
+    fun skipToPropertyRegistrationCheckAnswersPageWithSelectiveLicence(): CheckAnswersPagePropertyRegistration {
+        setJourneyStateInSession(PropertyStateSessionBuilder.beforePropertyRegistrationCheckAnswersWithSelectiveLicence().build())
+        navigateToPropertyRegistrationJourneyStep(PropertyRegistrationCyaStep.ROUTE_SEGMENT)
+        return createValidPage(page, CheckAnswersPagePropertyRegistration::class)
+    }
+
     fun skipToPropertyRegistrationCheckAnswersPageOccupied(
         households: Int = 2,
         people: Int = 4,

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/propertyRegistrationJourneyPages/CheckAnswersPagePropertyRegistration.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/propertyRegistrationJourneyPages/CheckAnswersPagePropertyRegistration.kt
@@ -44,6 +44,7 @@ class CheckAnswersPagePropertyRegistration(
     ) : SummaryList(page) {
         val ownershipRow = getRow("Ownership type")
         val licensingRow = getRow("Licensing type")
+        val licensingNumberRow = getRow("Licensing number")
         val numberOfHouseholdsRow = getRow("Number of households")
         val numberOfTenantsRow = getRow("Number of tenants")
         val numberOfBedroomsRow = getRow("Number of bedrooms")

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/testHelpers/builders/PropertyStateSessionBuilder.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/testHelpers/builders/PropertyStateSessionBuilder.kt
@@ -353,6 +353,15 @@ class PropertyStateSessionBuilder(
                 .withElectricalSafetyCertificateMissing()
                 .withCompliantEpc()
 
+        fun beforePropertyRegistrationCheckAnswersWithSelectiveLicence() =
+            beforePropertyRegistrationLicensingType()
+                .withLicensing(LicensingType.SELECTIVE_LICENCE, "SL-12345")
+                .withOccupancyStatus(false)
+                .withHasNoJointLandlords()
+                .withGasSafetyTaskCompletedWithNoGasSupply()
+                .withElectricalSafetyCertificateMissing()
+                .withCompliantEpc()
+
         fun beforePropertyRegistrationCheckAnswersOccupied(
             households: Int = 2,
             people: Int = 4,


### PR DESCRIPTION
## Ticket number

[PDJB-909](https://mhclgdigital.atlassian.net/browse/PDJB-909)

## Goal of change

fixes a bug where pressing 'Change' on the main CYA page for any license number lead to a service error
<img alt="check your answers page with license number highlighted" src="https://github.com/user-attachments/assets/1a24992b-4c86-4ab1-9076-d815b67fad68" />

## Description of main change(s)

if the steps are not included in this function, an exception will be thrown

## Anything you'd like to highlight to the reviewer?

copilot assures me this is the only case

## Checklist

Delete any that are not applicable, and add explanation below for any that are applicable but haven't been done

- [x] Screenshots of any UI changes have been added
- [ ] Test suite has been run in full locally and is passing
- [x] Branch has been rebased onto main and run locally, with everything working as expected (both for your new feature
  and any related functionality)
- [x] QA instructions have been added to the ticket (particularly if this is the last PR required to complete the ticket)
