### PR TITLE
PDJB-NONE: Removes references to database from beta banner content

### DIFF
--- a/src/main/resources/messages/betaBannerFeedback.yml
+++ b/src/main/resources/messages/betaBannerFeedback.yml
@@ -1,7 +1,7 @@
 title: Beta feedback
-heading: Give feedback on the PRS Database
+heading: Give feedback
 intro: 'Use this form to let us know if you’ve experienced any issues, or have ideas for how we can improve the service.'
-label: Tell us about your experience with the PRS Database
+label: Tell us about your experience
 hint: 'Do not include any personal or financial information, for example your National Insurance number or credit card details.'
 emailLabel: 'If you’re happy for us to contact you about your feedback, enter your email address (optional)'
 buttonText: Send feedback


### PR DESCRIPTION
## Ticket number

PDJB-NONE

## Goal of change

Remove rogue references to the PRS Database from the beta banner feedback page

## Description of main change(s)

Deletes last remaining references to "the PRS Database"

## Checklist

- [x] Screenshots of any UI changes have been added
- [ ] Test suite has been run in full locally and is passing
- [x] Branch has been rebased onto main and run locally, with everything working as expected (both for your new feature
  and any related functionality)
- [ ] QA instructions have been added to the ticket (particularly if this is the last PR required to complete the ticket)

<img width="1065" height="1177" alt="image" src="https://github.com/user-attachments/assets/9f2e9223-fcfe-462f-8719-7a8353f181f3" />

