### PR TITLE
PDJB-794: new compliance db fields

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/constants/enums/ComplianceCertStatus.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/constants/enums/ComplianceCertStatus.kt
@@ -5,5 +5,6 @@ enum class ComplianceCertStatus {
     NOT_STARTED,
     ADDED,
     NOT_ADDED,
+    PROVIDE_LATER,
     EXPIRED,
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/database/entity/PropertyCompliance.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/database/entity/PropertyCompliance.kt
@@ -101,6 +101,12 @@ class PropertyCompliance() : ModifiableAuditableEntity() {
 
     var hasGasSupply: Boolean? = null
 
+    var gasSafetyCertProvideLater: Boolean? = null
+
+    var electricalSafetyCertProvideLater: Boolean? = null
+
+    var epcProvideLater: Boolean? = null
+
     constructor(
         propertyOwnership: PropertyOwnership,
         gasSafetyCertIssueDate: LocalDate? = null,
@@ -113,6 +119,9 @@ class PropertyCompliance() : ModifiableAuditableEntity() {
         epcEnergyRating: String? = null,
         epcExemptionReason: EpcExemptionReason? = null,
         epcMeesExemptionReason: MeesExemptionReason? = null,
+        gasSafetyCertProvideLater: Boolean? = null,
+        electricalSafetyCertProvideLater: Boolean? = null,
+        epcProvideLater: Boolean? = null,
     ) : this() {
         this.propertyOwnership = propertyOwnership
         this.gasSafetyCertIssueDate = gasSafetyCertIssueDate
@@ -125,5 +134,8 @@ class PropertyCompliance() : ModifiableAuditableEntity() {
         this.epcEnergyRating = epcEnergyRating
         this.epcExemptionReason = epcExemptionReason
         this.epcMeesExemptionReason = epcMeesExemptionReason
+        this.gasSafetyCertProvideLater = gasSafetyCertProvideLater
+        this.electricalSafetyCertProvideLater = electricalSafetyCertProvideLater
+        this.epcProvideLater = epcProvideLater
     }
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/database/entity/PropertyOwnership.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/database/entity/PropertyOwnership.kt
@@ -90,6 +90,8 @@ class PropertyOwnership() : ModifiableAuditableEntity() {
     @Column(precision = 9, scale = 2)
     var rentAmount: BigDecimal? = null
 
+    var lastOccupiedDate: LocalDate? = null
+
     constructor(
         ownershipType: OwnershipType,
         currentNumHouseholds: Int,
@@ -108,6 +110,7 @@ class PropertyOwnership() : ModifiableAuditableEntity() {
         customRentFrequency: String? = null,
         rentAmount: BigDecimal? = null,
         customPropertyType: String? = null,
+        lastOccupiedDate: LocalDate? = null,
     ) : this() {
         this.ownershipType = ownershipType
         this.currentNumHouseholds = currentNumHouseholds
@@ -126,6 +129,7 @@ class PropertyOwnership() : ModifiableAuditableEntity() {
         this.customRentFrequency = customRentFrequency
         this.rentAmount = rentAmount
         this.customPropertyType = customPropertyType
+        this.lastOccupiedDate = lastOccupiedDate
     }
 
     // TODO PRSD-1550 once Old PropertyRegistration journey is removed revert this check to just currentNumTenants > 0

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/database/entity/PropertyOwnership.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/database/entity/PropertyOwnership.kt
@@ -15,6 +15,7 @@ import uk.gov.communities.prsdb.webapp.constants.enums.PropertyType
 import uk.gov.communities.prsdb.webapp.constants.enums.RentFrequency
 import uk.gov.communities.prsdb.webapp.database.entity.Address.Companion.SINGLE_LINE_ADDRESS_LENGTH
 import java.math.BigDecimal
+import java.time.LocalDate
 
 @Entity
 class PropertyOwnership() : ModifiableAuditableEntity() {

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/helpers/converters/MessageKeyConverter.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/helpers/converters/MessageKeyConverter.kt
@@ -162,6 +162,8 @@ class MessageKeyConverter {
 
                 ComplianceCertStatus.NOT_ADDED -> "complianceActions.status.notAdded"
 
+                ComplianceCertStatus.PROVIDE_LATER -> "complianceActions.status.notAdded"
+
                 ComplianceCertStatus.EXPIRED -> "complianceActions.status.expired"
 
                 else -> throw IllegalStateException(

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/SavePropertyRegistrationDataStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/SavePropertyRegistrationDataStepConfig.kt
@@ -112,9 +112,11 @@ class SavePropertyRegistrationDataStepConfig(
             hasGasSupply = state.hasGasSupplyStep.outcome == YesOrNo.YES,
             gasSafetyCertIssueDate = state.getGasSafetyCertificateIssueDateIfReachable()?.toJavaLocalDate(),
             gasSafetyFileUploadIds = state.gasUploadIds,
+            gasSafetyCertProvideLater = state.hasGasCertStep.outcome == HasGasCertMode.PROVIDE_THIS_LATER,
             electricalSafetyFileUploadIds = state.electricalUploadIds,
             electricalSafetyExpiryDate = state.getElectricalCertificateExpiryDateIfReachable()?.toJavaLocalDate(),
             electricalCertType = state.mapElectricalCertificateTypeToGlobalCertificateType(),
+            electricalSafetyCertProvideLater = state.hasElectricalCertStep.outcome == HasElectricalCertMode.PROVIDE_THIS_LATER,
             epcCertificateUrl =
                 state.acceptedEpcIfStillAccepted?.let {
                     epcCertificateUrlProvider.getEpcCertificateUrl(it.certificateNumber)
@@ -133,6 +135,7 @@ class SavePropertyRegistrationDataStepConfig(
                 state.meesExemptionStep
                     .formModelIfReachableOrNull
                     ?.exemptionReason,
+            epcProvideLater = state.hasEpcStep.outcome == HasEpcMode.PROVIDE_LATER,
         )
     }
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/dataModels/ComplianceStatusDataModel.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/dataModels/ComplianceStatusDataModel.kt
@@ -57,7 +57,7 @@ data class ComplianceStatusDataModel(
             get() =
                 when {
                     this.hasGasSupply == false -> ComplianceCertStatus.NOT_REQUIRED
-                    this.isGasSafetyCertMissing && this.gasSafetyCertProvideLater == true -> ComplianceCertStatus.PROVIDE_LATER
+                    this.gasSafetyCertProvideLater == true -> ComplianceCertStatus.PROVIDE_LATER
                     this.isGasSafetyCertMissing -> ComplianceCertStatus.NOT_ADDED
                     this.isGasSafetyCertExpired == true -> ComplianceCertStatus.EXPIRED
                     else -> ComplianceCertStatus.ADDED
@@ -66,7 +66,7 @@ data class ComplianceStatusDataModel(
         private val PropertyCompliance.eicrStatus: ComplianceCertStatus
             get() =
                 when {
-                    this.isElectricalSafetyMissing && this.electricalSafetyCertProvideLater == true -> ComplianceCertStatus.PROVIDE_LATER
+                    this.electricalSafetyCertProvideLater == true -> ComplianceCertStatus.PROVIDE_LATER
                     this.isElectricalSafetyMissing -> ComplianceCertStatus.NOT_ADDED
                     this.isElectricalSafetyExpired == true -> ComplianceCertStatus.EXPIRED
                     else -> ComplianceCertStatus.ADDED
@@ -76,7 +76,7 @@ data class ComplianceStatusDataModel(
             get() =
                 when {
                     this.isEpcNonCompliantDueToExpiry == true -> ComplianceCertStatus.EXPIRED
-                    this.isEpcMissing && this.epcProvideLater == true -> ComplianceCertStatus.PROVIDE_LATER
+                    this.epcProvideLater == true -> ComplianceCertStatus.PROVIDE_LATER
                     this.isEpcMissing -> ComplianceCertStatus.NOT_ADDED
                     else -> ComplianceCertStatus.ADDED
                 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/dataModels/ComplianceStatusDataModel.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/dataModels/ComplianceStatusDataModel.kt
@@ -57,6 +57,7 @@ data class ComplianceStatusDataModel(
             get() =
                 when {
                     this.hasGasSupply == false -> ComplianceCertStatus.NOT_REQUIRED
+                    this.isGasSafetyCertMissing && this.gasSafetyCertProvideLater == true -> ComplianceCertStatus.PROVIDE_LATER
                     this.isGasSafetyCertMissing -> ComplianceCertStatus.NOT_ADDED
                     this.isGasSafetyCertExpired == true -> ComplianceCertStatus.EXPIRED
                     else -> ComplianceCertStatus.ADDED
@@ -65,6 +66,7 @@ data class ComplianceStatusDataModel(
         private val PropertyCompliance.eicrStatus: ComplianceCertStatus
             get() =
                 when {
+                    this.isElectricalSafetyMissing && this.electricalSafetyCertProvideLater == true -> ComplianceCertStatus.PROVIDE_LATER
                     this.isElectricalSafetyMissing -> ComplianceCertStatus.NOT_ADDED
                     this.isElectricalSafetyExpired == true -> ComplianceCertStatus.EXPIRED
                     else -> ComplianceCertStatus.ADDED
@@ -74,6 +76,7 @@ data class ComplianceStatusDataModel(
             get() =
                 when {
                     this.isEpcNonCompliantDueToExpiry == true -> ComplianceCertStatus.EXPIRED
+                    this.isEpcMissing && this.epcProvideLater == true -> ComplianceCertStatus.PROVIDE_LATER
                     this.isEpcMissing -> ComplianceCertStatus.NOT_ADDED
                     else -> ComplianceCertStatus.ADDED
                 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/PropertyComplianceService.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/PropertyComplianceService.kt
@@ -41,15 +41,18 @@ class PropertyComplianceService(
         hasGasSupply: Boolean? = null,
         gasSafetyCertIssueDate: LocalDate? = null,
         gasSafetyFileUploadIds: List<Long> = listOf(),
+        gasSafetyCertProvideLater: Boolean? = null,
         electricalSafetyFileUploadIds: List<Long> = listOf(),
         electricalSafetyExpiryDate: LocalDate? = null,
         electricalCertType: CertificateType? = null,
+        electricalSafetyCertProvideLater: Boolean? = null,
         epcCertificateUrl: String? = null,
         epcExpiryDate: LocalDate? = null,
         epcEnergyRating: String? = null,
         tenancyStartedBeforeEpcExpiry: Boolean? = null,
         epcExemptionReason: EpcExemptionReason? = null,
         epcMeesExemptionReason: MeesExemptionReason? = null,
+        epcProvideLater: Boolean? = null,
     ) {
         val propertyOwnership =
             propertyOwnershipRepository.findByRegistrationNumber_Number(registrationNumberValue)
@@ -62,12 +65,14 @@ class PropertyComplianceService(
                     hasGasSupply = hasGasSupply,
                     gasSafetyCertIssueDate = gasSafetyCertIssueDate,
                     gasSafetyFileUploadIds = gasSafetyFileUploadIds,
+                    gasSafetyCertProvideLater = gasSafetyCertProvideLater,
                 )
                 populateElectricalSafetyFields(
                     record = this,
                     electricalSafetyFileUploadIds = electricalSafetyFileUploadIds,
                     electricalSafetyExpiryDate = electricalSafetyExpiryDate,
                     electricalCertType = electricalCertType,
+                    electricalSafetyCertProvideLater = electricalSafetyCertProvideLater,
                 )
                 populateEpcFields(
                     record = this,
@@ -77,6 +82,7 @@ class PropertyComplianceService(
                     tenancyStartedBeforeEpcExpiry = tenancyStartedBeforeEpcExpiry,
                     epcExemptionReason = epcExemptionReason,
                     epcMeesExemptionReason = epcMeesExemptionReason,
+                    epcProvideLater = epcProvideLater,
                 )
             }
 
@@ -95,9 +101,11 @@ class PropertyComplianceService(
         hasGasSupply: Boolean?,
         gasSafetyCertIssueDate: LocalDate?,
         gasSafetyFileUploadIds: List<Long>,
+        gasSafetyCertProvideLater: Boolean? = null,
     ) {
         record.hasGasSupply = hasGasSupply
         record.gasSafetyCertIssueDate = gasSafetyCertIssueDate
+        record.gasSafetyCertProvideLater = gasSafetyCertProvideLater
         record.gasSafetyFileUploads =
             gasSafetyFileUploadIds
                 .map { id -> fileUploadRepository.getReferenceById(id) }
@@ -109,6 +117,7 @@ class PropertyComplianceService(
         electricalSafetyFileUploadIds: List<Long>,
         electricalSafetyExpiryDate: LocalDate?,
         electricalCertType: CertificateType?,
+        electricalSafetyCertProvideLater: Boolean? = null,
     ) {
         record.electricalSafetyFileUploads =
             electricalSafetyFileUploadIds
@@ -116,6 +125,7 @@ class PropertyComplianceService(
                 .toMutableList()
         record.electricalSafetyExpiryDate = electricalSafetyExpiryDate
         record.electricalCertType = electricalCertType
+        record.electricalSafetyCertProvideLater = electricalSafetyCertProvideLater
     }
 
     private fun populateEpcFields(
@@ -126,6 +136,7 @@ class PropertyComplianceService(
         tenancyStartedBeforeEpcExpiry: Boolean?,
         epcExemptionReason: EpcExemptionReason?,
         epcMeesExemptionReason: MeesExemptionReason?,
+        epcProvideLater: Boolean? = null,
     ) {
         record.epcUrl = epcCertificateUrl
         record.epcExpiryDate = epcExpiryDate
@@ -133,6 +144,7 @@ class PropertyComplianceService(
         record.tenancyStartedBeforeEpcExpiry = tenancyStartedBeforeEpcExpiry
         record.epcExemptionReason = epcExemptionReason
         record.epcMeesExemptionReason = epcMeesExemptionReason
+        record.epcProvideLater = epcProvideLater
     }
 
     private fun updateFileUploadVirusScanningCallbacks(

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/PropertyOwnershipService.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/PropertyOwnershipService.kt
@@ -29,6 +29,7 @@ import uk.gov.communities.prsdb.webapp.models.viewModels.summaryModels.Registere
 import uk.gov.communities.prsdb.webapp.models.viewModels.summaryModels.RegisteredPropertyLocalCouncilViewModel
 import java.math.BigDecimal
 import java.time.Instant
+import java.time.LocalDate
 
 @PrsdbWebService
 class PropertyOwnershipService(
@@ -59,7 +60,7 @@ class PropertyOwnershipService(
     ): PropertyOwnership {
         val registrationNumber = registrationNumberService.createRegistrationNumber(RegistrationNumberType.PROPERTY)
 
-        return propertyOwnershipRepository.save(
+        val propertyOwnership =
             PropertyOwnership(
                 ownershipType = ownershipType,
                 currentNumHouseholds = numberOfHouseholds,
@@ -78,8 +79,10 @@ class PropertyOwnershipService(
                 rentFrequency = rentFrequency,
                 customRentFrequency = customRentFrequency,
                 rentAmount = rentAmount,
-            ),
-        )
+            )
+        propertyOwnership.updateLastOccupiedDateIfNowOccupied(wasOccupied = false)
+
+        return propertyOwnershipRepository.save(propertyOwnership)
     }
 
     fun getPropertyOwnershipIfAuthorizedUser(
@@ -246,6 +249,7 @@ class PropertyOwnershipService(
     ) {
         val propertyOwnership = getPropertyOwnership(id)
         throwErrorIfLastModifiedDatesConflict(propertyOwnership, initialLastModifiedDate)
+        val wasOccupied = propertyOwnership.isOccupied
         propertyOwnership.currentNumHouseholds = numberOfHouseholds
         propertyOwnership.currentNumTenants = numberOfPeople
         propertyOwnership.numBedrooms = numBedrooms
@@ -255,6 +259,7 @@ class PropertyOwnershipService(
         propertyOwnership.rentFrequency = rentFrequency
         propertyOwnership.customRentFrequency = customRentFrequency
         propertyOwnership.rentAmount = rentAmount
+        propertyOwnership.updateLastOccupiedDateIfNowOccupied(wasOccupied)
         propertyOwnershipRepository.save(propertyOwnership)
     }
 
@@ -354,6 +359,12 @@ class PropertyOwnershipService(
         propertyOwnershipRepository.existsByPrimaryLandlord_BaseUser_IdAndIsActiveTrue(baseUserId)
 
     fun getPropertyCountForLandlord(baseUserId: String): Long = propertyOwnershipRepository.countByPrimaryLandlord_BaseUser_Id(baseUserId)
+
+    private fun PropertyOwnership.updateLastOccupiedDateIfNowOccupied(wasOccupied: Boolean) {
+        if (!wasOccupied && isOccupied) {
+            lastOccupiedDate = LocalDate.now()
+        }
+    }
 
     private fun throwErrorIfLastModifiedDatesConflict(
         propertyOwnership: PropertyOwnership,

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/PropertyOwnershipService.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/PropertyOwnershipService.kt
@@ -60,7 +60,7 @@ class PropertyOwnershipService(
     ): PropertyOwnership {
         val registrationNumber = registrationNumberService.createRegistrationNumber(RegistrationNumberType.PROPERTY)
 
-        val propertyOwnership =
+        return propertyOwnershipRepository.save(
             PropertyOwnership(
                 ownershipType = ownershipType,
                 currentNumHouseholds = numberOfHouseholds,
@@ -79,10 +79,10 @@ class PropertyOwnershipService(
                 rentFrequency = rentFrequency,
                 customRentFrequency = customRentFrequency,
                 rentAmount = rentAmount,
-            )
-        propertyOwnership.updateLastOccupiedDateIfNowOccupied(wasOccupied = false)
-
-        return propertyOwnershipRepository.save(propertyOwnership)
+            ).apply {
+                if (isOccupied) lastOccupiedDate = LocalDate.now()
+            },
+        )
     }
 
     fun getPropertyOwnershipIfAuthorizedUser(
@@ -259,7 +259,9 @@ class PropertyOwnershipService(
         propertyOwnership.rentFrequency = rentFrequency
         propertyOwnership.customRentFrequency = customRentFrequency
         propertyOwnership.rentAmount = rentAmount
-        propertyOwnership.updateLastOccupiedDateIfNowOccupied(wasOccupied)
+        if (!wasOccupied && propertyOwnership.isOccupied) {
+            propertyOwnership.lastOccupiedDate = LocalDate.now()
+        }
         propertyOwnershipRepository.save(propertyOwnership)
     }
 
@@ -359,12 +361,6 @@ class PropertyOwnershipService(
         propertyOwnershipRepository.existsByPrimaryLandlord_BaseUser_IdAndIsActiveTrue(baseUserId)
 
     fun getPropertyCountForLandlord(baseUserId: String): Long = propertyOwnershipRepository.countByPrimaryLandlord_BaseUser_Id(baseUserId)
-
-    private fun PropertyOwnership.updateLastOccupiedDateIfNowOccupied(wasOccupied: Boolean) {
-        if (!wasOccupied && isOccupied) {
-            lastOccupiedDate = LocalDate.now()
-        }
-    }
 
     private fun throwErrorIfLastModifiedDatesConflict(
         propertyOwnership: PropertyOwnership,

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/PropertyRegistrationService.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/PropertyRegistrationService.kt
@@ -57,15 +57,18 @@ class PropertyRegistrationService(
         hasGasSupply: Boolean? = null,
         gasSafetyCertIssueDate: LocalDate? = null,
         gasSafetyFileUploadIds: List<Long> = emptyList(),
+        gasSafetyCertProvideLater: Boolean? = null,
         electricalSafetyFileUploadIds: List<Long> = emptyList(),
         electricalSafetyExpiryDate: LocalDate? = null,
         electricalCertType: CertificateType? = null,
+        electricalSafetyCertProvideLater: Boolean? = null,
         epcCertificateUrl: String? = null,
         epcExpiryDate: LocalDate? = null,
         epcEnergyRating: String? = null,
         tenancyStartedBeforeEpcExpiry: Boolean? = null,
         epcExemptionReason: EpcExemptionReason? = null,
         epcMeesExemptionReason: MeesExemptionReason? = null,
+        epcProvideLater: Boolean? = null,
     ) {
         val landlord =
             landlordRepository.findByBaseUser_Id(baseUserId)
@@ -96,15 +99,18 @@ class PropertyRegistrationService(
             hasGasSupply,
             gasSafetyCertIssueDate,
             gasSafetyFileUploadIds,
+            gasSafetyCertProvideLater = gasSafetyCertProvideLater,
             electricalSafetyFileUploadIds,
             electricalSafetyExpiryDate,
             electricalCertType,
+            electricalSafetyCertProvideLater = electricalSafetyCertProvideLater,
             epcCertificateUrl,
             epcExpiryDate,
             epcEnergyRating,
             tenancyStartedBeforeEpcExpiry,
             epcExemptionReason,
             epcMeesExemptionReason,
+            epcProvideLater = epcProvideLater,
         )
 
         confirmationService.setLastPrnRegisteredThisSession(propertyOwnership.registrationNumber.number)

--- a/src/main/resources/db/migrations/V1_26_0__add_compliance_tracking_fields.sql
+++ b/src/main/resources/db/migrations/V1_26_0__add_compliance_tracking_fields.sql
@@ -2,12 +2,7 @@ ALTER TABLE property_ownership ADD COLUMN last_occupied_date DATE;
 
 UPDATE property_ownership
 SET last_occupied_date = created_date::date
-WHERE current_num_tenants > 0
-  AND current_num_households > 0
-  AND num_bedrooms IS NOT NULL AND num_bedrooms > 0
-  AND furnished_status IS NOT NULL
-  AND rent_frequency IS NOT NULL
-  AND rent_amount IS NOT NULL;
+WHERE current_num_tenants > 0;
 
 ALTER TABLE property_compliance ADD COLUMN gas_safety_cert_provide_later BOOLEAN;
 ALTER TABLE property_compliance ADD COLUMN electrical_safety_cert_provide_later BOOLEAN;

--- a/src/main/resources/db/migrations/V1_26_0__add_compliance_tracking_fields.sql
+++ b/src/main/resources/db/migrations/V1_26_0__add_compliance_tracking_fields.sql
@@ -1,0 +1,14 @@
+ALTER TABLE property_ownership ADD COLUMN last_occupied_date DATE;
+
+UPDATE property_ownership
+SET last_occupied_date = CURRENT_DATE
+WHERE current_num_tenants > 0
+  AND current_num_households > 0
+  AND num_bedrooms IS NOT NULL AND num_bedrooms > 0
+  AND furnished_status IS NOT NULL
+  AND rent_frequency IS NOT NULL
+  AND rent_amount IS NOT NULL;
+
+ALTER TABLE property_compliance ADD COLUMN gas_safety_cert_provide_later BOOLEAN;
+ALTER TABLE property_compliance ADD COLUMN electrical_safety_cert_provide_later BOOLEAN;
+ALTER TABLE property_compliance ADD COLUMN epc_provide_later BOOLEAN;

--- a/src/main/resources/db/migrations/V1_26_0__add_compliance_tracking_fields.sql
+++ b/src/main/resources/db/migrations/V1_26_0__add_compliance_tracking_fields.sql
@@ -1,7 +1,7 @@
 ALTER TABLE property_ownership ADD COLUMN last_occupied_date DATE;
 
 UPDATE property_ownership
-SET last_occupied_date = CURRENT_DATE
+SET last_occupied_date = created_date::date
 WHERE current_num_tenants > 0
   AND current_num_households > 0
   AND num_bedrooms IS NOT NULL AND num_bedrooms > 0
@@ -12,3 +12,8 @@ WHERE current_num_tenants > 0
 ALTER TABLE property_compliance ADD COLUMN gas_safety_cert_provide_later BOOLEAN;
 ALTER TABLE property_compliance ADD COLUMN electrical_safety_cert_provide_later BOOLEAN;
 ALTER TABLE property_compliance ADD COLUMN epc_provide_later BOOLEAN;
+
+UPDATE property_compliance
+SET gas_safety_cert_provide_later = false,
+    electrical_safety_cert_provide_later = false,
+    epc_provide_later = false;

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/SavePropertyRegistrationDataStepConfigTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/SavePropertyRegistrationDataStepConfigTests.kt
@@ -144,15 +144,18 @@ class SavePropertyRegistrationDataStepConfigTests {
             hasGasSupply = eq(true),
             gasSafetyCertIssueDate = eq(gasCertIssueDate.toJavaLocalDate()),
             gasSafetyFileUploadIds = eq(gasUploadIds),
+            gasSafetyCertProvideLater = eq(false),
             electricalSafetyFileUploadIds = eq(electricalUploadIds),
             electricalSafetyExpiryDate = eq(electricalSafetyExpiryDate.toJavaLocalDate()),
             electricalCertType = eq(CertificateType.Eicr),
+            electricalSafetyCertProvideLater = eq(false),
             epcCertificateUrl = eq(epcUrl),
             epcExpiryDate = eq(acceptedEpc.expiryDate.toJavaLocalDate()),
             epcEnergyRating = eq(acceptedEpc.energyRating),
             tenancyStartedBeforeEpcExpiry = eq(true),
             epcExemptionReason = eq(epcExemptionReason),
             epcMeesExemptionReason = eq(meesExemptionReason),
+            epcProvideLater = eq(false),
         )
     }
 
@@ -186,15 +189,18 @@ class SavePropertyRegistrationDataStepConfigTests {
                 hasGasSupply = anyOrNull(),
                 gasSafetyCertIssueDate = anyOrNull(),
                 gasSafetyFileUploadIds = any(),
+                gasSafetyCertProvideLater = anyOrNull(),
                 electricalSafetyFileUploadIds = any(),
                 electricalSafetyExpiryDate = anyOrNull(),
                 electricalCertType = anyOrNull(),
+                electricalSafetyCertProvideLater = anyOrNull(),
                 epcCertificateUrl = anyOrNull(),
                 epcExpiryDate = anyOrNull(),
                 epcEnergyRating = anyOrNull(),
                 tenancyStartedBeforeEpcExpiry = anyOrNull(),
                 epcExemptionReason = anyOrNull(),
                 epcMeesExemptionReason = anyOrNull(),
+                epcProvideLater = anyOrNull(),
             ),
         ).thenThrow(EntityExistsException("Address already registered"))
 
@@ -238,15 +244,18 @@ class SavePropertyRegistrationDataStepConfigTests {
             hasGasSupply = anyOrNull(),
             gasSafetyCertIssueDate = isNull(),
             gasSafetyFileUploadIds = eq(emptyList()),
+            gasSafetyCertProvideLater = anyOrNull(),
             electricalSafetyFileUploadIds = eq(emptyList()),
             electricalSafetyExpiryDate = isNull(),
             electricalCertType = isNull(),
+            electricalSafetyCertProvideLater = anyOrNull(),
             epcCertificateUrl = isNull(),
             epcExpiryDate = isNull(),
             epcEnergyRating = isNull(),
             tenancyStartedBeforeEpcExpiry = isNull(),
             epcExemptionReason = isNull(),
             epcMeesExemptionReason = isNull(),
+            epcProvideLater = anyOrNull(),
         )
     }
 
@@ -333,6 +342,18 @@ class SavePropertyRegistrationDataStepConfigTests {
         whenever(mockState.hasGasSupplyStep).thenReturn(mockHasGasSupplyStep)
         whenever(mockHasGasSupplyStep.outcome).thenReturn(YesOrNo.YES)
 
+        val mockHasGasCertStep = mock<HasGasCertStep>()
+        whenever(mockState.hasGasCertStep).thenReturn(mockHasGasCertStep)
+        whenever(mockHasGasCertStep.outcome).thenReturn(HasGasCertMode.HAS_CERTIFICATE)
+
+        val mockHasElectricalCertStep = mock<HasElectricalCertStep>()
+        whenever(mockState.hasElectricalCertStep).thenReturn(mockHasElectricalCertStep)
+        whenever(mockHasElectricalCertStep.outcome).thenReturn(HasElectricalCertMode.HAS_EIC)
+
+        val mockHasEpcStep = mock<HasEpcStep>()
+        whenever(mockState.hasEpcStep).thenReturn(mockHasEpcStep)
+        whenever(mockHasEpcStep.outcome).thenReturn(HasEpcMode.HAS_EPC)
+
         whenever(mockState.getGasSafetyCertificateIssueDateIfReachable()).thenReturn(gasCertIssueDate)
         whenever(mockState.getElectricalCertificateExpiryDateIfReachable()).thenReturn(electricalCertExpiryDate)
 
@@ -373,6 +394,18 @@ class SavePropertyRegistrationDataStepConfigTests {
         val mockHasGasSupplyStep = mock<HasGasSupplyStep>()
         whenever(mockState.hasGasSupplyStep).thenReturn(mockHasGasSupplyStep)
         whenever(mockHasGasSupplyStep.outcome).thenReturn(YesOrNo.YES)
+
+        val mockHasGasCertStep = mock<HasGasCertStep>()
+        whenever(mockState.hasGasCertStep).thenReturn(mockHasGasCertStep)
+        whenever(mockHasGasCertStep.outcome).thenReturn(null)
+
+        val mockHasElectricalCertStep = mock<HasElectricalCertStep>()
+        whenever(mockState.hasElectricalCertStep).thenReturn(mockHasElectricalCertStep)
+        whenever(mockHasElectricalCertStep.outcome).thenReturn(null)
+
+        val mockHasEpcStep = mock<HasEpcStep>()
+        whenever(mockState.hasEpcStep).thenReturn(mockHasEpcStep)
+        whenever(mockHasEpcStep.outcome).thenReturn(null)
 
         whenever(mockState.getGasSafetyCertificateIssueDateIfReachable()).thenReturn(null)
         whenever(mockState.getElectricalCertificateExpiryDateIfReachable()).thenReturn(null)

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/PropertyComplianceServiceTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/PropertyComplianceServiceTests.kt
@@ -313,6 +313,76 @@ class PropertyComplianceServiceTests {
         }
 
         @Test
+        fun `sets gasSafetyCertProvideLater when provided`() {
+            whenever(mockPropertyOwnershipRepository.findByRegistrationNumber_Number(registrationNumberValue))
+                .thenReturn(mockPropertyOwnership)
+            whenever(mockPropertyComplianceRepository.save(any<PropertyCompliance>()))
+                .thenAnswer { it.arguments[0] }
+
+            propertyComplianceService.saveRegistrationComplianceData(
+                registrationNumberValue = registrationNumberValue,
+                gasSafetyCertProvideLater = true,
+            )
+
+            val captor = captor<PropertyCompliance>()
+            verify(mockPropertyComplianceRepository).save(captor.capture())
+            assertEquals(true, captor.value.gasSafetyCertProvideLater)
+        }
+
+        @Test
+        fun `sets electricalSafetyCertProvideLater when provided`() {
+            whenever(mockPropertyOwnershipRepository.findByRegistrationNumber_Number(registrationNumberValue))
+                .thenReturn(mockPropertyOwnership)
+            whenever(mockPropertyComplianceRepository.save(any<PropertyCompliance>()))
+                .thenAnswer { it.arguments[0] }
+
+            propertyComplianceService.saveRegistrationComplianceData(
+                registrationNumberValue = registrationNumberValue,
+                electricalSafetyCertProvideLater = true,
+            )
+
+            val captor = captor<PropertyCompliance>()
+            verify(mockPropertyComplianceRepository).save(captor.capture())
+            assertEquals(true, captor.value.electricalSafetyCertProvideLater)
+        }
+
+        @Test
+        fun `sets epcProvideLater when provided`() {
+            whenever(mockPropertyOwnershipRepository.findByRegistrationNumber_Number(registrationNumberValue))
+                .thenReturn(mockPropertyOwnership)
+            whenever(mockPropertyComplianceRepository.save(any<PropertyCompliance>()))
+                .thenAnswer { it.arguments[0] }
+
+            propertyComplianceService.saveRegistrationComplianceData(
+                registrationNumberValue = registrationNumberValue,
+                epcProvideLater = true,
+            )
+
+            val captor = captor<PropertyCompliance>()
+            verify(mockPropertyComplianceRepository).save(captor.capture())
+            assertEquals(true, captor.value.epcProvideLater)
+        }
+
+        @Test
+        fun `provideLater flags default to null when not specified`() {
+            whenever(mockPropertyOwnershipRepository.findByRegistrationNumber_Number(registrationNumberValue))
+                .thenReturn(mockPropertyOwnership)
+            whenever(mockPropertyComplianceRepository.save(any<PropertyCompliance>()))
+                .thenAnswer { it.arguments[0] }
+
+            propertyComplianceService.saveRegistrationComplianceData(
+                registrationNumberValue = registrationNumberValue,
+            )
+
+            val captor = captor<PropertyCompliance>()
+            verify(mockPropertyComplianceRepository).save(captor.capture())
+            val saved = captor.value
+            assertNull(saved.gasSafetyCertProvideLater)
+            assertNull(saved.electricalSafetyCertProvideLater)
+            assertNull(saved.epcProvideLater)
+        }
+
+        @Test
         fun `throws EntityNotFoundException when property ownership is not found`() {
             whenever(mockPropertyOwnershipRepository.findByRegistrationNumber_Number(registrationNumberValue))
                 .thenReturn(null)
@@ -481,6 +551,28 @@ class PropertyComplianceServiceTests {
             val captor = captor<PropertyCompliance>()
             verify(mockPropertyComplianceRepository).save(captor.capture())
             assertEquals(false, captor.value.hasGasSupply)
+        }
+
+        @Test
+        fun `resets gasSafetyCertProvideLater to null when gas safety is updated`() {
+            val compliance = createComplianceWithLastModifiedDate()
+            compliance.gasSafetyCertProvideLater = true
+
+            whenever(mockPropertyComplianceRepository.findByPropertyOwnership_Id(propertyOwnershipId))
+                .thenReturn(compliance)
+            whenever(mockPropertyComplianceRepository.save(any<PropertyCompliance>()))
+                .thenAnswer { it.arguments[0] }
+
+            propertyComplianceService.updateGasSafety(
+                propertyOwnershipId = propertyOwnershipId,
+                initialLastModifiedDate = initialLastModifiedDate,
+                hasGasSupply = true,
+                gasSafetyCertIssueDate = LocalDate.of(2025, 6, 15),
+            )
+
+            val captor = captor<PropertyCompliance>()
+            verify(mockPropertyComplianceRepository).save(captor.capture())
+            assertNull(captor.value.gasSafetyCertProvideLater)
         }
 
         @Test
@@ -853,6 +945,28 @@ class PropertyComplianceServiceTests {
             verify(mockVirusScanCallbackService).deleteAllCallbacksForFileUpload(10L)
             verify(mockVirusScanCallbackService).saveEmailToMonitoringTeam(propertyOwnershipId, 10L, CertificateType.Eicr)
             verify(mockVirusScanCallbackService).saveEmailToOwner(propertyOwnershipId, 10L, CertificateType.Eicr)
+        }
+
+        @Test
+        fun `resets electricalSafetyCertProvideLater to null when electrical safety is updated`() {
+            val compliance = createComplianceWithLastModifiedDate()
+            compliance.electricalSafetyCertProvideLater = true
+
+            whenever(mockPropertyComplianceRepository.findByPropertyOwnership_Id(propertyOwnershipId))
+                .thenReturn(compliance)
+            whenever(mockPropertyComplianceRepository.save(any<PropertyCompliance>()))
+                .thenAnswer { it.arguments[0] }
+
+            propertyComplianceService.updateElectricalSafety(
+                propertyOwnershipId = propertyOwnershipId,
+                initialLastModifiedDate = initialLastModifiedDate,
+                electricalCertType = CertificateType.Eicr,
+                electricalSafetyExpiryDate = LocalDate.of(2030, 3, 20),
+            )
+
+            val captor = captor<PropertyCompliance>()
+            verify(mockPropertyComplianceRepository).save(captor.capture())
+            assertNull(captor.value.electricalSafetyCertProvideLater)
         }
 
         @Test
@@ -1253,6 +1367,29 @@ class PropertyComplianceServiceTests {
             assertNull(saved.tenancyStartedBeforeEpcExpiry)
             assertNull(saved.epcExemptionReason)
             assertNull(saved.epcMeesExemptionReason)
+        }
+
+        @Test
+        fun `resets epcProvideLater to null when EPC is updated`() {
+            val compliance = createComplianceWithLastModifiedDate()
+            compliance.epcProvideLater = true
+
+            whenever(mockPropertyComplianceRepository.findByPropertyOwnership_Id(propertyOwnershipId))
+                .thenReturn(compliance)
+            whenever(mockPropertyComplianceRepository.save(any<PropertyCompliance>()))
+                .thenAnswer { it.arguments[0] }
+
+            propertyComplianceService.updateEpc(
+                propertyOwnershipId = propertyOwnershipId,
+                initialLastModifiedDate = initialLastModifiedDate,
+                epcCertificateUrl = "https://example.com/epc/1234-5678-9012-3456-7890",
+                epcExpiryDate = LocalDate.now().plusYears(5),
+                epcEnergyRating = "C",
+            )
+
+            val captor = captor<PropertyCompliance>()
+            verify(mockPropertyComplianceRepository).save(captor.capture())
+            assertNull(captor.value.epcProvideLater)
         }
 
         @Test

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/PropertyOwnershipServiceTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/PropertyOwnershipServiceTests.kt
@@ -50,6 +50,7 @@ import uk.gov.communities.prsdb.webapp.testHelpers.mockObjects.MockLandlordData
 import uk.gov.communities.prsdb.webapp.testHelpers.mockObjects.MockLocalCouncilData
 import uk.gov.communities.prsdb.webapp.testHelpers.mockObjects.MockPrsdbUserData
 import java.math.BigDecimal
+import java.time.LocalDate
 import java.time.temporal.ChronoUnit
 
 @ExtendWith(MockitoExtension::class)
@@ -206,6 +207,78 @@ class PropertyOwnershipServiceTests {
         val propertyOwnershipCaptor = captor<PropertyOwnership>()
         verify(mockPropertyOwnershipRepository).save(propertyOwnershipCaptor.capture())
         assertTrue(ReflectionEquals(expectedPropertyOwnership).matches(propertyOwnershipCaptor.value))
+    }
+
+    @Test
+    fun `createPropertyOwnership sets lastOccupiedDate when property is occupied`() {
+        val registrationNumber = RegistrationNumber(RegistrationNumberType.PROPERTY, 1233456)
+        val landlord = MockLandlordData.createLandlord()
+        val propertyBuildType = PropertyType.OTHER
+        val address = MockLandlordData.createAddress("11 Example Road, EG1 2AB")
+
+        whenever(mockRegistrationNumberService.createRegistrationNumber(RegistrationNumberType.PROPERTY)).thenReturn(
+            registrationNumber,
+        )
+        whenever(mockPropertyOwnershipRepository.save(any<PropertyOwnership>())).thenAnswer {
+            it.arguments[0] as PropertyOwnership
+        }
+
+        propertyOwnershipService.createPropertyOwnership(
+            ownershipType = OwnershipType.FREEHOLD,
+            numberOfHouseholds = 1,
+            numberOfPeople = 2,
+            primaryLandlord = landlord,
+            propertyBuildType = propertyBuildType,
+            customPropertyType = "End terrace",
+            address = address,
+            numBedrooms = 1,
+            billsIncludedList = "Electricity, Water",
+            customBillsIncluded = "Internet",
+            furnishedStatus = FurnishedStatus.FURNISHED,
+            rentFrequency = RentFrequency.OTHER,
+            customRentFrequency = "Fortnightly",
+            rentAmount = 123.toBigDecimal(),
+        )
+
+        val propertyOwnershipCaptor = captor<PropertyOwnership>()
+        verify(mockPropertyOwnershipRepository).save(propertyOwnershipCaptor.capture())
+        assertEquals(LocalDate.now(), propertyOwnershipCaptor.value.lastOccupiedDate)
+    }
+
+    @Test
+    fun `createPropertyOwnership does not set lastOccupiedDate when property is unoccupied`() {
+        val registrationNumber = RegistrationNumber(RegistrationNumberType.PROPERTY, 1233456)
+        val landlord = MockLandlordData.createLandlord()
+        val propertyBuildType = PropertyType.OTHER
+        val address = MockLandlordData.createAddress("11 Example Road, EG1 2AB")
+
+        whenever(mockRegistrationNumberService.createRegistrationNumber(RegistrationNumberType.PROPERTY)).thenReturn(
+            registrationNumber,
+        )
+        whenever(mockPropertyOwnershipRepository.save(any<PropertyOwnership>())).thenAnswer {
+            it.arguments[0] as PropertyOwnership
+        }
+
+        propertyOwnershipService.createPropertyOwnership(
+            ownershipType = OwnershipType.FREEHOLD,
+            numberOfHouseholds = 0,
+            numberOfPeople = 0,
+            primaryLandlord = landlord,
+            propertyBuildType = propertyBuildType,
+            customPropertyType = "End terrace",
+            address = address,
+            numBedrooms = null,
+            billsIncludedList = null,
+            customBillsIncluded = null,
+            furnishedStatus = null,
+            rentFrequency = null,
+            customRentFrequency = null,
+            rentAmount = null,
+        )
+
+        val propertyOwnershipCaptor = captor<PropertyOwnership>()
+        verify(mockPropertyOwnershipRepository).save(propertyOwnershipCaptor.capture())
+        assertEquals(null, propertyOwnershipCaptor.value.lastOccupiedDate)
     }
 
     @Nested
@@ -767,6 +840,91 @@ class PropertyOwnershipServiceTests {
 
             // Assert
             assertEquals(newNumberOfTenants, propertyOwnership.currentNumTenants)
+        }
+
+        @Test
+        fun `updateOccupancy sets lastOccupiedDate when property transitions to occupied`() {
+            // Arrange
+            val propertyOwnership = MockLandlordData.createPropertyOwnership(id = 1)
+            whenever(mockPropertyOwnershipRepository.findByIdAndIsActiveTrue(propertyOwnership.id)).thenReturn(
+                propertyOwnership,
+            )
+
+            // Act
+            propertyOwnershipService.updateOccupancy(
+                propertyOwnership.id,
+                numberOfPeople = 2,
+                numberOfHouseholds = 1,
+                numBedrooms = 1,
+                billsIncludedList = "Electricity, Water",
+                customBillsIncluded = "Internet",
+                furnishedStatus = FurnishedStatus.FURNISHED,
+                rentFrequency = RentFrequency.OTHER,
+                customRentFrequency = "Fortnightly",
+                rentAmount = 123.toBigDecimal(),
+                initialLastModifiedDate = propertyOwnership.getMostRecentlyUpdated(),
+            )
+
+            // Assert
+            assertEquals(LocalDate.now(), propertyOwnership.lastOccupiedDate)
+        }
+
+        @Test
+        fun `updateOccupancy does not change lastOccupiedDate when property remains occupied`() {
+            // Arrange
+            val propertyOwnership = MockLandlordData.createOccupiedPropertyOwnership(id = 1)
+            val existingLastOccupiedDate = LocalDate.now().minusDays(10)
+            ReflectionTestUtils.setField(propertyOwnership, "lastOccupiedDate", existingLastOccupiedDate)
+            whenever(mockPropertyOwnershipRepository.findByIdAndIsActiveTrue(propertyOwnership.id)).thenReturn(
+                propertyOwnership,
+            )
+
+            // Act
+            propertyOwnershipService.updateOccupancy(
+                propertyOwnership.id,
+                numberOfPeople = propertyOwnership.currentNumTenants + 1,
+                numberOfHouseholds = propertyOwnership.currentNumHouseholds,
+                numBedrooms = propertyOwnership.numBedrooms,
+                billsIncludedList = propertyOwnership.billsIncludedList,
+                customBillsIncluded = propertyOwnership.customBillsIncluded,
+                furnishedStatus = propertyOwnership.furnishedStatus,
+                rentFrequency = propertyOwnership.rentFrequency,
+                customRentFrequency = propertyOwnership.customRentFrequency,
+                rentAmount = propertyOwnership.rentAmount,
+                initialLastModifiedDate = propertyOwnership.getMostRecentlyUpdated(),
+            )
+
+            // Assert
+            assertEquals(existingLastOccupiedDate, propertyOwnership.lastOccupiedDate)
+        }
+
+        @Test
+        fun `updateOccupancy does not set lastOccupiedDate when property transitions to unoccupied`() {
+            // Arrange
+            val propertyOwnership = MockLandlordData.createOccupiedPropertyOwnership(id = 1)
+            val existingLastOccupiedDate = LocalDate.now().minusDays(10)
+            ReflectionTestUtils.setField(propertyOwnership, "lastOccupiedDate", existingLastOccupiedDate)
+            whenever(mockPropertyOwnershipRepository.findByIdAndIsActiveTrue(propertyOwnership.id)).thenReturn(
+                propertyOwnership,
+            )
+
+            // Act
+            propertyOwnershipService.updateOccupancy(
+                propertyOwnership.id,
+                numberOfPeople = 0,
+                numberOfHouseholds = propertyOwnership.currentNumHouseholds,
+                numBedrooms = propertyOwnership.numBedrooms,
+                billsIncludedList = propertyOwnership.billsIncludedList,
+                customBillsIncluded = propertyOwnership.customBillsIncluded,
+                furnishedStatus = propertyOwnership.furnishedStatus,
+                rentFrequency = propertyOwnership.rentFrequency,
+                customRentFrequency = propertyOwnership.customRentFrequency,
+                rentAmount = propertyOwnership.rentAmount,
+                initialLastModifiedDate = propertyOwnership.getMostRecentlyUpdated(),
+            )
+
+            // Assert
+            assertEquals(existingLastOccupiedDate, propertyOwnership.lastOccupiedDate)
         }
 
         @Test

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/PropertyOwnershipServiceTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/PropertyOwnershipServiceTests.kt
@@ -110,6 +110,7 @@ class PropertyOwnershipServiceTests {
                 rentFrequency = rentFrequency,
                 customRentFrequency = customRentFrequency,
                 rentAmount = rentAmount,
+                lastOccupiedDate = LocalDate.now(),
             )
 
         whenever(mockRegistrationNumberService.createRegistrationNumber(RegistrationNumberType.PROPERTY)).thenReturn(
@@ -178,6 +179,7 @@ class PropertyOwnershipServiceTests {
                 rentFrequency = rentFrequency,
                 customRentFrequency = customRentFrequency,
                 rentAmount = rentAmount,
+                lastOccupiedDate = LocalDate.now(),
             )
 
         whenever(mockRegistrationNumberService.createRegistrationNumber(RegistrationNumberType.PROPERTY)).thenReturn(


### PR DESCRIPTION
## Ticket number

PDJB-794

## Goal of change

Adds new compliance fields for PDJB-928 & PDJB-794

## Description of main change(s)

We need to calculate a date from the last time a property was made occupied, and we need to store whether a property is provide later or not provided

## Anything you'd like to highlight to the reviewer?

The migrations are my best stab at what is safest for live, but please review this carefully!

## Checklist

Delete any that are not applicable, and add explanation below for any that are applicable but haven't been done

- [x] Unit tests for new logic (e.g. new service methods) have been added
- [x] Test suite has been run in full locally and is passing
- [x] Branch has been rebased onto main and run locally, with everything working as expected (both for your new feature
  and any related functionality)
- [ ] QA instructions have been added to the ticket (particularly if this is the last PR required to complete the ticket)
