### PR TITLE
PDJB-922: Fix gas showing as non compliant when no gas supply is present

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/constants/enums/ComplianceCertStatus.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/constants/enums/ComplianceCertStatus.kt
@@ -1,6 +1,7 @@
 package uk.gov.communities.prsdb.webapp.constants.enums
 
 enum class ComplianceCertStatus {
+    NOT_REQUIRED,
     NOT_STARTED,
     ADDED,
     NOT_ADDED,

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/helpers/converters/MessageKeyConverter.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/helpers/converters/MessageKeyConverter.kt
@@ -158,8 +158,13 @@ class MessageKeyConverter {
 
         private fun convertComplianceCertStatus(complianceCertStatus: ComplianceCertStatus): String =
             when (complianceCertStatus) {
+                ComplianceCertStatus.NOT_REQUIRED -> throw IllegalStateException(
+                    "NOT_REQUIRED is a valid compliance state and should not be converted to a message key",
+                )
+                ComplianceCertStatus.ADDED -> throw IllegalStateException(
+                    "ADDED is a valid compliance state and should not be converted to a message key",
+                )
                 ComplianceCertStatus.NOT_STARTED -> "complianceActions.status.notStarted"
-                ComplianceCertStatus.ADDED -> "complianceActions.status.added"
                 ComplianceCertStatus.NOT_ADDED -> "complianceActions.status.notAdded"
                 ComplianceCertStatus.EXPIRED -> "complianceActions.status.expired"
             }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/helpers/converters/MessageKeyConverter.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/helpers/converters/MessageKeyConverter.kt
@@ -159,10 +159,13 @@ class MessageKeyConverter {
         private fun convertComplianceCertStatus(complianceCertStatus: ComplianceCertStatus): String =
             when (complianceCertStatus) {
                 ComplianceCertStatus.NOT_STARTED -> "complianceActions.status.notStarted"
+
                 ComplianceCertStatus.NOT_ADDED -> "complianceActions.status.notAdded"
+
                 ComplianceCertStatus.EXPIRED -> "complianceActions.status.expired"
+
                 else -> throw IllegalStateException(
-                    "${complianceCertStatus.name} is a valid compliance state and should not be converted to a message key",
+                    "${complianceCertStatus.name} should not be shown on the page and hence should not be converted to a message key",
                 )
             }
 

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/helpers/converters/MessageKeyConverter.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/helpers/converters/MessageKeyConverter.kt
@@ -158,15 +158,12 @@ class MessageKeyConverter {
 
         private fun convertComplianceCertStatus(complianceCertStatus: ComplianceCertStatus): String =
             when (complianceCertStatus) {
-                ComplianceCertStatus.NOT_REQUIRED -> throw IllegalStateException(
-                    "NOT_REQUIRED is a valid compliance state and should not be converted to a message key",
-                )
-                ComplianceCertStatus.ADDED -> throw IllegalStateException(
-                    "ADDED is a valid compliance state and should not be converted to a message key",
-                )
                 ComplianceCertStatus.NOT_STARTED -> "complianceActions.status.notStarted"
                 ComplianceCertStatus.NOT_ADDED -> "complianceActions.status.notAdded"
                 ComplianceCertStatus.EXPIRED -> "complianceActions.status.expired"
+                else -> throw IllegalStateException(
+                    "${complianceCertStatus.name} is a valid compliance state and should not be converted to a message key",
+                )
             }
 
         private fun convertUploadStatus(uploadStatus: FileUploadStatus): String =

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/dataModels/ComplianceStatusDataModel.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/dataModels/ComplianceStatusDataModel.kt
@@ -15,7 +15,8 @@ data class ComplianceStatusDataModel(
     val isOccupied: Boolean,
 ) {
     fun shouldShowCert(status: ComplianceCertStatus): Boolean =
-        status == ComplianceCertStatus.EXPIRED || (isOccupied && status != ComplianceCertStatus.ADDED)
+        status == ComplianceCertStatus.EXPIRED ||
+            (isOccupied && status != ComplianceCertStatus.ADDED && status != ComplianceCertStatus.NOT_REQUIRED)
 
     val shouldShowOnComplianceActionsPage: Boolean
         get() = certStatuses.any { shouldShowCert(it) }
@@ -55,6 +56,7 @@ data class ComplianceStatusDataModel(
         private val PropertyCompliance.gasSafetyStatus: ComplianceCertStatus
             get() =
                 when {
+                    this.hasGasSupply == false -> ComplianceCertStatus.NOT_REQUIRED
                     this.isGasSafetyCertMissing -> ComplianceCertStatus.NOT_ADDED
                     this.isGasSafetyCertExpired == true -> ComplianceCertStatus.EXPIRED
                     else -> ComplianceCertStatus.ADDED

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/dataModels/ComplianceStatusDataModel.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/dataModels/ComplianceStatusDataModel.kt
@@ -16,7 +16,7 @@ data class ComplianceStatusDataModel(
 ) {
     fun shouldShowCert(status: ComplianceCertStatus): Boolean =
         status == ComplianceCertStatus.EXPIRED ||
-            (isOccupied && status != ComplianceCertStatus.ADDED && status != ComplianceCertStatus.NOT_REQUIRED)
+            (isOccupied && !listOf(ComplianceCertStatus.ADDED, ComplianceCertStatus.NOT_REQUIRED).contains(status))
 
     val shouldShowOnComplianceActionsPage: Boolean
         get() = certStatuses.any { shouldShowCert(it) }

--- a/src/main/resources/messages/complianceActions.yml
+++ b/src/main/resources/messages/complianceActions.yml
@@ -10,7 +10,6 @@ action:
   goToProperty: Go to property
 status:
   notStarted: Not started
-  added: Added
   notAdded: Not added
   expired: Expired
 none:

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/helpers/converters/MessageKeyConverterTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/helpers/converters/MessageKeyConverterTests.kt
@@ -82,9 +82,23 @@ class MessageKeyConverterTests {
     }
 
     @ParameterizedTest
-    @EnumSource(ComplianceCertStatus::class)
+    @EnumSource(ComplianceCertStatus::class, names = ["NOT_REQUIRED", "ADDED"], mode = EnumSource.Mode.EXCLUDE)
     fun `convert returns a resolvable message key for every ComplianceCertStatus`(value: ComplianceCertStatus) {
         assertMessageKeyResolves(MessageKeyConverter.convert(value))
+    }
+
+    @Test
+    fun `convert throws IllegalStateException for NOT_REQUIRED ComplianceCertStatus`() {
+        org.junit.jupiter.api.assertThrows<IllegalStateException> {
+            MessageKeyConverter.convert(ComplianceCertStatus.NOT_REQUIRED)
+        }
+    }
+
+    @Test
+    fun `convert throws IllegalStateException for ADDED ComplianceCertStatus`() {
+        org.junit.jupiter.api.assertThrows<IllegalStateException> {
+            MessageKeyConverter.convert(ComplianceCertStatus.ADDED)
+        }
     }
 
     @ParameterizedTest

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/models/dataModels/ComplianceStatusDataModelTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/models/dataModels/ComplianceStatusDataModelTests.kt
@@ -101,6 +101,23 @@ class ComplianceStatusDataModelTests {
     }
 
     @Test
+    fun `fromPropertyCompliance returns ADDED gas safety status when property has no gas supply`() {
+        // Arrange
+        val propertyCompliance =
+            PropertyComplianceBuilder()
+                .withOccupiedPropertyOwnership()
+                .withHasGasSupply(false)
+                .withElectricalCertType()
+                .build()
+
+        // Act
+        val complianceStatusDataModel = ComplianceStatusDataModel.fromPropertyCompliance(propertyCompliance)
+
+        // Assert
+        assertEquals(ComplianceCertStatus.NOT_REQUIRED, complianceStatusDataModel.gasSafetyStatus)
+    }
+
+    @Test
     fun `fromPropertyOwnershipWithoutCompliance returns a ComplianceStatusDataModel with correct values`() {
         // Arrange
         val propertyOwnership = MockLandlordData.createPropertyOwnership()
@@ -171,6 +188,9 @@ class ComplianceStatusDataModelTests {
                 // ADDED never shows
                 arguments(ComplianceCertStatus.ADDED, true, false),
                 arguments(ComplianceCertStatus.ADDED, false, false),
+                // NOT_REQUIRED never shows
+                arguments(ComplianceCertStatus.NOT_REQUIRED, true, false),
+                arguments(ComplianceCertStatus.NOT_REQUIRED, false, false),
             )
 
         @JvmStatic

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/models/dataModels/ComplianceStatusDataModelTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/models/dataModels/ComplianceStatusDataModelTests.kt
@@ -101,7 +101,7 @@ class ComplianceStatusDataModelTests {
     }
 
     @Test
-    fun `fromPropertyCompliance returns ADDED gas safety status when property has no gas supply`() {
+    fun `fromPropertyCompliance returns NOT_REQUIRED gas safety status when property has no gas supply`() {
         // Arrange
         val propertyCompliance =
             PropertyComplianceBuilder()


### PR DESCRIPTION
## Ticket number

PDJB-922

## Goal of change

Gas was showing as non compliant when no gas supply is present. This fixes that

## Description of main change(s)

Adds a new NOT_REQUIRED compliance state.
Also handles errors better when the site attempts to display an ADDED state.

## Checklist

Delete any that are not applicable, and add explanation below for any that are applicable but haven't been done

- [x] Unit tests for new logic (e.g. new service methods) have been added
- [x] Test suite has been run in full locally and is passing
- [x] Branch has been rebased onto main and run locally, with everything working as expected (both for your new feature
  and any related functionality)
- [ ] QA instructions have been added to the ticket (particularly if this is the last PR required to complete the ticket)
