### PR TITLE
PDJB-819 Add standalone reusable skills for common development tasks

### DIFF
--- a/.github/skills/development-workflow/SKILL.md
+++ b/.github/skills/development-workflow/SKILL.md
@@ -166,13 +166,23 @@ explicitly confirms they want to continue.
       - The plan should almost always include adding a regression test for
         the bug. If TDD is appropriate, this test should be written first
         (it should fail before the fix and pass after).
-4. After the plan is written, present the PR breakdown and verification
+4. **TODO comment handling is mandatory.** Before writing the plan, search the
+   codebase for TODO comments that reference the current ticket ID (e.g.
+   `// TODO PDJB-123:` or `// TODO(PDJB-123)`). These are deferred work items
+   left by previous developers that should be resolved as part of this ticket.
+   For each TODO found:
+    - Include it in the plan with the file path and line number.
+    - Describe how it will be addressed (which PR and task).
+    - If it should NOT be addressed in this ticket, state why.
+
+   Present these as a table in the plan document, after the header.
+5. After the plan is written, present the PR breakdown and verification
    strategy to the user for confirmation. Do not proceed until the user
    agrees.
-5. If the plan defines more than one PR, ask the user:
+6. If the plan defines more than one PR, ask the user:
    *"Should the PRs be raised in parallel (stacked on each other) or
    sequentially (one at a time, waiting for each to be merged)?"*
-6. Record the PR strategy (if applicable) and the number of PRs for use in
+7. Record the PR strategy (if applicable) and the number of PRs for use in
    the per-PR cycle.
 
 **Override:** When the `writing-plans` skill offers an execution handoff

