### PR TITLE
PDJB-703: Fix broken back link on invite-new-user page

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/ManageLocalCouncilUsersController.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/ManageLocalCouncilUsersController.kt
@@ -241,7 +241,7 @@ class ManageLocalCouncilUsersController(
         model.addAttribute("councilName", councilName)
         model.addAttribute("councilNameBeginsWithVowel", councilNameBeginsWithVowel)
         model.addAttribute("confirmedEmailRequestModel", ConfirmedEmailRequestModel())
-        model.addAttribute("backLinkPath", "../$MANAGE_USERS_PATH_SEGMENT")
+        model.addAttribute("backLinkPath", MANAGE_USERS_PATH_SEGMENT)
 
         return "inviteLocalCouncilUser"
     }
@@ -260,7 +260,7 @@ class ManageLocalCouncilUsersController(
     ): String {
         val currentCouncil = getLocalCouncil(principal, localCouncilId, request)
         model.addAttribute("councilName", currentCouncil.name)
-        model.addAttribute("backLinkPath", "../$MANAGE_USERS_PATH_SEGMENT")
+        model.addAttribute("backLinkPath", MANAGE_USERS_PATH_SEGMENT)
 
         if (bindingResult.hasErrors()) {
             return "inviteLocalCouncilUser"

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/InviteLocalCouncilUsersSinglePageTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/InviteLocalCouncilUsersSinglePageTests.kt
@@ -1,8 +1,10 @@
 package uk.gov.communities.prsdb.webapp.integration
 
+import com.microsoft.playwright.Page
 import com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat
 import org.junit.jupiter.api.Test
-import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.BaseComponent.Companion.assertThat as assertComponent
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.ManageLocalCouncilUsersPage
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages.BasePage.Companion.assertPageIs
 
 class InviteLocalCouncilUsersSinglePageTests : IntegrationTestWithImmutableData("data-local.sql") {
     @Test
@@ -13,8 +15,9 @@ class InviteLocalCouncilUsersSinglePageTests : IntegrationTestWithImmutableData(
     }
 
     @Test
-    fun `the invite a new LocalCouncil user page has a back link`() {
+    fun `the invite a new LocalCouncil user page back link returns to the manage users page`(page: Page) {
         val invitePage = navigator.goToInviteNewLocalCouncilUser(1)
-        assertComponent(invitePage.backLink).isVisible()
+        invitePage.backLink.clickAndWait()
+        assertPageIs(page, ManageLocalCouncilUsersPage::class)
     }
 }


### PR DESCRIPTION
## Ticket number

PDJB-703

## Goal of change

Fix the broken back link on the invite-new-user page that 404s when clicked, and tighten the integration test so this kind of regression is caught in future.

## Description of main change(s)

- Change the back link path on the invite-new-user page from `../manage-users` to `manage-users` so the browser resolves it to `/local-council/{id}/manage-users` instead of `/local-council/manage-users`
- Update the single page integration test to actually click the back link and assert it lands on the manage users page (the previous assertion only checked the link was visible, which did not catch the bug)

The `../` prefix works on the cancel-invitation and delete-user pages because their URLs have an extra `{id}` segment for the browser to consume when resolving `..`, but the invite-new-user URL is only one segment deep below `{localCouncilId}`, so `..` ended up dropping the council id.

## Anything you''d like to highlight to the reviewer?

Spotted while testing on the integration environment after #1375 was merged.

## Checklist

- [x] Single page integration tests have been added for any unhappy-flow UI features, e.g. validation errors
- [x] Test suite has been run in full locally and is passing
- [x] Branch has been rebased onto main and run locally, with everything working as expected (both for your new feature
  and any related functionality)