### PR TITLE
PDJB-910: clear cya fields after reaching cya step

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/FinishCyaJourneyConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/FinishCyaJourneyConfig.kt
@@ -18,6 +18,7 @@ class FinishCyaJourneyConfig : AbstractInternalStepConfig<Complete, CheckYourAns
         val originalState = state.getBaseJourneyState()
         if (originalState.journeyMetadata.lastUpdated == state.originalJourneyUpdated) {
             state.copyJourneyTo(originalId)
+            originalState.clearCyaFields()
         } else {
             throw CyaDataHasChangedException("Journey data has changed since the user started checking their answers.")
         }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/shared/states/CheckYourAnswersJourneyState.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/shared/states/CheckYourAnswersJourneyState.kt
@@ -67,6 +67,12 @@ interface CheckYourAnswersJourneyState : JourneyState {
 
     var checkingAnswersFor: String?
 
+    fun clearCyaFields() {
+        checkingAnswersFor = null
+        originalJourneyUpdated = null
+        cyaRouteSegment = null
+    }
+
     val baseJourneyId: String
         get() = journeyMetadata.baseJourneyId ?: journeyId
 

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/FinishCyaJourneyConfigTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/FinishCyaJourneyConfigTests.kt
@@ -71,7 +71,7 @@ class FinishCyaJourneyConfigTests {
         }
 
         @Test
-        fun `clears CYA-specific fields from the parent state after copying`() {
+        fun `ensures CYA fields are not present in the parent state that will be saved`() {
             val metadata = JourneyMetadata(baseJourneyId, timestamp)
             whenever(mockOriginalState.journeyMetadata).thenReturn(metadata)
             whenever(mockState.originalJourneyUpdated).thenReturn(timestamp)

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/FinishCyaJourneyConfigTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/FinishCyaJourneyConfigTests.kt
@@ -69,6 +69,17 @@ class FinishCyaJourneyConfigTests {
 
             verify(mockState, never()).copyJourneyTo(baseJourneyId)
         }
+
+        @Test
+        fun `clears CYA-specific fields from the parent state after copying`() {
+            val metadata = JourneyMetadata(baseJourneyId, timestamp)
+            whenever(mockOriginalState.journeyMetadata).thenReturn(metadata)
+            whenever(mockState.originalJourneyUpdated).thenReturn(timestamp)
+
+            config.afterStepIsReached(mockState)
+
+            verify(mockOriginalState).clearCyaFields()
+        }
     }
 
     @Nested


### PR DESCRIPTION
## Ticket number

PDJB-910

## Goal of change

Fix not being able to resume a journey where CYA data has been changed.

## Description of main change(s)

Clears the CYA state upon reaching the CYA step

## Anything you'd like to highlight to the reviewer?

I've tested regressions with this including clicking multiple change links and back buttons, and it seems consistent with the old behaviour.

## Checklist

- [x] Unit tests for new logic (e.g. new service methods) have been added
- [x] Test suite has been run in full locally and is passing
- [x] Branch has been rebased onto main and run locally, with everything working as expected (both for your new feature
  and any related functionality)
- [x] QA instructions have been added to the ticket (particularly if this is the last PR required to complete the ticket)
