### PR TITLE
PDJB-819 Add project-tailored development skills

### DIFF
--- a/.github/skills/brainstorming/SKILL.md
+++ b/.github/skills/brainstorming/SKILL.md
@@ -1,0 +1,107 @@
+---
+name: brainstorming
+description: Use before any creative work — creating features, building components, adding functionality, or modifying behaviour. Explores intent, requirements, and design before implementation.
+---
+
+# Brainstorming
+
+Turn ideas into fully formed designs through collaborative dialogue. Understand
+what is being built before writing any code.
+
+**Hard gate:** Do NOT invoke any implementation skill, write any code, or take
+any implementation action until a design has been presented and the user has
+approved it.
+
+## Process
+
+1. **Explore context** — check relevant files, docs, recent commits
+2. **Ask clarifying questions** — one at a time, prefer multiple choice
+3. **Propose 2-3 approaches** — with trade-offs and a recommendation
+4. **Present design** — in sections scaled to complexity, get approval after each
+5. **Stress-test the design** — walk every decision branch, resolve gaps
+6. **Write design spec** — save to session workspace (`~/.copilot/session-state/<session-id>/files/design-spec.md`)
+7. **Self-review** — check for placeholders, contradictions, ambiguity
+8. **User reviews spec** — wait for approval before proceeding
+9. **Transition** — invoke `writing-plans` skill
+
+## Asking Questions
+
+- One question per message
+- Prefer multiple choice (with freeform allowed)
+- Focus on: purpose, constraints, success criteria, user-visible behaviour
+- If the request spans multiple independent subsystems, flag decomposition first
+
+## Exploring Approaches
+
+- Always propose 2-3 options with trade-offs
+- Lead with the recommended option and explain why
+- Consider existing patterns in the codebase before suggesting new ones
+
+## Presenting the Design
+
+Scale each section to its complexity — a few sentences if straightforward, a
+paragraph if nuanced. Cover:
+
+- Architecture and component boundaries
+- Data flow (entities, services, controllers)
+- Journey/form flow (if applicable)
+- Validation approach
+- Error handling
+- Feature flag strategy (if user-visible behaviour change)
+- Testing approach (which layers need tests)
+
+## Stress-Testing the Design
+
+After the user approves the high-level design, walk every branch of the decision
+tree to surface gaps before writing the spec. For each open question:
+
+1. State the decision point clearly
+2. Provide your recommended answer (with reasoning)
+3. Ask the user to confirm or redirect
+
+Rules:
+- One question at a time
+- If the answer can be found by exploring the codebase, check the codebase
+  instead of asking
+- Keep going until every branch is resolved — do not move on with "TBD" items
+- Cover: edge cases, error states, empty states, permissions, concurrency,
+  migration paths, feature flag transitions
+
+Only proceed to writing the spec once all branches are resolved.
+
+## Working in This Codebase
+
+Before proposing changes:
+- Search for existing patterns that solve a similar problem
+- Follow established conventions (custom annotations, journey framework, etc.)
+- If existing code has problems that affect the work, include targeted
+  improvements — do not propose unrelated refactoring
+
+## Design Spec Content
+
+The spec should include:
+
+- **Goal** — one sentence
+- **Approach** — architecture decisions and why
+- **Components** — what is created/modified and its responsibility
+- **Data model** — entities, relationships, migrations needed
+- **User flow** — step-by-step from user's perspective
+- **Validation** — what is validated, error messages
+- **Feature flags** — if applicable, which flag, which release
+- **Testing strategy** — which layers, what coverage
+- **Out of scope** — explicitly state what is NOT included
+
+## Self-Review
+
+After writing the spec:
+1. **Placeholder scan** — any "TBD", "TODO", vague sections? Fix them.
+2. **Internal consistency** — do sections contradict each other?
+3. **Scope check** — focused enough for a single plan, or needs decomposition?
+4. **Ambiguity check** — could any requirement be interpreted two ways?
+
+Fix inline. Do not re-review.
+
+## After Approval
+
+Invoke the `writing-plans` skill. Do NOT invoke any other implementation skill
+directly from brainstorming.

--- a/.github/skills/development-workflow/phases/phase-3-plan.md
+++ b/.github/skills/development-workflow/phases/phase-3-plan.md
@@ -60,8 +60,10 @@
    strategy to the user for confirmation. Do not proceed until the user agrees.
 
 7. If the plan defines more than one PR, ask the user:
-   *"Should the PRs be raised in parallel (stacked) or sequentially (one at a
-   time, waiting for each to be merged)?"*
+   *"Should the PRs be raised as a stack (all raised at once, each targeting the
+   previous branch — faster but harder to manage if early PRs change significantly)
+   or sequentially (one at a time, waiting for each to merge before raising the
+   next — slower but simpler to manage)?"*
 
 8. Record the PR strategy and number of PRs for use in the per-PR cycle.
 

--- a/.github/skills/development-workflow/phases/phase-5-verify.md
+++ b/.github/skills/development-workflow/phases/phase-5-verify.md
@@ -25,8 +25,8 @@ The sub-agent should use these commands:
 | Full suite | `.\gradlew test --console=plain` | `./gradlew test --console=plain` |
 | Linting | `.\gradlew ktlintCheck --console=plain` | `./gradlew ktlintCheck --console=plain` |
 | Frontend JS tests | `npm test` | `npm test` |
