### PR TITLE
PDJB-905: Fix no incomplete property details back links

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/IncompletePropertiesController.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/IncompletePropertiesController.kt
@@ -15,6 +15,7 @@ import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.server.ResponseStatusException
 import org.springframework.web.util.UriTemplate
 import uk.gov.communities.prsdb.webapp.annotations.webAnnotations.PrsdbController
+import uk.gov.communities.prsdb.webapp.config.interceptors.BackLinkInterceptor.Companion.overrideBackLinkForUrl
 import uk.gov.communities.prsdb.webapp.constants.BACK_URL_ATTR_NAME
 import uk.gov.communities.prsdb.webapp.constants.CONFIRMATION_PATH_SEGMENT
 import uk.gov.communities.prsdb.webapp.constants.CONTEXT_ID_URL_PARAMETER
@@ -63,12 +64,18 @@ class IncompletePropertiesController(
                 )
             }
 
+        val backUrlKey = backUrlStorageService.storeCurrentUrlReturningKey()
+
         model.addAttribute("incompleteProperties", incompletePropertyViewModels)
         model.addAttribute("paginationViewModel", PaginationViewModel(page, pagedIncompleteProperties.totalPages, request))
-        model.addAttribute("registerPropertyUrl", RegisterPropertyController.PROPERTY_REGISTRATION_ROUTE)
+        model.addAttribute(
+            "registerPropertyUrl",
+            RegisterPropertyController.PROPERTY_REGISTRATION_ROUTE.overrideBackLinkForUrl(backUrlKey),
+        )
         model.addAttribute(
             "viewRegisteredPropertiesUrl",
-            "${LandlordDetailsController.LANDLORD_DETAILS_FOR_LANDLORD_ROUTE}#${REGISTERED_PROPERTIES_FRAGMENT}",
+            "${LandlordDetailsController.LANDLORD_DETAILS_FOR_LANDLORD_ROUTE}#${REGISTERED_PROPERTIES_FRAGMENT}"
+                .overrideBackLinkForUrl(backUrlKey),
         )
 
         model.addAttribute("backUrl", LandlordController.LANDLORD_DASHBOARD_URL)

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/LandlordIncompletePropertiesPageTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/LandlordIncompletePropertiesPageTests.kt
@@ -93,5 +93,23 @@ class LandlordIncompletePropertiesPageTests : IntegrationTest() {
             incompletePropertiesPage.registerANewPropertyLink.clickAndWait()
             assertPageIs(page, RegisterPropertyStartPage::class)
         }
+
+        @Test
+        fun `clicking back from the view registered properties link returns to incomplete properties`(page: Page) {
+            val incompletePropertiesPage = navigator.goToLandlordIncompleteProperties()
+            incompletePropertiesPage.viewRegisteredPropertiesLink.clickAndWait()
+            val detailsPage = assertPageIs(page, LandlordDetailsPage::class)
+            detailsPage.backLink.clickAndWait()
+            assertPageIs(page, LandlordIncompletePropertiesPage::class)
+        }
+
+        @Test
+        fun `clicking back from the register a new property link returns to incomplete properties`(page: Page) {
+            val incompletePropertiesPage = navigator.goToLandlordIncompleteProperties()
+            incompletePropertiesPage.registerANewPropertyLink.clickAndWait()
+            val startPage = assertPageIs(page, RegisterPropertyStartPage::class)
+            startPage.backLink.clickAndWait()
+            assertPageIs(page, LandlordIncompletePropertiesPage::class)
+        }
     }
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/propertyRegistrationJourneyPages/RegisterPropertyStartPage.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/propertyRegistrationJourneyPages/RegisterPropertyStartPage.kt
@@ -4,12 +4,14 @@ import com.microsoft.playwright.Locator
 import com.microsoft.playwright.Page
 import com.microsoft.playwright.options.AriaRole
 import uk.gov.communities.prsdb.webapp.controllers.RegisterPropertyController
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.BackLink
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.Button
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages.BasePage
 
 class RegisterPropertyStartPage(
     page: Page,
 ) : BasePage(page, RegisterPropertyController.PROPERTY_REGISTRATION_ROUTE) {
+    val backLink = BackLink.default(page)
     val heading: Locator? = page.locator(".govuk-heading-l")
     val startButton = Button.byText(page, "Continue")
     val occupiedHeading: Locator = page.getByRole(AriaRole.HEADING, Page.GetByRoleOptions().setName("If your property is occupied"))


### PR DESCRIPTION
## Ticket number

[PDJB-905](https://mhclgdigital.atlassian.net/browse/PDJB-905)

## Goal of change

add back url overrides to the links on the incomplete properties page when there are no incomplete properties

## Description of main change(s)

both these pages support back url overrides, and incomplete properties controller already uses the back url storage service for the incomplete property links

<img alt="image" src="https://github.com/user-attachments/assets/26994e7d-3e8d-4df3-b038-11fcace1cd96" />

## Checklist

Delete any that are not applicable, and add explanation below for any that are applicable but haven't been done

- [x] Screenshots of any UI changes have been added
- [x] A new journey integration test has been added for any new journeys
- [x] Test suite has been run in full locally and is passing
- [x] Branch has been rebased onto main and run locally, with everything working as expected (both for your new feature
  and any related functionality)
- [x] TODO comments referencing this JIRA ticket have been searched for and removed - if a future PR will address them,
  mention that here
- [x] QA instructions have been added to the ticket (particularly if this is the last PR required to complete the ticket)
