### PR TITLE
Release main to test #34

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/ElectricalSafetyRegistrationCyaSummaryRowsFactory.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/ElectricalSafetyRegistrationCyaSummaryRowsFactory.kt
@@ -7,9 +7,12 @@ import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.Elec
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.ElectricalSafetyScenario
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.HasElectricalCertMode
 import uk.gov.communities.prsdb.webapp.models.viewModels.summaryModels.SummaryListRowViewModel
+import uk.gov.communities.prsdb.webapp.models.viewModels.summaryModels.propertyComplianceViewModels.toUploadedFileUrls
+import uk.gov.communities.prsdb.webapp.services.UploadService
 
 class ElectricalSafetyRegistrationCyaSummaryRowsFactory(
     private val state: ElectricalSafetyState,
+    private val uploadService: UploadService,
     private val destinationProvider: (JourneyStep.RequestableStep<*, *, *>) -> Destination = { Destination(it) },
 ) {
     private val scenario: ElectricalSafetyScenario = determineScenario(state)
@@ -33,16 +36,19 @@ class ElectricalSafetyRegistrationCyaSummaryRowsFactory(
         }
 
     private fun getCertUploadedRows(): List<SummaryListRowViewModel> {
-        val uploadFileNames =
+        val certType = state.getElectricalCertificateType()
+        val downloadMessageKey = getDownloadMessageKey(certType)
+        val uploadedFiles =
             state.electricalUploadMap
                 .toList()
                 .sortedBy { it.first }
-                .map { (_, upload) -> upload.fileName }
+                .map { (_, upload) -> uploadService.getFileUploadById(upload.fileUploadId) to upload.fileName }
+                .toUploadedFileUrls(downloadMessageKey, uploadService)
 
         return listOf(
             SummaryListRowViewModel.forCheckYourAnswersPage(
                 fieldHeading = "checkElectricalSafety.electricalCert.fieldHeading",
-                fieldValue = getCertTypeLabel(state.getElectricalCertificateType()),
+                fieldValue = getCertTypeLabel(certType),
                 destination = destinationProvider(state.hasElectricalCertStep),
             ),
             SummaryListRowViewModel.forCheckYourAnswersPage(
@@ -52,11 +58,24 @@ class ElectricalSafetyRegistrationCyaSummaryRowsFactory(
             ),
             SummaryListRowViewModel.forCheckYourAnswersPage(
                 fieldHeading = "checkElectricalSafety.yourCertificate.fieldHeading",
-                fieldValue = uploadFileNames,
+                fieldValue = uploadedFiles,
                 destination = destinationProvider(state.checkElectricalCertUploadsStep),
             ),
         )
     }
+
+    private fun getDownloadMessageKey(certType: HasElectricalSafetyCertificate?): String =
+        when (certType) {
+            HasElectricalSafetyCertificate.HAS_EIC ->
+                "propertyDetails.complianceInformation.electricalSafety.eic.downloadCertificate"
+
+            HasElectricalSafetyCertificate.HAS_EICR ->
+                "propertyDetails.complianceInformation.electricalSafety.eicr.downloadCertificate"
+
+            HasElectricalSafetyCertificate.NO_CERTIFICATE, null -> throw IllegalStateException(
+                "Cert uploaded scenario requires a certificate type",
+            )
+        }
 
     private fun getCertTypeLabel(certType: HasElectricalSafetyCertificate?): String =
         when (certType) {

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/GasSafetyRegistrationCyaSummaryRowsFactory.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/GasSafetyRegistrationCyaSummaryRowsFactory.kt
@@ -7,9 +7,12 @@ import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.GasSa
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.HasGasCertMode
 import uk.gov.communities.prsdb.webapp.journeys.shared.YesOrNo
 import uk.gov.communities.prsdb.webapp.models.viewModels.summaryModels.SummaryListRowViewModel
+import uk.gov.communities.prsdb.webapp.models.viewModels.summaryModels.propertyComplianceViewModels.toUploadedFileUrls
+import uk.gov.communities.prsdb.webapp.services.UploadService
 
 class GasSafetyRegistrationCyaSummaryRowsFactory(
     private val state: GasSafetyState,
+    private val uploadService: UploadService,
     private val destinationProvider: (JourneyStep.RequestableStep<*, *, *>) -> Destination = { Destination(it) },
 ) {
     private val scenario: GasSafetyScenario = determineScenario(state)
@@ -58,11 +61,15 @@ class GasSafetyRegistrationCyaSummaryRowsFactory(
         }
 
     private fun getUploadedCertRows(): List<SummaryListRowViewModel> {
-        val uploadFileNames =
+        val uploadedFiles =
             state.gasUploadMap
                 .toList()
                 .sortedBy { it.first }
-                .map { (_, upload) -> upload.fileName }
+                .map { (_, upload) -> uploadService.getFileUploadById(upload.fileUploadId) to upload.fileName }
+                .toUploadedFileUrls(
+                    downloadMessageKey = "propertyDetails.complianceInformation.gasSafety.downloadCertificate",
+                    uploadService = uploadService,
+                )
 
         return listOf(
             SummaryListRowViewModel.forCheckYourAnswersPage(
@@ -77,7 +84,7 @@ class GasSafetyRegistrationCyaSummaryRowsFactory(
             ),
             SummaryListRowViewModel.forCheckYourAnswersPage(
                 fieldHeading = "checkGasSafety.yourCertificate.fieldHeading",
-                fieldValue = uploadFileNames,
+                fieldValue = uploadedFiles,
                 destination = destinationProvider(state.checkGasCertUploadsStep),
             ),
         )

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/PropertyRegistrationJourneyFactory.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/PropertyRegistrationJourneyFactory.kt
@@ -165,7 +165,11 @@ class PropertyRegistrationJourneyFactory(
                     checkAnswerStep(journey.ownershipTypeStep, OwnershipTypeStep.ROUTE_SEGMENT)
                 }
 
-                LicensingTypeStep.ROUTE_SEGMENT -> {
+                LicensingTypeStep.ROUTE_SEGMENT,
+                SelectiveLicenceStep.ROUTE_SEGMENT,
+                HmoMandatoryLicenceStep.ROUTE_SEGMENT,
+                HmoAdditionalLicenceStep.ROUTE_SEGMENT,
+                -> {
                     checkAnswerTask(journey.licensingTask)
                 }
 

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/CheckElectricalSafetyAnswersStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/CheckElectricalSafetyAnswersStepConfig.kt
@@ -7,13 +7,16 @@ import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.ElectricalS
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.ElectricalSafetyState
 import uk.gov.communities.prsdb.webapp.journeys.shared.Complete
 import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.NoInputFormModel
+import uk.gov.communities.prsdb.webapp.services.UploadService
 
 @JourneyFrameworkComponent
-class CheckElectricalSafetyAnswersStepConfig : AbstractRequestableStepConfig<Complete, NoInputFormModel, ElectricalSafetyState>() {
+class CheckElectricalSafetyAnswersStepConfig(
+    private val uploadService: UploadService,
+) : AbstractRequestableStepConfig<Complete, NoInputFormModel, ElectricalSafetyState>() {
     override val formModelClass = NoInputFormModel::class
 
     override fun getStepSpecificContent(state: ElectricalSafetyState): Map<String, Any?> {
-        val factory = ElectricalSafetyRegistrationCyaSummaryRowsFactory(state)
+        val factory = ElectricalSafetyRegistrationCyaSummaryRowsFactory(state, uploadService)
         return mapOf(
             "rows" to factory.createRows(),
             "insetTextKey" to factory.getInsetTextKey(),

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/CheckGasSafetyAnswersStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/CheckGasSafetyAnswersStepConfig.kt
@@ -7,13 +7,16 @@ import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.GasSafetyRe
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.GasSafetyState
 import uk.gov.communities.prsdb.webapp.journeys.shared.Complete
 import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.NoInputFormModel
+import uk.gov.communities.prsdb.webapp.services.UploadService
 
 @JourneyFrameworkComponent
-class CheckGasSafetyAnswersStepConfig : AbstractRequestableStepConfig<Complete, NoInputFormModel, GasSafetyState>() {
+class CheckGasSafetyAnswersStepConfig(
+    private val uploadService: UploadService,
+) : AbstractRequestableStepConfig<Complete, NoInputFormModel, GasSafetyState>() {
     override val formModelClass = NoInputFormModel::class
 
     override fun getStepSpecificContent(state: GasSafetyState): Map<String, Any?> {
-        val factory = GasSafetyRegistrationCyaSummaryRowsFactory(state)
+        val factory = GasSafetyRegistrationCyaSummaryRowsFactory(state, uploadService)
         return mapOf(
             "gasSupplyRows" to factory.createGasSupplyRows(),
             "certRows" to factory.createCertRows(),

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/FinishCyaJourneyConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/FinishCyaJourneyConfig.kt
@@ -18,6 +18,7 @@ class FinishCyaJourneyConfig : AbstractInternalStepConfig<Complete, CheckYourAns
         val originalState = state.getBaseJourneyState()
         if (originalState.journeyMetadata.lastUpdated == state.originalJourneyUpdated) {
             state.copyJourneyTo(originalId)
+            originalState.clearCyaFields()
         } else {
             throw CyaDataHasChangedException("Journey data has changed since the user started checking their answers.")
         }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/update/electricalSafety/UpdateCheckElectricalSafetyAnswersStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/update/electricalSafety/UpdateCheckElectricalSafetyAnswersStepConfig.kt
@@ -7,15 +7,17 @@ import uk.gov.communities.prsdb.webapp.journeys.JourneyStep.RequestableStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.ElectricalSafetyRegistrationCyaSummaryRowsFactory
 import uk.gov.communities.prsdb.webapp.journeys.shared.Complete
 import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.NoInputFormModel
+import uk.gov.communities.prsdb.webapp.services.UploadService
 
 @JourneyFrameworkComponent
-class UpdateCheckElectricalSafetyAnswersStepConfig :
-    AbstractRequestableStepConfig<Complete, NoInputFormModel, UpdateElectricalSafetyJourneyState>() {
+class UpdateCheckElectricalSafetyAnswersStepConfig(
+    private val uploadService: UploadService,
+) : AbstractRequestableStepConfig<Complete, NoInputFormModel, UpdateElectricalSafetyJourneyState>() {
     override val formModelClass = NoInputFormModel::class
 
     override fun getStepSpecificContent(state: UpdateElectricalSafetyJourneyState): Map<String, Any?> {
         val factory =
-            ElectricalSafetyRegistrationCyaSummaryRowsFactory(state) { step ->
+            ElectricalSafetyRegistrationCyaSummaryRowsFactory(state, uploadService) { step ->
                 Destination.VisitableStep(step, state.getCyaJourneyId(step))
             }
         return mapOf(

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/update/gasSafety/UpdateCheckGasSafetyAnswersStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/update/gasSafety/UpdateCheckGasSafetyAnswersStepConfig.kt
@@ -7,14 +7,17 @@ import uk.gov.communities.prsdb.webapp.journeys.JourneyStep.RequestableStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.GasSafetyRegistrationCyaSummaryRowsFactory
 import uk.gov.communities.prsdb.webapp.journeys.shared.Complete
 import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.NoInputFormModel
+import uk.gov.communities.prsdb.webapp.services.UploadService
 
 @JourneyFrameworkComponent
-class UpdateCheckGasSafetyAnswersStepConfig : AbstractRequestableStepConfig<Complete, NoInputFormModel, UpdateGasSafetyJourneyState>() {
+class UpdateCheckGasSafetyAnswersStepConfig(
+    private val uploadService: UploadService,
+) : AbstractRequestableStepConfig<Complete, NoInputFormModel, UpdateGasSafetyJourneyState>() {
     override val formModelClass = NoInputFormModel::class
 
     override fun getStepSpecificContent(state: UpdateGasSafetyJourneyState): Map<String, Any?> {
         val factory =
-            GasSafetyRegistrationCyaSummaryRowsFactory(state) { step ->
+            GasSafetyRegistrationCyaSummaryRowsFactory(state, uploadService) { step ->
                 Destination.VisitableStep(step, state.getCyaJourneyId(step))
             }
         return mapOf(

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/update/householdsAndTenants/UpdateHouseholdsAndTenantsJourneyFactory.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/update/householdsAndTenants/UpdateHouseholdsAndTenantsJourneyFactory.kt
@@ -58,6 +58,7 @@ class UpdateHouseholdsAndTenantsJourneyFactory(
             unreachableStepUrl { propertyDetailsRoute }
             task(journey.householdsAndTenantsTask) {
                 initialStep()
+                backUrl { propertyDetailsRoute }
                 nextStep { journey.cyaStep }
                 withAdditionalContentProperty {
                     "title" to "propertyDetails.update.title"

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/update/occupancy/UpdateOccupancyJourneyFactory.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/update/occupancy/UpdateOccupancyJourneyFactory.kt
@@ -73,6 +73,7 @@ class UpdateOccupancyJourneyFactory(
             unreachableStepUrl { propertyDetailsRoute }
             task(journey.occupationTask) {
                 initialStep()
+                backUrl { propertyDetailsRoute }
                 nextStep { journey.cyaStep }
                 withAdditionalContentProperty {
                     "title" to "propertyDetails.update.title"

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/update/rentFrequencyAndAmount/UpdateRentFrequencyAndAmountJourneyFactory.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/update/rentFrequencyAndAmount/UpdateRentFrequencyAndAmountJourneyFactory.kt
@@ -59,6 +59,7 @@ class UpdateRentFrequencyAndAmountJourneyFactory(
             unreachableStepUrl { propertyDetailsRoute }
             task(journey.rentFrequencyAndAmountTask) {
                 initialStep()
+                backUrl { propertyDetailsRoute }
                 nextStep { journey.cyaStep }
                 withAdditionalContentProperty {
                     "title" to "propertyDetails.update.title"

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/update/rentIncludesBills/UpdateRentIncludesBillsJourneyFactory.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/update/rentIncludesBills/UpdateRentIncludesBillsJourneyFactory.kt
@@ -60,6 +60,7 @@ class UpdateRentIncludesBillsJourneyFactory(
             unreachableStepUrl { propertyDetailsRoute }
             task(journey.rentIncludesBillsTask) {
                 initialStep()
+                backUrl { propertyDetailsRoute }
                 nextStep { journey.cyaStep }
                 withAdditionalContentProperty {
                     "title" to "propertyDetails.update.title"

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/update/updateLicensing/UpdatePropertyLicensingJourneyFactory.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/update/updateLicensing/UpdatePropertyLicensingJourneyFactory.kt
@@ -4,7 +4,7 @@ import kotlinx.datetime.Instant
 import org.springframework.beans.factory.ObjectFactory
 import uk.gov.communities.prsdb.webapp.annotations.webAnnotations.JourneyFrameworkComponent
 import uk.gov.communities.prsdb.webapp.annotations.webAnnotations.PrsdbWebService
-import uk.gov.communities.prsdb.webapp.controllers.PropertyDetailsController.Companion.LANDLORD_PROPERTY_DETAILS_ROUTE
+import uk.gov.communities.prsdb.webapp.controllers.PropertyDetailsController
 import uk.gov.communities.prsdb.webapp.exceptions.PrsdbWebException
 import uk.gov.communities.prsdb.webapp.journeys.AbstractPropertyOwnershipUpdateJourneyState
 import uk.gov.communities.prsdb.webapp.journeys.Destination
@@ -75,9 +75,11 @@ class UpdateLicensingJourneyFactory(
 
     private fun mainJourneyMap(state: UpdateLicensingJourney): Map<String, StepLifecycleOrchestrator> =
         journey(state) {
-            unreachableStepUrl { "/" }
+            val propertyDetailsRoute = PropertyDetailsController.getPropertyDetailsPath(journey.propertyId)
+            unreachableStepUrl { propertyDetailsRoute }
             task(journey.licensingTask) {
                 initialStep()
+                backUrl { propertyDetailsRoute }
                 nextStep { journey.cyaStep }
                 withAdditionalContentProperty {
                     "title" to "propertyDetails.update.title"
@@ -86,7 +88,7 @@ class UpdateLicensingJourneyFactory(
             step(journey.cyaStep) {
                 routeSegment(UpdateLicensingCyaStep.ROUTE_SEGMENT)
                 parents { journey.licensingTask.isComplete() }
-                nextUrl { LANDLORD_PROPERTY_DETAILS_ROUTE }
+                nextUrl { propertyDetailsRoute }
             }
             configureStep(journey.licensingTypeStep) {
                 withAdditionalContentProperty {

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/shared/helpers/ComplianceDetailsHelper.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/shared/helpers/ComplianceDetailsHelper.kt
@@ -10,14 +10,16 @@ import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.EpcS
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.GasSafetyState
 import uk.gov.communities.prsdb.webapp.journeys.shared.states.CheckYourAnswersJourneyState
 import uk.gov.communities.prsdb.webapp.services.EpcCertificateUrlProvider
+import uk.gov.communities.prsdb.webapp.services.UploadService
 
 @PrsdbWebService
 class ComplianceDetailsHelper(
     private val epcCertificateUrlProvider: EpcCertificateUrlProvider,
+    private val uploadService: UploadService,
 ) {
     fun <T> getGasSafetyCyaContent(state: T): Map<String, Any?> where T : GasSafetyState, T : CheckYourAnswersJourneyState {
         val factory =
-            GasSafetyRegistrationCyaSummaryRowsFactory(state) { step ->
+            GasSafetyRegistrationCyaSummaryRowsFactory(state, uploadService) { step ->
                 Destination.VisitableStep(step, state.getCyaJourneyId(step))
             }
         return mapOf(
@@ -29,7 +31,7 @@ class ComplianceDetailsHelper(
 
     fun <T> getElectricalSafetyCyaContent(state: T): Map<String, Any?> where T : ElectricalSafetyState, T : CheckYourAnswersJourneyState {
         val factory =
-            ElectricalSafetyRegistrationCyaSummaryRowsFactory(state) { step ->
+            ElectricalSafetyRegistrationCyaSummaryRowsFactory(state, uploadService) { step ->
                 Destination.VisitableStep(step, state.getCyaJourneyId(step))
             }
         return mapOf(

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/shared/states/CheckYourAnswersJourneyState.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/shared/states/CheckYourAnswersJourneyState.kt
@@ -53,7 +53,7 @@ interface CheckYourAnswersJourneyState : JourneyState {
 
     private fun makePair(step: JourneyStep.RequestableStep<*, *, *>): Pair<String, String> {
         val routeSegment = step.routeSegment
-        val cyaJourneyId = generateJourneyId()
+        val cyaJourneyId = generateJourneyId("$baseJourneyId-$routeSegment")
         val childJourney = createChildJourneyState(cyaJourneyId)
         childJourney.checkingAnswersFor = routeSegment
         childJourney.returnToCyaPageDestination = Destination.VisitableStep(cyaStep, baseJourneyId)

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/shared/states/CheckYourAnswersJourneyState.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/shared/states/CheckYourAnswersJourneyState.kt
@@ -67,6 +67,12 @@ interface CheckYourAnswersJourneyState : JourneyState {
 
     var checkingAnswersFor: String?
 
+    fun clearCyaFields() {
+        checkingAnswersFor = null
+        originalJourneyUpdated = null
+        cyaRouteSegment = null
+    }
+
     val baseJourneyId: String
         get() = journeyMetadata.baseJourneyId ?: journeyId
 

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/summaryModels/propertyComplianceViewModels/ComplianceUploadRowHelper.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/summaryModels/propertyComplianceViewModels/ComplianceUploadRowHelper.kt
@@ -21,29 +21,36 @@ fun MutableList<SummaryListRowViewModel>.addFileUploadRows(
     }
 
     val values =
-        visibleUploads.mapNotNull { upload ->
-            val displayName = upload.fileName ?: "$fallbackFileName.${upload.extension}"
-            when (upload.status) {
-                FileUploadStatus.SCANNED ->
-                    UploadedFileUrl(
-                        messageKey = downloadMessageKey,
-                        displayName = displayName,
-                        url = uploadService.getDownloadUrlOrNull(upload, displayName),
-                    )
-
-                FileUploadStatus.QUARANTINED ->
-                    UploadedFileUrl(
-                        messageKey = VIRUS_SCAN_PENDING_WITH_NAME_KEY,
-                        displayName = displayName,
-                    )
-
-                else -> null
-            }
-        }
+        visibleUploads
+            .map { upload -> upload to (upload.fileName ?: "$fallbackFileName.${upload.extension}") }
+            .toUploadedFileUrls(downloadMessageKey, uploadService)
 
     if (values.isNotEmpty()) {
         add(SummaryListRowViewModel(certificateKey, values))
     }
 }
+
+fun List<Pair<FileUpload, String>>.toUploadedFileUrls(
+    downloadMessageKey: String,
+    uploadService: UploadService,
+): List<UploadedFileUrl> =
+    mapNotNull { (upload, displayName) ->
+        when (upload.status) {
+            FileUploadStatus.SCANNED ->
+                UploadedFileUrl(
+                    messageKey = downloadMessageKey,
+                    displayName = displayName,
+                    url = uploadService.getDownloadUrlOrNull(upload, displayName),
+                )
+
+            FileUploadStatus.QUARANTINED ->
+                UploadedFileUrl(
+                    messageKey = VIRUS_SCAN_PENDING_WITH_NAME_KEY,
+                    displayName = displayName,
+                )
+
+            FileUploadStatus.DELETED -> null
+        }
+    }
 
 private const val VIRUS_SCAN_PENDING_WITH_NAME_KEY = "propertyCompliance.uploadedFile.virusScanPendingWithName"

--- a/src/main/resources/emails/LocalCouncilUserInvitationInformAdminEmail.md
+++ b/src/main/resources/emails/LocalCouncilUserInvitationInformAdminEmail.md
@@ -4,8 +4,6 @@
 
 ^ ((Local Council Name))
 
-You'll receive an email if this person accepts the invitation to register as a local council user.
-
 If the person invited does not respond, contact them directly.
 
 If you think this was a mistake, you can cancel the invite.

--- a/src/main/resources/emails/emailTemplates.json
+++ b/src/main/resources/emails/emailTemplates.json
@@ -122,10 +122,10 @@
     "bodyLocation": "/emails/LocalCouncilRegistrationConfirmation.md"
   },
   {
-    "test_id": "df6e1f82-2a36-4a83-86e1-a1c122bf81aa",
-    "prod_id": "a7de7897-0758-4e8d-823f-6c652d502045",
+    "test_id": "aafefbd6-f109-4728-ad8b-c7b0bc44ef54",
+    "prod_id": "c916a57a-4099-490b-b195-41e337530c0f",
     "enumName": "LOCAL_COUNCIL_USER_DELETION_EMAIL",
-    "subject": "You can no longer access check rental properties or landlords",
+    "subject": "You can no longer access Check a rental property or landlord",
     "bodyLocation": "/emails/LocalCouncilUserDeletion.md"
   },
   {
@@ -136,8 +136,8 @@
     "bodyLocation": "/emails/LocalCouncilUserDeletionAdminEmail.md"
   },
   {
-    "test_id": "f2de4378-b15f-437b-b1df-2cc94362a130",
-    "prod_id": "473dc4ec-b6ea-4437-ab43-eaf6ac8b60ef",
+    "test_id": "180829b1-6d2b-4346-86c0-53d65a6d0eb4",
+    "prod_id": "4ee75f0d-b182-4577-80e8-1f79184ac6ae",
     "enumName": "LOCAL_COUNCIL_USER_INVITATION_INFORM_ADMIN_EMAIL",
     "subject": "A user has been invited to register as a local council user on Check a rental property or landlord",
     "bodyLocation": "/emails/LocalCouncilUserInvitationInformAdminEmail.md"

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/PropertyRegistrationSinglePageTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/PropertyRegistrationSinglePageTests.kt
@@ -47,6 +47,7 @@ import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyReg
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyRegistrationJourneyPages.OccupancyFormPagePropertyRegistration
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyRegistrationJourneyPages.OwnershipTypeFormPagePropertyRegistration
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyRegistrationJourneyPages.RemoveJointLandlordAreYouSureFormPagePropertyRegistration
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyRegistrationJourneyPages.SelectiveLicenceFormPagePropertyRegistration
 import uk.gov.communities.prsdb.webapp.models.dataModels.AddressDataModel
 import uk.gov.communities.prsdb.webapp.testHelpers.builders.PropertyStateSessionBuilder
 import kotlin.test.assertTrue
@@ -1315,6 +1316,15 @@ class PropertyRegistrationSinglePageTests : IntegrationTestWithImmutableData("da
             val checkAnswersPage = navigator.skipToPropertyRegistrationCheckAnswersPageNoEpc()
             checkAnswersPage.complianceSummaryList.hasEpcRow.clickFirstActionLinkAndWait()
             assertPageIs(page, HasEpcFormPagePropertyRegistration::class)
+        }
+
+        @Test
+        fun `the licensing number change link navigates to the licensing page`(page: Page) {
+            val checkAnswersPage = navigator.skipToPropertyRegistrationCheckAnswersPageWithSelectiveLicence()
+            checkAnswersPage.summaryList.licensingNumberRow.clickFirstActionLinkAndWait()
+            val selectiveLicencePage = assertPageIs(page, SelectiveLicenceFormPagePropertyRegistration::class)
+            selectiveLicencePage.submitLicenseNumber("SL-99999")
+            assertPageIs(page, CheckAnswersPagePropertyRegistration::class)
         }
     }
 

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/Navigator.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/Navigator.kt
@@ -743,6 +743,12 @@ class Navigator(
         return createValidPage(page, CheckAnswersPagePropertyRegistration::class)
     }
 
+    fun skipToPropertyRegistrationCheckAnswersPageWithSelectiveLicence(): CheckAnswersPagePropertyRegistration {
+        setJourneyStateInSession(PropertyStateSessionBuilder.beforePropertyRegistrationCheckAnswersWithSelectiveLicence().build())
+        navigateToPropertyRegistrationJourneyStep(PropertyRegistrationCyaStep.ROUTE_SEGMENT)
+        return createValidPage(page, CheckAnswersPagePropertyRegistration::class)
+    }
+
     fun skipToPropertyRegistrationCheckAnswersPageOccupied(
         households: Int = 2,
         people: Int = 4,

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/propertyRegistrationJourneyPages/CheckAnswersPagePropertyRegistration.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/propertyRegistrationJourneyPages/CheckAnswersPagePropertyRegistration.kt
@@ -44,6 +44,7 @@ class CheckAnswersPagePropertyRegistration(
     ) : SummaryList(page) {
         val ownershipRow = getRow("Ownership type")
         val licensingRow = getRow("Licensing type")
+        val licensingNumberRow = getRow("Licensing number")
         val numberOfHouseholdsRow = getRow("Number of households")
         val numberOfTenantsRow = getRow("Number of tenants")
         val numberOfBedroomsRow = getRow("Number of bedrooms")

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/ElectricalSafetyRegistrationCyaSummaryRowsFactoryTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/ElectricalSafetyRegistrationCyaSummaryRowsFactoryTests.kt
@@ -8,15 +8,21 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
+import uk.gov.communities.prsdb.webapp.constants.enums.FileUploadStatus
 import uk.gov.communities.prsdb.webapp.constants.enums.HasElectricalSafetyCertificate
+import uk.gov.communities.prsdb.webapp.database.entity.FileUpload
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.CertificateUpload
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.ElectricalSafetyState
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.CheckElectricalCertUploadsStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.ElectricalCertExpiryDateStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.HasElectricalCertMode
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.HasElectricalCertStep
+import uk.gov.communities.prsdb.webapp.models.viewModels.summaryModels.UploadedFileUrl
+import uk.gov.communities.prsdb.webapp.services.UploadService
 
 @ExtendWith(MockitoExtension::class)
 class ElectricalSafetyRegistrationCyaSummaryRowsFactoryTests {
@@ -26,6 +32,20 @@ class ElectricalSafetyRegistrationCyaSummaryRowsFactoryTests {
     private val mockHasElectricalCertStep: HasElectricalCertStep = mock()
     private val mockElectricalCertExpiryDateStep: ElectricalCertExpiryDateStep = mock()
     private val mockCheckElectricalCertUploadsStep: CheckElectricalCertUploadsStep = mock()
+    private val mockUploadService: UploadService = mock()
+
+    private fun fileUploadWithStatus(status: FileUploadStatus): FileUpload =
+        mock<FileUpload>().also { whenever(it.status).thenReturn(status) }
+
+    private fun stubUpload(
+        fileUploadId: Long,
+        status: FileUploadStatus,
+        downloadUrl: String? = null,
+    ) {
+        val fileUpload = fileUploadWithStatus(status)
+        whenever(mockUploadService.getFileUploadById(fileUploadId)).thenReturn(fileUpload)
+        whenever(mockUploadService.getDownloadUrlOrNull(eq(fileUpload), any())).thenReturn(downloadUrl)
+    }
 
     private fun setupCommonStateMocks() {
         whenever(mockState.hasElectricalCertStep).thenReturn(mockHasElectricalCertStep)
@@ -35,7 +55,7 @@ class ElectricalSafetyRegistrationCyaSummaryRowsFactoryTests {
     @Nested
     inner class CertUploaded {
         @Test
-        fun `factory returns correct content for EIC with uploads`() {
+        fun `factory wires up EIC download messageKey and sorts uploads by map index`() {
             setupCommonStateMocks()
             whenever(mockHasElectricalCertStep.outcome).thenReturn(HasElectricalCertMode.HAS_EIC)
             whenever(mockState.getElectricalCertificateIsOutdated()).thenReturn(false)
@@ -43,60 +63,6 @@ class ElectricalSafetyRegistrationCyaSummaryRowsFactoryTests {
 
             val expiryDate = LocalDate(2026, 6, 15)
             whenever(mockState.getElectricalCertificateExpiryDateIfReachable()).thenReturn(expiryDate)
-
-            whenever(mockState.electricalCertExpiryDateStep).thenReturn(mockElectricalCertExpiryDateStep)
-            whenever(mockState.checkElectricalCertUploadsStep).thenReturn(mockCheckElectricalCertUploadsStep)
-            whenever(mockElectricalCertExpiryDateStep.currentJourneyId).thenReturn("test-journey-id")
-            whenever(mockCheckElectricalCertUploadsStep.currentJourneyId).thenReturn("test-journey-id")
-            whenever(mockState.electricalUploadMap).thenReturn(
-                mapOf(1 to CertificateUpload(1L, "cert.pdf")),
-            )
-
-            val factory = ElectricalSafetyRegistrationCyaSummaryRowsFactory(mockState)
-
-            val rows = factory.createRows()
-            assertEquals(3, rows.size)
-            assertEquals("checkElectricalSafety.eicLabel", rows[0].fieldValue)
-            assertEquals(expiryDate, rows[1].fieldValue)
-            assertEquals(listOf("cert.pdf"), rows[2].fieldValue)
-
-            assertNull(factory.getInsetTextKey())
-        }
-
-        @Test
-        fun `factory returns correct content for EICR with uploads`() {
-            setupCommonStateMocks()
-            whenever(mockHasElectricalCertStep.outcome).thenReturn(HasElectricalCertMode.HAS_EICR)
-            whenever(mockState.getElectricalCertificateIsOutdated()).thenReturn(false)
-            whenever(mockState.getElectricalCertificateType()).thenReturn(HasElectricalSafetyCertificate.HAS_EICR)
-
-            val expiryDate = LocalDate(2026, 6, 15)
-            whenever(mockState.getElectricalCertificateExpiryDateIfReachable()).thenReturn(expiryDate)
-
-            whenever(mockState.electricalCertExpiryDateStep).thenReturn(mockElectricalCertExpiryDateStep)
-            whenever(mockState.checkElectricalCertUploadsStep).thenReturn(mockCheckElectricalCertUploadsStep)
-            whenever(mockElectricalCertExpiryDateStep.currentJourneyId).thenReturn("test-journey-id")
-            whenever(mockCheckElectricalCertUploadsStep.currentJourneyId).thenReturn("test-journey-id")
-            whenever(mockState.electricalUploadMap).thenReturn(
-                mapOf(1 to CertificateUpload(1L, "cert.pdf")),
-            )
-
-            val factory = ElectricalSafetyRegistrationCyaSummaryRowsFactory(mockState)
-
-            val rows = factory.createRows()
-            assertEquals(3, rows.size)
-            assertEquals("checkElectricalSafety.eicrLabel", rows[0].fieldValue)
-
-            assertNull(factory.getInsetTextKey())
-        }
-
-        @Test
-        fun `factory sorts uploads by map key and returns file names`() {
-            setupCommonStateMocks()
-            whenever(mockHasElectricalCertStep.outcome).thenReturn(HasElectricalCertMode.HAS_EIC)
-            whenever(mockState.getElectricalCertificateIsOutdated()).thenReturn(false)
-            whenever(mockState.getElectricalCertificateType()).thenReturn(HasElectricalSafetyCertificate.HAS_EIC)
-            whenever(mockState.getElectricalCertificateExpiryDateIfReachable()).thenReturn(LocalDate(2026, 6, 15))
 
             whenever(mockState.electricalCertExpiryDateStep).thenReturn(mockElectricalCertExpiryDateStep)
             whenever(mockState.checkElectricalCertUploadsStep).thenReturn(mockCheckElectricalCertUploadsStep)
@@ -104,16 +70,71 @@ class ElectricalSafetyRegistrationCyaSummaryRowsFactoryTests {
             whenever(mockCheckElectricalCertUploadsStep.currentJourneyId).thenReturn("test-journey-id")
             whenever(mockState.electricalUploadMap).thenReturn(
                 mapOf(
-                    3 to CertificateUpload(3L, "third.pdf"),
-                    1 to CertificateUpload(1L, "first.pdf"),
                     2 to CertificateUpload(2L, "second.pdf"),
+                    1 to CertificateUpload(1L, "first.pdf"),
                 ),
             )
+            stubUpload(1L, FileUploadStatus.SCANNED, downloadUrl = "/download/first.pdf")
+            stubUpload(2L, FileUploadStatus.SCANNED, downloadUrl = "/download/second.pdf")
 
-            val factory = ElectricalSafetyRegistrationCyaSummaryRowsFactory(mockState)
+            val factory = ElectricalSafetyRegistrationCyaSummaryRowsFactory(mockState, mockUploadService)
 
             val rows = factory.createRows()
-            assertEquals(listOf("first.pdf", "second.pdf", "third.pdf"), rows[2].fieldValue)
+            assertEquals(3, rows.size)
+            assertEquals("checkElectricalSafety.eicLabel", rows[0].fieldValue)
+            assertEquals(expiryDate, rows[1].fieldValue)
+            assertEquals(
+                listOf(
+                    UploadedFileUrl(
+                        messageKey = "propertyDetails.complianceInformation.electricalSafety.eic.downloadCertificate",
+                        displayName = "first.pdf",
+                        url = "/download/first.pdf",
+                    ),
+                    UploadedFileUrl(
+                        messageKey = "propertyDetails.complianceInformation.electricalSafety.eic.downloadCertificate",
+                        displayName = "second.pdf",
+                        url = "/download/second.pdf",
+                    ),
+                ),
+                rows[2].fieldValue,
+            )
+
+            assertNull(factory.getInsetTextKey())
+        }
+
+        @Test
+        fun `factory wires up EICR download messageKey`() {
+            setupCommonStateMocks()
+            whenever(mockHasElectricalCertStep.outcome).thenReturn(HasElectricalCertMode.HAS_EICR)
+            whenever(mockState.getElectricalCertificateIsOutdated()).thenReturn(false)
+            whenever(mockState.getElectricalCertificateType()).thenReturn(HasElectricalSafetyCertificate.HAS_EICR)
+
+            whenever(mockState.getElectricalCertificateExpiryDateIfReachable()).thenReturn(LocalDate(2026, 6, 15))
+
+            whenever(mockState.electricalCertExpiryDateStep).thenReturn(mockElectricalCertExpiryDateStep)
+            whenever(mockState.checkElectricalCertUploadsStep).thenReturn(mockCheckElectricalCertUploadsStep)
+            whenever(mockElectricalCertExpiryDateStep.currentJourneyId).thenReturn("test-journey-id")
+            whenever(mockCheckElectricalCertUploadsStep.currentJourneyId).thenReturn("test-journey-id")
+            whenever(mockState.electricalUploadMap).thenReturn(
+                mapOf(1 to CertificateUpload(1L, "cert.pdf")),
+            )
+            stubUpload(1L, FileUploadStatus.SCANNED, downloadUrl = "/download/cert.pdf")
+
+            val factory = ElectricalSafetyRegistrationCyaSummaryRowsFactory(mockState, mockUploadService)
+
+            val rows = factory.createRows()
+            assertEquals(3, rows.size)
+            assertEquals("checkElectricalSafety.eicrLabel", rows[0].fieldValue)
+            assertEquals(
+                listOf(
+                    UploadedFileUrl(
+                        messageKey = "propertyDetails.complianceInformation.electricalSafety.eicr.downloadCertificate",
+                        displayName = "cert.pdf",
+                        url = "/download/cert.pdf",
+                    ),
+                ),
+                rows[2].fieldValue,
+            )
         }
     }
 
@@ -125,7 +146,7 @@ class ElectricalSafetyRegistrationCyaSummaryRowsFactoryTests {
             whenever(mockHasElectricalCertStep.outcome).thenReturn(HasElectricalCertMode.PROVIDE_THIS_LATER)
             whenever(mockState.isOccupied).thenReturn(true)
 
-            val factory = ElectricalSafetyRegistrationCyaSummaryRowsFactory(mockState)
+            val factory = ElectricalSafetyRegistrationCyaSummaryRowsFactory(mockState, mockUploadService)
 
             val rows = factory.createRows()
             assertEquals(1, rows.size)
@@ -140,7 +161,7 @@ class ElectricalSafetyRegistrationCyaSummaryRowsFactoryTests {
             whenever(mockHasElectricalCertStep.outcome).thenReturn(HasElectricalCertMode.PROVIDE_THIS_LATER)
             whenever(mockState.isOccupied).thenReturn(false)
 
-            val factory = ElectricalSafetyRegistrationCyaSummaryRowsFactory(mockState)
+            val factory = ElectricalSafetyRegistrationCyaSummaryRowsFactory(mockState, mockUploadService)
 
             val rows = factory.createRows()
             assertEquals(1, rows.size)
@@ -158,7 +179,7 @@ class ElectricalSafetyRegistrationCyaSummaryRowsFactoryTests {
             whenever(mockHasElectricalCertStep.outcome).thenReturn(HasElectricalCertMode.NO_CERTIFICATE)
             whenever(mockState.isOccupied).thenReturn(true)
 
-            val factory = ElectricalSafetyRegistrationCyaSummaryRowsFactory(mockState)
+            val factory = ElectricalSafetyRegistrationCyaSummaryRowsFactory(mockState, mockUploadService)
 
             val rows = factory.createRows()
             assertEquals(1, rows.size)
@@ -173,7 +194,7 @@ class ElectricalSafetyRegistrationCyaSummaryRowsFactoryTests {
             whenever(mockHasElectricalCertStep.outcome).thenReturn(HasElectricalCertMode.NO_CERTIFICATE)
             whenever(mockState.isOccupied).thenReturn(false)
 
-            val factory = ElectricalSafetyRegistrationCyaSummaryRowsFactory(mockState)
+            val factory = ElectricalSafetyRegistrationCyaSummaryRowsFactory(mockState, mockUploadService)
 
             val rows = factory.createRows()
             assertEquals(1, rows.size)
@@ -192,7 +213,7 @@ class ElectricalSafetyRegistrationCyaSummaryRowsFactoryTests {
             whenever(mockState.getElectricalCertificateIsOutdated()).thenReturn(true)
             whenever(mockState.isOccupied).thenReturn(true)
 
-            val factory = ElectricalSafetyRegistrationCyaSummaryRowsFactory(mockState)
+            val factory = ElectricalSafetyRegistrationCyaSummaryRowsFactory(mockState, mockUploadService)
 
             val rows = factory.createRows()
             assertEquals(1, rows.size)
@@ -208,7 +229,7 @@ class ElectricalSafetyRegistrationCyaSummaryRowsFactoryTests {
             whenever(mockState.getElectricalCertificateIsOutdated()).thenReturn(true)
             whenever(mockState.isOccupied).thenReturn(false)
 
-            val factory = ElectricalSafetyRegistrationCyaSummaryRowsFactory(mockState)
+            val factory = ElectricalSafetyRegistrationCyaSummaryRowsFactory(mockState, mockUploadService)
 
             val rows = factory.createRows()
             assertEquals(1, rows.size)

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/GasSafetyRegistrationCyaSummaryRowsFactoryTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/GasSafetyRegistrationCyaSummaryRowsFactoryTests.kt
@@ -8,8 +8,12 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
+import uk.gov.communities.prsdb.webapp.constants.enums.FileUploadStatus
+import uk.gov.communities.prsdb.webapp.database.entity.FileUpload
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.CertificateUpload
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.GasSafetyState
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.CheckGasCertUploadsStep
@@ -19,6 +23,8 @@ import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.HasGa
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.HasGasSupplyStep
 import uk.gov.communities.prsdb.webapp.journeys.shared.YesOrNo
 import uk.gov.communities.prsdb.webapp.models.viewModels.summaryModels.SummaryListRowViewModel
+import uk.gov.communities.prsdb.webapp.models.viewModels.summaryModels.UploadedFileUrl
+import uk.gov.communities.prsdb.webapp.services.UploadService
 
 @ExtendWith(MockitoExtension::class)
 class GasSafetyRegistrationCyaSummaryRowsFactoryTests {
@@ -29,6 +35,20 @@ class GasSafetyRegistrationCyaSummaryRowsFactoryTests {
     private val mockHasGasCertStep: HasGasCertStep = mock()
     private val mockGasCertIssueDateStep: GasCertIssueDateStep = mock()
     private val mockCheckGasCertUploadsStep: CheckGasCertUploadsStep = mock()
+    private val mockUploadService: UploadService = mock()
+
+    private fun fileUploadWithStatus(status: FileUploadStatus): FileUpload =
+        mock<FileUpload>().also { whenever(it.status).thenReturn(status) }
+
+    private fun stubUpload(
+        fileUploadId: Long,
+        status: FileUploadStatus,
+        downloadUrl: String? = null,
+    ) {
+        val fileUpload = fileUploadWithStatus(status)
+        whenever(mockUploadService.getFileUploadById(fileUploadId)).thenReturn(fileUpload)
+        whenever(mockUploadService.getDownloadUrlOrNull(eq(fileUpload), any())).thenReturn(downloadUrl)
+    }
 
     private fun setupCommonStateMocks() {
         whenever(mockState.hasGasSupplyStep).thenReturn(mockHasGasSupplyStep)
@@ -45,7 +65,7 @@ class GasSafetyRegistrationCyaSummaryRowsFactoryTests {
             whenever(mockHasGasSupplyStep.currentJourneyId).thenReturn("test-journey-id")
             whenever(mockHasGasSupplyStep.outcome).thenReturn(YesOrNo.NO)
 
-            val factory = GasSafetyRegistrationCyaSummaryRowsFactory(mockState)
+            val factory = GasSafetyRegistrationCyaSummaryRowsFactory(mockState, mockUploadService)
 
             val gasSupplyRows = factory.createGasSupplyRows()
             assertEquals(1, gasSupplyRows.size)
@@ -61,7 +81,7 @@ class GasSafetyRegistrationCyaSummaryRowsFactoryTests {
     @Nested
     inner class UploadedCertificate {
         @Test
-        fun `factory returns correct content for valid cert with uploads`() {
+        fun `factory wires up gas download messageKey and sorts uploads by map index`() {
             setupCommonStateMocks()
             whenever(mockHasGasSupplyStep.outcome).thenReturn(YesOrNo.YES)
             whenever(mockHasGasCertStep.outcome).thenReturn(HasGasCertMode.HAS_CERTIFICATE)
@@ -75,10 +95,15 @@ class GasSafetyRegistrationCyaSummaryRowsFactoryTests {
             whenever(mockGasCertIssueDateStep.currentJourneyId).thenReturn("test-journey-id")
             whenever(mockCheckGasCertUploadsStep.currentJourneyId).thenReturn("test-journey-id")
             whenever(mockState.gasUploadMap).thenReturn(
-                mapOf(1 to CertificateUpload(1L, "cert.pdf")),
+                mapOf(
+                    2 to CertificateUpload(2L, "second.pdf"),
+                    1 to CertificateUpload(1L, "first.pdf"),
+                ),
             )
+            stubUpload(1L, FileUploadStatus.SCANNED, downloadUrl = "/download/first.pdf")
+            stubUpload(2L, FileUploadStatus.SCANNED, downloadUrl = "/download/second.pdf")
 
-            val factory = GasSafetyRegistrationCyaSummaryRowsFactory(mockState)
+            val factory = GasSafetyRegistrationCyaSummaryRowsFactory(mockState, mockUploadService)
 
             val gasSupplyRows = factory.createGasSupplyRows()
             assertEquals(1, gasSupplyRows.size)
@@ -88,34 +113,23 @@ class GasSafetyRegistrationCyaSummaryRowsFactoryTests {
             assertEquals(3, certRows.size)
             assertEquals(true, certRows[0].fieldValue)
             assertEquals(issueDate, certRows[1].fieldValue)
-            assertEquals(listOf("cert.pdf"), certRows[2].fieldValue)
-
-            assertNull(factory.getInsetTextKey())
-        }
-
-        @Test
-        fun `factory sorts uploads by map key and returns file names`() {
-            setupCommonStateMocks()
-            whenever(mockHasGasSupplyStep.outcome).thenReturn(YesOrNo.YES)
-            whenever(mockHasGasCertStep.outcome).thenReturn(HasGasCertMode.HAS_CERTIFICATE)
-            whenever(mockState.getGasSafetyCertificateIsOutdated()).thenReturn(false)
-            whenever(mockState.getGasSafetyCertificateIssueDateIfReachable()).thenReturn(LocalDate(2024, 6, 15))
-            whenever(mockState.gasCertIssueDateStep).thenReturn(mockGasCertIssueDateStep)
-            whenever(mockState.checkGasCertUploadsStep).thenReturn(mockCheckGasCertUploadsStep)
-            whenever(mockGasCertIssueDateStep.currentJourneyId).thenReturn("test-journey-id")
-            whenever(mockCheckGasCertUploadsStep.currentJourneyId).thenReturn("test-journey-id")
-            whenever(mockState.gasUploadMap).thenReturn(
-                mapOf(
-                    3 to CertificateUpload(3L, "third.pdf"),
-                    1 to CertificateUpload(1L, "first.pdf"),
-                    2 to CertificateUpload(2L, "second.pdf"),
+            assertEquals(
+                listOf(
+                    UploadedFileUrl(
+                        messageKey = "propertyDetails.complianceInformation.gasSafety.downloadCertificate",
+                        displayName = "first.pdf",
+                        url = "/download/first.pdf",
+                    ),
+                    UploadedFileUrl(
+                        messageKey = "propertyDetails.complianceInformation.gasSafety.downloadCertificate",
+                        displayName = "second.pdf",
+                        url = "/download/second.pdf",
+                    ),
                 ),
+                certRows[2].fieldValue,
             )
 
-            val factory = GasSafetyRegistrationCyaSummaryRowsFactory(mockState)
-
-            val certRows = factory.createCertRows()
-            assertEquals(listOf("first.pdf", "second.pdf", "third.pdf"), certRows[2].fieldValue)
+            assertNull(factory.getInsetTextKey())
         }
     }
 
@@ -128,7 +142,7 @@ class GasSafetyRegistrationCyaSummaryRowsFactoryTests {
             whenever(mockHasGasCertStep.outcome).thenReturn(HasGasCertMode.PROVIDE_THIS_LATER)
             whenever(mockState.isOccupied).thenReturn(true)
 
-            val factory = GasSafetyRegistrationCyaSummaryRowsFactory(mockState)
+            val factory = GasSafetyRegistrationCyaSummaryRowsFactory(mockState, mockUploadService)
 
             val gasSupplyRows = factory.createGasSupplyRows()
             assertEquals(2, gasSupplyRows.size)
@@ -148,7 +162,7 @@ class GasSafetyRegistrationCyaSummaryRowsFactoryTests {
             whenever(mockHasGasCertStep.outcome).thenReturn(HasGasCertMode.PROVIDE_THIS_LATER)
             whenever(mockState.isOccupied).thenReturn(false)
 
-            val factory = GasSafetyRegistrationCyaSummaryRowsFactory(mockState)
+            val factory = GasSafetyRegistrationCyaSummaryRowsFactory(mockState, mockUploadService)
 
             val gasSupplyRows = factory.createGasSupplyRows()
             assertEquals(2, gasSupplyRows.size)
@@ -171,7 +185,7 @@ class GasSafetyRegistrationCyaSummaryRowsFactoryTests {
             whenever(mockHasGasCertStep.outcome).thenReturn(HasGasCertMode.NO_CERTIFICATE)
             whenever(mockState.isOccupied).thenReturn(true)
 
-            val factory = GasSafetyRegistrationCyaSummaryRowsFactory(mockState)
+            val factory = GasSafetyRegistrationCyaSummaryRowsFactory(mockState, mockUploadService)
 
             val gasSupplyRows = factory.createGasSupplyRows()
             assertEquals(2, gasSupplyRows.size)
@@ -191,7 +205,7 @@ class GasSafetyRegistrationCyaSummaryRowsFactoryTests {
             whenever(mockHasGasCertStep.outcome).thenReturn(HasGasCertMode.NO_CERTIFICATE)
             whenever(mockState.isOccupied).thenReturn(false)
 
-            val factory = GasSafetyRegistrationCyaSummaryRowsFactory(mockState)
+            val factory = GasSafetyRegistrationCyaSummaryRowsFactory(mockState, mockUploadService)
 
             val gasSupplyRows = factory.createGasSupplyRows()
             assertEquals(2, gasSupplyRows.size)
@@ -215,7 +229,7 @@ class GasSafetyRegistrationCyaSummaryRowsFactoryTests {
             whenever(mockState.getGasSafetyCertificateIsOutdated()).thenReturn(true)
             whenever(mockState.isOccupied).thenReturn(true)
 
-            val factory = GasSafetyRegistrationCyaSummaryRowsFactory(mockState)
+            val factory = GasSafetyRegistrationCyaSummaryRowsFactory(mockState, mockUploadService)
 
             val gasSupplyRows = factory.createGasSupplyRows()
             assertEquals(2, gasSupplyRows.size)
@@ -236,7 +250,7 @@ class GasSafetyRegistrationCyaSummaryRowsFactoryTests {
             whenever(mockState.getGasSafetyCertificateIsOutdated()).thenReturn(true)
             whenever(mockState.isOccupied).thenReturn(false)
 
-            val factory = GasSafetyRegistrationCyaSummaryRowsFactory(mockState)
+            val factory = GasSafetyRegistrationCyaSummaryRowsFactory(mockState, mockUploadService)
 
             val gasSupplyRows = factory.createGasSupplyRows()
             assertEquals(2, gasSupplyRows.size)

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/CheckElectricalSafetyAnswersStepConfigTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/CheckElectricalSafetyAnswersStepConfigTests.kt
@@ -6,9 +6,11 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.ElectricalSafetyState
 import uk.gov.communities.prsdb.webapp.journeys.shared.Complete
+import uk.gov.communities.prsdb.webapp.services.UploadService
 import uk.gov.communities.prsdb.webapp.testHelpers.mockObjects.AlwaysTrueValidator
 
 @ExtendWith(MockitoExtension::class)
@@ -16,8 +18,10 @@ class CheckElectricalSafetyAnswersStepConfigTests {
     @Mock
     lateinit var mockState: ElectricalSafetyState
 
+    private val mockUploadService: UploadService = mock()
+
     private fun setupStepConfig(): CheckElectricalSafetyAnswersStepConfig {
-        val stepConfig = CheckElectricalSafetyAnswersStepConfig()
+        val stepConfig = CheckElectricalSafetyAnswersStepConfig(mockUploadService)
         stepConfig.routeSegment = CheckElectricalSafetyAnswersStep.ROUTE_SEGMENT
         stepConfig.validator = AlwaysTrueValidator()
         return stepConfig

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/CheckGasSafetyAnswersStepConfigTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/CheckGasSafetyAnswersStepConfigTests.kt
@@ -6,9 +6,11 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.GasSafetyState
 import uk.gov.communities.prsdb.webapp.journeys.shared.Complete
+import uk.gov.communities.prsdb.webapp.services.UploadService
 import uk.gov.communities.prsdb.webapp.testHelpers.mockObjects.AlwaysTrueValidator
 
 @ExtendWith(MockitoExtension::class)
@@ -16,8 +18,10 @@ class CheckGasSafetyAnswersStepConfigTests {
     @Mock
     lateinit var mockState: GasSafetyState
 
+    private val mockUploadService: UploadService = mock()
+
     private fun setupStepConfig(): CheckGasSafetyAnswersStepConfig {
-        val stepConfig = CheckGasSafetyAnswersStepConfig()
+        val stepConfig = CheckGasSafetyAnswersStepConfig(mockUploadService)
         stepConfig.routeSegment = CheckGasSafetyAnswersStep.ROUTE_SEGMENT
         stepConfig.validator = AlwaysTrueValidator()
         return stepConfig

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/FinishCyaJourneyConfigTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/FinishCyaJourneyConfigTests.kt
@@ -69,6 +69,17 @@ class FinishCyaJourneyConfigTests {
 
             verify(mockState, never()).copyJourneyTo(baseJourneyId)
         }
+
+        @Test
+        fun `ensures CYA fields are not present in the parent state that will be saved`() {
+            val metadata = JourneyMetadata(baseJourneyId, timestamp)
+            whenever(mockOriginalState.journeyMetadata).thenReturn(metadata)
+            whenever(mockState.originalJourneyUpdated).thenReturn(timestamp)
+
+            config.afterStepIsReached(mockState)
+
+            verify(mockOriginalState).clearCyaFields()
+        }
     }
 
     @Nested

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/shared/helpers/ComplianceDetailsHelperTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/shared/helpers/ComplianceDetailsHelperTests.kt
@@ -12,6 +12,8 @@ import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
+import uk.gov.communities.prsdb.webapp.constants.enums.FileUploadStatus
+import uk.gov.communities.prsdb.webapp.database.entity.FileUpload
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.CertificateUpload
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.ElectricalSafetyState
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.EpcState
@@ -29,6 +31,7 @@ import uk.gov.communities.prsdb.webapp.journeys.shared.YesOrNo
 import uk.gov.communities.prsdb.webapp.journeys.shared.states.CheckYourAnswersJourneyState
 import uk.gov.communities.prsdb.webapp.models.viewModels.summaryModels.SummaryListRowViewModel
 import uk.gov.communities.prsdb.webapp.services.EpcCertificateUrlProvider
+import uk.gov.communities.prsdb.webapp.services.UploadService
 
 internal interface TestableGasSafetyState : GasSafetyState, CheckYourAnswersJourneyState
 
@@ -41,7 +44,9 @@ class ComplianceDetailsHelperTests {
     @Mock
     lateinit var mockEpcCertificateUrlProvider: EpcCertificateUrlProvider
 
-    private val helper by lazy { ComplianceDetailsHelper(mockEpcCertificateUrlProvider) }
+    private val mockUploadService: UploadService = mock()
+
+    private val helper by lazy { ComplianceDetailsHelper(mockEpcCertificateUrlProvider, mockUploadService) }
 
     @Nested
     inner class GetGasSafetyCyaContent {
@@ -86,6 +91,10 @@ class ComplianceDetailsHelperTests {
             whenever(mockState.gasCertIssueDateStep).thenReturn(mockGasCertIssueDateStep)
             whenever(mockState.checkGasCertUploadsStep).thenReturn(mockCheckGasCertUploadsStep)
             whenever(mockState.gasUploadMap).thenReturn(mapOf(1 to CertificateUpload(1L, "cert.pdf")))
+            val mockFileUpload: FileUpload = mock()
+            whenever(mockFileUpload.status).thenReturn(FileUploadStatus.SCANNED)
+            whenever(mockUploadService.getFileUploadById(1L)).thenReturn(mockFileUpload)
+            whenever(mockUploadService.getDownloadUrlOrNull(any(), any())).thenReturn("/download/cert.pdf")
 
             val content = helper.getGasSafetyCyaContent(mockState)
 

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/summaryModels/propertyComplianceViewModels/ComplianceUploadRowHelperTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/summaryModels/propertyComplianceViewModels/ComplianceUploadRowHelperTests.kt
@@ -1,0 +1,123 @@
+package uk.gov.communities.prsdb.webapp.models.viewModels.summaryModels.propertyComplianceViewModels
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import uk.gov.communities.prsdb.webapp.constants.enums.FileUploadStatus
+import uk.gov.communities.prsdb.webapp.database.entity.FileUpload
+import uk.gov.communities.prsdb.webapp.models.viewModels.summaryModels.UploadedFileUrl
+import uk.gov.communities.prsdb.webapp.services.UploadService
+
+@ExtendWith(MockitoExtension::class)
+class ComplianceUploadRowHelperTests {
+    private val mockUploadService: UploadService = mock()
+
+    private fun fileUploadWithStatus(status: FileUploadStatus): FileUpload =
+        mock<FileUpload>().also { whenever(it.status).thenReturn(status) }
+
+    private fun scannedUpload(
+        displayName: String,
+        downloadUrl: String?,
+    ): Pair<FileUpload, String> {
+        val fileUpload = fileUploadWithStatus(FileUploadStatus.SCANNED)
+        whenever(mockUploadService.getDownloadUrlOrNull(eq(fileUpload), any())).thenReturn(downloadUrl)
+        return fileUpload to displayName
+    }
+
+    private fun quarantinedUpload(displayName: String): Pair<FileUpload, String> =
+        fileUploadWithStatus(FileUploadStatus.QUARANTINED) to displayName
+
+    private fun deletedUpload(displayName: String): Pair<FileUpload, String> = fileUploadWithStatus(FileUploadStatus.DELETED) to displayName
+
+    @Test
+    fun `toUploadedFileUrls maps scanned uploads to UploadedFileUrl with download messageKey and url`() {
+        val uploads = listOf(scannedUpload("cert.pdf", "/download/cert.pdf"))
+
+        val result = uploads.toUploadedFileUrls("download.messageKey", mockUploadService)
+
+        assertEquals(
+            listOf(
+                UploadedFileUrl(
+                    messageKey = "download.messageKey",
+                    displayName = "cert.pdf",
+                    url = "/download/cert.pdf",
+                ),
+            ),
+            result,
+        )
+    }
+
+    @Test
+    fun `toUploadedFileUrls maps scanned uploads with no download url to UploadedFileUrl with null url`() {
+        val uploads = listOf(scannedUpload("cert.pdf", null))
+
+        val result = uploads.toUploadedFileUrls("download.messageKey", mockUploadService)
+
+        assertEquals(1, result.size)
+        assertEquals("download.messageKey", result[0].messageKey)
+        assertEquals("cert.pdf", result[0].displayName)
+        assertNull(result[0].url)
+    }
+
+    @Test
+    fun `toUploadedFileUrls maps quarantined uploads to UploadedFileUrl with pending scan messageKey and no url`() {
+        val uploads = listOf(quarantinedUpload("cert.pdf"))
+
+        val result = uploads.toUploadedFileUrls("download.messageKey", mockUploadService)
+
+        assertEquals(
+            listOf(
+                UploadedFileUrl(
+                    messageKey = "propertyCompliance.uploadedFile.virusScanPendingWithName",
+                    displayName = "cert.pdf",
+                    url = null,
+                ),
+            ),
+            result,
+        )
+    }
+
+    @Test
+    fun `toUploadedFileUrls filters out deleted uploads`() {
+        val uploads =
+            listOf(
+                scannedUpload("scanned.pdf", "/download/scanned.pdf"),
+                deletedUpload("deleted.pdf"),
+            )
+
+        val result = uploads.toUploadedFileUrls("download.messageKey", mockUploadService)
+
+        assertEquals(1, result.size)
+        assertEquals("scanned.pdf", result[0].displayName)
+    }
+
+    @Test
+    fun `toUploadedFileUrls preserves input ordering across mixed status uploads`() {
+        val uploads =
+            listOf(
+                scannedUpload("first.pdf", "/download/first.pdf"),
+                quarantinedUpload("second.pdf"),
+                scannedUpload("third.pdf", "/download/third.pdf"),
+            )
+
+        val result = uploads.toUploadedFileUrls("download.messageKey", mockUploadService)
+
+        assertEquals(listOf("first.pdf", "second.pdf", "third.pdf"), result.map { it.displayName })
+        assertEquals("/download/first.pdf", result[0].url)
+        assertNull(result[1].url)
+        assertEquals("/download/third.pdf", result[2].url)
+    }
+
+    @Test
+    fun `toUploadedFileUrls returns empty list when given empty input`() {
+        val result = emptyList<Pair<FileUpload, String>>().toUploadedFileUrls("download.messageKey", mockUploadService)
+
+        assertEquals(emptyList<UploadedFileUrl>(), result)
+    }
+}

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/testHelpers/builders/PropertyStateSessionBuilder.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/testHelpers/builders/PropertyStateSessionBuilder.kt
@@ -353,6 +353,15 @@ class PropertyStateSessionBuilder(
                 .withElectricalSafetyCertificateMissing()
                 .withCompliantEpc()
 
+        fun beforePropertyRegistrationCheckAnswersWithSelectiveLicence() =
+            beforePropertyRegistrationLicensingType()
+                .withLicensing(LicensingType.SELECTIVE_LICENCE, "SL-12345")
+                .withOccupancyStatus(false)
+                .withHasNoJointLandlords()
+                .withGasSafetyTaskCompletedWithNoGasSupply()
+                .withElectricalSafetyCertificateMissing()
+                .withCompliantEpc()
+
         fun beforePropertyRegistrationCheckAnswersOccupied(
             households: Int = 2,
             people: Int = 4,


### PR DESCRIPTION
## Release notes

PDJB-851: Show CYA certificate filenames as download links once scanned
PDJB-598: Update Notify email templates
PDJB-884: Update page back link fixes
PDJB-909: Add missing license steps to CYA map
PDJB-910: Clear CYA fields after reaching CYA step
PDJB-NONE: Restore deterministic seed for CYA child journey IDs