-| Build check | `jetbrains-build_project` with worktree projectPath | same |
-| Smoke test | Use `smoke-testing` skill (Playwright CLI) | same |
+| Build check | `jetbrains-build_project` with worktree projectPath | `jetbrains-build_project` with worktree projectPath |
+| Smoke test | Use `smoke-testing` skill (Playwright CLI) | Use `smoke-testing` skill (Playwright CLI) |
 
 The sub-agent returns a structured report:
 ```json

--- a/.github/skills/receiving-code-review/SKILL.md
+++ b/.github/skills/receiving-code-review/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: receiving-code-review
+description: Use when receiving code review feedback on a PR. Requires technical evaluation and verification before implementing suggestions.
+---
+
+# Receiving Code Review
+
+Evaluate review feedback technically before implementing. Do not blindly agree
+or blindly implement.
+
+**Core principle:** Verify before implementing. Ask before assuming. Technical
+correctness over social comfort.
+
+## Response Process
+
+1. **READ** — Complete feedback without reacting
+2. **UNDERSTAND** — Restate each item in own words (or ask for clarification)
+3. **VERIFY** — Check suggestion against codebase reality
+4. **EVALUATE** — Is it technically sound for THIS codebase and its conventions?
+5. **RESPOND** — Technical acknowledgment or reasoned pushback
+6. **IMPLEMENT** — One item at a time, verify each
+
+## Handling Unclear Feedback
+
+If any item is unclear, stop and ask before implementing anything. Items may be
+related — partial understanding leads to wrong implementation.
+
+## Evaluating Suggestions
+
+Before implementing a suggestion, check:
+
+- Does it follow project conventions? (custom annotations, validation framework,
+  journey patterns, entity base classes)
+- Does it break existing functionality?
+- Is there a reason for the current implementation? (check git history)
+- Does the reviewer have full context?
+- Does it conflict with prior architectural decisions?
+
+## When to Push Back
+
+Push back (with technical reasoning) when:
+- Suggestion breaks existing functionality
+- Reviewer lacks context (explain what they missed)
+- Violates YAGNI (feature not used)
+- Contradicts established project patterns
+- Technically incorrect for this stack
+
+How:
+- Reference specific code, tests, or patterns
+- Ask clarifying questions
+- Propose alternatives
+- Escalate to user if architectural disagreement
+
+## When Feedback Is Correct
+
+Acknowledge briefly and fix:
+- "Fixed — [brief description]"
+- "Good catch. [What was wrong and what changed]."
+- Or just fix it without commentary.
+
+Do NOT use performative agreement ("Great point!", "You're absolutely right!").
+
+## Before Responding
+
+After evaluating all feedback items, ask the user:
+
+> "I've reviewed the comments. Would you like me to respond to them on GitHub,
+> or would you prefer to respond yourself?"
+
+If the user wants to respond themselves, summarise your evaluation of each item
+(agree/disagree/need clarification) so they can use it as input.
+
+## Implementation Order
+
+For multi-item feedback:
+1. Clarify anything unclear FIRST
+2. Implement in order: blocking issues → simple fixes → complex changes
+3. Verify each fix individually (run relevant tests)
+4. Check for regressions
+
+## Replying on GitHub
+
+Reply in the comment thread, not as top-level PR comments:
+
+```bash
+gh api repos/{owner}/{repo}/pulls/{pr}/comments/{id}/replies -f body="Fixed — ..."
+```
+
+```powershell
+gh api repos/{owner}/{repo}/pulls/{pr}/comments/{id}/replies -f body="Fixed — ..."
+```

--- a/.github/skills/subagent-driven-development/SKILL.md
+++ b/.github/skills/subagent-driven-development/SKILL.md
@@ -1,0 +1,107 @@
+---
+name: subagent-driven-development
+description: Use when executing implementation plans with independent tasks. Dispatches fresh sub-agents per task with two-stage review.
+---
+
+# Subagent-Driven Development
+
+Execute a plan by dispatching a fresh sub-agent per task, with two-stage review
+after each: spec compliance first, then code quality.
+
+**Core principle:** Fresh sub-agent per task + two-stage review = high quality,
+fast iteration, no context pollution.
+
+**Continuous execution:** Do not pause between tasks to check in with the user.
+Execute all tasks without stopping. Only stop for: BLOCKED status, genuine
+ambiguity, or all tasks complete.
+
+## Process
+
+For each task in the plan:
+
+### 1. Dispatch Implementer
+
+Launch a `general-purpose` sub-agent with:
+- The task description from the plan (verbatim)
+- The worktree path as `projectPath`
+- Instructions to use `making-code-edits` skill (JetBrains MCP as default)
+- The full file list for the task
+- Any code examples from the plan
+- Verification command to run after implementation
+
+The implementer prompt must include:
+
+```
+## Project Conventions
+- Use @PrsdbController, @PrsdbWebService, @PrsdbWebComponent (not bare Spring)
+- Entities extend AuditableEntity or ModifiableAuditableEntity
+- Validation uses @IsValidPrioritised + @ValidatedBy (not @NotBlank, @Size)
+- Constructor injection only (private val parameters)
+- Test methods use backtick-quoted names
+- Use JetBrains MCP tools for all code operations (projectPath: "<worktree>")
+
+## Your Task
+[task content from plan]
+
+## Verification
+Run: [command from plan]
+Expected: [expected outcome]
+```
+
+### 2. Spec Review
+
+After the implementer completes, launch an `explore` sub-agent to review:
+- Does the implementation match what the plan specified?
+- Are all files listed in the task present and correct?
+- Does the verification command pass?
+
+If gaps found: re-dispatch implementer with specific fixes.
+
+### 3. Code Quality Review
+
+Launch an `explore` sub-agent to check:
+- Custom annotations used correctly (`@PrsdbController` not `@Controller`, etc.)
+- Entity auditing base classes used
+- Constructor injection (no `@Autowired`)
+- Validation framework (`@ValidatedBy` not Bean Validation)
+- Journey framework hierarchy (if applicable)
+- `@Transactional` on write methods
+- `@PreAuthorize` on controllers
+
+If issues found: re-dispatch implementer with specific fixes.
+
+### 4. Record Result
+
+Extract and record only:
+- **Status:** DONE / DONE_WITH_CONCERNS / BLOCKED
+- **Files changed:** list of file paths
+- **Concerns:** any issues (empty if none)
+
+Write one-line summary to checkpoint. Do NOT carry forward full sub-agent output.
+
+## Sub-Agent Tool Instructions
+
+Every implementer prompt must include:
+
+```
+## Tools
+- Use JetBrains MCP tools for searching, reading, and editing code
+  (jetbrains-search_text, jetbrains-read_file, jetbrains-replace_text_in_file, etc.)
+- Always pass projectPath: "<worktree-path>"
+- After edits: jetbrains-reformat_file, then jetbrains-build_project
+- For new files: jetbrains-create_new_file
+- For renames: jetbrains-rename_refactoring
+- Fall back to CLI tools only for files outside the repository
+```
+
+## Error Handling
+
+- If an implementer returns BLOCKED: assess whether you can provide the missing
+  context. If yes, re-dispatch with context. If no, stop and report to user.
+- If spec review fails twice: stop task, report to user with details.
+- If code quality review fails twice: accept with DONE_WITH_CONCERNS, note issues.
+
+## Parallelisation
+
+Tasks that have no dependency between them may be dispatched in parallel. Check
+the plan's task dependency structure before parallelising.

--- a/.github/skills/subagent-driven-development/SKILL.md
+++ b/.github/skills/subagent-driven-development/SKILL.md
@@ -101,6 +101,20 @@ Every implementer prompt must include:
 - If spec review fails twice: stop task, report to user with details.
 - If code quality review fails twice: accept with DONE_WITH_CONCERNS, note issues.
 
+## Progress Monitoring
+
+When a sub-agent is running in background mode, check its status every 60-120
+seconds using `read_agent`. Report progress to the user:
+
+```
+Sub-agent (Task 3): Running — last output: "Running test class FooServiceTests..."
+```
+
+If no new output for 3+ minutes, investigate:
+- Check if the sub-agent is stuck on a prompt or confirmation
+- Check if tests are hanging (database locks, Docker issues)
+- If genuinely stuck, stop the agent and re-dispatch with adjusted instructions
+
 ## Parallelisation
 
 Tasks that have no dependency between them may be dispatched in parallel. Check

--- a/.github/skills/systematic-debugging/SKILL.md
+++ b/.github/skills/systematic-debugging/SKILL.md
@@ -1,0 +1,105 @@
+---
+name: systematic-debugging
+description: Use when encountering any bug, test failure, or unexpected behavior. Requires root cause investigation before proposing fixes.
+---
+
+# Systematic Debugging
+
+**Core principle:** Find root cause before attempting fixes. Symptom fixes are
+failure.
+
+## When to Use
+
+Use for ANY technical issue: test failures, bugs, unexpected behaviour, build
+failures, integration issues.
+
+Use ESPECIALLY when:
+- "Just one quick fix" seems obvious
+- You have already tried multiple fixes
+- Previous fix did not work
+
+## The Four Phases
+
+Complete each phase before proceeding to the next.
+
+### Phase 1: Reproduce and Observe
+
+1. **Reproduce the failure** with a specific command:
+
+   PowerShell:
+   ```powershell
+   .\gradlew test --tests "uk.gov.communities.prsdb.webapp.FailingTest" --console=plain
+   ```
+   Bash:
+   ```bash
+   ./gradlew test --tests "uk.gov.communities.prsdb.webapp.FailingTest" --console=plain
+   ```
+
+2. **Record exact output:** error message, stack trace, exit code
+3. **Identify the failing assertion:** what was expected vs actual?
+
+### Phase 2: Gather Evidence
+
+Use these project-specific evidence sources:
+
+| Source | Tool | What It Shows |
+|--------|------|---------------|
+| Stack trace | Test output | Call chain to failure point |
+| Spring logs | JetBrains console / test output | Request handling, bean wiring |
+| Controller mapping | `jetbrains-search_symbol` for handler method | URL routing |
+| Service logic | `jetbrains-read_file` with line ranges | Business logic flow |
+| Thymeleaf rendering | Template file + model attributes | View layer issues |
+| Journey step flow | Step config + StepId enum | Navigation/routing logic |
+| Form validation | `@ValidatedBy` annotations + validator classes | Validation chain |
+| Database state | Migration files + entity definitions | Schema/data issues |
+| Integration test page objects | `src/test/.../integration/pageObjects/` | Expected page structure |
+| JetBrains inspections | `jetbrains-get_file_problems` | Compile errors, type issues |
+
+**Do NOT skip this phase.** Gather at least 3 pieces of evidence before forming
+a hypothesis.
+
+### Phase 3: Form and Test Hypothesis
+
+1. State the hypothesis explicitly: "The failure occurs because..."
+2. Identify what evidence supports it
+3. Identify what evidence would disprove it
+4. Test the hypothesis with a targeted check (read code, add logging, evaluate
+   expression in debugger)
+
+If hypothesis is wrong: return to Phase 2 with new evidence.
+
+### Phase 4: Fix and Verify
+
+1. Make the minimal fix that addresses root cause
+2. Run the original failing test — must now pass
+3. Run related tests to check for regressions:
+
+   PowerShell:
+   ```powershell
+   .\gradlew test --tests "uk.gov.communities.prsdb.webapp.related.*" --console=plain
+   ```
+   Bash:
+   ```bash
+   ./gradlew test --tests "uk.gov.communities.prsdb.webapp.related.*" --console=plain
+   ```
+
+4. If fixing a bug: add a regression test that would have caught it
+
+## Using the Debugger
+
+For complex issues, use JetBrains MCP debugging tools:
+
+1. Set breakpoint: `jetbrains-xdebug_set_breakpoint`
+2. Start debug session: `jetbrains-xdebug_start_debugger_session`
+3. Wait for pause: `jetbrains-xdebug_control_session` (WAIT_FOR_PAUSE)
+4. Inspect variables: `jetbrains-xdebug_get_frame_values`
+5. Evaluate expressions: `jetbrains-xdebug_evaluate_expression`
+6. Step through: `jetbrains-xdebug_control_session` (STEP_OVER / STEP_INTO)
+
+## Anti-Patterns
+
+- Changing code without understanding why it failed
+- Fixing the test instead of the code (unless the test was wrong)
+- Adding try/catch to suppress errors
+- "It works now" without understanding what changed
+- Guessing and checking repeatedly

--- a/.github/skills/test-driven-development/SKILL.md
+++ b/.github/skills/test-driven-development/SKILL.md
@@ -11,7 +11,8 @@ tests the right thing.
 ## When to Use
 
 - New features (always)
-- Bug fixes (always — write regression test first)
+- Bug fixes (always — diagnose first with `systematic-debugging`, then write
+  regression test before fixing)
 - Behaviour changes (always)
 
 Exceptions (confirm with user): throwaway prototypes, generated code, config files.

--- a/.github/skills/test-driven-development/SKILL.md
+++ b/.github/skills/test-driven-development/SKILL.md
@@ -1,0 +1,182 @@
+---
+name: test-driven-development
+description: Use when implementing any feature or bugfix. Write the test first, watch it fail, write minimal code to pass.
+---
+
+# Test-Driven Development
+
+**Core principle:** If you did not watch the test fail, you do not know if it
+tests the right thing.
+
+## When to Use
+
+- New features (always)
+- Bug fixes (always — write regression test first)
+- Behaviour changes (always)
+
+Exceptions (confirm with user): throwaway prototypes, generated code, config files.
+
+## Red-Green-Refactor
+
+1. **RED** — Write a failing test
+2. **Verify RED** — Run it, confirm it fails for the right reason
+3. **GREEN** — Write minimal code to make it pass
+4. **Verify GREEN** — Run it, confirm it passes
+5. **REFACTOR** — Clean up (tests still passing)
+6. **Commit**
+
+## Test Stack Reference
+
+### Unit Tests
+
+```kotlin
+@ExtendWith(MockitoExtension::class)
+class FooServiceTests {
+    @Mock
+    private lateinit var mockRepository: FooRepository
+
+    private lateinit var service: FooService
+
+    @BeforeEach
+    fun setup() {
+        service = FooService(mockRepository)
+    }
+
+    @Test
+    fun `descriptive name explaining expected behaviour`() {
+        // arrange
+        whenever(mockRepository.findById(1L)).thenReturn(Optional.of(fooEntity))
+
+        // act
+        val result = service.getFoo(1L)
+
+        // assert
+        assertThat(result.name).isEqualTo("expected")
+    }
+}
+```
+
+Run:
+```powershell
+.\gradlew test --tests "uk.gov.communities.prsdb.webapp.services.FooServiceTests" --console=plain
+```
+```bash
+./gradlew test --tests "uk.gov.communities.prsdb.webapp.services.FooServiceTests" --console=plain
+```
+
+### Controller Tests
+
+```kotlin
+class FooControllerTests : ControllerTest() {
+    @MockitoBean
+    private lateinit var mockService: FooService
+
+    @Test
+    fun `GET foo returns 200 with expected model`() {
+        whenever(mockService.getFoo()).thenReturn(fooData)
+
+        mockMvc.get("/landlord/foo")
+            .andExpect {
+                status { isOk() }
+                model { attributeExists("fooData") }
+                view { name("foo") }
+            }
+    }
+}
+```
+
+Run:
+```powershell
+.\gradlew test --tests "uk.gov.communities.prsdb.webapp.controllers.FooControllerTests" --console=plain
+```
+```bash
+./gradlew test --tests "uk.gov.communities.prsdb.webapp.controllers.FooControllerTests" --console=plain
+```
+
+### Integration Tests
+
+```kotlin
+@UsePlaywright
+class FooJourneyTests : IntegrationTest("db/integrationTestData.sql") {
+    @Test
+    fun `completing foo journey creates record`(page: Page) {
+        navigator.goTo(page, FooPage::class)
+        val fooPage = FooPage(page)
+        fooPage.fillName("Test")
+        fooPage.submit()
+        // assertions...
+    }
+}
+```
+
+Run (requires Docker):
+```powershell
+.\gradlew test --tests "uk.gov.communities.prsdb.webapp.integration.FooJourneyTests" --console=plain
+```
+```bash
+./gradlew test --tests "uk.gov.communities.prsdb.webapp.integration.FooJourneyTests" --console=plain
+```
+
+### Journey Step Configuration Tests
+
+```kotlin
+class FooStepConfigTests {
+    @Test
+    fun `step config produces expected page`() {
+        val config = FooStepConfig()
+        val page = config.page(FooFormModel())
+        assertThat(page).isInstanceOf(Page::class.java)
+    }
+}
+```
+
+## Test Naming
+
+Always use backtick-quoted descriptive strings:
+```kotlin
+@Test
+fun `submitting empty form returns validation errors`() { }
+
+@Test
+fun `landlord with expired EPC sees warning banner`() { }
+
+@Test
+fun `deregistering property sends confirmation email`() { }
+```
+
+## Test Location
+
+| Source Under Test | Test Location |
+|-------------------|---------------|
+| `src/main/.../services/FooService.kt` | `src/test/.../services/FooServiceTests.kt` |
+| `src/main/.../controllers/FooController.kt` | `src/test/.../controllers/FooControllerTests.kt` |
+| `src/main/.../validation/FooValidator.kt` | `src/test/.../validation/FooValidatorTests.kt` |
+| Integration (journey flow) | `src/test/.../integration/FooJourneyTests.kt` |
+| Integration (single page) | `src/test/.../integration/pageTests/FooPageTests.kt` |
+
+## When TDD Does Not Apply
+
+- Database migrations (SQL, not testable via unit tests)
+- Thymeleaf templates (verified via integration tests, not unit-testable)
+- Configuration classes (verified by application startup)
+- Pure wiring (Spring bean registration)
+
+For these, write the code first, then verify via integration tests or smoke testing.
+
+## Verification Commands
+
+Quick feedback (unit + controller, no Docker):
+```powershell
+.\gradlew testWithoutIntegration --console=plain
+```
+```bash
+./gradlew testWithoutIntegration --console=plain
+```
+
+Full suite (requires Docker, ~20 min):
+```powershell
+.\gradlew test --console=plain
+```
+```bash
+./gradlew test --console=plain
+```

--- a/.github/skills/using-skills/SKILL.md
+++ b/.github/skills/using-skills/SKILL.md
@@ -1,0 +1,40 @@
+---
+name: using-skills
+description: Use when starting any conversation or task to check which repository skills apply before taking action.
+---
+
+# Using Skills
+
+Before responding to any task, check whether a repository skill applies.
+
+## Available Skills
+
+| Skill | When to Use |
+|-------|-------------|
+| `development-workflow` | Starting a new development task from a Jira ticket |
+| `brainstorming` | Any creative work — features, components, behaviour changes |
+| `writing-plans` | Turning a spec/requirements into an implementation plan |
+| `subagent-driven-development` | Executing a plan with independent tasks |
+| `test-driven-development` | Implementing any feature or bugfix |
+| `systematic-debugging` | Any bug, test failure, or unexpected behaviour |
+| `verification-before-completion` | About to claim work is complete or passing |
+| `receiving-code-review` | PR has review comments to address |
+| `raising-pull-requests` | Creating a PR |
+| `making-code-edits` | Searching, reading, or editing code |
+| `running-locally` | Starting/stopping the application |
+| `smoke-testing` | Verifying pages load and forms work |
+| `reading-figma-designs` | Interpreting a Figma design for implementation |
+| `preflight-checks` | Verifying tools and services are available |
+| `branch-and-commit-naming` | Creating branches or writing commit messages |
+| `reviewing-code` | Reviewing code changes |
+
+## The Rule
+
+If a skill applies to the task, invoke it before responding. Process skills
+(brainstorming, debugging, TDD) take priority over implementation skills.
+
+## Priority
+
+1. **User's explicit instructions** — always highest priority
+2. **Repository skills** — override default behaviour where they apply
+3. **Default behaviour** — only when no skill applies

--- a/.github/skills/verification-before-completion/SKILL.md
+++ b/.github/skills/verification-before-completion/SKILL.md
@@ -1,0 +1,105 @@
+---
+name: verification-before-completion
+description: Use when about to claim work is complete, fixed, or passing. Requires running verification commands and confirming output before making any success claims.
+---
+
+# Verification Before Completion
+
+**Core principle:** Evidence before claims, always.
+
+If you have not run the verification command in this session, you cannot claim it
+passes.
+
+## The Gate
+
+Before claiming any status:
+
+1. **IDENTIFY** — What command proves this claim?
+2. **RUN** — Execute the full command (fresh, not cached)
+3. **READ** — Full output, check exit code, count failures
+4. **VERIFY** — Does output confirm the claim?
+5. **ONLY THEN** — Make the claim with evidence
+
+## Verification Commands
+
+| Claim | Command (PowerShell) | Command (Bash) |
+|-------|---------------------|----------------|
+| Unit tests pass | `.\gradlew testWithoutIntegration --console=plain` | `./gradlew testWithoutIntegration --console=plain` |
+| Specific test passes | `.\gradlew test --tests "fully.qualified.Class" --console=plain` | `./gradlew test --tests "fully.qualified.Class" --console=plain` |
+| All tests pass | `.\gradlew test --console=plain` | `./gradlew test --console=plain` |
+| Lint clean | `.\gradlew ktlintCheck --console=plain` | `./gradlew ktlintCheck --console=plain` |
+| Build succeeds | `jetbrains-build_project` with worktree `projectPath` | same |
+| Frontend tests pass | `npm test` | `npm test` |
+| No compilation errors | `jetbrains-get_file_problems` on modified files | same |
+| Bug fixed | Reproduce → fix → verify symptom gone | same |
+
+## Streaming Output
+
+**CRITICAL:** Tests can take up to 20 minutes. Commands MUST stream output so
+progress can be monitored.
+
+### PowerShell
+
+```powershell
+# Use sync mode with long initial_wait
+.\gradlew test --console=plain
+```
+
+Via the powershell tool:
+```
+powershell:
+  command: ".\gradlew test --console=plain"
+  mode: "sync"
+  initial_wait: 300
+```
+
+If still running after `initial_wait`, use `read_powershell` every 30-60 seconds
+to check progress.
+
+### Bash
+
+```bash
+./gradlew test --console=plain
+```
+
+Via the powershell tool:
+```
+powershell:
+  command: "./gradlew test --console=plain"
+  mode: "sync"
+  initial_wait: 300
+```
+
+### Progress Indicators
+
+Look for these to confirm tests are progressing:
+- `> Task :test` — tests starting
+- `uk.gov.communities.prsdb.webapp.` — individual test classes
+- `X tests completed, Y failed` — periodic summary
+- `BUILD SUCCESSFUL` / `BUILD FAILED` — completion
+
+If no new output for 2+ minutes, investigate (database locks, Docker health).
+
+## What Counts as Evidence
+
+| ✓ Evidence | ✗ Not Evidence |
+|-----------|---------------|
+| Command output showing 0 failures | Previous run from earlier |
+| Exit code 0 from fresh run | "Should pass based on changes" |
+| `BUILD SUCCESSFUL` in output | Linter passing (does not prove tests pass) |
+| Test originally failing, now passing | Code changed, assumed fixed |
+| `jetbrains-build_project` reporting 0 errors | File looks correct |
+
+## Common Failures
+
+- Claiming tests pass without running them
+- Running only one test class and claiming "all tests pass"
+- Assuming linter passing means build passes
+- Not re-running after a fix (verifying the fix actually worked)
+- Running tests from stale context (wrong branch, outdated code)
+
+## Smoke Test Verification
+
+For UI/runtime claims, use the `smoke-testing` skill (Playwright CLI via
+`.claude/skills/playwright-cli/`). Verify pages load, forms render, and
+navigation works as expected.

--- a/.github/skills/writing-plans/SKILL.md
+++ b/.github/skills/writing-plans/SKILL.md
@@ -1,0 +1,203 @@
+---
+name: writing-plans
+description: Use when you have a spec or requirements for a multi-step task, before touching code. Produces implementation plans tailored to the prsdb-webapp codebase.
+---
+
+# Writing Plans
+
+Write comprehensive implementation plans assuming the implementing agent has zero
+context for this codebase. Document everything needed: which files to touch, code
+examples, testing approach, and verification commands.
+
+**Save plans to:** `~/.copilot/session-state/<session-id>/files/plan.md`
+Plans are session artifacts and must NOT be committed to the repository.
+
+## Scope Check
+
+If the spec covers multiple independent subsystems, suggest breaking into separate
+plans — one per subsystem. Each plan should produce working, testable software on
+its own.
+
+## File Structure
+
+Before defining tasks, map out which files will be created or modified:
+
+- Follow existing package structure conventions (see below)
+- Each file should have one clear responsibility
+- Files that change together should live together
+- Follow established patterns — do not restructure without agreement
+
+### Package Layout Reference
+
+```
+src/main/kotlin/uk/gov/communities/prsdb/webapp/
+├── annotations/        Custom Spring annotations
+├── application/        Scheduled task runners
+├── clients/            External API clients
+├── config/             Spring configuration, security, filters
+├── constants/          Constants and domain enums
+├── controllers/        HTTP endpoints (@PrsdbController)
+├── database/entity/    JPA entities
+├── database/repository/ JPA repositories
+├── exceptions/         Custom exception classes
+├── forms/              Multi-step form page classes
+├── helpers/            Converters, extensions, utilities
+├── journeys/           Journey framework, state management, and definitions
+├── local/api/          Local dev stubs (@Profile("local"))
+├── models/             Data, request, and view models
+├── services/           Business logic (@PrsdbWebService)
+└── validation/         Custom validation framework
+```
+
+## Plan Document Header
+
+Every plan MUST start with:
+
+```markdown
+# [Feature Name] Implementation Plan
+
+**Goal:** [One sentence]
+
+**Architecture:** [2-3 sentences about approach]
+
+**Tech Stack:** Kotlin, Spring Boot, Thymeleaf, GOV.UK Frontend, PostgreSQL
+```
+
+## TODO Table
+
+After the header, include a table mapping Jira acceptance criteria and codebase
+TODO comments to plan tasks:
+
+```markdown
+## Jira ToDos
+
+| ToDo | Addressed In |
+|------|-------------|
+| [Acceptance criterion from ticket] | PR N: Task M |
+| `// TODO PDJB-XXX: [comment text]` in `SomeFile.kt:42` | PR N: Task M |
+| [Item intentionally not addressed] | Out of scope — [reason] |
+```
+
+## Decomposition
+
+Break the problem down recursively until each task is simple to build and simple
+to verify. If a task requires touching more than 2-3 files, or its verification
+step is not obvious, it is too big — split it further.
+
+Good decomposition:
+- Each task produces a single testable behaviour change
+- A developer can hold the entire task in their head at once
+- The verification command proves the task is done (one test class, one endpoint)
+
+Bad decomposition:
+- "Implement the journey" (too broad — split into: step config, form model,
+  validation, controller wiring, templates, integration test)
+- "Add service and tests" (two things — split into: failing test, then implementation)
+
+Keep splitting until every task feels trivially small. Tasks that feel too small
+are the right size.
+
+## Task Structure
+
+Each task must include exact file paths, code, and verification commands:
+
+````markdown
+### Task N: [Component Name]
+
+**Depends on:** Task X, Task Y (omit if no dependencies)
+
+**Files:**
+- Create: `src/main/kotlin/.../NewFile.kt`
+- Modify: `src/main/kotlin/.../ExistingFile.kt`
+- Test: `src/test/kotlin/.../NewFileTests.kt`
+
+- [ ] **Step 1: Write the failing test**
+
+```kotlin
+@Test
+fun `descriptive test name in backticks`() {
+    // arrange, act, assert
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+PowerShell:
+```powershell
+.\gradlew test --tests "uk.gov.communities.prsdb.webapp.TestClass.descriptive test name in backticks" --console=plain
+```
+Bash:
+```bash
+./gradlew test --tests "uk.gov.communities.prsdb.webapp.TestClass.descriptive test name in backticks" --console=plain
+```
+
+- [ ] **Step 3: Write minimal implementation**
+
+- [ ] **Step 4: Run test to verify it passes**
+
+- [ ] **Step 5: Commit**
+````
+
+## Project-Specific Conventions
+
+Plans must account for these patterns:
+
+### Custom Annotations
+- Controllers: `@PrsdbController` (not `@Controller`)
+- Services: `@PrsdbWebService` (not `@Service`)
+- Components: `@PrsdbWebComponent` (not `@Component`)
+- Config: `@PrsdbWebConfiguration` (not `@Configuration`)
+
+### Entities
+- Extend `AuditableEntity` or `ModifiableAuditableEntity`
+- Flyway migrations in `src/main/resources/db/migrations/`
+- Naming: `V<major>_<minor>_<fix>__<description>.sql`
+
+### Journey Framework
+- StepId enums implement `StepId` or `GroupedStepId<T>`
+- Steps extend `RequestableStep`, annotated `@JourneyFrameworkComponent`
+- Journey factories annotated `@PrsdbWebService`
+
+### Validation
+- Form models annotated `@IsValidPrioritised`
+- Properties annotated `@ValidatedBy` with `ConstraintDescriptor` entries
+- Do NOT use standard Bean Validation (`@NotBlank`, `@Size`, etc.)
+
+### Testing
+- Unit tests: JUnit 5 + Mockito Kotlin, backtick method names
+- Controller tests: `@WebMvcTest` extending `ControllerTest`
+- Integration tests: `@UsePlaywright` extending `IntegrationTest*` base classes
+- Journey step tests: test step configuration compliance
+
+### Feature Flags
+- Non-bug-fix user-visible changes need feature flags
+- Flag names in `FeatureFlagNames.kt`, releases in `FeatureFlagReleaseNames.kt`
+- Endpoint: `@AvailableWhenFeatureEnabled("FLAG_NAME")`
+
+## Verification Strategy
+
+Every plan must include a verification strategy covering:
+
+1. **TDD suitability** — which tests to write first
+2. **Test types** — unit, controller, journey step config, integration, frontend JS
+3. **Full suite** — whether needed (~20 min; prefer targeted)
+4. **Smoke test** — unless no observable runtime effect
+5. **Figma comparison** — if UI/content changes
+
+## No Placeholders
+
+Every step must contain actual content. These are plan failures:
+- "TBD", "TODO", "implement later"
+- "Add appropriate error handling"
+- "Write tests for the above" (without actual test code)
+- "Similar to Task N" (repeat the content)
+- Steps that describe what to do without showing how
+
+## Self-Review
+
+After writing the complete plan:
+1. **Spec coverage:** Can every requirement point to a task?
+2. **Placeholder scan:** Any vague steps remaining?
+3. **Type consistency:** Do names match across tasks?
+
+Fix inline. Do not re-review.

--- a/docs/AIDevelopmentReadMe.md
+++ b/docs/AIDevelopmentReadMe.md
@@ -165,27 +165,11 @@ MCP server configuration goes in `~/.copilot/settings.json` (global) or `.copilo
 combine all three servers in a single config file. See the
 [MCP documentation](https://modelcontextprotocol.io/quickstart) for more details.
 
-### Superpowers Plugin
+### Structured Workflow Skills
 
-We recommend installing the [Superpowers](https://github.com/obra/superpowers) plugin — it enforces structured workflows
-for brainstorming, test-driven development, systematic debugging, and implementation planning. It makes a noticeable
-difference to output quality by automatically guiding Copilot through a brainstorm → plan → implement cycle.
-
-**Install via the Copilot CLI:**
-
-```
-/plugin marketplace add obra/superpowers-marketplace
-/plugin install superpowers@superpowers-marketplace
-```
-
-**Update to the latest version:**
-
-```
-/plugin update superpowers
-```
-
-Start a new session after installing. Skills activate automatically when relevant — for example, asking Copilot to plan a
-feature will invoke the brainstorming and planning skills.
+The repository includes project-tailored skills for brainstorming, test-driven development, systematic debugging, and
+implementation planning. These activate automatically when relevant — for example, asking Copilot to plan a feature will
+invoke the brainstorming and planning skills. No external plugins are required.
 
 ## Copilot Instructions
 
@@ -271,24 +255,19 @@ Useful when adding a new instruction file or regenerating all files after a sign
 ### Development workflow
 
 `development-workflow/SKILL.md` orchestrates the full lifecycle of a development task, from setup through to PR creation.
-It chains together other skills automatically across 10 phases:
+It chains together other skills automatically across 9 phases:
 
 0. **Preflight** — invokes the `preflight-checks` skill to verify tooling (gh CLI, IntelliJ, Docker, Playwright; Figma MCP for UI tasks)
 1. **Setup** — asks for the task and ticket ID, uses `branch-and-commit-naming` to name the branch, creates a worktree via `using-git-worktrees`, and launches IntelliJ
 2. **Brainstorm** — invokes the `brainstorming` skill, incorporating any Figma links the user provides for UI tasks
-3. **Plan** — invokes the `writing-plans` skill, requires a multi-PR splitting strategy for non-trivial tasks, and asks the user whether PRs should be stacked (parallel) or sequential
+3. **Plan** — invokes the `writing-plans` skill, requires a multi-PR splitting strategy for non-trivial tasks, and asks the user whether PRs should be stacked or sequential
 4. **Implement** — executes the plan using `subagent-driven-development` or directly, follows TDD where specified, does not commit
 5. **Verify** — proposes a verification plan covering unit/controller/integration tests, local smoke tests via Playwright, and Figma comparison for UI changes; executes after user approval
-6. **Code review** — launches a sub-agent review using the `reviewing-code` skill, loops back to fix if issues found, then prompts the user to review in IntelliJ before proceeding
-7. **Commit & PR** — uses `branch-and-commit-naming` for the commit message, pushes, creates the PR via `raising-pull-requests`, and cleans up the worktree
-8. **PR feedback** — reads review comments via GitHub MCP, uses `receiving-code-review` to evaluate each (action, partially action, or push back), implements approved changes in a fresh worktree, re-verifies, and optionally drafts responses to the reviewer
-9. **Next PR** — for stacked PRs, branches off the previous PR's branch and returns to Phase 4; for sequential PRs, saves state to `~/.copilot/workflow-state.json` and waits for the current PR to merge
+6. **Review** — launches a sub-agent review using the `reviewing-code` skill, loops back to fix if issues found, then prompts the user to review in IntelliJ before proceeding
+7. **Commit & PR** — uses `branch-and-commit-naming` for the commit message, pushes, creates the PR via `raising-pull-requests`
+8. **Next or Finish** — for stacked PRs, branches off the previous PR's branch and returns to Phase 4; for sequential PRs, waits for the current PR to merge
 
-Invoke it by describing a task, or type `/development-workflow` to trigger it explicitly:
-
-> "I need to implement PDJB-789 — add landlord notifications for expired gas certificates"
-
-The skill saves state to `~/.copilot/workflow-state.json` so sessions can be resumed.
+Phases 0-3 run once. Phases 4-8 repeat per PR. The PR feedback loop (`pr-feedback-loop.md`) is invoked when review comments arrive.
 
 ### Preflight checks
 


### PR DESCRIPTION
## What does this PR do?

Adds 7 project-tailored skills replacing the generic superpowers plugin equivalents with versions customised for prsdb conventions:

- `writing-plans` — Package layout, decomposition guidance, TODO table, dependency tracking, verification strategy
- `subagent-driven-development` — Fresh sub-agent per task with two-stage review and project conventions in prompt
- `verification-before-completion` — Evidence-before-claims with streaming output guidance (PowerShell + Bash)
- `systematic-debugging` — Four-phase debugging with project evidence sources and JetBrains debugger workflow
- `test-driven-development` — Red-green-refactor with Kotlin test examples for unit, controller, integration, and journey tests
- `brainstorming` — Collaborative design with stress-test phase, project-specific design spec content
- `receiving-code-review` — Technical evaluation of review feedback with user choice on responding

## Jira ticket link

https://mhclgdigital.atlassian.net/browse/PDJB-819

## How to test

Review each skill file for accuracy against existing codebase conventions. No runtime changes.

## Stacked on

- PR 1: #1387 (standalone skills)
- PR 2: #1388 (preflight + workflow restructuring)