### PR TITLE
PDJB-928: Remove incomplete properties logic from compliance actions

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/LandlordController.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/LandlordController.kt
@@ -93,12 +93,11 @@ class LandlordController(
         model: Model,
         principal: Principal,
     ): String {
-        val incompleteComplianceProperties = propertyOwnershipService.getIncompleteCompliancesForLandlord(principal.name)
         val nonCompliantProperties = propertyComplianceService.getNonCompliantPropertiesForLandlord(principal.name)
 
         val useMay2026Redesign = featureFlagManager.checkFeature(COMPLIANCE_ACTIONS_PAGE_MAY26_REDESIGN)
         val complianceActions =
-            (incompleteComplianceProperties + nonCompliantProperties).map {
+            nonCompliantProperties.map {
                 if (useMay2026Redesign) {
                     ComplianceActionViewModelBuilderMay26Redesign.fromDataModel(it)
                 } else {

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/dataModels/ComplianceStatusDataModel.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/dataModels/ComplianceStatusDataModel.kt
@@ -2,7 +2,6 @@ package uk.gov.communities.prsdb.webapp.models.dataModels
 
 import uk.gov.communities.prsdb.webapp.constants.enums.ComplianceCertStatus
 import uk.gov.communities.prsdb.webapp.database.entity.PropertyCompliance
-import uk.gov.communities.prsdb.webapp.database.entity.PropertyOwnership
 
 data class ComplianceStatusDataModel(
     val propertyOwnershipId: Long,
@@ -24,19 +23,6 @@ data class ComplianceStatusDataModel(
     private val certStatuses = listOf(gasSafetyStatus, eicrStatus, epcStatus)
 
     companion object {
-        // TODO PDJB-928 - Update this to use real state instead of NOT_STARTED
-        fun fromPropertyOwnershipWithoutCompliance(propertyOwnership: PropertyOwnership): ComplianceStatusDataModel =
-            ComplianceStatusDataModel(
-                propertyOwnershipId = propertyOwnership.id,
-                singleLineAddress = propertyOwnership.address.singleLineAddress,
-                registrationNumber = RegistrationNumberDataModel.fromRegistrationNumber(propertyOwnership.registrationNumber).toString(),
-                gasSafetyStatus = ComplianceCertStatus.NOT_STARTED,
-                eicrStatus = ComplianceCertStatus.NOT_STARTED,
-                epcStatus = ComplianceCertStatus.NOT_STARTED,
-                isComplete = false,
-                isOccupied = propertyOwnership.isOccupied,
-            )
-
         fun fromPropertyCompliance(propertyCompliance: PropertyCompliance): ComplianceStatusDataModel =
             ComplianceStatusDataModel(
                 propertyOwnershipId = propertyCompliance.propertyOwnership.id,

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/PropertyOwnershipService.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/PropertyOwnershipService.kt
@@ -22,7 +22,6 @@ import uk.gov.communities.prsdb.webapp.database.repository.PropertyOwnershipRepo
 import uk.gov.communities.prsdb.webapp.exceptions.RepositoryQueryTimeoutException
 import uk.gov.communities.prsdb.webapp.exceptions.UpdateConflictException
 import uk.gov.communities.prsdb.webapp.helpers.AddressHelper
-import uk.gov.communities.prsdb.webapp.models.dataModels.ComplianceStatusDataModel
 import uk.gov.communities.prsdb.webapp.models.dataModels.RegistrationNumberDataModel
 import uk.gov.communities.prsdb.webapp.models.viewModels.searchResultModels.PropertySearchResultViewModel
 import uk.gov.communities.prsdb.webapp.models.viewModels.summaryModels.RegisteredPropertyLandlordViewModel
@@ -347,14 +346,6 @@ class PropertyOwnershipService(
     fun getNumberOfIncompleteCompliancesForLandlord(principalName: String): Int {
         val propertyOwnerships = retrieveAllActivePropertiesForLandlord(principalName)
         return propertyOwnerships.count { it.isOccupied && it.propertyCompliance == null }
-    }
-
-    fun getIncompleteCompliancesForLandlord(principalName: String): List<ComplianceStatusDataModel> {
-        val propertyOwnerships = retrieveAllActivePropertiesForLandlord(principalName)
-
-        return propertyOwnerships
-            .filter { it.isOccupied && it.propertyCompliance == null }
-            .map { ComplianceStatusDataModel.fromPropertyOwnershipWithoutCompliance(it) }
     }
 
     fun doesLandlordHaveRegisteredProperties(baseUserId: String): Boolean =

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/controllers/LandlordControllerTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/controllers/LandlordControllerTests.kt
@@ -183,20 +183,6 @@ class LandlordControllerTests(
     @Test
     @WithMockUser(roles = ["LANDLORD"], username = "user")
     fun `getComplianceActions returns 200 for authorised landlord user`() {
-        // Arrange
-        val incompleteComplianceDataModel =
-            ComplianceStatusDataModel(
-                1,
-                "123 Example Street, EX",
-                "P-XXXX-XXXX",
-                ComplianceCertStatus.ADDED,
-                ComplianceCertStatus.NOT_STARTED,
-                ComplianceCertStatus.NOT_STARTED,
-                false,
-                true,
-            )
-        whenever(propertyOwnershipService.getIncompleteCompliancesForLandlord("user")).thenReturn(listOf(incompleteComplianceDataModel))
-
         val nonCompliantDataModel =
             ComplianceStatusDataModel(
                 2,
@@ -213,7 +199,6 @@ class LandlordControllerTests(
         // Act and Assert
         val expectedComplianceActions =
             listOf(
-                ComplianceActionViewModelBuilderOld.fromDataModel(incompleteComplianceDataModel),
                 ComplianceActionViewModelBuilderOld.fromDataModel(nonCompliantDataModel),
             )
 
@@ -235,7 +220,6 @@ class LandlordControllerTests(
     @Test
     @WithMockUser(roles = ["LANDLORD"], username = "user")
     fun `getComplianceActions returns complianceActions view when redesign feature flag is enabled`() {
-        whenever(propertyOwnershipService.getIncompleteCompliancesForLandlord("user")).thenReturn(emptyList())
         whenever(propertyComplianceService.getNonCompliantPropertiesForLandlord("user")).thenReturn(emptyList())
         whenever(featureFlagManager.checkFeature(COMPLIANCE_ACTIONS_PAGE_MAY26_REDESIGN)).thenReturn(true)
 
@@ -250,7 +234,6 @@ class LandlordControllerTests(
     @Test
     @WithMockUser(roles = ["LANDLORD"], username = "user")
     fun `getComplianceActions returns complianceActionsOld view when redesign feature flag is disabled`() {
-        whenever(propertyOwnershipService.getIncompleteCompliancesForLandlord("user")).thenReturn(emptyList())
         whenever(propertyComplianceService.getNonCompliantPropertiesForLandlord("user")).thenReturn(emptyList())
         whenever(featureFlagManager.checkFeature(COMPLIANCE_ACTIONS_PAGE_MAY26_REDESIGN)).thenReturn(false)
 

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/models/dataModels/ComplianceStatusDataModelTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/models/dataModels/ComplianceStatusDataModelTests.kt
@@ -8,7 +8,6 @@ import org.junit.jupiter.params.provider.MethodSource
 import uk.gov.communities.prsdb.webapp.constants.enums.ComplianceCertStatus
 import uk.gov.communities.prsdb.webapp.database.entity.PropertyCompliance
 import uk.gov.communities.prsdb.webapp.testHelpers.builders.PropertyComplianceBuilder
-import uk.gov.communities.prsdb.webapp.testHelpers.mockObjects.MockLandlordData
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
@@ -115,26 +114,6 @@ class ComplianceStatusDataModelTests {
 
         // Assert
         assertEquals(ComplianceCertStatus.NOT_REQUIRED, complianceStatusDataModel.gasSafetyStatus)
-    }
-
-    @Test
-    fun `fromPropertyOwnershipWithoutCompliance returns a ComplianceStatusDataModel with correct values`() {
-        // Arrange
-        val propertyOwnership = MockLandlordData.createPropertyOwnership()
-        val propertyOwnershipRegNum = RegistrationNumberDataModel.fromRegistrationNumber(propertyOwnership.registrationNumber).toString()
-
-        // Act
-        val complianceStatusDataModel = ComplianceStatusDataModel.fromPropertyOwnershipWithoutCompliance(propertyOwnership)
-
-        // Assert
-        assertEquals(propertyOwnership.id, complianceStatusDataModel.propertyOwnershipId)
-        assertEquals(propertyOwnership.address.singleLineAddress, complianceStatusDataModel.singleLineAddress)
-        assertEquals(propertyOwnershipRegNum, complianceStatusDataModel.registrationNumber)
-        assertFalse(complianceStatusDataModel.isComplete)
-        assertEquals(ComplianceCertStatus.NOT_STARTED, complianceStatusDataModel.gasSafetyStatus)
-        assertEquals(ComplianceCertStatus.NOT_STARTED, complianceStatusDataModel.eicrStatus)
-        assertEquals(ComplianceCertStatus.NOT_STARTED, complianceStatusDataModel.epcStatus)
-        assertEquals(propertyOwnership.isOccupied, complianceStatusDataModel.isOccupied)
     }
 
     @Test

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/PropertyOwnershipServiceTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/PropertyOwnershipServiceTests.kt
@@ -41,7 +41,6 @@ import uk.gov.communities.prsdb.webapp.database.entity.RegistrationNumber
 import uk.gov.communities.prsdb.webapp.database.repository.PropertyOwnershipRepository
 import uk.gov.communities.prsdb.webapp.exceptions.RepositoryQueryTimeoutException
 import uk.gov.communities.prsdb.webapp.exceptions.UpdateConflictException
-import uk.gov.communities.prsdb.webapp.models.dataModels.ComplianceStatusDataModel
 import uk.gov.communities.prsdb.webapp.models.dataModels.RegistrationNumberDataModel
 import uk.gov.communities.prsdb.webapp.models.viewModels.searchResultModels.PropertySearchResultViewModel
 import uk.gov.communities.prsdb.webapp.models.viewModels.summaryModels.RegisteredPropertyLandlordViewModel
@@ -1308,57 +1307,6 @@ class PropertyOwnershipServiceTests {
 
         // Assert
         assertEquals(expectedPropertyOwnerships, propertyOwnerships)
-    }
-
-    @Nested
-    inner class GetIncompleteCompliancesForLandlord {
-        private val principalName = "principalName"
-
-        @Test
-        fun `getIncompleteCompliancesForLandlord returns occupied properties without completed compliance`() {
-            // Arrange
-            val occupiedPropertyWithoutCompliance =
-                MockLandlordData.createOccupiedPropertyOwnership(currentNumTenants = 1)
-            val occupiedPropertyWithCompliance =
-                MockLandlordData.createOccupiedPropertyOwnership(currentNumTenants = 1, id = 2)
-            ReflectionTestUtils.setField(
-                occupiedPropertyWithCompliance,
-                "propertyCompliance",
-                mock<PropertyCompliance>(),
-            )
-            val unoccupiedProperty = MockLandlordData.createPropertyOwnership(currentNumTenants = 0)
-            val properties =
-                listOf(
-                    unoccupiedProperty,
-                    occupiedPropertyWithCompliance,
-                    occupiedPropertyWithoutCompliance,
-                )
-
-            whenever(
-                mockPropertyOwnershipRepository.findAllByPrimaryLandlord_BaseUser_IdAndIsActiveTrue(principalName),
-            ).thenReturn(properties)
-
-            // Act
-            val returnedIncompleteCompliances = propertyOwnershipService.getIncompleteCompliancesForLandlord(principalName)
-
-            // Assert
-            val expectedIncompleteCompliances =
-                listOf(ComplianceStatusDataModel.fromPropertyOwnershipWithoutCompliance(occupiedPropertyWithoutCompliance))
-            assertEquals(expectedIncompleteCompliances, returnedIncompleteCompliances)
-        }
-
-        @Test
-        fun `getIncompleteCompliancesForLandlord returns an emptyList if the landlord has no properties`() {
-            // Arrange
-            whenever(
-                mockPropertyOwnershipRepository.findAllByPrimaryLandlord_BaseUser_IdAndIsActiveTrue(principalName),
-            ).thenReturn(emptyList())
-
-            // Act
-            val incompleteCompliances = propertyOwnershipService.getIncompleteCompliancesForLandlord(principalName)
-
-            assertTrue(incompleteCompliances.isEmpty())
-        }
     }
 
     @Nested


### PR DESCRIPTION
## Ticket number

[PDJB-928](https://mhclgdigital.atlassian.net/browse/PDJB-928)

## Goal of change

this has been deprecated for some time, all properties now have compliance actions. splitting into its own PR to remove this as it's not really related to any copy changes

## Description of main change(s)

remove all logic that attempts to show NOT_STARTED compliance on the compliance actions page

now all journey will have complete compliance

## Anything you'd like to highlight to the reviewer?

well, I'm fairly certain this is now unused from what I've seen from context, such as [this comment](https://github.com/communitiesuk/prsdb-webapp/pull/1213/changes#r3094408314)

## Checklist

Delete any that are not applicable, and add explanation below for any that are applicable but haven't been done

- [x] Test suite has been run in full locally and is passing
- [x] Branch has been rebased onto main and run locally, with everything working as expected (both for your new feature
  and any related functionality)
- [x] TODO comments referencing this JIRA ticket have been searched for and removed - if a future PR will address them,
  mention that here
- [ ] QA instructions have been added to the ticket (particularly if this is the last PR required to complete the ticket) (no relevant QA, this is already impossible behaviour)
