### PR TITLE
PDJB-906: Fix no registered property details back links

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/LandlordDetailsController.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/LandlordDetailsController.kt
@@ -50,7 +50,7 @@ class LandlordDetailsController(
         val registeredPropertiesList = propertyOwnershipService.getRegisteredPropertiesForLandlordUser(principal.name)
 
         model.addAttribute("registeredPropertiesList", registeredPropertiesList)
-        val backUrlKey = backUrlStorageService.storeCurrentUrlReturningKey()
+        val backUrlKey = backUrlStorageService.storeCurrentUrlReturningKey(REGISTERED_PROPERTIES_FRAGMENT)
         model.addAttribute(
             "registerPropertyUrl",
             RegisterPropertyController.PROPERTY_REGISTRATION_ROUTE.overrideBackLinkForUrl(backUrlKey),

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/LandlordDetailsController.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/LandlordDetailsController.kt
@@ -10,6 +10,7 @@ import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.server.ResponseStatusException
 import org.springframework.web.util.UriTemplate
 import uk.gov.communities.prsdb.webapp.annotations.webAnnotations.PrsdbController
+import uk.gov.communities.prsdb.webapp.config.interceptors.BackLinkInterceptor.Companion.overrideBackLinkForUrl
 import uk.gov.communities.prsdb.webapp.constants.LANDLORD_DETAILS_PATH_SEGMENT
 import uk.gov.communities.prsdb.webapp.constants.LANDLORD_PATH_SEGMENT
 import uk.gov.communities.prsdb.webapp.constants.LOCAL_COUNCIL_PATH_SEGMENT
@@ -19,6 +20,7 @@ import uk.gov.communities.prsdb.webapp.controllers.LandlordController.Companion.
 import uk.gov.communities.prsdb.webapp.exceptions.PrsdbWebException
 import uk.gov.communities.prsdb.webapp.helpers.DateTimeHelper
 import uk.gov.communities.prsdb.webapp.models.viewModels.summaryModels.LandlordViewModel
+import uk.gov.communities.prsdb.webapp.services.BackUrlStorageService
 import uk.gov.communities.prsdb.webapp.services.LandlordService
 import uk.gov.communities.prsdb.webapp.services.PropertyOwnershipService
 import java.security.Principal
@@ -28,6 +30,7 @@ import java.security.Principal
 class LandlordDetailsController(
     private val landlordService: LandlordService,
     private val propertyOwnershipService: PropertyOwnershipService,
+    private val backUrlStorageService: BackUrlStorageService,
 ) {
     @PreAuthorize("hasRole('LANDLORD')")
     @GetMapping(LANDLORD_DETAILS_FOR_LANDLORD_ROUTE)
@@ -47,7 +50,11 @@ class LandlordDetailsController(
         val registeredPropertiesList = propertyOwnershipService.getRegisteredPropertiesForLandlordUser(principal.name)
 
         model.addAttribute("registeredPropertiesList", registeredPropertiesList)
-        model.addAttribute("registerPropertyUrl", RegisterPropertyController.PROPERTY_REGISTRATION_ROUTE)
+        val backUrlKey = backUrlStorageService.storeCurrentUrlReturningKey()
+        model.addAttribute(
+            "registerPropertyUrl",
+            RegisterPropertyController.PROPERTY_REGISTRATION_ROUTE.overrideBackLinkForUrl(backUrlKey),
+        )
         model.addAttribute("backUrl", LANDLORD_DASHBOARD_URL)
         model.addAttribute("registeredPropertiesTabId", REGISTERED_PROPERTIES_FRAGMENT)
 

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/BackUrlStorageService.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/BackUrlStorageService.kt
@@ -12,24 +12,25 @@ import kotlin.math.abs
 class BackUrlStorageService(
     val session: HttpSession,
 ) {
-    fun storeCurrentUrlReturningKey(): Int {
+    fun storeCurrentUrlReturningKey(fragment: String? = null): Int {
         val currentUrl = getCurrentUrl() ?: throw IllegalStateException("Current URL is null")
-        val currentUrlHash = abs(currentUrl.hashCode())
+        val urlToStore = if (fragment != null) "$currentUrl#$fragment" else currentUrl
+        val urlHash = abs(urlToStore.hashCode())
         val backUrlMap = session.getAttribute(BACK_URL_STORAGE_SESSION_ATTRIBUTE).toBackUrlMap()
 
-        val storedUrl = backUrlMap[currentUrlHash]
+        val storedUrl = backUrlMap[urlHash]
         return when (storedUrl) {
-            currentUrl -> {
-                currentUrlHash
+            urlToStore -> {
+                urlHash
             }
 
             null -> {
-                session.setAttribute(BACK_URL_STORAGE_SESSION_ATTRIBUTE, backUrlMap + (currentUrlHash to currentUrl))
-                currentUrlHash
+                session.setAttribute(BACK_URL_STORAGE_SESSION_ATTRIBUTE, backUrlMap + (urlHash to urlToStore))
+                urlHash
             }
 
             else -> {
-                storeUrlWithHashCollisionReturningKey(backUrlMap, currentUrl)
+                storeUrlWithHashCollisionReturningKey(backUrlMap, urlToStore)
             }
         }
     }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/LandlordDetailTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/LandlordDetailTests.kt
@@ -68,6 +68,17 @@ class LandlordDetailTests : IntegrationTestWithImmutableData("data-local.sql") {
                 detailsPage.noRegisteredPropertiesLink.clickAndWait()
                 assertPageIs(page, RegisterPropertyStartPage::class)
             }
+
+            @Test
+            fun `clicking back from register a property link returns to landlord details registered properties tab`(page: Page) {
+                val detailsPage = navigator.goToLandlordDetails()
+                detailsPage.tabs.goToRegisteredProperties()
+                detailsPage.noRegisteredPropertiesLink.clickAndWait()
+                val startPage = assertPageIs(page, RegisterPropertyStartPage::class)
+                startPage.backLink.clickAndWait()
+                val returnedDetailsPage = assertPageIs(page, LandlordDetailsPage::class)
+                assertEquals("registered-properties", returnedDetailsPage.tabs.activeTabPanelId)
+            }
         }
     }
 

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/propertyRegistrationJourneyPages/RegisterPropertyStartPage.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/propertyRegistrationJourneyPages/RegisterPropertyStartPage.kt
@@ -4,12 +4,14 @@ import com.microsoft.playwright.Locator
 import com.microsoft.playwright.Page
 import com.microsoft.playwright.options.AriaRole
 import uk.gov.communities.prsdb.webapp.controllers.RegisterPropertyController
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.BackLink
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.Button
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages.BasePage
 
 class RegisterPropertyStartPage(
     page: Page,
 ) : BasePage(page, RegisterPropertyController.PROPERTY_REGISTRATION_ROUTE) {
+    val backLink = BackLink.default(page)
     val heading: Locator? = page.locator(".govuk-heading-l")
     val startButton = Button.byText(page, "Continue")
     val occupiedHeading: Locator = page.getByRole(AriaRole.HEADING, Page.GetByRoleOptions().setName("If your property is occupied"))

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/BackUrlStorageServiceTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/BackUrlStorageServiceTests.kt
@@ -109,6 +109,36 @@ class BackUrlStorageServiceTests {
 
             assertEquals(usedKey, urlKey)
         }
+
+        @Test
+        fun `storeCurrentUrlReturningKey with fragment appends the fragment to the stored URL`() {
+            val fragment = "my-section"
+            val expectedUrl = "$exampleUrl#$fragment"
+            val urlMapCaptor = argumentCaptor<Map<Int, String>>()
+
+            val urlKey = backUrlStorageService.storeCurrentUrlReturningKey(fragment)
+            verify(httpSession).setAttribute(
+                eq(BACK_URL_STORAGE_SESSION_ATTRIBUTE),
+                urlMapCaptor.capture(),
+            )
+
+            val storedUrl = urlMapCaptor.firstValue[urlKey]
+            assertEquals(expectedUrl, storedUrl)
+        }
+
+        @Test
+        fun `storeCurrentUrlReturningKey with null fragment stores the URL without a fragment`() {
+            val urlMapCaptor = argumentCaptor<Map<Int, String>>()
+
+            val urlKey = backUrlStorageService.storeCurrentUrlReturningKey(null)
+            verify(httpSession).setAttribute(
+                eq(BACK_URL_STORAGE_SESSION_ATTRIBUTE),
+                urlMapCaptor.capture(),
+            )
+
+            val storedUrl = urlMapCaptor.firstValue[urlKey]
+            assertEquals(exampleUrl, storedUrl)
+        }
     }
 
     @Test


### PR DESCRIPTION
## Ticket number

[PDJB-906](https://mhclgdigital.atlassian.net/browse/PDJB-906)

## Goal of change

add back url overrides to the links on the registered properties page when there are no registered properties

## Description of main change(s)

adds back link service to the controller
allows for back links to include a fragment

<img alt="no registered properties view" src="https://github.com/user-attachments/assets/a9e2b3ee-a4e6-4223-9cdc-95af6b4c7537" />

## Anything you'd like to highlight to the reviewer?

see comments

## Checklist

Delete any that are not applicable, and add explanation below for any that are applicable but haven't been done

- [x] Screenshots of any UI changes have been added
- [x] A new journey integration test has been added for any new journeys
- [x] Test suite has been run in full locally and is passing
- [x] Branch has been rebased onto main and run locally, with everything working as expected (both for your new feature
  and any related functionality)
- [x] TODO comments referencing this JIRA ticket have been searched for and removed - if a future PR will address them,
  mention that here
- [x] QA instructions have been added to the ticket (particularly if this is the last PR required to complete the ticket)
