### PR TITLE
PDJB-792: Move to a single feature flag for the entire compliance redesign

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/constants/FeatureFlagNames.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/constants/FeatureFlagNames.kt
@@ -14,12 +14,12 @@ const val JOINT_LANDLORDS = "joint-landlords"
 
 const val SUBJECT_IDENTIFIER_PAGE = "subject-identifier-page"
 
-const val COMPLIANCE_ACTIONS_PAGE_MAY26_REDESIGN = "compliance-actions-page-may26-redesign"
+const val COMPLIANCE_ACTIONS_MAY2026_REDESIGN = "compliance-actions-may2026-redesign"
 
 val featureFlagNames =
     listOf(
         FAILOVER_TEST_ENDPOINTS,
         JOINT_LANDLORDS,
         SUBJECT_IDENTIFIER_PAGE,
-        COMPLIANCE_ACTIONS_PAGE_MAY26_REDESIGN,
+        COMPLIANCE_ACTIONS_MAY2026_REDESIGN,
     )

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/LandlordController.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/LandlordController.kt
@@ -7,7 +7,7 @@ import org.springframework.web.bind.annotation.RequestMapping
 import uk.gov.communities.prsdb.webapp.annotations.webAnnotations.PrsdbController
 import uk.gov.communities.prsdb.webapp.config.interceptors.BackLinkInterceptor.Companion.overrideBackLinkForUrl
 import uk.gov.communities.prsdb.webapp.config.managers.FeatureFlagManager
-import uk.gov.communities.prsdb.webapp.constants.COMPLIANCE_ACTIONS_PAGE_MAY26_REDESIGN
+import uk.gov.communities.prsdb.webapp.constants.COMPLIANCE_ACTIONS_MAY2026_REDESIGN
 import uk.gov.communities.prsdb.webapp.constants.COMPLIANCE_ACTIONS_PATH_SEGMENT
 import uk.gov.communities.prsdb.webapp.constants.DASHBOARD_PATH_SEGMENT
 import uk.gov.communities.prsdb.webapp.constants.INCOMPLETE_PROPERTIES_PATH_SEGMENT
