### PR TITLE
PDJB-NONE: Restore deterministic seed for CYA child journey IDs

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/shared/states/CheckYourAnswersJourneyState.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/shared/states/CheckYourAnswersJourneyState.kt
@@ -53,7 +53,7 @@ interface CheckYourAnswersJourneyState : JourneyState {
 
     private fun makePair(step: JourneyStep.RequestableStep<*, *, *>): Pair<String, String> {
         val routeSegment = step.routeSegment
-        val cyaJourneyId = generateJourneyId()
+        val cyaJourneyId = generateJourneyId("$baseJourneyId-$routeSegment")
         val childJourney = createChildJourneyState(cyaJourneyId)
         childJourney.checkingAnswersFor = routeSegment
         childJourney.returnToCyaPageDestination = Destination.VisitableStep(cyaStep, baseJourneyId)


### PR DESCRIPTION
## Ticket number

PDJB-NONE

## Goal of change

Fix the OOM crash that occurs in production when a user repeatedly renders a property registration CYA page (e.g. by navigating into change links and back), caused by unbounded session growth.

## Description of main change(s)

Restores the deterministic seed argument to `generateJourneyId` in `CheckYourAnswersJourneyState.makePair`. This is a one-line revert of the seed-removal that was made in PR #1084.

Without the seed, each call to `makePair` minted a new random child journey workspace ID. The `cyaJourneys` map that gates child workspace creation is declared as a plain in-memory `var` on each factory state class (not session-backed), and the state classes are `@Scope("prototype")`, so a fresh empty map is allocated for every request. The `containsKey` guard therefore returns `false` on every render for every section, and `makePair` runs ~23 times per render. With a deterministic seed, every render produces the same set of IDs, and `createChildJourneyState` overwrites the same Redis hash fields in place — bounded. Without the seed, every render mints fresh random IDs and adds ~23 new orphan workspaces to the session.

A single user's session reached ~2 MB after 30 reloads in local repro. The resulting Spring Session re-serialization (~250x amplification factor measured via JFR) was enough to OOM a 2 GB container in a couple of requests.

Re-seeding the ID with `"$baseJourneyId-$routeSegment"` restores the in-place-overwrite property.

Verified locally: across 20 main-CYA reloads + a change-and-abandon cycle, session HLEN stays flat at 30 (vs +23/reload on buggy main).

## Anything you''d like to highlight to the reviewer?

PR #1084 deliberately removed this seed to give independent tabs independent child workspaces (per its description). Restoring the seed reinstates the earlier behaviour where two tabs on the same session share child workspaces, so a refresh in tab A can wipe in-flight CYA edits in tab B.

That trade-off is being knowingly accepted as a quick stabilising fix for the OOM. Follow-ups that should be raised as separate tickets:

1. **Dead-code removal.** With deterministic IDs, the `cyaJourneys` map and the `containsKey` guard in `getCyaJourneyId` are dead state — the guard never hits (per the analysis above) and removing it changes no runtime behaviour. Cleanup would delete the `var cyaJourneys` from the `CheckYourAnswersJourneyState` interface, the 12 `override var cyaJourneys = mapOf()` declarations across the factory state classes, the two `originalState.cyaJourneys -= …` lines in `FinishCyaJourneyConfig` (the existing `state.deleteJourney()` does the real cleanup), and update the two affected test classes. Kept out of this PR to keep the OOM fix to a single line for bisect/review clarity.
2. **Proper architectural fix.** Explicit `init-cya-journey?parentId=…&step=…` endpoints that mint a fresh workspace on demand. Eliminates the eager pre-create-on-render pattern entirely and restores per-tab independence.

## Checklist

- [x] Test suite has been run in full locally and is passing
- [x] Branch has been rebased onto main and run locally, with everything working as expected (both for your new feature and any related functionality)