--- a/.github/skills/making-code-edits/SKILL.md
+++ b/.github/skills/making-code-edits/SKILL.md
@@ -1,0 +1,103 @@
+---
+name: making-code-edits
+description: Use when searching, reading, or editing code files. Prefers JetBrains MCP tools for IDE-aware operations with semantic understanding, automatic formatting, build verification, and LF line ending enforcement.
+---
+
+# Making Code Edits
+
+Instructions for searching, reading, and editing code using JetBrains MCP tools.
+
+## ALWAYS Use JetBrains MCP for Code
+
+**JetBrains MCP tools are the default and preferred approach for ALL code operations
+in this repository.** Do not use CLI tools (`grep`, `glob`, `view`, `edit`) for code
+files when the JetBrains MCP server is available. JetBrains tools understand Kotlin
+semantics, respect project settings, and produce correct formatting automatically.
+
+## Searching and Reading
+
+| Task | Tool |
+|------|------|
+| Find a symbol by name | `jetbrains-search_symbol` — semantic, understands overloads and extensions |
+| Search file contents by text | `jetbrains-search_text` or `jetbrains-search_in_files_by_text` |
+| Search file contents by regex | `jetbrains-search_regex` or `jetbrains-search_in_files_by_regex` |
+| Find files by name | `jetbrains-find_files_by_name_keyword` — indexed, fast |
+| Find files by glob pattern | `jetbrains-search_file` or `jetbrains-find_files_by_glob` |
+| Read file content | `jetbrains-read_file` — supports line ranges, JARs, decompiled classes |
+| Understand a symbol | `jetbrains-get_symbol_info` — type, docs, declaration location |
+| Browse directory structure | `jetbrains-list_directory_tree` |
+
+## Editing
+
+| Task | Tool |
+|------|------|
+| Replace text in a file | `jetbrains-replace_text_in_file` — auto-saves, respects `.editorconfig` |
+| Rename a symbol | `jetbrains-rename_refactoring` — updates all references across project |
+| Reformat after edits | `jetbrains-reformat_file` — applies project code style rules |
+| Create a new file | `jetbrains-create_new_file` — creates parent directories automatically |
+
+## Edit Workflow
+
+1. **Make the edit** — use `jetbrains-replace_text_in_file` with the exact text to
+   replace and the new text. Set `caseSensitive: true` and use enough surrounding
+   context to ensure a unique match.
+
+2. **Reformat** — run `jetbrains-reformat_file` on the modified file to ensure code
+   style compliance (indentation, spacing, imports).
+
+3. **Build** — run `jetbrains-build_project` to verify the edit compiles. Check the
+   output for errors.
+
+4. **Inspect** — run `jetbrains-get_file_problems` to catch warnings or issues the
+   build alone might not surface.
+
+## CLI Fallback
+
+Use CLI tools only when:
+- The JetBrains MCP server is unavailable and the user cannot start it when prompted
+- The file is outside the repository (e.g. session workspace files, system config)
+
+CLI equivalents (Copilot built-in / PowerShell):
+
+| JetBrains MCP | Copilot built-in | PowerShell |
+|---------------|-----------------|------------|
+| `jetbrains-search_text` | `grep` | `Select-String` |
+| `jetbrains-find_files_by_name_keyword` | `glob` | `Get-ChildItem` |
+| `jetbrains-read_file` | `view` | `Get-Content` |
+| `jetbrains-replace_text_in_file` | `edit` | n/a |
+| `jetbrains-create_new_file` | `create` | `Set-Content` |
+
+When falling back to CLI tools on Windows, convert code files to LF before committing:
+
+```powershell
+(Get-Content .\path\to\file.kt -Raw) -replace "`r`n", "`n" | Set-Content -NoNewline .\path\to\file.kt
+```
+
+```bash
+sed -i 's/\r$//' path/to/file.kt
+```
+
+JetBrains MCP tools handle line endings automatically via `.editorconfig`.
+
+## Kotlin-Specific Tips
+
+- Use `jetbrains-rename_refactoring` for renaming classes, methods, or variables —
+  it handles companion objects, extension functions, named arguments, etc.
+- Use `jetbrains-get_symbol_info` to understand a symbol before modifying it
+- Use `jetbrains-search_symbol` over grep for Kotlin symbols (understands overloads)
+
+## Project Path
+
+Always pass `projectPath` to JetBrains MCP tools. When working in a worktree, this
+is the worktree path (e.g. `C:\Work\Projects\MHCLG\pdjb-819`), NOT the main
+repository path.
+
+Incorrect:
+```
+projectPath: "C:\Work\Projects\MHCLG\prsdb-webapp"
+```
+
+Correct:
+```
+projectPath: "C:\Work\Projects\MHCLG\pdjb-819"
+```

--- a/.github/skills/raising-pull-requests/SKILL.md
+++ b/.github/skills/raising-pull-requests/SKILL.md
@@ -21,6 +21,15 @@ See the `branch-and-commit-naming` skill for full naming conventions.
 
 Use the repository PR template at `.github/pull_request_template.md`. Fill in each section as follows:
 
+### Brevity Principle
+
+Be as concise as possible. The reviewer has the diff — the description explains
+**why**, not **how**.
+
+- If a section would be empty or repeat what the diff shows, delete it entirely.
+- The PR template's hints are instructions, not suggestions. "A single sentence"
+  means one sentence. Do not pad.
+
 ### Ticket number
 
 The JIRA ticket ID (e.g. `PDJB-632` or `PRSD-1021`). GitHub auto-links to JIRA when formatted correctly.
@@ -50,7 +59,7 @@ Use this section when there is genuine uncertainty or something unusual. Example
 - Debate over implementation approach where specific feedback is wanted
 - Concerns about correctness in a particular area
 - Cross-cutting changes that affect other journeys
-- Leave empty if there is nothing to highlight
+- Delete this section entirely if there is nothing to highlight
 
 ### Checklist
 

--- a/.github/skills/reading-figma-designs/SKILL.md
+++ b/.github/skills/reading-figma-designs/SKILL.md
@@ -1,0 +1,120 @@
+---
+name: reading-figma-designs
+description: Use when interpreting Figma designs into implementation requirements. Covers extracting design tokens, mapping to GOV.UK components, and producing implementation-ready specs.
+---
+
+# Reading Figma Designs
+
+Instructions for interpreting Figma MCP output into implementation requirements.
+
+## Prerequisites
+
+- Figma MCP server must be connected (check via preflight activation checks)
+- The user must provide a Figma file URL or have the relevant frame selected in the
+  Figma desktop app
+
+## Process
+
+### 1. Navigate to the Correct Frame
+
+Use Figma MCP tools to locate the relevant design:
+- If a URL is provided, navigate directly to that frame
+- If no URL, ask the user to select the relevant layer/screen in the Figma desktop
+  app — the MCP server can read the current selection
+
+### 2. Extract Design Tokens
+
+For each component or section in the design, extract:
+- **Spacing:** margins, padding (map to GOV.UK spacing scale: 0-9)
+- **Typography:** font size, weight, line height (map to GOV.UK typography classes)
+- **Colours:** hex values (map to GOV.UK colour palette variables)
+- **Layout:** grid structure, column widths, responsive breakpoints
+
+### 3. Map to GOV.UK Design System Components
+
+Identify which GOV.UK Design System components match the design:
+- Standard components: buttons, inputs, radios, checkboxes, panels, tables
+- MOJ Frontend components: multi-select, sub-navigation, timeline
+- Custom components: identify where bespoke markup is needed
+
+Common mappings:
+
+| Figma Pattern | GOV.UK Component |
+|---------------|-----------------|
+| Text input with label above | `govuk-input` with `govuk-label` |
+| Radio buttons in a fieldset | `govuk-radios` with `govuk-fieldset` |
+| Green confirmation panel | `govuk-panel--confirmation` |
+| Summary list (key-value pairs) | `govuk-summary-list` |
+| Table with sortable columns | `moj-sortable-table` |
+| Tabs with content panels | `govuk-tabs` |
+| Warning text with icon | `govuk-warning-text` |
+| Inset text (quoted/highlighted) | `govuk-inset-text` |
+| Details (expandable) | `govuk-details` |
+| Notification banner | `govuk-notification-banner` |
+| Tag (status label) | `govuk-tag` |
+| Task list | `govuk-task-list` |
+
+### 4. Handle Responsive Variants
+
+If the design includes mobile/tablet variants:
+- Note breakpoint-specific layout changes
+- Identify components that stack vs remain side-by-side
+- Check for mobile-specific content visibility
+
+### 5. Produce Implementation Spec
+
+Output a structured summary for each page/component:
+- Template path (based on project conventions: `src/main/resources/templates/`)
+- GOV.UK components to use (with specific variants)
+- Content text (exact copy from the design)
+- Conditional visibility rules (if elements show/hide based on state)
+- Form field names and types (if the page contains a form)
+- Validation requirements visible in the design (error states, hint text)
+
+## GOV.UK Design System Reference
+
+This project uses:
+- GOV.UK Frontend 5.11.0
+- Ministry of Justice Frontend 3.3.1
+- Thymeleaf templates with fragment composition
+
+Template conventions:
+- Layouts extend `layout.html`
+- Fragments are in `components/` subdirectories
+- Form pages use `formPageWrapper.html` fragment
+- Page titles follow `<page> - <service> - GOV.UK` pattern
+
+## Taking Screenshots for Validation
+
+When extracting designs, also capture screenshots of the relevant Figma frames. These
+screenshots serve as reference images during implementation validation — allowing
+visual comparison between the design and the running application.
+
+- Take a screenshot of each distinct page or state shown in the design
+- Name screenshots clearly (e.g. `landlord-dashboard.png`, `registration-step-3-error.png`)
+- Store screenshots in the session workspace for later use during smoke testing and
+  verification phases
+
+## Output Format
+
+Present findings as a structured list the implementing agent can act on directly:
+
+```
+Page: [name]
+Template: src/main/resources/templates/[path].html
+Layout: formPageWrapper / contentPage / taskList (etc.)
+
+Components:
+- govuk-heading-xl: "[heading text]"
+- govuk-body: "[body text]"
+- govuk-radios:
+  - name: [field name]
+  - items: [list of options from design]
+  - hint: "[hint text if present]"
+
+Conditional elements:
+- [element]: shown when [condition]
+
+Validation (visible in design):
+- [field]: [error message text shown in error state]
+```

--- a/.github/skills/running-locally/SKILL.md
+++ b/.github/skills/running-locally/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: running-locally
+description: Use when starting or stopping the application locally via JetBrains MCP run configurations. Covers startup, health verification, and shutdown.
+---
+
+# Running the Application Locally
+
+Instructions for starting and stopping the application using JetBrains MCP run
+configurations. The run configuration handles all infrastructure setup automatically.
+
+## Starting the Application
+
+Use the JetBrains MCP server to execute the `local` run configuration:
+
+```
+jetbrains-execute_run_configuration:
+  configurationName: "local"
+  projectPath: "<worktree-path>"
+  waitForExit: false
+  timeout: 60000
+```
+
+This single run configuration handles everything:
+- Starts Docker Compose services (PostgreSQL on `POSTGRES_PORT`, Redis on `REDIS_PORT`)
+- Runs Flyway migrations (via `flywayClean-local` pre-task)
+- Configures Spring profiles: `local, local-no-auth`
+- Starts the application on the port defined in `.env` (`SERVER_PORT`, default 8080)
+
+**Do NOT manually run `docker-compose up` or `./gradlew bootRun`.** The run
+configuration handles all of this.
+
+## Verifying Startup
+
+After executing the run configuration, check the console output for:
+```
+Started PrsdbWebappApplication in X.XXX seconds
+```
+
+The application is then accessible at:
+```
+http://localhost:<SERVER_PORT>/
+```
+
+Read the `SERVER_PORT` value from the worktree's `.env` file to determine the correct
+port. Each worktree has a unique port assigned by the worktree creation script.
+
+## Available Run Configurations
+
+| Name | Purpose | Profiles |
+|------|---------|----------|
+| `local` | Standard local development | `local, local-no-auth` |
+| `local-no-server` | Run without web server (tasks only) | `local, web-server-deactivated, scheduled-task` |
+| `local-nft-seeder` | Seed NFT test data | `local, local-no-auth, nft-data-seeder` |
+
+## Stopping the Application
+
+When finished with local testing, stop the application. If it was started via
+`execute_run_configuration`, use the JetBrains MCP to stop it:
+
+```powershell
+# PowerShell
+Stop-Process -Id <PID>
+```
+
+```bash
+# Bash
+kill <PID>
+```
+
+Pass the command via `jetbrains-execute_terminal_command` with the worktree's
+`projectPath`, or use the IDE's run tool window stop button via the MCP tools.
+
+**Always stop the application when finished.** Running applications consume resources
+and hold ports that other worktrees may need.
+
+## Troubleshooting
+
+| Problem | Cause | Fix |
+|---------|-------|-----|
+| Port already in use | Another worktree/process on same port | Check `.env` for assigned port; stop conflicting process |
+| Docker not running | Docker Desktop not started | Start Docker Desktop before running |
+| Database migration failure | PostgreSQL not accessible | Ensure Docker started and port matches `.env` |
+| Redis connection refused | Redis container not running | Docker Compose services may have failed to start |
+
+## Notes
+
+- The `local-no-auth` profile provides mock authentication with all roles — no real
+  One Login integration needed for local development
+- Redis is used for session storage; if Redis is not running, the application fails to start
+- The application serves on HTTP (not HTTPS) locally
+- The `flywayClean-local` pre-task drops and recreates the database schema on every
+  start — local data does not persist between runs

--- a/.github/skills/smoke-testing/SKILL.md
+++ b/.github/skills/smoke-testing/SKILL.md
@@ -1,0 +1,118 @@
+---
+name: smoke-testing
+description: Use when navigating the running application to verify pages and journeys work correctly. Mandates Playwright CLI usage and prohibits MCP server tools for app navigation.
+---
+
+# Smoke Testing
+
+Instructions for navigating the running application to verify pages and journeys work
+correctly after changes.
+
+## CRITICAL: Use the Playwright CLI
+
+**MANDATORY:** All smoke testing MUST use the **Playwright CLI** via the
+`playwright-cli` skill (located at `.claude/skills/playwright-cli/`). Invoke that
+skill for browser interactions — it provides navigation, clicking, form filling,
+screenshots, and data extraction.
+
+**PROHIBITED:** Do NOT use the Playwright MCP server tools (`playwright-playwright_navigate`,
+`playwright-playwright_click`, `playwright-playwright_fill`, etc.) for smoke testing
+the application. The MCP server tools share a single global browser state that
+conflicts with parallel development.
+
+## Session Naming
+
+Use the worktree name as the session name to avoid conflicts:
+```
+playwright-cli -s=pdjb-819 open http://localhost:8080/
+```
+
+This allows multiple developers (or worktrees) to smoke test simultaneously without
+interfering with each other.
+
+## Before You Start
+
+1. Ensure the application is running (use the `running-locally` skill)
+2. Read the `SERVER_PORT` from the worktree's `.env` file
+3. Construct the base URL: `http://localhost:<SERVER_PORT>`
+
+## Common Smoke Test Flows
+
+### Verify a Dashboard Page
+
+```bash
+# Navigate to the landlord dashboard
+playwright-cli -s=pdjb-819 open http://localhost:8080/landlord/dashboard
+
+# Expected: Page renders without errors, shows navigation and content sections
+```
+
+### Verify a Registration Journey
+
+```bash
+# Start the landlord registration journey
+playwright-cli -s=pdjb-819 open http://localhost:8080/landlord/register-as-a-landlord
+
+# Navigate through each step manually in the browser
+# Verify: each page loads, form fields appear, validation messages show on empty submit
+```
+
+### Verify a Search Page
+
+```bash
+# Navigate to the property search page
+playwright-cli -s=pdjb-819 open http://localhost:8080/local-council/search
+
+# Enter search criteria and verify results appear
+```
+
+### Verify Form Validation
+
+```bash
+# Navigate to a form page
+playwright-cli -s=pdjb-819 open http://localhost:8080/landlord/register-as-a-landlord/name
+
+# Submit the form empty to trigger validation errors
+# Expected: error summary appears at top, individual field errors appear inline
+```
+
+### Verify Conditional Page Visibility
+
+```bash
+# Navigate to a page that should only appear under certain conditions
+# Expected: the page either renders correctly or redirects as expected
+```
+
+### Verify a Local Council Page
+
+```bash
+# Navigate to a local council management page
+playwright-cli -s=pdjb-819 open http://localhost:8080/local-council/dashboard
+
+# Expected: LA-specific navigation and content renders
+```
+
+## After Smoke Testing
+
+Close the Playwright session when finished:
+```bash
+playwright-cli -s=pdjb-819 close
+```
+
+## What to Check
+
+During a smoke test, verify:
+1. **Pages load** — no 500 errors, no blank pages, no Thymeleaf rendering errors
+2. **Navigation works** — links between pages function correctly
+3. **Form fields appear** — all expected inputs are rendered
+4. **Validation messages** — submitting empty forms shows GOV.UK error summary + inline errors
+5. **Conditional content** — elements that depend on state show/hide correctly
+6. **Data displays** — if the page shows data from the database, verify it renders
+7. **Role-based access** — pages that require specific roles are accessible (mock auth provides all roles)
+
+## Limitations
+
+- Smoke testing verifies pages load and render correctly — it is not a substitute for
+  integration tests which assert specific business logic and data flows
+- The `local-no-auth` profile auto-authenticates with all roles, so role-based access
+  issues will not surface during local smoke testing


### PR DESCRIPTION
## Ticket number

PDJB-819

## Goal of change

Add standalone reusable skills that can be invoked independently outside the development workflow.

## What changed

- New skill: `making-code-edits` — JetBrains MCP as default for searching, reading, and editing code
- New skill: `reading-figma-designs` — interpreting Figma designs into implementation specs
- New skill: `running-locally` — starting/stopping the app via JetBrains MCP run configurations
- New skill: `smoke-testing` — verifying pages via Playwright CLI (MCP server prohibited)
- Modified: `development-workflow` — added TODO comment handling in planning phase
- Modified: `raising-pull-requests` — added brevity principle, delete empty sections

## How to test

Skills are documentation only — review for correctness against project conventions.