### PR TITLE
PRSD-1550: clean out old TODOs

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/database/entity/PropertyOwnership.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/database/entity/PropertyOwnership.kt
@@ -128,16 +128,8 @@ class PropertyOwnership() : ModifiableAuditableEntity() {
         this.customPropertyType = customPropertyType
     }
 
-    // TODO PRSD-1550 once Old PropertyRegistration journey is removed revert this check to just currentNumTenants > 0
     val isOccupied: Boolean
-        get() =
-            currentNumTenants > 0 &&
-                currentNumHouseholds > 0 &&
-                numBedrooms != null &&
-                numBedrooms!! > 0 &&
-                furnishedStatus != null &&
-                rentFrequency != null &&
-                rentAmount != null
+        get() = currentNumTenants > 0
 
     val rentIncludesBills: Boolean
         get() = billsIncludedList != null

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/AbstractStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/AbstractStepConfig.kt
@@ -96,7 +96,7 @@ sealed class AbstractStepConfig<out TEnum : Enum<out TEnum>, TFormModel : FormMo
         getFormModelFromStateOrNull(state)
             ?: throw NotNullFormModelValueIsNullException("Form model for step '$routeSegment' is null in journey state")
 
-    // TODO PRSD-1550: It is ugly that step config has a value set during JourneyStep initialisation - it is only used to make "getFormModelFromState" work
+    // TODO PDJB-585: It is ugly that step config has a value set during JourneyStep initialisation - it is only used to make "getFormModelFromState" work
     // Perhaps either the routeSegment or formModel should be passed into that method instead (and therefore all the other functions)
     // Alternatively, steps could reflexively access the form model on the JourneyStep in state without needing the route segment
     // Another idea would to have this be set directly in the DSL (but enforce that it is set before the other values)

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/LandlordIncompletePropertiesPageTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/LandlordIncompletePropertiesPageTests.kt
@@ -4,7 +4,6 @@ import com.microsoft.playwright.Page
 import com.microsoft.playwright.assertions.LocatorAssertions
 import kotlinx.datetime.DatePeriod
 import kotlinx.datetime.plus
-import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Nested
 import uk.gov.communities.prsdb.webapp.helpers.DateTimeHelper
 import uk.gov.communities.prsdb.webapp.integration.IntegrationTestWithImmutableData.NestedIntegrationTestWithImmutableData
@@ -49,7 +48,6 @@ class LandlordIncompletePropertiesPageTests : IntegrationTest() {
             ).containsText(formattedCompleteByDate2, LocatorAssertions.ContainsTextOptions().setIgnoreCase(true))
         }
 
-        @Disabled("TODO PRSD-1550: Migrate test once journey can be migrated")
         @Test
         fun `Clicking on a summary card Continue link redirects to the task list page`(page: Page) {
             val incompletePropertiesPage = navigator.goToLandlordIncompleteProperties()


### PR DESCRIPTION
## Ticket number

PRSD-1550

## Goal of change

Cleans out some old TODOs related to removing the old compliance journey, that were missed due to the ticket being in the old Jira project

## Description of main change(s)

Simplifies the isOccupied logic
Reinstates a test
Updates a more complex todo to a modern ticket

## Checklist

- [x] Test suite has been run in full locally and is passing
- [x] Branch has been rebased onto main and run locally, with everything working as expected (both for your new feature
  and any related functionality)
- [x] TODO comments referencing this JIRA ticket have been searched for and removed - if a future PR will address them,
  mention that here
- [ ] QA instructions have been added to the ticket (particularly if this is the last PR required to complete the ticket)