@@ -96,7 +96,7 @@ class LandlordController(
         val incompleteComplianceProperties = propertyOwnershipService.getIncompleteCompliancesForLandlord(principal.name)
         val nonCompliantProperties = propertyComplianceService.getNonCompliantPropertiesForLandlord(principal.name)
 
-        val useMay2026Redesign = featureFlagManager.checkFeature(COMPLIANCE_ACTIONS_PAGE_MAY26_REDESIGN)
+        val useMay2026Redesign = featureFlagManager.checkFeature(COMPLIANCE_ACTIONS_MAY2026_REDESIGN)
         val complianceActions =
             (incompleteComplianceProperties + nonCompliantProperties).map {
                 if (useMay2026Redesign) {

--- a/src/main/resources/application-integration.yml
+++ b/src/main/resources/application-integration.yml
@@ -9,7 +9,7 @@ features:
     - name: "subject-identifier-page"
       enabled: true
       expiry-date: "2027-03-30"
-    - name: "compliance-actions-page-may26-redesign"
+    - name: "compliance-actions-may2026-redesign"
       enabled: false
       expiry-date: "2026-12-31"
       release: "private-beta-release-2"

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -103,7 +103,7 @@ features:
     - name: "subject-identifier-page"
       enabled: true
       expiry-date: "2027-03-30"
-    - name: "compliance-actions-page-may26-redesign"
+    - name: "compliance-actions-may2026-redesign"
       enabled: false
       expiry-date: "2026-12-31"
       release: "private-beta-release-2"

--- a/src/main/resources/application-nft.yml
+++ b/src/main/resources/application-nft.yml
@@ -9,7 +9,7 @@ features:
     - name: "subject-identifier-page"
       enabled: true
       expiry-date: "2027-03-30"
-    - name: "compliance-actions-page-may26-redesign"
+    - name: "compliance-actions-may2026-redesign"
       enabled: false
       expiry-date: "2026-12-31"
       release: "private-beta-release-2"

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -9,7 +9,7 @@ features:
     - name: "subject-identifier-page"
       enabled: true
       expiry-date: "2027-03-30"
-    - name: "compliance-actions-page-may26-redesign"
+    - name: "compliance-actions-may2026-redesign"
       enabled: false
       expiry-date: "2026-12-31"
       release: "private-beta-release-2"

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -100,7 +100,7 @@ features:
     - name: "subject-identifier-page"
       enabled: true
       expiry-date: "2027-03-30"
-    - name: "compliance-actions-page-may26-redesign"
+    - name: "compliance-actions-may2026-redesign"
       enabled: false
       expiry-date: "2026-12-31"
       release: "private-beta-release-2"

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/controllers/LandlordControllerTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/controllers/LandlordControllerTests.kt
@@ -11,7 +11,7 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean
 import org.springframework.test.web.servlet.get
 import org.springframework.web.context.WebApplicationContext
 import uk.gov.communities.prsdb.webapp.config.managers.FeatureFlagManager
-import uk.gov.communities.prsdb.webapp.constants.COMPLIANCE_ACTIONS_PAGE_MAY26_REDESIGN
+import uk.gov.communities.prsdb.webapp.constants.COMPLIANCE_ACTIONS_MAY2026_REDESIGN
 import uk.gov.communities.prsdb.webapp.constants.LANDLORD_PATH_SEGMENT
 import uk.gov.communities.prsdb.webapp.constants.REGISTERED_PROPERTIES_FRAGMENT
 import uk.gov.communities.prsdb.webapp.constants.enums.ComplianceCertStatus
@@ -237,7 +237,7 @@ class LandlordControllerTests(
     fun `getComplianceActions returns complianceActions view when redesign feature flag is enabled`() {
         whenever(propertyOwnershipService.getIncompleteCompliancesForLandlord("user")).thenReturn(emptyList())
         whenever(propertyComplianceService.getNonCompliantPropertiesForLandlord("user")).thenReturn(emptyList())
-        whenever(featureFlagManager.checkFeature(COMPLIANCE_ACTIONS_PAGE_MAY26_REDESIGN)).thenReturn(true)
+        whenever(featureFlagManager.checkFeature(COMPLIANCE_ACTIONS_MAY2026_REDESIGN)).thenReturn(true)
 
         mvc
             .get(COMPLIANCE_ACTIONS_URL)
@@ -252,7 +252,7 @@ class LandlordControllerTests(
     fun `getComplianceActions returns complianceActionsOld view when redesign feature flag is disabled`() {
         whenever(propertyOwnershipService.getIncompleteCompliancesForLandlord("user")).thenReturn(emptyList())
         whenever(propertyComplianceService.getNonCompliantPropertiesForLandlord("user")).thenReturn(emptyList())
-        whenever(featureFlagManager.checkFeature(COMPLIANCE_ACTIONS_PAGE_MAY26_REDESIGN)).thenReturn(false)
+        whenever(featureFlagManager.checkFeature(COMPLIANCE_ACTIONS_MAY2026_REDESIGN)).thenReturn(false)
 
         mvc
             .get(COMPLIANCE_ACTIONS_URL)

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/ComplianceActionsPageTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/ComplianceActionsPageTests.kt
@@ -3,7 +3,7 @@ package uk.gov.communities.prsdb.webapp.integration
 import com.microsoft.playwright.Page
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
-import uk.gov.communities.prsdb.webapp.constants.COMPLIANCE_ACTIONS_PAGE_MAY26_REDESIGN
+import uk.gov.communities.prsdb.webapp.constants.COMPLIANCE_ACTIONS_MAY2026_REDESIGN
 import uk.gov.communities.prsdb.webapp.constants.COMPLIANCE_INFO_FRAGMENT
 import uk.gov.communities.prsdb.webapp.integration.IntegrationTestWithImmutableData.NestedIntegrationTestWithImmutableData
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.BaseComponent.Companion.assertThat
@@ -19,7 +19,7 @@ class ComplianceActionsPageTests : IntegrationTest() {
         NestedIntegrationTestWithImmutableData("data-mockuser-landlord-with-compliance-actions.sql") {
         @BeforeEach
         fun disableRedesignFlag() {
-            featureFlagManager.disableFeature(COMPLIANCE_ACTIONS_PAGE_MAY26_REDESIGN)
+            featureFlagManager.disableFeature(COMPLIANCE_ACTIONS_MAY2026_REDESIGN)
         }
 
         @Test
@@ -86,7 +86,7 @@ class ComplianceActionsPageTests : IntegrationTest() {
         NestedIntegrationTestWithImmutableData("data-mockuser-landlord-with-compliance-actions.sql") {
         @BeforeEach
         fun enableRedesignFlag() {
-            FeatureFlagConfigUpdater(featureFlagManager).enableUnreleasedFeature(COMPLIANCE_ACTIONS_PAGE_MAY26_REDESIGN)
+            FeatureFlagConfigUpdater(featureFlagManager).enableUnreleasedFeature(COMPLIANCE_ACTIONS_MAY2026_REDESIGN)
         }
 
         @Test

--- a/src/test/resources/application-integration.yml
+++ b/src/test/resources/application-integration.yml
@@ -9,7 +9,7 @@ features:
     - name: "subject-identifier-page"
       enabled: true
       expiry-date: "2027-03-30"
-    - name: "compliance-actions-page-may26-redesign"
+    - name: "compliance-actions-may2026-redesign"
       enabled: false
       expiry-date: "2026-12-31"
       release: "private-beta-release-2"

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -58,7 +58,7 @@ features:
     - name: "subject-identifier-page"
       enabled: false
       expiry-date: "2027-03-30"
-    - name: "compliance-actions-page-may26-redesign"
+    - name: "compliance-actions-may2026-redesign"
       enabled: false
       expiry-date: "2026-12-31"
       release: "private-beta-release-2"


### PR DESCRIPTION
## Ticket number

[PDJB-792](https://mhclgdigital.atlassian.net/browse/PDJB-792)

## Goal of change

rename the compliance feature flag to one that encompasses the entire redesign, for #1374, #1384 and #1378 

## Description of main change(s)

renames to just the compliance may2026 redesign

specifies the whole year, may26 was a bit ambiguous. there's some other may26 references we could change but I'll leave to just the feature flag for now

## Anything you'd like to highlight to the reviewer?

no

## Checklist

Delete any that are not applicable, and add explanation below for any that are applicable but haven't been done

- [ ] Test suite has been run in full locally and is passing
- [x] Branch has been rebased onto main and run locally, with everything working as expected (both for your new feature
  and any related functionality)
