### PR TITLE
PDJB-NONE: Bump vulnerable transitive dependencies

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -31,6 +31,12 @@ repositories {
     mavenCentral()
 }
 
+// Override Spring Boot 3.5.14 managed versions to pick up security fixes ahead of the next Spring Boot release.
+extra["tomcat.version"] = "10.1.55"
+extra["netty.version"] = "4.1.133.Final"
+extra["postgresql.version"] = "42.7.11"
+extra["commons-lang3.version"] = "3.18.0"
+
 dependencies {
     // Spring Boot Web
     implementation("org.springframework.boot:spring-boot-starter-web")
@@ -105,6 +111,11 @@ dependencies {
 
     // Fake data generation
     implementation("net.datafaker:datafaker:2.4.2")
+
+    // Force commons-compress (transitive of Testcontainers and axe-core/playwright) to a version without known CVEs.
+    constraints {
+        testImplementation("org.apache.commons:commons-compress:1.26.0")
+    }
 }
 
 kotlin {


### PR DESCRIPTION
## Ticket number

PDJB-NONE

## Goal of change

Resolve outstanding Dependabot security alerts on transitive dependencies without waiting for the next Spring Boot release.

## Description of main change(s)

Overrides the Spring Boot 3.5.14 BOM managed versions in `build.gradle.kts` to pick up patched releases of vulnerable transitive dependencies, and adds a test-scope constraint for `commons-compress` (which is not managed by Spring Boot but is pulled in transitively by Testcontainers and axe-core/playwright).

- Tomcat: 10.1.54 → 10.1.55
- Netty: 4.1.132.Final → 4.1.133.Final
- PostgreSQL JDBC: 42.7.10 → 42.7.11
- commons-lang3: 3.17.0 → 3.18.0
- commons-compress (test only): 1.24.0 → 1.26.0

Together these resolve all 20 currently open Dependabot alerts. All bumps are patch-level on libraries that Spring Boot already ships, so the risk of behavioural change is low.

## Anything you'd like to highlight to the reviewer?

Spring Boot 3.5.x reaches OSS end-of-life on 30 June 2026 and there is no guarantee the remaining 3.5.x patch releases will bump all the way to these versions, so overriding them now is the cleanest way to get back to a clean Dependabot dashboard.

## Checklist

- [ ] Test suite has been run in full locally and is passing
