### PR TITLE
PDJB-925: Fix EPC unchangeable in specific case

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/EpcRegistrationCyaSummaryRowsFactory.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/EpcRegistrationCyaSummaryRowsFactory.kt
@@ -27,7 +27,7 @@ class EpcRegistrationCyaSummaryRowsFactory(
                 if (isOccupied) EpcScenario.SKIPPED_OCCUPIED else EpcScenario.SKIPPED_UNOCCUPIED
             }
 
-            state.acceptedEpcIfReachable == null -> {
+            state.acceptedEpcIfStillAccepted == null -> {
                 determineNoEpcScenario(state, isOccupied)
             }
 

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/states/EpcState.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/states/EpcState.kt
@@ -24,6 +24,8 @@ import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.Prope
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.ProvideEpcLaterStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.StartEpcStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.EpcDetailsTask
+import uk.gov.communities.prsdb.webapp.journeys.shared.Complete
+import uk.gov.communities.prsdb.webapp.journeys.shared.YesOrNo
 import uk.gov.communities.prsdb.webapp.models.dataModels.EpcDataModel
 
 interface EpcState : JourneyState {
@@ -38,10 +40,11 @@ interface EpcState : JourneyState {
     var acceptedEpc: EpcDataModel?
     val allowProvideCertificateLaterRoute: Boolean
 
-    val acceptedEpcIfReachable: EpcDataModel?
+    val acceptedEpcIfStillAccepted: EpcDataModel?
         get() =
-            if (checkUprnMatchedEpcStep.isStepReachable || confirmEpcDetailsRetrievedByCertificateNumberStep.isStepReachable ||
-                checkSupersededEpcStep.isStepReachable
+            if (checkUprnMatchedEpcStep.outcome == YesOrNo.YES ||
+                confirmEpcDetailsRetrievedByCertificateNumberStep.outcome == YesOrNo.YES ||
+                checkSupersededEpcStep.outcome == Complete.COMPLETE
             ) {
                 acceptedEpc
             } else {

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/states/EpcState.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/states/EpcState.kt
@@ -47,6 +47,7 @@ interface EpcState : JourneyState {
                 checkSupersededEpcStep.outcome == Complete.COMPLETE
             ) {
                 acceptedEpc
+                    ?: throw PrsdbWebException("acceptedEpc is null despite a confirm step having a positive outcome")
             } else {
                 null
             }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/HasMissingComplianceStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/HasMissingComplianceStepConfig.kt
@@ -36,7 +36,7 @@ class HasMissingComplianceStepConfig : AbstractInternalStepConfig<ConfirmMissing
         fun isEpcInvalid(state: EpcState): Boolean {
             if (state.hasEpcStep.outcome == HasEpcMode.PROVIDE_LATER) return false
             val acceptedEpc =
-                state.acceptedEpcIfReachable
+                state.acceptedEpcIfStillAccepted
                     ?: return state.epcExemptionStep.formModelIfReachableOrNull?.exemptionReason == null
             return acceptedEpc.isPastExpiryDate() ||
                 (

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/SavePropertyRegistrationDataStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/SavePropertyRegistrationDataStepConfig.kt
@@ -116,11 +116,11 @@ class SavePropertyRegistrationDataStepConfig(
             electricalSafetyExpiryDate = state.getElectricalCertificateExpiryDateIfReachable()?.toJavaLocalDate(),
             electricalCertType = state.mapElectricalCertificateTypeToGlobalCertificateType(),
             epcCertificateUrl =
-                state.acceptedEpcIfReachable?.let {
+                state.acceptedEpcIfStillAccepted?.let {
                     epcCertificateUrlProvider.getEpcCertificateUrl(it.certificateNumber)
                 },
-            epcExpiryDate = state.acceptedEpcIfReachable?.expiryDateAsJavaLocalDate,
-            epcEnergyRating = state.acceptedEpcIfReachable?.energyRating,
+            epcExpiryDate = state.acceptedEpcIfStillAccepted?.expiryDateAsJavaLocalDate,
+            epcEnergyRating = state.acceptedEpcIfStillAccepted?.energyRating,
             tenancyStartedBeforeEpcExpiry =
                 state.epcInDateAtStartOfTenancyCheckStep
                     .formModelIfReachableOrNull

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/update/epc/CompleteEpcUpdateStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/update/epc/CompleteEpcUpdateStepConfig.kt
@@ -20,7 +20,7 @@ class CompleteEpcUpdateStepConfig(
     override fun mode(state: UpdateEpcJourneyState): Complete = Complete.COMPLETE
 
     override fun afterStepIsReached(state: UpdateEpcJourneyState) {
-        val acceptedEpc = state.acceptedEpcIfReachable
+        val acceptedEpc = state.acceptedEpcIfStillAccepted
 
         try {
             propertyComplianceService.updateEpc(

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/CompleteEpcUpdateStepConfigTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/CompleteEpcUpdateStepConfigTests.kt
@@ -3,7 +3,6 @@ package uk.gov.communities.prsdb.webapp.journeys.propertyRegistration
 import kotlinx.datetime.Clock
 import kotlinx.datetime.DateTimeUnit.Companion.DAY
 import kotlinx.datetime.minus
-import kotlinx.datetime.plus
 import kotlinx.datetime.toJavaInstant
 import kotlinx.datetime.toJavaLocalDate
 import org.junit.jupiter.api.BeforeEach
@@ -182,7 +181,7 @@ class CompleteEpcUpdateStepConfigTests {
 
         whenever(mockState.propertyId).thenReturn(propertyId)
         whenever(mockState.lastModifiedDate).thenReturn(initialLastModifiedDate.toString())
-        whenever(mockState.acceptedEpcIfReachable).thenReturn(acceptedEpc)
+        whenever(mockState.acceptedEpcIfStillAccepted).thenReturn(acceptedEpc)
         whenever(mockState.epcExemptionStep).thenReturn(mockEpcExemptionStep)
         whenever(mockState.meesExemptionStep).thenReturn(mockMeesExemptionStep)
         whenever(mockState.epcInDateAtStartOfTenancyCheckStep).thenReturn(mockEpcInDateAtStartOfTenancyCheckStep)

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/EpcRegistrationCyaSummaryRowsFactoryTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/EpcRegistrationCyaSummaryRowsFactoryTests.kt
@@ -110,14 +110,14 @@ class EpcRegistrationCyaSummaryRowsFactoryTests {
             }
 
             EpcScenario.VALID_EPC -> {
-                whenever(mockState.acceptedEpcIfReachable).thenReturn(validEpc)
+                whenever(mockState.acceptedEpcIfStillAccepted).thenReturn(validEpc)
                 whenever(mockState.acceptedEpc).thenReturn(validEpc)
                 whenever(mockEpcAgeCheckStep.outcome).thenReturn(EpcAgeCheckMode.EPC_10_YEARS_OR_NEWER)
                 whenever(mockEpcEnergyRatingCheckStep.outcome).thenReturn(EpcEnergyRatingCheckMode.EPC_MEETS_ENERGY_REQUIREMENTS)
             }
 
             EpcScenario.LOW_ENERGY_EPC_MEES_EXEMPTION -> {
-                whenever(mockState.acceptedEpcIfReachable).thenReturn(validEpc)
+                whenever(mockState.acceptedEpcIfStillAccepted).thenReturn(validEpc)
                 whenever(mockState.acceptedEpc).thenReturn(validEpc)
                 whenever(mockEpcAgeCheckStep.outcome).thenReturn(EpcAgeCheckMode.EPC_10_YEARS_OR_NEWER)
                 whenever(mockEpcEnergyRatingCheckStep.outcome).thenReturn(EpcEnergyRatingCheckMode.EPC_LOW_ENERGY_RATING)
@@ -125,7 +125,7 @@ class EpcRegistrationCyaSummaryRowsFactoryTests {
             }
 
             EpcScenario.LOW_ENERGY_EPC_NO_EXEMPTION_OCCUPIED -> {
-                whenever(mockState.acceptedEpcIfReachable).thenReturn(validEpc)
+                whenever(mockState.acceptedEpcIfStillAccepted).thenReturn(validEpc)
                 whenever(mockState.acceptedEpc).thenReturn(validEpc)
                 whenever(mockEpcAgeCheckStep.outcome).thenReturn(EpcAgeCheckMode.EPC_10_YEARS_OR_NEWER)
                 whenever(mockEpcEnergyRatingCheckStep.outcome).thenReturn(EpcEnergyRatingCheckMode.EPC_LOW_ENERGY_RATING)
@@ -133,7 +133,7 @@ class EpcRegistrationCyaSummaryRowsFactoryTests {
             }
 
             EpcScenario.LOW_ENERGY_EPC_NO_EXEMPTION_UNOCCUPIED -> {
-                whenever(mockState.acceptedEpcIfReachable).thenReturn(validEpc)
+                whenever(mockState.acceptedEpcIfStillAccepted).thenReturn(validEpc)
                 whenever(mockState.acceptedEpc).thenReturn(validEpc)
                 whenever(mockEpcAgeCheckStep.outcome).thenReturn(EpcAgeCheckMode.EPC_10_YEARS_OR_NEWER)
                 whenever(mockEpcEnergyRatingCheckStep.outcome).thenReturn(EpcEnergyRatingCheckMode.EPC_LOW_ENERGY_RATING)
@@ -141,14 +141,14 @@ class EpcRegistrationCyaSummaryRowsFactoryTests {
             }
 
             EpcScenario.EPC_EXPIRED_UNOCCUPIED -> {
-                whenever(mockState.acceptedEpcIfReachable).thenReturn(validEpc)
+                whenever(mockState.acceptedEpcIfStillAccepted).thenReturn(validEpc)
                 whenever(mockState.acceptedEpc).thenReturn(validEpc)
                 whenever(mockEpcAgeCheckStep.outcome).thenReturn(EpcAgeCheckMode.EPC_OLDER_THAN_10_YEARS)
                 whenever(mockState.isOccupied).thenReturn(false)
             }
 
             EpcScenario.EPC_EXPIRED_NOT_IN_DATE_OCCUPIED -> {
-                whenever(mockState.acceptedEpcIfReachable).thenReturn(validEpc)
+                whenever(mockState.acceptedEpcIfStillAccepted).thenReturn(validEpc)
                 whenever(mockState.acceptedEpc).thenReturn(validEpc)
                 whenever(mockEpcAgeCheckStep.outcome).thenReturn(EpcAgeCheckMode.EPC_OLDER_THAN_10_YEARS)
                 whenever(mockState.isOccupied).thenReturn(true)
@@ -156,7 +156,7 @@ class EpcRegistrationCyaSummaryRowsFactoryTests {
             }
 
             EpcScenario.EPC_EXPIRED_IN_DATE_OCCUPIED -> {
-                whenever(mockState.acceptedEpcIfReachable).thenReturn(validEpc)
+                whenever(mockState.acceptedEpcIfStillAccepted).thenReturn(validEpc)
                 whenever(mockState.acceptedEpc).thenReturn(validEpc)
                 whenever(mockEpcAgeCheckStep.outcome).thenReturn(EpcAgeCheckMode.EPC_OLDER_THAN_10_YEARS)
                 whenever(mockState.isOccupied).thenReturn(true)
@@ -165,7 +165,7 @@ class EpcRegistrationCyaSummaryRowsFactoryTests {
             }
 
             EpcScenario.LOW_ENERGY_EPC_EXPIRED_IN_DATE_MEES_EXEMPTION_OCCUPIED -> {
-                whenever(mockState.acceptedEpcIfReachable).thenReturn(validEpc)
+                whenever(mockState.acceptedEpcIfStillAccepted).thenReturn(validEpc)
                 whenever(mockState.acceptedEpc).thenReturn(validEpc)
                 whenever(mockEpcAgeCheckStep.outcome).thenReturn(EpcAgeCheckMode.EPC_OLDER_THAN_10_YEARS)
                 whenever(mockState.isOccupied).thenReturn(true)
@@ -175,7 +175,7 @@ class EpcRegistrationCyaSummaryRowsFactoryTests {
             }
 
             EpcScenario.LOW_ENERGY_EPC_EXPIRED_IN_DATE_NO_EXEMPTION_OCCUPIED -> {
-                whenever(mockState.acceptedEpcIfReachable).thenReturn(validEpc)
+                whenever(mockState.acceptedEpcIfStillAccepted).thenReturn(validEpc)
                 whenever(mockState.acceptedEpc).thenReturn(validEpc)
                 whenever(mockEpcAgeCheckStep.outcome).thenReturn(EpcAgeCheckMode.EPC_OLDER_THAN_10_YEARS)
                 whenever(mockState.isOccupied).thenReturn(true)

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/states/EpcStateTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/states/EpcStateTests.kt
@@ -3,8 +3,10 @@ package uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertNull
+import org.junit.jupiter.api.assertThrows
 import org.mockito.Mockito.mock
 import org.mockito.kotlin.whenever
+import uk.gov.communities.prsdb.webapp.exceptions.PrsdbWebException
 import uk.gov.communities.prsdb.webapp.journeys.AbstractJourneyState
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.CheckEpcAnswersStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.ConfirmEpcDetailsRetrievedByCertificateNumberStep
@@ -66,26 +68,10 @@ class EpcStateTests {
     }
 
     @Test
-    fun `acceptedEpcIfStillAccepted returns null when acceptedEpc is null and a confirm step has positive outcome`() {
+    fun `acceptedEpcIfStillAccepted throws when acceptedEpc is null and a confirm step has positive outcome`() {
         val state = buildTestEpcState(acceptedEpc = null, uprnStepOutcome = YesOrNo.YES)
 
-        assertNull(state.acceptedEpcIfStillAccepted)
-    }
-
-    @Test
-    fun `acceptedEpcIfStillAccepted returns null when checkUprnMatchedEpcStep has outcome NO`() {
-        val epc = mock<EpcDataModel>()
-        val state = buildTestEpcState(acceptedEpc = epc, uprnStepOutcome = YesOrNo.NO)
-
-        assertNull(state.acceptedEpcIfStillAccepted)
-    }
-
-    @Test
-    fun `acceptedEpcIfStillAccepted returns null when confirmEpcDetailsRetrievedByCertificateNumberStep has outcome NO`() {
-        val epc = mock<EpcDataModel>()
-        val state = buildTestEpcState(acceptedEpc = epc, certStepOutcome = YesOrNo.NO)
-
-        assertNull(state.acceptedEpcIfStillAccepted)
+        assertThrows<PrsdbWebException> { state.acceptedEpcIfStillAccepted }
     }
 
     private fun buildTestEpcState(

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/states/EpcStateTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/states/EpcStateTests.kt
@@ -28,54 +28,71 @@ import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.Prope
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.ProvideEpcLaterStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.StartEpcStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.EpcDetailsTask
+import uk.gov.communities.prsdb.webapp.journeys.shared.Complete
+import uk.gov.communities.prsdb.webapp.journeys.shared.YesOrNo
 import uk.gov.communities.prsdb.webapp.models.dataModels.EpcDataModel
 
 class EpcStateTests {
     @Test
-    fun `acceptedEpcIfReachable returns acceptedEpc when checkUprnMatchedEpcStep is reachable`() {
+    fun `acceptedEpcIfStillAccepted returns acceptedEpc when checkUprnMatchedEpcStep has outcome YES`() {
         val epc = mock<EpcDataModel>()
-        val state = buildTestEpcState(acceptedEpc = epc, uprnStepReachable = true, certStepReachable = false)
+        val state = buildTestEpcState(acceptedEpc = epc, uprnStepOutcome = YesOrNo.YES)
 
-        assertEquals(epc, state.acceptedEpcIfReachable)
+        assertEquals(epc, state.acceptedEpcIfStillAccepted)
     }
 
     @Test
-    fun `acceptedEpcIfReachable returns acceptedEpc when confirmEpcDetailsRetrievedByCertificateNumberStep is reachable`() {
+    fun `acceptedEpcIfStillAccepted returns acceptedEpc when confirmEpcDetailsRetrievedByCertificateNumberStep has outcome YES`() {
         val epc = mock<EpcDataModel>()
-        val state = buildTestEpcState(acceptedEpc = epc, uprnStepReachable = false, certStepReachable = true)
+        val state = buildTestEpcState(acceptedEpc = epc, certStepOutcome = YesOrNo.YES)
 
-        assertEquals(epc, state.acceptedEpcIfReachable)
+        assertEquals(epc, state.acceptedEpcIfStillAccepted)
     }
 
     @Test
-    fun `acceptedEpcIfReachable returns acceptedEpc when checkSuperseededEpcStep is reachable`() {
+    fun `acceptedEpcIfStillAccepted returns acceptedEpc when checkSuperseededEpcStep has outcome COMPLETE`() {
         val epc = mock<EpcDataModel>()
-        val state =
-            buildTestEpcState(acceptedEpc = epc, uprnStepReachable = false, certStepReachable = false, supersededStepReachable = true)
+        val state = buildTestEpcState(acceptedEpc = epc, supersededStepOutcome = Complete.COMPLETE)
 
-        assertEquals(epc, state.acceptedEpcIfReachable)
+        assertEquals(epc, state.acceptedEpcIfStillAccepted)
     }
 
     @Test
-    fun `acceptedEpcIfReachable returns null when neither confirm step is reachable`() {
+    fun `acceptedEpcIfStillAccepted returns null when no confirm step has a positive outcome`() {
         val epc = mock<EpcDataModel>()
-        val state = buildTestEpcState(acceptedEpc = epc, uprnStepReachable = false, certStepReachable = false)
+        val state = buildTestEpcState(acceptedEpc = epc)
 
-        assertNull(state.acceptedEpcIfReachable)
+        assertNull(state.acceptedEpcIfStillAccepted)
     }
 
     @Test
-    fun `acceptedEpcIfReachable returns null when acceptedEpc is null and a confirm step is reachable`() {
-        val state = buildTestEpcState(acceptedEpc = null, uprnStepReachable = true, certStepReachable = false)
+    fun `acceptedEpcIfStillAccepted returns null when acceptedEpc is null and a confirm step has positive outcome`() {
+        val state = buildTestEpcState(acceptedEpc = null, uprnStepOutcome = YesOrNo.YES)
 
-        assertNull(state.acceptedEpcIfReachable)
+        assertNull(state.acceptedEpcIfStillAccepted)
+    }
+
+    @Test
+    fun `acceptedEpcIfStillAccepted returns null when checkUprnMatchedEpcStep has outcome NO`() {
+        val epc = mock<EpcDataModel>()
+        val state = buildTestEpcState(acceptedEpc = epc, uprnStepOutcome = YesOrNo.NO)
+
+        assertNull(state.acceptedEpcIfStillAccepted)
+    }
+
+    @Test
+    fun `acceptedEpcIfStillAccepted returns null when confirmEpcDetailsRetrievedByCertificateNumberStep has outcome NO`() {
+        val epc = mock<EpcDataModel>()
+        val state = buildTestEpcState(acceptedEpc = epc, certStepOutcome = YesOrNo.NO)
+
+        assertNull(state.acceptedEpcIfStillAccepted)
     }
 
     private fun buildTestEpcState(
         acceptedEpc: EpcDataModel? = null,
-        uprnStepReachable: Boolean = false,
-        certStepReachable: Boolean = false,
-        supersededStepReachable: Boolean = false,
+        uprnStepOutcome: YesOrNo? = null,
+        certStepOutcome: YesOrNo? = null,
+        supersededStepOutcome: Complete? = null,
     ): EpcState =
         object : AbstractJourneyState(journeyStateService = mock()), EpcState {
             override val isOccupied: Boolean? = null
@@ -94,17 +111,17 @@ class EpcStateTests {
 
             override val checkUprnMatchedEpcStep =
                 mock<ConfirmEpcRetrievedByUprnStep>().apply {
-                    whenever(this.isStepReachable).thenReturn(uprnStepReachable)
+                    whenever(this.outcome).thenReturn(uprnStepOutcome)
                 }
 
             override val confirmEpcDetailsRetrievedByCertificateNumberStep =
                 mock<ConfirmEpcDetailsRetrievedByCertificateNumberStep>().apply {
-                    whenever(this.isStepReachable).thenReturn(certStepReachable)
+                    whenever(this.outcome).thenReturn(certStepOutcome)
                 }
 
             override val checkSupersededEpcStep =
                 mock<EpcSuperseededStep>().apply {
-                    whenever(this.isStepReachable).thenReturn(supersededStepReachable)
+                    whenever(this.outcome).thenReturn(supersededStepOutcome)
                 }
 
             override val epcLookupByUprnStep = mock<EpcLookupByUprnStep>()

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/HasMissingComplianceStepConfigTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/HasMissingComplianceStepConfigTests.kt
@@ -142,7 +142,7 @@ class HasMissingComplianceStepConfigTests {
 
         private fun setupEpcMissing() {
             whenever(mockState.hasEpcStep).thenReturn(mock<HasEpcStep>())
-            whenever(mockState.acceptedEpcIfReachable).thenReturn(null)
+            whenever(mockState.acceptedEpcIfStillAccepted).thenReturn(null)
             val mockEpcExemptionStep = mock<EpcExemptionStep>()
             whenever(mockEpcExemptionStep.formModelIfReachableOrNull).thenReturn(null)
             whenever(mockState.epcExemptionStep).thenReturn(mockEpcExemptionStep)
@@ -153,7 +153,7 @@ class HasMissingComplianceStepConfigTests {
             val mockEpc = mock<EpcDataModel>()
             whenever(mockEpc.isPastExpiryDate()).thenReturn(false)
             whenever(mockEpc.isEnergyRatingEOrBetter()).thenReturn(true)
-            whenever(mockState.acceptedEpcIfReachable).thenReturn(mockEpc)
+            whenever(mockState.acceptedEpcIfStillAccepted).thenReturn(mockEpc)
         }
 
         private fun setupGasCertProvideLater() {
@@ -303,7 +303,7 @@ class HasMissingComplianceStepConfigTests {
             val mockEpc = mock<EpcDataModel>()
             whenever(mockEpc.isPastExpiryDate()).thenReturn(false)
             whenever(mockEpc.isEnergyRatingEOrBetter()).thenReturn(true)
-            whenever(mockState.acceptedEpcIfReachable).thenReturn(mockEpc)
+            whenever(mockState.acceptedEpcIfStillAccepted).thenReturn(mockEpc)
 
             assertFalse(HasMissingComplianceStepConfig.isEpcInvalid(mockState))
         }
@@ -313,7 +313,7 @@ class HasMissingComplianceStepConfigTests {
             whenever(mockState.hasEpcStep).thenReturn(mock<HasEpcStep>())
             val mockEpc = mock<EpcDataModel>()
             whenever(mockEpc.isPastExpiryDate()).thenReturn(true)
-            whenever(mockState.acceptedEpcIfReachable).thenReturn(mockEpc)
+            whenever(mockState.acceptedEpcIfStillAccepted).thenReturn(mockEpc)
 
             assertTrue(HasMissingComplianceStepConfig.isEpcInvalid(mockState))
         }
@@ -324,7 +324,7 @@ class HasMissingComplianceStepConfigTests {
             val mockEpc = mock<EpcDataModel>()
             whenever(mockEpc.isPastExpiryDate()).thenReturn(false)
             whenever(mockEpc.isEnergyRatingEOrBetter()).thenReturn(false)
-            whenever(mockState.acceptedEpcIfReachable).thenReturn(mockEpc)
+            whenever(mockState.acceptedEpcIfStillAccepted).thenReturn(mockEpc)
             val mockMeesExemptionStep = mock<MeesExemptionStep>()
             whenever(mockMeesExemptionStep.formModelIfReachableOrNull).thenReturn(null)
             whenever(mockState.meesExemptionStep).thenReturn(mockMeesExemptionStep)
@@ -338,7 +338,7 @@ class HasMissingComplianceStepConfigTests {
             val mockEpc = mock<EpcDataModel>()
             whenever(mockEpc.isPastExpiryDate()).thenReturn(false)
             whenever(mockEpc.isEnergyRatingEOrBetter()).thenReturn(false)
-            whenever(mockState.acceptedEpcIfReachable).thenReturn(mockEpc)
+            whenever(mockState.acceptedEpcIfStillAccepted).thenReturn(mockEpc)
             val mockMeesExemptionStep = mock<MeesExemptionStep>()
             val formModel =
                 MeesExemptionReasonFormModel().apply {
@@ -353,7 +353,7 @@ class HasMissingComplianceStepConfigTests {
         @Test
         fun `returns true when no accepted epc and no exemption`() {
             whenever(mockState.hasEpcStep).thenReturn(mock<HasEpcStep>())
-            whenever(mockState.acceptedEpcIfReachable).thenReturn(null)
+            whenever(mockState.acceptedEpcIfStillAccepted).thenReturn(null)
             val mockEpcExemptionStep = mock<EpcExemptionStep>()
             whenever(mockEpcExemptionStep.formModelIfReachableOrNull).thenReturn(null)
             whenever(mockState.epcExemptionStep).thenReturn(mockEpcExemptionStep)
@@ -364,7 +364,7 @@ class HasMissingComplianceStepConfigTests {
         @Test
         fun `returns false when no accepted epc but exemption present`() {
             whenever(mockState.hasEpcStep).thenReturn(mock<HasEpcStep>())
-            whenever(mockState.acceptedEpcIfReachable).thenReturn(null)
+            whenever(mockState.acceptedEpcIfStillAccepted).thenReturn(null)
             val mockEpcExemptionStep = mock<EpcExemptionStep>()
             val formModel =
                 EpcExemptionFormModel().apply {
@@ -379,7 +379,7 @@ class HasMissingComplianceStepConfigTests {
         @Test
         fun `returns true when no accepted epc and exemption reason is null`() {
             whenever(mockState.hasEpcStep).thenReturn(mock<HasEpcStep>())
-            whenever(mockState.acceptedEpcIfReachable).thenReturn(null)
+            whenever(mockState.acceptedEpcIfStillAccepted).thenReturn(null)
             val mockEpcExemptionStep = mock<EpcExemptionStep>()
             val formModel = EpcExemptionFormModel()
             whenever(mockEpcExemptionStep.formModelIfReachableOrNull).thenReturn(formModel)

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/SavePropertyRegistrationDataStepConfigTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/SavePropertyRegistrationDataStepConfigTests.kt
@@ -340,7 +340,7 @@ class SavePropertyRegistrationDataStepConfigTests {
             whenever(mockEpcCertificateUrlProvider.getEpcCertificateUrl(acceptedEpc.certificateNumber)).thenReturn(epcUrl)
         }
 
-        whenever(mockState.acceptedEpcIfReachable).thenReturn(acceptedEpc)
+        whenever(mockState.acceptedEpcIfStillAccepted).thenReturn(acceptedEpc)
 
         val mockTenancyStep = mock<EpcInDateAtStartOfTenancyCheckStep>()
         val mockEpcExemptionStep = mock<EpcExemptionStep>()
@@ -376,7 +376,7 @@ class SavePropertyRegistrationDataStepConfigTests {
 
         whenever(mockState.getGasSafetyCertificateIssueDateIfReachable()).thenReturn(null)
         whenever(mockState.getElectricalCertificateExpiryDateIfReachable()).thenReturn(null)
-        whenever(mockState.acceptedEpcIfReachable).thenReturn(null)
+        whenever(mockState.acceptedEpcIfStillAccepted).thenReturn(null)
 
         val mockTenancyStep = mock<EpcInDateAtStartOfTenancyCheckStep>()
         val mockEpcExemptionStep = mock<EpcExemptionStep>()


### PR DESCRIPTION
## Ticket number

PDJB-925

## Goal of change

Fixes the EPC being unremoveable in a very specific case

## Description of main change(s)

If the user has an automatched EPC, rejects it, adds a manual EPC, goes back and tries to say they have no EPC, you'd still get the manually entered one. This fixes that by altering logic to remove isStepReachable and use outcomes instead.

## Checklist

- [x] Unit tests for new logic (e.g. new service methods) have been added
- [x] Test suite has been run in full locally and is passing
- [x] Branch has been rebased onto main and run locally, with everything working as expected (both for your new feature
  and any related functionality)
- [x] QA instructions have been added to the ticket (particularly if this is the last PR required to complete the ticket)
