### PR TITLE
PDJB-NONE: Decompose PropertyOwnership entity into @Embeddable value objects

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/PropertyDetailsController.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/PropertyDetailsController.kt
@@ -61,7 +61,7 @@ class PropertyDetailsController(
 
         val landlordViewModel =
             PropertyDetailsLandlordViewModelBuilder.fromEntity(
-                propertyOwnership.primaryLandlord,
+                propertyOwnership.landlordship.primaryLandlord,
                 landlordDetailsUrl,
             )
 
@@ -96,10 +96,10 @@ class PropertyDetailsController(
             propertyOwnershipService.getPropertyOwnershipIfAuthorizedUser(propertyOwnershipId, principal.name)
 
         val lastModifiedDate = DateTimeHelper.getDateInUK(propertyOwnership.getMostRecentlyUpdated().toKotlinInstant())
-        val lastModifiedBy = propertyOwnership.primaryLandlord.name
+        val lastModifiedBy = propertyOwnership.landlordship.primaryLandlord.name
         val primaryLandlordDetailsUrl =
             LandlordDetailsController
-                .getLandlordDetailsForLocalCouncilUserPath(propertyOwnership.primaryLandlord.id)
+                .getLandlordDetailsForLocalCouncilUserPath(propertyOwnership.landlordship.primaryLandlord.id)
                 .overrideBackLinkForUrl(backLinkStorageService.storeCurrentUrlReturningKey(LANDLORD_DETAILS_FRAGMENT))
 
         val propertyCompliance = propertyComplianceService.getComplianceForPropertyOrNull(propertyOwnershipId)
@@ -114,7 +114,7 @@ class PropertyDetailsController(
 
         val landlordViewModel =
             PropertyDetailsLandlordViewModelBuilder.fromEntity(
-                propertyOwnership.primaryLandlord,
+                propertyOwnership.landlordship.primaryLandlord,
                 primaryLandlordDetailsUrl,
             )
 

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/RegisterPropertyController.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/RegisterPropertyController.kt
@@ -101,14 +101,14 @@ class RegisterPropertyController(
                     "No property ownership with registration number $propertyRegistrationNumber was found in the database",
                 )
 
-        model.addAttribute("addressParts", propertyOwnership.address.singleLineAddress.split(", "))
+        model.addAttribute("addressParts", propertyOwnership.propertyDetails.address.singleLineAddress.split(", "))
         model.addAttribute(
             "prn",
-            RegistrationNumberDataModel.fromRegistrationNumber(propertyOwnership.registrationNumber).toString(),
+            RegistrationNumberDataModel.fromRegistrationNumber(propertyOwnership.landlordship.registrationNumber).toString(),
         )
 
         val actionRequiredForCompliance =
-            if (propertyOwnership.isOccupied) {
+            if (propertyOwnership.tenancyDetails.isOccupied) {
                 val compliance = propertyComplianceService.getComplianceForPropertyOrNull(propertyOwnership.id)
                 compliance == null || compliance.isGasSafetyCertMissing || compliance.isElectricalSafetyMissing || compliance.isEpcMissing
             } else {

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/database/entity/Landlord.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/database/entity/Landlord.kt
@@ -66,7 +66,7 @@ class Landlord() : ModifiableAuditableEntity() {
     @Column(nullable = false)
     var hasRespondedToFeedback: Boolean = false
 
-    @OneToMany(mappedBy = "primaryLandlord", orphanRemoval = true)
+    @OneToMany(mappedBy = "landlordship.primaryLandlord", orphanRemoval = true)
     private lateinit var propertyOwnerships: MutableSet<PropertyOwnership>
 
     @OneToMany(

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/database/entity/Landlordship.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/database/entity/Landlordship.kt
@@ -1,0 +1,69 @@
+package uk.gov.communities.prsdb.webapp.database.entity
+
+import jakarta.persistence.Column
+import jakarta.persistence.Embeddable
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+import jakarta.persistence.OneToOne
+import uk.gov.communities.prsdb.webapp.constants.enums.OwnershipType
+
+@Embeddable
+class Landlordship() {
+    @Column(nullable = false)
+    var isActive: Boolean = false
+
+    @Column(nullable = false)
+    lateinit var ownershipType: OwnershipType
+
+    @OneToOne(optional = false)
+    @JoinColumn(name = "registration_number_id", nullable = false, unique = true)
+    lateinit var registrationNumber: RegistrationNumber
+        private set
+
+    @ManyToOne(optional = false)
+    @JoinColumn(name = "primary_landlord_id", nullable = false)
+    lateinit var primaryLandlord: Landlord
+        private set
+
+    @OneToOne(optional = true, orphanRemoval = true)
+    @JoinColumn(name = "license_id", nullable = true, unique = true)
+    var license: License? = null
+
+    // We use this generated duplicate of isActive to influence the query planner into using the GIST index
+    // (as opposed to the GIN index) for searches where it's likely to be more efficient
+    @Column(nullable = false, insertable = false, updatable = false)
+    private val isActiveDuplicateForGistIndex: Boolean = false
+
+    constructor(
+        ownershipType: OwnershipType,
+        registrationNumber: RegistrationNumber,
+        primaryLandlord: Landlord,
+        license: License?,
+        isActive: Boolean = true,
+    ) : this() {
+        this.ownershipType = ownershipType
+        this.registrationNumber = registrationNumber
+        this.primaryLandlord = primaryLandlord
+        this.license = license
+        this.isActive = isActive
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is Landlordship) return false
+        return isActive == other.isActive &&
+            ownershipType == other.ownershipType &&
+            registrationNumber == other.registrationNumber &&
+            primaryLandlord == other.primaryLandlord &&
+            license == other.license
+    }
+
+    override fun hashCode(): Int {
+        var result = isActive.hashCode()
+        result = 31 * result + ownershipType.hashCode()
+        result = 31 * result + registrationNumber.hashCode()
+        result = 31 * result + primaryLandlord.hashCode()
+        result = 31 * result + (license?.hashCode() ?: 0)
+        return result
+    }
+}

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/database/entity/PropertyDetails.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/database/entity/PropertyDetails.kt
@@ -1,0 +1,58 @@
+package uk.gov.communities.prsdb.webapp.database.entity
+
+import jakarta.persistence.Column
+import jakarta.persistence.Embeddable
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+import uk.gov.communities.prsdb.webapp.constants.enums.PropertyType
+import uk.gov.communities.prsdb.webapp.database.entity.Address.Companion.SINGLE_LINE_ADDRESS_LENGTH
+
+@Embeddable
+class PropertyDetails() {
+    @ManyToOne(optional = false)
+    @JoinColumn(name = "address_id", nullable = false)
+    lateinit var address: Address
+        private set
+
+    @Column(nullable = false)
+    lateinit var propertyBuildType: PropertyType
+
+    var numBedrooms: Int? = null
+
+    var customPropertyType: String? = null
+
+    @Column(nullable = false, insertable = false, updatable = false, length = SINGLE_LINE_ADDRESS_LENGTH)
+    private lateinit var singleLineAddress: String
+
+    @Column(insertable = false, updatable = false)
+    private val localCouncilId: Int? = null
+
+    constructor(
+        address: Address,
+        propertyBuildType: PropertyType,
+        numBedrooms: Int? = null,
+        customPropertyType: String? = null,
+    ) : this() {
+        this.address = address
+        this.propertyBuildType = propertyBuildType
+        this.numBedrooms = numBedrooms
+        this.customPropertyType = customPropertyType
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is PropertyDetails) return false
+        return address == other.address &&
+            propertyBuildType == other.propertyBuildType &&
+            numBedrooms == other.numBedrooms &&
+            customPropertyType == other.customPropertyType
+    }
+
+    override fun hashCode(): Int {
+        var result = address.hashCode()
+        result = 31 * result + propertyBuildType.hashCode()
+        result = 31 * result + (numBedrooms ?: 0)
+        result = 31 * result + (customPropertyType?.hashCode() ?: 0)
+        return result
+    }
+}

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/database/entity/PropertyOwnership.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/database/entity/PropertyOwnership.kt
@@ -1,19 +1,16 @@
 package uk.gov.communities.prsdb.webapp.database.entity
 
-import jakarta.persistence.Column
+import jakarta.persistence.Embedded
 import jakarta.persistence.Entity
 import jakarta.persistence.GeneratedValue
 import jakarta.persistence.GenerationType
 import jakarta.persistence.Id
-import jakarta.persistence.JoinColumn
-import jakarta.persistence.ManyToOne
 import jakarta.persistence.OneToMany
 import jakarta.persistence.OneToOne
 import uk.gov.communities.prsdb.webapp.constants.enums.FurnishedStatus
 import uk.gov.communities.prsdb.webapp.constants.enums.OwnershipType
 import uk.gov.communities.prsdb.webapp.constants.enums.PropertyType
 import uk.gov.communities.prsdb.webapp.constants.enums.RentFrequency
-import uk.gov.communities.prsdb.webapp.database.entity.Address.Companion.SINGLE_LINE_ADDRESS_LENGTH
 import java.math.BigDecimal
 import java.time.LocalDate
 
@@ -23,75 +20,20 @@ class PropertyOwnership() : ModifiableAuditableEntity() {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     val id: Long = 0
 
-    @Column(nullable = false)
-    var isActive: Boolean = false
+    @Embedded
+    lateinit var landlordship: Landlordship
 
-    @Column(nullable = false)
-    lateinit var ownershipType: OwnershipType
+    @Embedded
+    lateinit var propertyDetails: PropertyDetails
 
-    @Column(nullable = false)
-    var currentNumHouseholds: Int = 0
-
-    @Column(nullable = false)
-    var currentNumTenants: Int = 0
-
-    @OneToOne(optional = false)
-    @JoinColumn(name = "registration_number_id", nullable = false, unique = true)
-    lateinit var registrationNumber: RegistrationNumber
-        private set
-
-    @ManyToOne(optional = false)
-    @JoinColumn(name = "primary_landlord_id", nullable = false)
-    lateinit var primaryLandlord: Landlord
-        private set
-
-    @Column(nullable = false)
-    lateinit var propertyBuildType: PropertyType
-
-    @ManyToOne(optional = false)
-    @JoinColumn(name = "address_id", nullable = false)
-    lateinit var address: Address
-        private set
-
-    @OneToOne(optional = true, orphanRemoval = true)
-    @JoinColumn(name = "license_id", nullable = true, unique = true)
-    var license: License? = null
-
-    @Column(nullable = false, insertable = false, updatable = false, length = SINGLE_LINE_ADDRESS_LENGTH)
-    private lateinit var singleLineAddress: String
-
-    @Column(insertable = false, updatable = false)
-    private val localCouncilId: Int? = null
-
-    // We use this generated duplicate of isActive to influence the query planner into using the GIST index (as opposed to the GIN index)
-    // for searches where it's likely to be more efficient
-    @Column(nullable = false, insertable = false, updatable = false)
-    private val isActiveDuplicateForGistIndex: Boolean = false
+    @Embedded
+    lateinit var tenancyDetails: TenancyDetails
 
     @OneToOne(mappedBy = "propertyOwnership", orphanRemoval = true)
     val propertyCompliance: PropertyCompliance? = null
 
     @OneToMany(mappedBy = "registeredOwnership", orphanRemoval = true)
     private val jointLandlordInvitations: MutableSet<JointLandlordInvitation> = mutableSetOf()
-
-    var numBedrooms: Int? = null
-
-    var billsIncludedList: String? = null
-
-    var customBillsIncluded: String? = null
-
-    var furnishedStatus: FurnishedStatus? = null
-
-    var rentFrequency: RentFrequency? = null
-
-    var customRentFrequency: String? = null
-
-    var customPropertyType: String? = null
-
-    @Column(precision = 9, scale = 2)
-    var rentAmount: BigDecimal? = null
-
-    var lastOccupiedDate: LocalDate? = null
 
     constructor(
         ownershipType: OwnershipType,
@@ -113,29 +55,32 @@ class PropertyOwnership() : ModifiableAuditableEntity() {
         customPropertyType: String? = null,
         lastOccupiedDate: LocalDate? = null,
     ) : this() {
-        this.ownershipType = ownershipType
-        this.currentNumHouseholds = currentNumHouseholds
-        this.currentNumTenants = currentNumTenants
-        this.registrationNumber = registrationNumber
-        this.primaryLandlord = primaryLandlord
-        this.propertyBuildType = propertyBuildType
-        this.address = address
-        this.license = license
-        this.isActive = isActive
-        this.numBedrooms = numBedrooms
-        this.billsIncludedList = billsIncludedList
-        this.customBillsIncluded = customBillsIncluded
-        this.furnishedStatus = furnishedStatus
-        this.rentFrequency = rentFrequency
-        this.customRentFrequency = customRentFrequency
-        this.rentAmount = rentAmount
-        this.customPropertyType = customPropertyType
-        this.lastOccupiedDate = lastOccupiedDate
+        this.landlordship =
+            Landlordship(
+                ownershipType = ownershipType,
+                registrationNumber = registrationNumber,
+                primaryLandlord = primaryLandlord,
+                license = license,
+                isActive = isActive,
+            )
+        this.propertyDetails =
+            PropertyDetails(
+                address = address,
+                propertyBuildType = propertyBuildType,
+                numBedrooms = numBedrooms,
+                customPropertyType = customPropertyType,
+            )
+        this.tenancyDetails =
+            TenancyDetails(
+                currentNumHouseholds = currentNumHouseholds,
+                currentNumTenants = currentNumTenants,
+                lastOccupiedDate = lastOccupiedDate,
+                furnishedStatus = furnishedStatus,
+                rentFrequency = rentFrequency,
+                customRentFrequency = customRentFrequency,
+                rentAmount = rentAmount,
+                billsIncludedList = billsIncludedList,
+                customBillsIncluded = customBillsIncluded,
+            )
     }
-
-    val isOccupied: Boolean
-        get() = currentNumTenants > 0
-
-    val rentIncludesBills: Boolean
-        get() = billsIncludedList != null
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/database/entity/TenancyDetails.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/database/entity/TenancyDetails.kt
@@ -1,0 +1,87 @@
+package uk.gov.communities.prsdb.webapp.database.entity
+
+import jakarta.persistence.Column
+import jakarta.persistence.Embeddable
+import uk.gov.communities.prsdb.webapp.constants.enums.FurnishedStatus
+import uk.gov.communities.prsdb.webapp.constants.enums.RentFrequency
+import java.math.BigDecimal
+import java.time.LocalDate
+
+@Embeddable
+class TenancyDetails() {
+    @Column(nullable = false)
+    var currentNumHouseholds: Int = 0
+
+    @Column(nullable = false)
+    var currentNumTenants: Int = 0
+
+    var lastOccupiedDate: LocalDate? = null
+
+    var furnishedStatus: FurnishedStatus? = null
+
+    var rentFrequency: RentFrequency? = null
+
+    var customRentFrequency: String? = null
+
+    @Column(precision = 9, scale = 2)
+    var rentAmount: BigDecimal? = null
+
+    var billsIncludedList: String? = null
+
+    var customBillsIncluded: String? = null
+
+    val isOccupied: Boolean
+        get() = currentNumTenants > 0
+
+    val rentIncludesBills: Boolean
+        get() = billsIncludedList != null
+
+    constructor(
+        currentNumHouseholds: Int,
+        currentNumTenants: Int,
+        lastOccupiedDate: LocalDate? = null,
+        furnishedStatus: FurnishedStatus? = null,
+        rentFrequency: RentFrequency? = null,
+        customRentFrequency: String? = null,
+        rentAmount: BigDecimal? = null,
+        billsIncludedList: String? = null,
+        customBillsIncluded: String? = null,
+    ) : this() {
+        this.currentNumHouseholds = currentNumHouseholds
+        this.currentNumTenants = currentNumTenants
+        this.lastOccupiedDate = lastOccupiedDate
+        this.furnishedStatus = furnishedStatus
+        this.rentFrequency = rentFrequency
+        this.customRentFrequency = customRentFrequency
+        this.rentAmount = rentAmount
+        this.billsIncludedList = billsIncludedList
+        this.customBillsIncluded = customBillsIncluded
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is TenancyDetails) return false
+        return currentNumHouseholds == other.currentNumHouseholds &&
+            currentNumTenants == other.currentNumTenants &&
+            lastOccupiedDate == other.lastOccupiedDate &&
+            furnishedStatus == other.furnishedStatus &&
+            rentFrequency == other.rentFrequency &&
+            customRentFrequency == other.customRentFrequency &&
+            (rentAmount?.compareTo(other.rentAmount) == 0 || rentAmount == other.rentAmount) &&
+            billsIncludedList == other.billsIncludedList &&
+            customBillsIncluded == other.customBillsIncluded
+    }
+
+    override fun hashCode(): Int {
+        var result = currentNumHouseholds
+        result = 31 * result + currentNumTenants
+        result = 31 * result + (lastOccupiedDate?.hashCode() ?: 0)
+        result = 31 * result + (furnishedStatus?.hashCode() ?: 0)
+        result = 31 * result + (rentFrequency?.hashCode() ?: 0)
+        result = 31 * result + (customRentFrequency?.hashCode() ?: 0)
+        result = 31 * result + (rentAmount?.hashCode() ?: 0)
+        result = 31 * result + (billsIncludedList?.hashCode() ?: 0)
+        result = 31 * result + (customBillsIncluded?.hashCode() ?: 0)
+        return result
+    }
+}

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/database/repository/PropertyComplianceRepository.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/database/repository/PropertyComplianceRepository.kt
@@ -7,7 +7,7 @@ import uk.gov.communities.prsdb.webapp.database.entity.PropertyCompliance
 interface PropertyComplianceRepository : JpaRepository<PropertyCompliance, Long> {
     fun findByPropertyOwnership_Id(propertyOwnershipId: Long): PropertyCompliance?
 
-    fun findAllByPropertyOwnership_PrimaryLandlord_BaseUser_Id(landlordBaseUserId: String): List<PropertyCompliance>
+    fun findAllByPropertyOwnership_Landlordship_PrimaryLandlord_BaseUser_Id(landlordBaseUserId: String): List<PropertyCompliance>
 
     fun deleteByPropertyOwnership_IdIn(propertyOwnershipIds: List<Long>)
 

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/database/repository/PropertyOwnershipRepository.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/database/repository/PropertyOwnershipRepository.kt
@@ -3,27 +3,26 @@ package uk.gov.communities.prsdb.webapp.database.repository
 import org.springframework.data.jpa.repository.JpaRepository
 import uk.gov.communities.prsdb.webapp.database.entity.PropertyOwnership
 
-// The underscore tells JPA to access fields relating to the referenced table
 @Suppress("ktlint:standard:function-naming")
 interface PropertyOwnershipRepository :
     JpaRepository<PropertyOwnership, Long>,
     PropertyOwnershipSearchRepository {
-    fun existsByIsActiveTrueAndAddress_Uprn(uprn: Long): Boolean
+    fun existsByLandlordship_IsActiveTrueAndPropertyDetails_Address_Uprn(uprn: Long): Boolean
 
-    fun findAllByPrimaryLandlord_BaseUser_IdAndIsActiveTrue(userId: String): List<PropertyOwnership>
+    fun findAllByLandlordship_PrimaryLandlord_BaseUser_IdAndLandlordship_IsActiveTrue(userId: String): List<PropertyOwnership>
 
-    fun findAllByPrimaryLandlord_IdAndIsActiveTrue(landlordId: Long): List<PropertyOwnership>
+    fun findAllByLandlordship_PrimaryLandlord_IdAndLandlordship_IsActiveTrue(landlordId: Long): List<PropertyOwnership>
 
-    fun findByRegistrationNumber_Number(registrationNumber: Long): PropertyOwnership?
+    fun findByLandlordship_RegistrationNumber_Number(registrationNumber: Long): PropertyOwnership?
 
-    fun findByIdAndIsActiveTrue(id: Long): PropertyOwnership?
+    fun findByIdAndLandlordship_IsActiveTrue(id: Long): PropertyOwnership?
 
-    fun existsByPrimaryLandlord_BaseUser_IdAndIsActiveTrue(userId: String): Boolean
+    fun existsByLandlordship_PrimaryLandlord_BaseUser_IdAndLandlordship_IsActiveTrue(userId: String): Boolean
 
-    fun existsByPrimaryLandlord_BaseUser_IdAndIsActiveTrueAndAddress_Uprn(
+    fun existsByLandlordship_PrimaryLandlord_BaseUser_IdAndLandlordship_IsActiveTrueAndPropertyDetails_Address_Uprn(
         userId: String,
         uprn: Long,
     ): Boolean
 
-    fun countByPrimaryLandlord_BaseUser_Id(userId: String): Long
+    fun countByLandlordship_PrimaryLandlord_BaseUser_Id(userId: String): Long
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/helpers/BillsIncludedHelper.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/helpers/BillsIncludedHelper.kt
@@ -26,10 +26,10 @@ class BillsIncludedHelper {
             messageSource: MessageSource,
         ): String {
             // TODO PDJB-548 remove not-null assertion !! once occupancy is embedded in PropertyOwnership
-            val allBillsIncluded = propertyOwnership.billsIncludedList!!.split(",").map { BillsIncluded.valueOf(it) }
+            val allBillsIncluded = propertyOwnership.tenancyDetails.billsIncludedList!!.split(",").map { BillsIncluded.valueOf(it) }
             return buildBillsIncludedString(
                 billsIncluded = allBillsIncluded,
-                customBillsIncluded = propertyOwnership.customBillsIncluded,
+                customBillsIncluded = propertyOwnership.tenancyDetails.customBillsIncluded,
                 messageSource = messageSource,
             )
         }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/acceptOrRejectJointLandlordInvitation/steps/AcceptOrRejectStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/acceptOrRejectJointLandlordInvitation/steps/AcceptOrRejectStepConfig.kt
@@ -27,7 +27,7 @@ class AcceptOrRejectStepConfig(
             "heading" to "acceptOrRejectJointLandlordInvitation.acceptOrReject.heading",
             "inviterName" to invitation.invitingLandlord.name,
             "propertyAddress" to
-                invitation.registeredOwnership.address
+                invitation.registeredOwnership.propertyDetails.address
                     .toMultiLineAddress()
                     .split("\n"),
             "fieldSetHeading" to "acceptOrRejectJointLandlordInvitation.acceptOrReject.radios.fieldSetHeading",

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyDeregistration/stepConfig/AreYouSureStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyDeregistration/stepConfig/AreYouSureStepConfig.kt
@@ -29,7 +29,7 @@ class AreYouSureStepConfig(
         }
 
     private fun getPropertySingleLineAddress(propertyOwnershipId: Long): String =
-        propertyOwnershipService.getPropertyOwnership(propertyOwnershipId).address.singleLineAddress
+        propertyOwnershipService.getPropertyOwnership(propertyOwnershipId).propertyDetails.address.singleLineAddress
 }
 
 @JourneyFrameworkComponent

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyDeregistration/stepConfig/ReasonStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyDeregistration/stepConfig/ReasonStepConfig.kt
@@ -35,9 +35,9 @@ class ReasonStepConfig(
     override fun afterStepDataIsAdded(state: PropertyDeregistrationJourneyState) {
         val propertyOwnership = propertyOwnershipService.getPropertyOwnership(state.propertyOwnershipId)
 
-        val primaryLandlordEmailAddress = propertyOwnership.primaryLandlord.email
-        val propertyRegistrationNumber = propertyOwnership.registrationNumber
-        val propertyAddress = propertyOwnership.address.singleLineAddress
+        val primaryLandlordEmailAddress = propertyOwnership.landlordship.primaryLandlord.email
+        val propertyRegistrationNumber = propertyOwnership.landlordship.registrationNumber
+        val propertyAddress = propertyOwnership.propertyDetails.address.singleLineAddress
 
         propertyDeregistrationService.deregisterProperty(state.propertyOwnershipId)
         propertyDeregistrationService.addDeregisteredPropertyOwnershipIdToSession(state.propertyOwnershipId)

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/update/electricalSafety/UpdateElectricalSafetyJourneyFactory.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/update/electricalSafety/UpdateElectricalSafetyJourneyFactory.kt
@@ -50,7 +50,7 @@ class UpdateElectricalSafetyJourneyFactory(
 
             state.propertyId = propertyId
             state.lastModifiedDate = propertyCompliance.getMostRecentlyUpdated().toString()
-            state.isOccupied = propertyOwnership.isOccupied
+            state.isOccupied = propertyOwnership.tenancyDetails.isOccupied
             state.previousUploadIds = propertyCompliance.electricalSafetyFileUploads.map { it.id }
             state.isStateInitialized = true
         }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/update/epc/UpdateEpcJourneyFactory.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/update/epc/UpdateEpcJourneyFactory.kt
@@ -61,8 +61,8 @@ class UpdateEpcJourneyFactory(
 
             state.propertyId = propertyId
             state.lastModifiedDate = propertyCompliance.getMostRecentlyUpdated().toString()
-            state.isOccupied = propertyOwnership.isOccupied
-            state.uprn = propertyOwnership.address.uprn
+            state.isOccupied = propertyOwnership.tenancyDetails.isOccupied
+            state.uprn = propertyOwnership.propertyDetails.address.uprn
             state.isStateInitialized = true
         }
 

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/update/gasSafety/UpdateGasSafetyJourneyFactory.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/update/gasSafety/UpdateGasSafetyJourneyFactory.kt
@@ -52,7 +52,7 @@ class UpdateGasSafetyJourneyFactory(
             state.propertyId = propertyId
             state.lastModifiedDate = propertyCompliance.getMostRecentlyUpdated().toString()
             state.previousUploadIds = propertyCompliance.gasSafetyFileUploads.map { it.id }
-            state.isOccupied = propertyOwnership.isOccupied
+            state.isOccupied = propertyOwnership.tenancyDetails.isOccupied
             state.isStateInitialized = true
         }
 

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/update/householdsAndTenants/UpdateHouseholdsAndTenantsCyaConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/update/householdsAndTenants/UpdateHouseholdsAndTenantsCyaConfig.kt
@@ -57,10 +57,13 @@ class UpdateHouseholdsAndTenantsCyaConfig(
     private fun sendUpdateConfirmationEmail(state: UpdateHouseholdsAndTenantsJourneyState) {
         val propertyOwnership = propertyOwnershipService.getPropertyOwnership(state.propertyId)
         updateConfirmationEmailService.sendEmail(
-            propertyOwnership.primaryLandlord.email,
+            propertyOwnership.landlordship.primaryLandlord.email,
             PropertyUpdateConfirmation(
-                singleLineAddress = propertyOwnership.address.singleLineAddress,
-                registrationNumber = RegistrationNumberDataModel.fromRegistrationNumber(propertyOwnership.registrationNumber).toString(),
+                singleLineAddress = propertyOwnership.propertyDetails.address.singleLineAddress,
+                registrationNumber =
+                    RegistrationNumberDataModel.fromRegistrationNumber(
+                        propertyOwnership.landlordship.registrationNumber,
+                    ).toString(),
                 updatedBullets =
                     listOf(
                         "The number of households living in this property",

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/update/occupancy/UpdateOccupancyCyaConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/update/occupancy/UpdateOccupancyCyaConfig.kt
@@ -107,10 +107,13 @@ class UpdateOccupancyCyaConfig(
                 }
             }
         updateConfirmationEmailService.sendEmail(
-            propertyOwnership.primaryLandlord.email,
+            propertyOwnership.landlordship.primaryLandlord.email,
             PropertyUpdateConfirmation(
-                singleLineAddress = propertyOwnership.address.singleLineAddress,
-                registrationNumber = RegistrationNumberDataModel.fromRegistrationNumber(propertyOwnership.registrationNumber).toString(),
+                singleLineAddress = propertyOwnership.propertyDetails.address.singleLineAddress,
+                registrationNumber =
+                    RegistrationNumberDataModel.fromRegistrationNumber(
+                        propertyOwnership.landlordship.registrationNumber,
+                    ).toString(),
                 updatedBullets = bullets,
                 dashboardUrl = absoluteUrlProvider.buildLandlordDashboardUri(),
             ),

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/update/occupancy/UpdateOccupancyJourneyFactory.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/update/occupancy/UpdateOccupancyJourneyFactory.kt
@@ -47,7 +47,7 @@ class UpdateOccupancyJourneyFactory(
             val propertyOwnership = propertyOwnershipService.getPropertyOwnership(propertyId)
             state.propertyId = propertyId
             state.lastModifiedDate = propertyOwnership.getMostRecentlyUpdated().toString()
-            state.wasOccupied = propertyOwnership.isOccupied
+            state.wasOccupied = propertyOwnership.tenancyDetails.isOccupied
             state.isStateInitialized = true
         }
 

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/update/ownershipType/CompleteOwnershipTypeUpdateStep.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/update/ownershipType/CompleteOwnershipTypeUpdateStep.kt
@@ -41,10 +41,13 @@ class CompleteOwnershipTypeUpdateStepConfig(
     private fun sendUpdateConfirmationEmail(state: UpdateOwnershipTypeJourneyState) {
         val propertyOwnership = propertyOwnershipService.getPropertyOwnership(state.propertyId)
         updateConfirmationEmailService.sendEmail(
-            propertyOwnership.primaryLandlord.email,
+            propertyOwnership.landlordship.primaryLandlord.email,
             PropertyUpdateConfirmation(
-                singleLineAddress = propertyOwnership.address.singleLineAddress,
-                registrationNumber = RegistrationNumberDataModel.fromRegistrationNumber(propertyOwnership.registrationNumber).toString(),
+                singleLineAddress = propertyOwnership.propertyDetails.address.singleLineAddress,
+                registrationNumber =
+                    RegistrationNumberDataModel.fromRegistrationNumber(
+                        propertyOwnership.landlordship.registrationNumber,
+                    ).toString(),
                 updatedBullets = listOf("The ownership type"),
                 dashboardUrl = absoluteUrlProvider.buildLandlordDashboardUri(),
             ),

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/update/updateLicensing/UpdateLicensingCyaConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/update/updateLicensing/UpdateLicensingCyaConfig.kt
@@ -59,10 +59,13 @@ class UpdateLicensingCyaConfig(
     private fun sendUpdateConfirmationEmail(state: UpdateLicensingJourneyState) {
         val propertyOwnership = propertyOwnershipService.getPropertyOwnership(state.propertyId)
         updateConfirmationEmailService.sendEmail(
-            propertyOwnership.primaryLandlord.email,
+            propertyOwnership.landlordship.primaryLandlord.email,
             PropertyUpdateConfirmation(
-                singleLineAddress = propertyOwnership.address.singleLineAddress,
-                registrationNumber = RegistrationNumberDataModel.fromRegistrationNumber(propertyOwnership.registrationNumber).toString(),
+                singleLineAddress = propertyOwnership.propertyDetails.address.singleLineAddress,
+                registrationNumber =
+                    RegistrationNumberDataModel.fromRegistrationNumber(
+                        propertyOwnership.landlordship.registrationNumber,
+                    ).toString(),
                 updatedBullets = listOf("The licensing information"),
                 dashboardUrl = absoluteUrlProvider.buildLandlordDashboardUri(),
             ),

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/update/updateLicensing/UpdatePropertyLicensingJourneyFactory.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/update/updateLicensing/UpdatePropertyLicensingJourneyFactory.kt
@@ -36,7 +36,7 @@ class UpdateLicensingJourneyFactory(
         if (!state.isStateInitialized) {
             state.propertyId = propertyId
             val propertyOwnership = ownershipService.getPropertyOwnership(propertyId)
-            state.hasOriginalLicense = propertyOwnership.license != null
+            state.hasOriginalLicense = propertyOwnership.landlordship.license != null
             state.lastModifiedDate = propertyOwnership.getMostRecentlyUpdated().toString()
             state.isStateInitialized = true
         }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/dataModels/ComplianceStatusDataModel.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/dataModels/ComplianceStatusDataModel.kt
@@ -26,17 +26,17 @@ data class ComplianceStatusDataModel(
         fun fromPropertyCompliance(propertyCompliance: PropertyCompliance): ComplianceStatusDataModel =
             ComplianceStatusDataModel(
                 propertyOwnershipId = propertyCompliance.propertyOwnership.id,
-                singleLineAddress = propertyCompliance.propertyOwnership.address.singleLineAddress,
+                singleLineAddress = propertyCompliance.propertyOwnership.propertyDetails.address.singleLineAddress,
                 registrationNumber =
                     RegistrationNumberDataModel
                         .fromRegistrationNumber(
-                            propertyCompliance.propertyOwnership.registrationNumber,
+                            propertyCompliance.propertyOwnership.landlordship.registrationNumber,
                         ).toString(),
                 gasSafetyStatus = propertyCompliance.gasSafetyStatus,
                 eicrStatus = propertyCompliance.eicrStatus,
                 epcStatus = propertyCompliance.epcStatus,
                 isComplete = true,
-                isOccupied = propertyCompliance.propertyOwnership.isOccupied,
+                isOccupied = propertyCompliance.propertyOwnership.tenancyDetails.isOccupied,
             )
 
         private val PropertyCompliance.gasSafetyStatus: ComplianceCertStatus

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/requestModels/formModels/FurnishedStatusFormModel.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/requestModels/formModels/FurnishedStatusFormModel.kt
@@ -12,6 +12,6 @@ class FurnishedStatusFormModel : FormModel {
 
     companion object {
         fun fromPropertyOwnership(propertyOwnership: PropertyOwnership): FurnishedStatusFormModel =
-            FurnishedStatusFormModel().apply { furnishedStatus = propertyOwnership.furnishedStatus }
+            FurnishedStatusFormModel().apply { furnishedStatus = propertyOwnership.tenancyDetails.furnishedStatus }
     }
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/requestModels/formModels/HmoAdditionalLicenceFormModel.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/requestModels/formModels/HmoAdditionalLicenceFormModel.kt
@@ -27,7 +27,7 @@ class HmoAdditionalLicenceFormModel : FormModel {
     companion object {
         fun fromPropertyOwnership(propertyOwnership: PropertyOwnership): HmoAdditionalLicenceFormModel =
             HmoAdditionalLicenceFormModel().apply {
-                licenceNumber = propertyOwnership.license?.licenseNumber
+                licenceNumber = propertyOwnership.landlordship.license?.licenseNumber
             }
     }
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/requestModels/formModels/HmoMandatoryLicenceFormModel.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/requestModels/formModels/HmoMandatoryLicenceFormModel.kt
@@ -27,7 +27,7 @@ class HmoMandatoryLicenceFormModel : FormModel {
     companion object {
         fun fromPropertyOwnership(propertyOwnership: PropertyOwnership): HmoMandatoryLicenceFormModel =
             HmoMandatoryLicenceFormModel().apply {
-                licenceNumber = propertyOwnership.license?.licenseNumber
+                licenceNumber = propertyOwnership.landlordship.license?.licenseNumber
             }
     }
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/requestModels/formModels/LicensingTypeFormModel.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/requestModels/formModels/LicensingTypeFormModel.kt
@@ -13,7 +13,7 @@ class LicensingTypeFormModel : FormModel {
     companion object {
         fun fromPropertyOwnership(propertyOwnership: PropertyOwnership): LicensingTypeFormModel =
             LicensingTypeFormModel().apply {
-                licensingType = propertyOwnership.license?.licenseType ?: LicensingType.NO_LICENSING
+                licensingType = propertyOwnership.landlordship.license?.licenseType ?: LicensingType.NO_LICENSING
             }
     }
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/requestModels/formModels/NumberOfHouseholdsFormModel.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/requestModels/formModels/NumberOfHouseholdsFormModel.kt
@@ -24,6 +24,6 @@ class NumberOfHouseholdsFormModel : FormModel {
 
     companion object {
         fun fromPropertyOwnership(propertyOwnership: PropertyOwnership): NumberOfHouseholdsFormModel =
-            NumberOfHouseholdsFormModel().apply { numberOfHouseholds = propertyOwnership.currentNumHouseholds.toString() }
+            NumberOfHouseholdsFormModel().apply { numberOfHouseholds = propertyOwnership.tenancyDetails.currentNumHouseholds.toString() }
     }
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/requestModels/formModels/NumberOfPeopleFormModel.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/requestModels/formModels/NumberOfPeopleFormModel.kt
@@ -35,8 +35,8 @@ class NumberOfPeopleFormModel : FormModel {
     companion object {
         fun fromPropertyOwnership(propertyOwnership: PropertyOwnership): NumberOfPeopleFormModel =
             NumberOfPeopleFormModel().apply {
-                numberOfPeople = propertyOwnership.currentNumTenants.toString()
-                numberOfHouseholds = propertyOwnership.currentNumHouseholds.toString()
+                numberOfPeople = propertyOwnership.tenancyDetails.currentNumTenants.toString()
+                numberOfHouseholds = propertyOwnership.tenancyDetails.currentNumHouseholds.toString()
             }
     }
 }
@@ -59,7 +59,7 @@ class NewNumberOfPeopleFormModel : FormModel {
     companion object {
         fun fromPropertyOwnership(propertyOwnership: PropertyOwnership): NewNumberOfPeopleFormModel =
             NewNumberOfPeopleFormModel().apply {
-                numberOfPeople = propertyOwnership.currentNumTenants.toString()
+                numberOfPeople = propertyOwnership.tenancyDetails.currentNumTenants.toString()
             }
     }
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/requestModels/formModels/OccupancyFormModel.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/requestModels/formModels/OccupancyFormModel.kt
@@ -11,6 +11,6 @@ class OccupancyFormModel : FormModel {
 
     companion object {
         fun fromPropertyOwnership(propertyOwnership: PropertyOwnership): OccupancyFormModel =
-            OccupancyFormModel().apply { occupied = propertyOwnership.isOccupied }
+            OccupancyFormModel().apply { occupied = propertyOwnership.tenancyDetails.isOccupied }
     }
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/requestModels/formModels/OwnershipTypeFormModel.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/requestModels/formModels/OwnershipTypeFormModel.kt
@@ -12,6 +12,6 @@ class OwnershipTypeFormModel : FormModel {
 
     companion object {
         fun fromPropertyOwnership(propertyOwnership: PropertyOwnership): OwnershipTypeFormModel =
-            OwnershipTypeFormModel().apply { ownershipType = propertyOwnership.ownershipType }
+            OwnershipTypeFormModel().apply { ownershipType = propertyOwnership.landlordship.ownershipType }
     }
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/requestModels/formModels/SelectiveLicenceFormModel.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/requestModels/formModels/SelectiveLicenceFormModel.kt
@@ -27,7 +27,7 @@ class SelectiveLicenceFormModel : FormModel {
     companion object {
         fun fromPropertyOwnership(propertyOwnership: PropertyOwnership): SelectiveLicenceFormModel =
             SelectiveLicenceFormModel().apply {
-                licenceNumber = propertyOwnership.license?.licenseNumber
+                licenceNumber = propertyOwnership.landlordship.license?.licenseNumber
             }
     }
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/emailModels/PropertyDetailsEmailSectionList.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/emailModels/PropertyDetailsEmailSectionList.kt
@@ -12,13 +12,13 @@ data class PropertyDetailsEmailSectionList(
         fun fromPropertyOwnerships(propertyOwnerships: List<PropertyOwnership>): PropertyDetailsEmailSectionList =
             PropertyDetailsEmailSectionList(
                 propertyOwnerships
-                    .filter { it.isActive }
+                    .filter { it.landlordship.isActive }
                     .withIndex()
                     .map {
                         PropertyDetailsEmailSection(
                             it.index + 1,
-                            RegistrationNumberDataModel.fromRegistrationNumber(it.value.registrationNumber).toString(),
-                            it.value.address.singleLineAddress,
+                            RegistrationNumberDataModel.fromRegistrationNumber(it.value.landlordship.registrationNumber).toString(),
+                            it.value.propertyDetails.address.singleLineAddress,
                         )
                     },
             )

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/searchResultModels/PropertySearchResultViewModel.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/searchResultModels/PropertySearchResultViewModel.kt
@@ -20,21 +20,21 @@ data class PropertySearchResultViewModel(
             currentUrlKey: Int? = null,
         ) = PropertySearchResultViewModel(
             id = propertyOwnership.id,
-            address = propertyOwnership.address.singleLineAddress,
+            address = propertyOwnership.propertyDetails.address.singleLineAddress,
             registrationNumber =
                 RegistrationNumberDataModel
-                    .fromRegistrationNumber(propertyOwnership.registrationNumber)
+                    .fromRegistrationNumber(propertyOwnership.landlordship.registrationNumber)
                     .toString(),
             localCouncil =
-                propertyOwnership.address.localCouncil
+                propertyOwnership.propertyDetails.address.localCouncil
                     ?.name,
             landlord =
                 PropertySearchResultLandlordViewModel(
-                    id = propertyOwnership.primaryLandlord.id,
-                    name = propertyOwnership.primaryLandlord.name,
+                    id = propertyOwnership.landlordship.primaryLandlord.id,
+                    name = propertyOwnership.landlordship.primaryLandlord.name,
                     recordLink =
                         LandlordDetailsController
-                            .getLandlordDetailsForLocalCouncilUserPath(propertyOwnership.primaryLandlord.id)
+                            .getLandlordDetailsForLocalCouncilUserPath(propertyOwnership.landlordship.primaryLandlord.id)
                             .overrideBackLinkForUrl(currentUrlKey),
                 ),
             recordLink =

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/summaryModels/PropertyDetailsViewModel.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/summaryModels/PropertyDetailsViewModel.kt
@@ -33,11 +33,11 @@ class PropertyDetailsViewModel(
     private val hideNullUprn: Boolean = true,
     private val messageSource: MessageSource,
 ) {
-    val address: String = propertyOwnership.address.singleLineAddress
+    val address: String = propertyOwnership.propertyDetails.address.singleLineAddress
 
     private val changeLinkMessageKey = "forms.links.change"
 
-    val isOccupied = propertyOwnership.isOccupied
+    val isOccupied = propertyOwnership.tenancyDetails.isOccupied
 
     val isOccupiedKey: String = getIsTenantedKey(isOccupied)
 
@@ -50,13 +50,13 @@ class PropertyDetailsViewModel(
                 )
                 addRow(
                     "propertyDetails.propertyRecord.registrationNumber",
-                    RegistrationNumberDataModel.fromRegistrationNumber(propertyOwnership.registrationNumber),
+                    RegistrationNumberDataModel.fromRegistrationNumber(propertyOwnership.landlordship.registrationNumber),
                 )
                 addRow("propertyDetails.propertyRecord.address", address)
-                if (propertyOwnership.address.uprn != null) {
+                if (propertyOwnership.propertyDetails.address.uprn != null) {
                     addRow(
                         "propertyDetails.propertyRecord.uprn",
-                        propertyOwnership.address.uprn
+                        propertyOwnership.propertyDetails.address.uprn
                             .toString(),
                     )
                 } else if (!hideNullUprn) {
@@ -64,16 +64,19 @@ class PropertyDetailsViewModel(
                 }
                 addRow(
                     "propertyDetails.propertyRecord.localCouncil",
-                    propertyOwnership.address.localCouncil
+                    propertyOwnership.propertyDetails.address.localCouncil
                         ?.name,
                 )
                 addRow(
                     "propertyDetails.propertyRecord.propertyType",
-                    propertyOwnership.customPropertyType ?: MessageKeyConverter.convert(propertyOwnership.propertyBuildType),
+                    propertyOwnership.propertyDetails.customPropertyType
+                        ?: MessageKeyConverter.convert(
+                            propertyOwnership.propertyDetails.propertyBuildType,
+                        ),
                 )
                 addRow(
                     "propertyDetails.propertyRecord.ownershipType",
-                    MessageKeyConverter.convert(propertyOwnership.ownershipType),
+                    MessageKeyConverter.convert(propertyOwnership.landlordship.ownershipType),
                     changeLinkMessageKey,
                     UpdateOwnershipTypeController.getUpdateOwnershipTypeRoute(propertyOwnership.id) +
                         "/${OwnershipTypeStep.ROUTE_SEGMENT}",
@@ -86,7 +89,7 @@ class PropertyDetailsViewModel(
             .apply {
                 addRow(
                     "propertyDetails.propertyRecord.licensingInformation.licensingType",
-                    propertyOwnership.license?.let {
+                    propertyOwnership.landlordship.license?.let {
                         MessageKeyConverter.convert(it.licenseType)
                     } ?: MessageKeyConverter.convert(LicensingType.NO_LICENSING),
                     changeLinkMessageKey,
@@ -94,10 +97,12 @@ class PropertyDetailsViewModel(
                         "/${LicensingTypeStep.ROUTE_SEGMENT}",
                     withChangeLinks,
                 )
-                if (propertyOwnership.license != null && propertyOwnership.license!!.licenseType != LicensingType.NO_LICENSING) {
+                if (propertyOwnership.landlordship.license != null &&
+                    propertyOwnership.landlordship.license!!.licenseType != LicensingType.NO_LICENSING
+                ) {
                     addRow(
                         "propertyDetails.propertyRecord.licensingInformation.licensingNumber",
-                        propertyOwnership.license!!.licenseNumber,
+                        propertyOwnership.landlordship.license!!.licenseNumber,
                     )
                 }
             }.toList()
@@ -116,7 +121,7 @@ class PropertyDetailsViewModel(
                 if (isOccupied) {
                     addRow(
                         "propertyDetails.propertyRecord.tenancyAndRentalInformation.numberOfHouseholds.rowName",
-                        propertyOwnership.currentNumHouseholds,
+                        propertyOwnership.tenancyDetails.currentNumHouseholds,
                         changeLinkMessageKey,
                         UpdateHouseholdsAndTenantsController.getUpdateHouseholdsAndTenantsRoute(propertyOwnership.id) +
                             "/${HouseholdStep.ROUTE_SEGMENT}",
@@ -127,11 +132,11 @@ class PropertyDetailsViewModel(
                     )
                     addRow(
                         "propertyDetails.propertyRecord.tenancyAndRentalInformation.numberOfPeople",
-                        propertyOwnership.currentNumTenants,
+                        propertyOwnership.tenancyDetails.currentNumTenants,
                     )
                     addRow(
                         "propertyDetails.propertyRecord.tenancyAndRentalInformation.numberOfBedrooms",
-                        propertyOwnership.numBedrooms,
+                        propertyOwnership.propertyDetails.numBedrooms,
                         changeLinkMessageKey,
                         UpdateBedroomsController.getUpdateBedroomsRoute(propertyOwnership.id) +
                             "/${BedroomsStep.ROUTE_SEGMENT}",
@@ -139,16 +144,16 @@ class PropertyDetailsViewModel(
                     )
                     addRow(
                         "propertyDetails.propertyRecord.tenancyAndRentalInformation.rentIncludesBills.rowName",
-                        MessageKeyConverter.convert(propertyOwnership.rentIncludesBills),
+                        MessageKeyConverter.convert(propertyOwnership.tenancyDetails.rentIncludesBills),
                         changeLinkMessageKey,
                         UpdateRentIncludesBillsController.getUpdateRentIncludesBillsRoute(propertyOwnership.id) +
                             "/${RentIncludesBillsStep.ROUTE_SEGMENT}",
                         withChangeLinks,
-                        withoutBottomBorder = propertyOwnership.rentIncludesBills,
+                        withoutBottomBorder = propertyOwnership.tenancyDetails.rentIncludesBills,
                         withAriaLabelForAction =
                             "propertyDetails.propertyRecord.tenancyAndRentalInformation.rentIncludesBills.changeLinkAriaLabel",
                     )
-                    if (propertyOwnership.rentIncludesBills) {
+                    if (propertyOwnership.tenancyDetails.rentIncludesBills) {
                         addRow(
                             "propertyDetails.propertyRecord.tenancyAndRentalInformation.billsIncluded",
                             BillsIncludedHelper.getBillsIncludedForPropertyDetails(propertyOwnership, messageSource),
@@ -157,7 +162,7 @@ class PropertyDetailsViewModel(
                     addRow(
                         "propertyDetails.propertyRecord.tenancyAndRentalInformation.furnishedStatus",
                         // TODO PDJB-548 remove not-null assertion !! once occupancy is embedded in PropertyOwnership
-                        MessageKeyConverter.convert(propertyOwnership.furnishedStatus!!),
+                        MessageKeyConverter.convert(propertyOwnership.tenancyDetails.furnishedStatus!!),
                         changeLinkMessageKey,
                         UpdateFurnishedStatusController.getUpdateFurnishedStatusRoute(propertyOwnership.id) +
                             "/${FurnishedStatusStep.ROUTE_SEGMENT}",
@@ -166,7 +171,10 @@ class PropertyDetailsViewModel(
                     addRow(
                         "propertyDetails.propertyRecord.tenancyAndRentalInformation.rentFrequency.rowName",
                         // TODO PDJB-548 remove not-null assertion !! once occupancy is embedded in PropertyOwnership
-                        RentDataHelper.getRentFrequency(propertyOwnership.rentFrequency!!, propertyOwnership.customRentFrequency),
+                        RentDataHelper.getRentFrequency(
+                            propertyOwnership.tenancyDetails.rentFrequency!!,
+                            propertyOwnership.tenancyDetails.customRentFrequency,
+                        ),
                         changeLinkMessageKey,
                         UpdateRentFrequencyAndAmountController.getUpdateRentFrequencyAndAmountRoute(propertyOwnership.id) +
                             "/${RentFrequencyStep.ROUTE_SEGMENT}",
@@ -179,8 +187,8 @@ class PropertyDetailsViewModel(
                         "propertyDetails.propertyRecord.tenancyAndRentalInformation.rentAmount",
                         // TODO PDJB-548 remove not-null assertions !! once occupancy is embedded in PropertyOwnership
                         RentDataHelper.getRentAmount(
-                            propertyOwnership.rentAmount!!.toString(),
-                            propertyOwnership.rentFrequency!!,
+                            propertyOwnership.tenancyDetails.rentAmount!!.toString(),
+                            propertyOwnership.tenancyDetails.rentFrequency!!,
                             messageSource,
                         ),
                     )

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/summaryModels/RegisteredPropertylViewModels.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/summaryModels/RegisteredPropertylViewModels.kt
@@ -21,20 +21,20 @@ data class RegisteredPropertyLocalCouncilViewModel(
             currentUrlKey: Int? = null,
         ): RegisteredPropertyLocalCouncilViewModel =
             RegisteredPropertyLocalCouncilViewModel(
-                address = propertyOwnership.address.singleLineAddress,
+                address = propertyOwnership.propertyDetails.address.singleLineAddress,
                 registrationNumber =
                     RegistrationNumberDataModel
                         .fromRegistrationNumber(
-                            propertyOwnership.registrationNumber,
+                            propertyOwnership.landlordship.registrationNumber,
                         ).toString(),
                 localCouncilName =
-                    propertyOwnership.address.localCouncil!!
+                    propertyOwnership.propertyDetails.address.localCouncil!!
                         .name,
                 licenseTypeMessageKey =
                     MessageKeyConverter.convert(
-                        propertyOwnership.license?.licenseType ?: LicensingType.NO_LICENSING,
+                        propertyOwnership.landlordship.license?.licenseType ?: LicensingType.NO_LICENSING,
                     ),
-                isTenantedMessageKey = MessageKeyConverter.convert(propertyOwnership.isOccupied),
+                isTenantedMessageKey = MessageKeyConverter.convert(propertyOwnership.tenancyDetails.isOccupied),
                 recordLink =
                     PropertyDetailsController
                         .getPropertyDetailsPath(propertyOwnership.id, isLocalCouncilView = true)
@@ -54,11 +54,11 @@ data class RegisteredPropertyLandlordViewModel(
             currentUrlKey: Int? = null,
         ): RegisteredPropertyLandlordViewModel =
             RegisteredPropertyLandlordViewModel(
-                address = propertyOwnership.address.singleLineAddress,
+                address = propertyOwnership.propertyDetails.address.singleLineAddress,
                 registrationNumber =
                     RegistrationNumberDataModel
                         .fromRegistrationNumber(
-                            propertyOwnership.registrationNumber,
+                            propertyOwnership.landlordship.registrationNumber,
                         ).toString(),
                 recordLink =
                     PropertyDetailsController

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/summaryModels/propertyComplianceViewModels/EpcViewModelBuilder.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/summaryModels/propertyComplianceViewModels/EpcViewModelBuilder.kt
@@ -34,7 +34,7 @@ class EpcViewModelBuilder {
                             value = getEpcExemptionReasonValue(propertyCompliance.epcExemptionReason),
                         )
                     }
-                    if (propertyCompliance.isEpcExpired == true && propertyCompliance.propertyOwnership.isOccupied) {
+                    if (propertyCompliance.isEpcExpired == true && propertyCompliance.propertyOwnership.tenancyDetails.isOccupied) {
                         addRow(
                             key = "propertyDetails.complianceInformation.energyPerformance.didTenancyStartBeforeEpcExpired",
                             value = propertyCompliance.tenancyStartedBeforeEpcExpiry?.let { MessageKeyConverter.convert(it) },

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/AddressAvailabilityService.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/AddressAvailabilityService.kt
@@ -7,10 +7,16 @@ import uk.gov.communities.prsdb.webapp.database.repository.PropertyOwnershipRepo
 class AddressAvailabilityService(
     private val propertyOwnershipRepository: PropertyOwnershipRepository,
 ) {
-    fun isAddressOwned(uprn: Long): Boolean = propertyOwnershipRepository.existsByIsActiveTrueAndAddress_Uprn(uprn)
+    fun isAddressOwned(uprn: Long): Boolean =
+        propertyOwnershipRepository.existsByLandlordship_IsActiveTrueAndPropertyDetails_Address_Uprn(uprn)
 
     fun isAddressOwnedByUser(
         uprn: Long,
         userId: String,
-    ): Boolean = propertyOwnershipRepository.existsByPrimaryLandlord_BaseUser_IdAndIsActiveTrueAndAddress_Uprn(userId, uprn)
+    ): Boolean =
+        propertyOwnershipRepository
+            .existsByLandlordship_PrimaryLandlord_BaseUser_IdAndLandlordship_IsActiveTrueAndPropertyDetails_Address_Uprn(
+                userId,
+                uprn,
+            )
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/JointLandlordInvitationService.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/JointLandlordInvitationService.kt
@@ -23,7 +23,7 @@ class JointLandlordInvitationService(
         invitingLandlord: Landlord,
     ) {
         val senderName = invitingLandlord.name
-        val propertyAddress = propertyOwnership.address.toMultiLineAddress()
+        val propertyAddress = propertyOwnership.propertyDetails.address.toMultiLineAddress()
 
         jointLandlordEmails.forEach { email ->
             val token = createInvitationToken(email, propertyOwnership, invitingLandlord)

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/LegacyAddressCheckingService.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/LegacyAddressCheckingService.kt
@@ -17,7 +17,7 @@ class LegacyAddressCheckingService(
             if (cachedResult != null) return cachedResult
         }
 
-        val databaseResult = propertyOwnershipRepository.existsByIsActiveTrueAndAddress_Uprn(uprn)
+        val databaseResult = propertyOwnershipRepository.existsByLandlordship_IsActiveTrueAndPropertyDetails_Address_Uprn(uprn)
         registeredAddressCache.setCachedAddressRegisteredResult(uprn, databaseResult)
         return databaseResult
     }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/PropertyComplianceService.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/PropertyComplianceService.kt
@@ -55,7 +55,7 @@ class PropertyComplianceService(
         epcProvideLater: Boolean? = null,
     ) {
         val propertyOwnership =
-            propertyOwnershipRepository.findByRegistrationNumber_Number(registrationNumberValue)
+            propertyOwnershipRepository.findByLandlordship_RegistrationNumber_Number(registrationNumberValue)
                 ?: throw EntityNotFoundException("Property ownership not found for registration number $registrationNumberValue")
 
         val record =
@@ -178,8 +178,12 @@ class PropertyComplianceService(
         getNonCompliantPropertiesForLandlord(landlordBaseUserId).size
 
     fun getNonCompliantPropertiesForLandlord(landlordBaseUserId: String): List<ComplianceStatusDataModel> {
-        val compliances = propertyComplianceRepository.findAllByPropertyOwnership_PrimaryLandlord_BaseUser_Id(landlordBaseUserId)
-        return compliances.map { ComplianceStatusDataModel.fromPropertyCompliance(it) }.filter { it.shouldShowOnComplianceActionsPage }
+        val compliances =
+            propertyComplianceRepository.findAllByPropertyOwnership_Landlordship_PrimaryLandlord_BaseUser_Id(
+                landlordBaseUserId,
+            )
+        return compliances.map { ComplianceStatusDataModel.fromPropertyCompliance(it) }
+            .filter { it.shouldShowOnComplianceActionsPage }
     }
 
     @Transactional
@@ -310,7 +314,7 @@ class PropertyComplianceService(
         expiredOccupiedType: ComplianceUpdateConfirmationEmail.UpdateType =
             ComplianceUpdateConfirmationEmail.UpdateType.EXPIRED_CERTIFICATE_OCCUPIED,
     ) {
-        val isOccupied = propertyCompliance.propertyOwnership.isOccupied
+        val isOccupied = propertyCompliance.propertyOwnership.tenancyDetails.isOccupied
         val updateType =
             if (!isExpired) {
                 ComplianceUpdateConfirmationEmail.UpdateType.CERTIFICATE_ADDED
@@ -335,11 +339,11 @@ class PropertyComplianceService(
 
         val propertyOwnership = propertyCompliance.propertyOwnership
         complianceUpdateConfirmationSender.sendEmail(
-            propertyOwnership.primaryLandlord.email,
+            propertyOwnership.landlordship.primaryLandlord.email,
             ComplianceUpdateConfirmationEmail(
-                landlordName = propertyOwnership.primaryLandlord.name,
-                multiLineAddress = propertyOwnership.address.toMultiLineAddress(),
-                registrationNumber = RegistrationNumberDataModel.fromRegistrationNumber(propertyOwnership.registrationNumber),
+                landlordName = propertyOwnership.landlordship.primaryLandlord.name,
+                multiLineAddress = propertyOwnership.propertyDetails.address.toMultiLineAddress(),
+                registrationNumber = RegistrationNumberDataModel.fromRegistrationNumber(propertyOwnership.landlordship.registrationNumber),
                 dashboardUrl = absoluteUrlProvider.buildLandlordDashboardUri(),
                 newCertificateUrl = absoluteUrlProvider.buildComplianceInformationUri(propertyOwnership.id),
                 complianceUpdateType = updateType,

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/PropertyOwnershipService.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/PropertyOwnershipService.kt
@@ -79,7 +79,7 @@ class PropertyOwnershipService(
                 customRentFrequency = customRentFrequency,
                 rentAmount = rentAmount,
             ).apply {
-                if (isOccupied) lastOccupiedDate = LocalDate.now()
+                if (tenancyDetails.isOccupied) tenancyDetails.lastOccupiedDate = LocalDate.now()
             },
         )
     }
@@ -92,7 +92,7 @@ class PropertyOwnershipService(
 
         val isLocalCouncil = localCouncilDataService.getIsLocalCouncilUser(baseUserId)
 
-        val isPrimaryLandlord = propertyOwnership.primaryLandlord.baseUser.id == baseUserId
+        val isPrimaryLandlord = propertyOwnership.landlordship.primaryLandlord.baseUser.id == baseUserId
 
         if (!isLocalCouncil && !isPrimaryLandlord) {
             throw ResponseStatusException(
@@ -114,12 +114,12 @@ class PropertyOwnershipService(
     fun getIsAuthorizedToEditRecord(
         propertyOwnershipId: Long,
         baseUserId: String,
-    ): Boolean = getPropertyOwnership(propertyOwnershipId).primaryLandlord.baseUser.id == baseUserId
+    ): Boolean = getPropertyOwnership(propertyOwnershipId).landlordship.primaryLandlord.baseUser.id == baseUserId
 
     fun getIsPrimaryLandlord(
         propertyOwnershipId: Long,
         baseUserId: String,
-    ): Boolean = getPropertyOwnership(propertyOwnershipId).primaryLandlord.baseUser.id == baseUserId
+    ): Boolean = getPropertyOwnership(propertyOwnershipId).landlordship.primaryLandlord.baseUser.id == baseUserId
 
     fun getRegisteredPropertiesForLandlordUser(
         baseUserId: String,
@@ -136,19 +136,20 @@ class PropertyOwnershipService(
         landlordId: Long,
         currentUrlFragment: String? = null,
     ): List<RegisteredPropertyLocalCouncilViewModel> =
-        propertyOwnershipRepository.findAllByPrimaryLandlord_IdAndIsActiveTrue(landlordId).map { propertyOwnership ->
-            RegisteredPropertyLocalCouncilViewModel.fromPropertyOwnership(
-                propertyOwnership,
-                currentUrlKey = backLinkService.storeCurrentUrlReturningKey(currentUrlFragment),
-            )
-        }
+        propertyOwnershipRepository.findAllByLandlordship_PrimaryLandlord_IdAndLandlordship_IsActiveTrue(landlordId)
+            .map { propertyOwnership ->
+                RegisteredPropertyLocalCouncilViewModel.fromPropertyOwnership(
+                    propertyOwnership,
+                    currentUrlKey = backLinkService.storeCurrentUrlReturningKey(currentUrlFragment),
+                )
+            }
 
     fun retrievePropertyOwnership(registrationNumber: Long): PropertyOwnership? =
         propertyOwnershipRepository
-            .findByRegistrationNumber_Number(registrationNumber)
+            .findByLandlordship_RegistrationNumber_Number(registrationNumber)
 
     fun retrievePropertyOwnershipById(propertyOwnershipId: Long): PropertyOwnership? =
-        propertyOwnershipRepository.findByIdAndIsActiveTrue(propertyOwnershipId)
+        propertyOwnershipRepository.findByIdAndLandlordship_IsActiveTrue(propertyOwnershipId)
 
     fun searchForProperties(
         searchTerm: String,
@@ -212,11 +213,11 @@ class PropertyOwnershipService(
         throwErrorIfLastModifiedDatesConflict(propertyOwnership, initialLastModifiedDate)
         val updatedLicence =
             licenseService.updateLicence(
-                propertyOwnership.license,
+                propertyOwnership.landlordship.license,
                 licensingType,
                 licenceNumber,
             )
-        propertyOwnership.license = updatedLicence
+        propertyOwnership.landlordship.license = updatedLicence
         propertyOwnershipRepository.save(propertyOwnership)
     }
 
@@ -228,7 +229,7 @@ class PropertyOwnershipService(
     ) {
         val propertyOwnership = getPropertyOwnership(id)
         throwErrorIfLastModifiedDatesConflict(propertyOwnership, initialLastModifiedDate)
-        propertyOwnership.ownershipType = ownershipType
+        propertyOwnership.landlordship.ownershipType = ownershipType
         propertyOwnershipRepository.save(propertyOwnership)
     }
 
@@ -248,18 +249,18 @@ class PropertyOwnershipService(
     ) {
         val propertyOwnership = getPropertyOwnership(id)
         throwErrorIfLastModifiedDatesConflict(propertyOwnership, initialLastModifiedDate)
-        val wasOccupied = propertyOwnership.isOccupied
-        propertyOwnership.currentNumHouseholds = numberOfHouseholds
-        propertyOwnership.currentNumTenants = numberOfPeople
-        propertyOwnership.numBedrooms = numBedrooms
-        propertyOwnership.billsIncludedList = billsIncludedList
-        propertyOwnership.customBillsIncluded = customBillsIncluded
-        propertyOwnership.furnishedStatus = furnishedStatus
-        propertyOwnership.rentFrequency = rentFrequency
-        propertyOwnership.customRentFrequency = customRentFrequency
-        propertyOwnership.rentAmount = rentAmount
-        if (!wasOccupied && propertyOwnership.isOccupied) {
-            propertyOwnership.lastOccupiedDate = LocalDate.now()
+        val wasOccupied = propertyOwnership.tenancyDetails.isOccupied
+        propertyOwnership.tenancyDetails.currentNumHouseholds = numberOfHouseholds
+        propertyOwnership.tenancyDetails.currentNumTenants = numberOfPeople
+        propertyOwnership.propertyDetails.numBedrooms = numBedrooms
+        propertyOwnership.tenancyDetails.billsIncludedList = billsIncludedList
+        propertyOwnership.tenancyDetails.customBillsIncluded = customBillsIncluded
+        propertyOwnership.tenancyDetails.furnishedStatus = furnishedStatus
+        propertyOwnership.tenancyDetails.rentFrequency = rentFrequency
+        propertyOwnership.tenancyDetails.customRentFrequency = customRentFrequency
+        propertyOwnership.tenancyDetails.rentAmount = rentAmount
+        if (!wasOccupied && propertyOwnership.tenancyDetails.isOccupied) {
+            propertyOwnership.tenancyDetails.lastOccupiedDate = LocalDate.now()
         }
         propertyOwnershipRepository.save(propertyOwnership)
     }
@@ -273,8 +274,8 @@ class PropertyOwnershipService(
     ) {
         val propertyOwnership = getPropertyOwnership(id)
         throwErrorIfLastModifiedDatesConflict(propertyOwnership, initialLastModifiedDate)
-        propertyOwnership.currentNumHouseholds = numberOfHouseholds
-        propertyOwnership.currentNumTenants = numberOfPeople
+        propertyOwnership.tenancyDetails.currentNumHouseholds = numberOfHouseholds
+        propertyOwnership.tenancyDetails.currentNumTenants = numberOfPeople
         propertyOwnershipRepository.save(propertyOwnership)
     }
 
@@ -286,7 +287,7 @@ class PropertyOwnershipService(
     ) {
         val propertyOwnership = getPropertyOwnership(id)
         throwErrorIfLastModifiedDatesConflict(propertyOwnership, initialLastModifiedDate)
-        propertyOwnership.numBedrooms = numberOfBedrooms
+        propertyOwnership.propertyDetails.numBedrooms = numberOfBedrooms
         propertyOwnershipRepository.save(propertyOwnership)
     }
 
@@ -299,8 +300,8 @@ class PropertyOwnershipService(
     ) {
         val propertyOwnership = getPropertyOwnership(id)
         throwErrorIfLastModifiedDatesConflict(propertyOwnership, initialLastModifiedDate)
-        propertyOwnership.billsIncludedList = billsIncludedList
-        propertyOwnership.customBillsIncluded = customBillsIncluded
+        propertyOwnership.tenancyDetails.billsIncludedList = billsIncludedList
+        propertyOwnership.tenancyDetails.customBillsIncluded = customBillsIncluded
         propertyOwnershipRepository.save(propertyOwnership)
     }
 
@@ -312,7 +313,7 @@ class PropertyOwnershipService(
     ) {
         val propertyOwnership = getPropertyOwnership(id)
         throwErrorIfLastModifiedDatesConflict(propertyOwnership, initialLastModifiedDate)
-        propertyOwnership.furnishedStatus = furnishedStatus
+        propertyOwnership.tenancyDetails.furnishedStatus = furnishedStatus
         propertyOwnershipRepository.save(propertyOwnership)
     }
 
@@ -326,14 +327,16 @@ class PropertyOwnershipService(
     ) {
         val propertyOwnership = getPropertyOwnership(id)
         throwErrorIfLastModifiedDatesConflict(propertyOwnership, initialLastModifiedDate)
-        propertyOwnership.rentFrequency = rentFrequency
-        propertyOwnership.customRentFrequency = customRentFrequency
-        propertyOwnership.rentAmount = rentAmount
+        propertyOwnership.tenancyDetails.rentFrequency = rentFrequency
+        propertyOwnership.tenancyDetails.customRentFrequency = customRentFrequency
+        propertyOwnership.tenancyDetails.rentAmount = rentAmount
         propertyOwnershipRepository.save(propertyOwnership)
     }
 
     fun retrieveAllActivePropertiesForLandlord(baseUserId: String): List<PropertyOwnership> =
-        propertyOwnershipRepository.findAllByPrimaryLandlord_BaseUser_IdAndIsActiveTrue(baseUserId)
+        propertyOwnershipRepository.findAllByLandlordship_PrimaryLandlord_BaseUser_IdAndLandlordship_IsActiveTrue(
+            baseUserId,
+        )
 
     fun deletePropertyOwnership(propertyOwnershipId: Long) {
         propertyOwnershipRepository.deleteById(propertyOwnershipId)
@@ -345,13 +348,18 @@ class PropertyOwnershipService(
 
     fun getNumberOfIncompleteCompliancesForLandlord(principalName: String): Int {
         val propertyOwnerships = retrieveAllActivePropertiesForLandlord(principalName)
-        return propertyOwnerships.count { it.isOccupied && it.propertyCompliance == null }
+        return propertyOwnerships.count { it.tenancyDetails.isOccupied && it.propertyCompliance == null }
     }
 
     fun doesLandlordHaveRegisteredProperties(baseUserId: String): Boolean =
-        propertyOwnershipRepository.existsByPrimaryLandlord_BaseUser_IdAndIsActiveTrue(baseUserId)
+        propertyOwnershipRepository.existsByLandlordship_PrimaryLandlord_BaseUser_IdAndLandlordship_IsActiveTrue(
+            baseUserId,
+        )
 
-    fun getPropertyCountForLandlord(baseUserId: String): Long = propertyOwnershipRepository.countByPrimaryLandlord_BaseUser_Id(baseUserId)
+    fun getPropertyCountForLandlord(baseUserId: String): Long =
+        propertyOwnershipRepository.countByLandlordship_PrimaryLandlord_BaseUser_Id(
+            baseUserId,
+        )
 
     private fun throwErrorIfLastModifiedDatesConflict(
         propertyOwnership: PropertyOwnership,

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/PropertyRegistrationService.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/PropertyRegistrationService.kt
@@ -95,7 +95,7 @@ class PropertyRegistrationService(
             )
 
         propertyComplianceService.saveRegistrationComplianceData(
-            propertyOwnership.registrationNumber.number,
+            propertyOwnership.landlordship.registrationNumber.number,
             hasGasSupply,
             gasSafetyCertIssueDate,
             gasSafetyFileUploadIds,
@@ -113,7 +113,7 @@ class PropertyRegistrationService(
             epcProvideLater = epcProvideLater,
         )
 
-        confirmationService.setLastPrnRegisteredThisSession(propertyOwnership.registrationNumber.number)
+        confirmationService.setLastPrnRegisteredThisSession(propertyOwnership.landlordship.registrationNumber.number)
 
         sendConfirmationEmails(landlord, propertyOwnership, addressModel, jointLandlordEmails)
     }
@@ -136,7 +136,11 @@ class PropertyRegistrationService(
         customPropertyType: String?,
         landlord: Landlord,
     ): PropertyOwnership {
-        if (addressModel.uprn != null && propertyOwnershipRepository.existsByIsActiveTrueAndAddress_Uprn(addressModel.uprn)) {
+        if (addressModel.uprn != null &&
+            propertyOwnershipRepository.existsByLandlordship_IsActiveTrueAndPropertyDetails_Address_Uprn(
+                addressModel.uprn,
+            )
+        ) {
             throw EntityExistsException("Address already registered")
         }
 
@@ -178,11 +182,11 @@ class PropertyRegistrationService(
             landlord.email,
             PropertyRegistrationConfirmationEmail(
                 RegistrationNumberDataModel.Companion
-                    .fromRegistrationNumber(propertyOwnership.registrationNumber)
+                    .fromRegistrationNumber(propertyOwnership.landlordship.registrationNumber)
                     .toString(),
                 addressModel.singleLineAddress,
                 absoluteUrlProvider.buildLandlordDashboardUri().toString(),
-                propertyOwnership.currentNumTenants > 0,
+                propertyOwnership.tenancyDetails.currentNumTenants > 0,
                 jointLandlordEmails,
             ),
         )

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/VirusNotificationEmailHandler.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/VirusNotificationEmailHandler.kt
@@ -37,7 +37,7 @@ class VirusNotificationEmailHandler(
         val ownership = getPropertyOwnership(notification.propertyOwnershipId)
 
         val email = buildAlertEmail(ownership, notification.certificateType)
-        emailNotificationService.sendEmail(emailAddress ?: ownership.primaryLandlord.email, email)
+        emailNotificationService.sendEmail(emailAddress ?: ownership.landlordship.primaryLandlord.email, email)
     }
 
     private fun sendAlertToMonitoringTeam(notification: VirusMonitoringEmailNotification) =
@@ -56,7 +56,7 @@ class VirusNotificationEmailHandler(
         }
 
     private fun getPropertyOwnership(id: Long): PropertyOwnership =
-        propertyOwnershipRepository.findByIdAndIsActiveTrue(id)
+        propertyOwnershipRepository.findByIdAndLandlordship_IsActiveTrue(id)
             ?: throw IllegalStateException("No active property ownership found for id: $id")
 
     private fun buildAlertEmail(
@@ -67,8 +67,8 @@ class VirusNotificationEmailHandler(
             certificateDescriptionForSubject(certificateType),
             certificateDescriptionForHeading(certificateType),
             certificateDescriptionForBody(certificateType),
-            propertyOwnership.address.singleLineAddress,
-            RegistrationNumberDataModel.fromRegistrationNumber(propertyOwnership.registrationNumber).toString(),
+            propertyOwnership.propertyDetails.address.singleLineAddress,
+            RegistrationNumberDataModel.fromRegistrationNumber(propertyOwnership.landlordship.registrationNumber).toString(),
             absoluteUrlProvider.buildComplianceInformationUri(propertyOwnership.id),
         )
 

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/controllers/RegisterPropertyControllerTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/controllers/RegisterPropertyControllerTests.kt
@@ -155,7 +155,7 @@ class RegisterPropertyControllerTests(
 
         val expectedPrn =
             RegistrationNumberDataModel
-                .fromRegistrationNumber(propertyOwnership.registrationNumber)
+                .fromRegistrationNumber(propertyOwnership.landlordship.registrationNumber)
                 .toString()
         val expectedCompleteByDate =
             CompleteByDateHelper

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/PropertyRegistrationJourneyTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/PropertyRegistrationJourneyTests.kt
@@ -499,7 +499,10 @@ class PropertyRegistrationJourneyTests : IntegrationTestWithMutableData("data-lo
         // Confirmation - render page
         val propertyOwnershipCaptor = captor<PropertyOwnership>()
         verify(propertyOwnershipRepository).save(propertyOwnershipCaptor.capture())
-        val expectedPropertyRegNum = RegistrationNumberDataModel.fromRegistrationNumber(propertyOwnershipCaptor.value.registrationNumber)
+        val expectedPropertyRegNum =
+            RegistrationNumberDataModel.fromRegistrationNumber(
+                propertyOwnershipCaptor.value.landlordship.registrationNumber,
+            )
         assertEquals(expectedPropertyRegNum.toString(), confirmationPage.registrationNumberText)
         assertFalse(confirmationPage.whatYouNeedToDoNextHeading.isVisible)
         assertTrue(confirmationPage.goToDashboardLink.locator.isVisible)
@@ -688,7 +691,10 @@ class PropertyRegistrationJourneyTests : IntegrationTestWithMutableData("data-lo
         // Confirmation - render page
         val propertyOwnershipCaptor = captor<PropertyOwnership>()
         verify(propertyOwnershipRepository).save(propertyOwnershipCaptor.capture())
-        val expectedPropertyRegNum = RegistrationNumberDataModel.fromRegistrationNumber(propertyOwnershipCaptor.value.registrationNumber)
+        val expectedPropertyRegNum =
+            RegistrationNumberDataModel.fromRegistrationNumber(
+                propertyOwnershipCaptor.value.landlordship.registrationNumber,
+            )
         assertEquals(expectedPropertyRegNum.toString(), confirmationPage.registrationNumberText)
         assertTrue(confirmationPage.whatYouNeedToDoNextHeading.isHidden)
         assertTrue(confirmationPage.goToDashboardLink.locator.isVisible)
@@ -960,7 +966,10 @@ class PropertyRegistrationJourneyTests : IntegrationTestWithMutableData("data-lo
         // Confirmation - verify record saved
         val propertyOwnershipCaptor = captor<PropertyOwnership>()
         verify(propertyOwnershipRepository).save(propertyOwnershipCaptor.capture())
-        val expectedPropertyRegNum = RegistrationNumberDataModel.fromRegistrationNumber(propertyOwnershipCaptor.value.registrationNumber)
+        val expectedPropertyRegNum =
+            RegistrationNumberDataModel.fromRegistrationNumber(
+                propertyOwnershipCaptor.value.landlordship.registrationNumber,
+            )
         assertEquals(expectedPropertyRegNum.toString(), confirmationPage.registrationNumberText)
         assertTrue(confirmationPage.goToDashboardLink.locator.isVisible)
     }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/models/dataModels/ComplianceStatusDataModelTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/models/dataModels/ComplianceStatusDataModelTests.kt
@@ -122,7 +122,7 @@ class ComplianceStatusDataModelTests {
         val propertyCompliance = PropertyComplianceBuilder.createWithInDateCerts()
         val propertyOwnershipRegNum =
             RegistrationNumberDataModel
-                .fromRegistrationNumber(propertyCompliance.propertyOwnership.registrationNumber)
+                .fromRegistrationNumber(propertyCompliance.propertyOwnership.landlordship.registrationNumber)
                 .toString()
 
         // Act
@@ -130,10 +130,13 @@ class ComplianceStatusDataModelTests {
 
         // Assert
         assertEquals(propertyCompliance.propertyOwnership.id, complianceStatusDataModel.propertyOwnershipId)
-        assertEquals(propertyCompliance.propertyOwnership.address.singleLineAddress, complianceStatusDataModel.singleLineAddress)
+        assertEquals(
+            propertyCompliance.propertyOwnership.propertyDetails.address.singleLineAddress,
+            complianceStatusDataModel.singleLineAddress,
+        )
         assertEquals(propertyOwnershipRegNum, complianceStatusDataModel.registrationNumber)
         assertTrue(complianceStatusDataModel.isComplete)
-        assertEquals(propertyCompliance.propertyOwnership.isOccupied, complianceStatusDataModel.isOccupied)
+        assertEquals(propertyCompliance.propertyOwnership.tenancyDetails.isOccupied, complianceStatusDataModel.isOccupied)
     }
 
     @ParameterizedTest(name = "when {0}")

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/searchResultModels/PropertySearchResultViewModelTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/searchResultModels/PropertySearchResultViewModelTests.kt
@@ -15,20 +15,20 @@ class PropertySearchResultViewModelTests {
         val expectedPropertySearchResultViewModel =
             PropertySearchResultViewModel(
                 id = propertyOwnership.id,
-                address = propertyOwnership.address.singleLineAddress,
+                address = propertyOwnership.propertyDetails.address.singleLineAddress,
                 registrationNumber =
                     RegistrationNumberDataModel
-                        .fromRegistrationNumber(propertyOwnership.registrationNumber)
+                        .fromRegistrationNumber(propertyOwnership.landlordship.registrationNumber)
                         .toString(),
                 localCouncil =
-                    propertyOwnership.address.localCouncil?.name,
+                    propertyOwnership.propertyDetails.address.localCouncil?.name,
                 landlord =
                     PropertySearchResultLandlordViewModel(
-                        id = propertyOwnership.primaryLandlord.id,
-                        name = propertyOwnership.primaryLandlord.name,
+                        id = propertyOwnership.landlordship.primaryLandlord.id,
+                        name = propertyOwnership.landlordship.primaryLandlord.name,
                         recordLink =
                             LandlordDetailsController.getLandlordDetailsForLocalCouncilUserPath(
-                                propertyOwnership.primaryLandlord.id,
+                                propertyOwnership.landlordship.primaryLandlord.id,
                             ),
                     ),
                 recordLink = PropertyDetailsController.getPropertyDetailsPath(propertyOwnership.id, isLocalCouncilView = true),

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/summaryModels/RegisteredPropertyViewModelsTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/summaryModels/RegisteredPropertyViewModelsTests.kt
@@ -110,11 +110,11 @@ class RegisteredPropertyViewModelsTests {
 
             val expectedRegisteredPropertyLandlordViewModel =
                 RegisteredPropertyLandlordViewModel(
-                    address = propertyOwnership.address.singleLineAddress,
+                    address = propertyOwnership.propertyDetails.address.singleLineAddress,
                     registrationNumber =
                         RegistrationNumberDataModel
                             .fromRegistrationNumber(
-                                propertyOwnership.registrationNumber,
+                                propertyOwnership.landlordship.registrationNumber,
                             ).toString(),
                     recordLink = PropertyDetailsController.getPropertyDetailsPath(propertyOwnership.id),
                 )

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/AddressAvailabilityServiceTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/AddressAvailabilityServiceTests.kt
@@ -1,3 +1,5 @@
+@file:Suppress("ktlint:standard:max-line-length")
+
 package uk.gov.communities.prsdb.webapp.services
 
 import org.junit.jupiter.api.Assertions.assertFalse
@@ -19,7 +21,10 @@ class AddressAvailabilityServiceTests {
         // Arrange
         val service = AddressAvailabilityService(mockPropertyOwnershipRepository)
         whenever(
-            mockPropertyOwnershipRepository.existsByPrimaryLandlord_BaseUser_IdAndIsActiveTrueAndAddress_Uprn("user-1", 123L),
+            mockPropertyOwnershipRepository.existsByLandlordship_PrimaryLandlord_BaseUser_IdAndLandlordship_IsActiveTrueAndPropertyDetails_Address_Uprn(
+                "user-1",
+                123L,
+            ),
         ).thenReturn(true)
 
         // Act & Assert
@@ -31,7 +36,10 @@ class AddressAvailabilityServiceTests {
         // Arrange
         val service = AddressAvailabilityService(mockPropertyOwnershipRepository)
         whenever(
-            mockPropertyOwnershipRepository.existsByPrimaryLandlord_BaseUser_IdAndIsActiveTrueAndAddress_Uprn("user-1", 123L),
+            mockPropertyOwnershipRepository.existsByLandlordship_PrimaryLandlord_BaseUser_IdAndLandlordship_IsActiveTrueAndPropertyDetails_Address_Uprn(
+                "user-1",
+                123L,
+            ),
         ).thenReturn(false)
 
         // Act & Assert

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/LegacyAddressCheckingServiceTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/LegacyAddressCheckingServiceTests.kt
@@ -44,7 +44,9 @@ class LegacyAddressCheckingServiceTests {
         // Arrange
         val uprn = 0L
         whenever(mockRegisteredAddressCache.getCachedAddressRegisteredResult(uprn)).thenReturn(null)
-        whenever(mockPropertyOwnershipRepository.existsByIsActiveTrueAndAddress_Uprn(uprn)).thenReturn(expectedValue)
+        whenever(
+            mockPropertyOwnershipRepository.existsByLandlordship_IsActiveTrueAndPropertyDetails_Address_Uprn(uprn),
+        ).thenReturn(expectedValue)
 
         // Act
         val result = legacyAddressCheckingService.getIsAddressRegistered(uprn)
@@ -59,7 +61,9 @@ class LegacyAddressCheckingServiceTests {
         // Arrange
         val uprn = 0L
         val expectedValue = true
-        whenever(mockPropertyOwnershipRepository.existsByIsActiveTrueAndAddress_Uprn(uprn)).thenReturn(expectedValue)
+        whenever(
+            mockPropertyOwnershipRepository.existsByLandlordship_IsActiveTrueAndPropertyDetails_Address_Uprn(uprn),
+        ).thenReturn(expectedValue)
 
         // Act
         val result = legacyAddressCheckingService.getIsAddressRegistered(uprn, ignoreCache = true)

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/PropertyComplianceServiceTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/PropertyComplianceServiceTests.kt
@@ -134,7 +134,7 @@ class PropertyComplianceServiceTests {
         val compliances = nonCompliantProperties + compliantProperties
 
         whenever(
-            mockPropertyComplianceRepository.findAllByPropertyOwnership_PrimaryLandlord_BaseUser_Id(landlordBaseUserId),
+            mockPropertyComplianceRepository.findAllByPropertyOwnership_Landlordship_PrimaryLandlord_BaseUser_Id(landlordBaseUserId),
         ).thenReturn(compliances)
 
         // Act
@@ -162,7 +162,7 @@ class PropertyComplianceServiceTests {
         val compliances = nonCompliantProperties + compliantProperties
 
         whenever(
-            mockPropertyComplianceRepository.findAllByPropertyOwnership_PrimaryLandlord_BaseUser_Id(landlordBaseUserId),
+            mockPropertyComplianceRepository.findAllByPropertyOwnership_Landlordship_PrimaryLandlord_BaseUser_Id(landlordBaseUserId),
         ).thenReturn(compliances)
 
         // Act
@@ -190,7 +190,7 @@ class PropertyComplianceServiceTests {
         val compliances = nonCompliantProperties + compliantProperties
 
         whenever(
-            mockPropertyComplianceRepository.findAllByPropertyOwnership_PrimaryLandlord_BaseUser_Id(landlordBaseUserId),
+            mockPropertyComplianceRepository.findAllByPropertyOwnership_Landlordship_PrimaryLandlord_BaseUser_Id(landlordBaseUserId),
         ).thenReturn(compliances)
 
         val expectedNonCompliantProperties =
@@ -223,7 +223,7 @@ class PropertyComplianceServiceTests {
         val compliances = nonCompliantProperties + compliantProperties
 
         whenever(
-            mockPropertyComplianceRepository.findAllByPropertyOwnership_PrimaryLandlord_BaseUser_Id(landlordBaseUserId),
+            mockPropertyComplianceRepository.findAllByPropertyOwnership_Landlordship_PrimaryLandlord_BaseUser_Id(landlordBaseUserId),
         ).thenReturn(compliances)
 
         val expectedNonCompliantProperties =
@@ -255,7 +255,7 @@ class PropertyComplianceServiceTests {
 
         @Test
         fun `creates new compliance record and sets all compliance fields correctly`() {
-            whenever(mockPropertyOwnershipRepository.findByRegistrationNumber_Number(registrationNumberValue))
+            whenever(mockPropertyOwnershipRepository.findByLandlordship_RegistrationNumber_Number(registrationNumberValue))
                 .thenReturn(mockPropertyOwnership)
             whenever(mockPropertyComplianceRepository.save(any<PropertyCompliance>()))
                 .thenAnswer { it.arguments[0] }
@@ -295,7 +295,7 @@ class PropertyComplianceServiceTests {
 
         @Test
         fun `sets gasSafetyCertProvideLater when provided`() {
-            whenever(mockPropertyOwnershipRepository.findByRegistrationNumber_Number(registrationNumberValue))
+            whenever(mockPropertyOwnershipRepository.findByLandlordship_RegistrationNumber_Number(registrationNumberValue))
                 .thenReturn(mockPropertyOwnership)
             whenever(mockPropertyComplianceRepository.save(any<PropertyCompliance>()))
                 .thenAnswer { it.arguments[0] }
@@ -312,7 +312,7 @@ class PropertyComplianceServiceTests {
 
         @Test
         fun `sets electricalSafetyCertProvideLater when provided`() {
-            whenever(mockPropertyOwnershipRepository.findByRegistrationNumber_Number(registrationNumberValue))
+            whenever(mockPropertyOwnershipRepository.findByLandlordship_RegistrationNumber_Number(registrationNumberValue))
                 .thenReturn(mockPropertyOwnership)
             whenever(mockPropertyComplianceRepository.save(any<PropertyCompliance>()))
                 .thenAnswer { it.arguments[0] }
@@ -329,7 +329,7 @@ class PropertyComplianceServiceTests {
 
         @Test
         fun `sets epcProvideLater when provided`() {
-            whenever(mockPropertyOwnershipRepository.findByRegistrationNumber_Number(registrationNumberValue))
+            whenever(mockPropertyOwnershipRepository.findByLandlordship_RegistrationNumber_Number(registrationNumberValue))
                 .thenReturn(mockPropertyOwnership)
             whenever(mockPropertyComplianceRepository.save(any<PropertyCompliance>()))
                 .thenAnswer { it.arguments[0] }
@@ -346,7 +346,7 @@ class PropertyComplianceServiceTests {
 
         @Test
         fun `provideLater flags default to null when not specified`() {
-            whenever(mockPropertyOwnershipRepository.findByRegistrationNumber_Number(registrationNumberValue))
+            whenever(mockPropertyOwnershipRepository.findByLandlordship_RegistrationNumber_Number(registrationNumberValue))
                 .thenReturn(mockPropertyOwnership)
             whenever(mockPropertyComplianceRepository.save(any<PropertyCompliance>()))
                 .thenAnswer { it.arguments[0] }
@@ -365,7 +365,7 @@ class PropertyComplianceServiceTests {
 
         @Test
         fun `throws EntityNotFoundException when property ownership is not found`() {
-            whenever(mockPropertyOwnershipRepository.findByRegistrationNumber_Number(registrationNumberValue))
+            whenever(mockPropertyOwnershipRepository.findByLandlordship_RegistrationNumber_Number(registrationNumberValue))
                 .thenReturn(null)
 
             assertThrows<EntityNotFoundException> {
@@ -377,7 +377,7 @@ class PropertyComplianceServiceTests {
 
         @Test
         fun `sets hasGasSupply when hasGasSupply is false`() {
-            whenever(mockPropertyOwnershipRepository.findByRegistrationNumber_Number(registrationNumberValue))
+            whenever(mockPropertyOwnershipRepository.findByLandlordship_RegistrationNumber_Number(registrationNumberValue))
                 .thenReturn(mockPropertyOwnership)
             whenever(mockPropertyComplianceRepository.save(any<PropertyCompliance>()))
                 .thenAnswer { it.arguments[0] }
@@ -394,7 +394,7 @@ class PropertyComplianceServiceTests {
 
         @Test
         fun `sets hasGasSupply when hasGasSupply is true`() {
-            whenever(mockPropertyOwnershipRepository.findByRegistrationNumber_Number(registrationNumberValue))
+            whenever(mockPropertyOwnershipRepository.findByLandlordship_RegistrationNumber_Number(registrationNumberValue))
                 .thenReturn(mockPropertyOwnership)
             whenever(mockPropertyComplianceRepository.save(any<PropertyCompliance>()))
                 .thenAnswer { it.arguments[0] }
@@ -414,7 +414,7 @@ class PropertyComplianceServiceTests {
             val gasUpload = FileUpload(FileUploadStatus.QUARANTINED, "gas-1", "pdf", "etag1", "v1")
             val electricalUpload = FileUpload(FileUploadStatus.QUARANTINED, "eicr-1", "pdf", "etag2", "v2")
 
-            whenever(mockPropertyOwnershipRepository.findByRegistrationNumber_Number(registrationNumberValue))
+            whenever(mockPropertyOwnershipRepository.findByLandlordship_RegistrationNumber_Number(registrationNumberValue))
                 .thenReturn(mockPropertyOwnership)
             whenever(mockPropertyComplianceRepository.save(any<PropertyCompliance>()))
                 .thenAnswer { it.arguments[0] }
@@ -438,7 +438,7 @@ class PropertyComplianceServiceTests {
 
         @Test
         fun `throws IllegalArgumentException when electrical uploads are present but electricalCertType is null`() {
-            whenever(mockPropertyOwnershipRepository.findByRegistrationNumber_Number(registrationNumberValue))
+            whenever(mockPropertyOwnershipRepository.findByLandlordship_RegistrationNumber_Number(registrationNumberValue))
                 .thenReturn(mockPropertyOwnership)
             whenever(mockPropertyComplianceRepository.save(any<PropertyCompliance>()))
                 .thenAnswer { it.arguments[0] }
@@ -460,7 +460,7 @@ class PropertyComplianceServiceTests {
             val gasUpload2 = FileUpload(FileUploadStatus.QUARANTINED, "gas-2", "pdf", "etag2", "v2")
             val electricalUpload1 = FileUpload(FileUploadStatus.QUARANTINED, "eicr-1", "pdf", "etag3", "v3")
 
-            whenever(mockPropertyOwnershipRepository.findByRegistrationNumber_Number(registrationNumberValue))
+            whenever(mockPropertyOwnershipRepository.findByLandlordship_RegistrationNumber_Number(registrationNumberValue))
                 .thenReturn(mockPropertyOwnership)
             whenever(mockPropertyComplianceRepository.save(any<PropertyCompliance>()))
                 .thenAnswer { it.arguments[0] }
@@ -676,12 +676,15 @@ class PropertyComplianceServiceTests {
             )
 
             verify(mockComplianceUpdateConfirmationSender).sendEmail(
-                eq(mockPropertyOwnership.primaryLandlord.email),
+                eq(mockPropertyOwnership.landlordship.primaryLandlord.email),
                 eq(
                     ComplianceUpdateConfirmationEmail(
-                        landlordName = mockPropertyOwnership.primaryLandlord.name,
-                        multiLineAddress = mockPropertyOwnership.address.toMultiLineAddress(),
-                        registrationNumber = RegistrationNumberDataModel.fromRegistrationNumber(mockPropertyOwnership.registrationNumber),
+                        landlordName = mockPropertyOwnership.landlordship.primaryLandlord.name,
+                        multiLineAddress = mockPropertyOwnership.propertyDetails.address.toMultiLineAddress(),
+                        registrationNumber =
+                            RegistrationNumberDataModel.fromRegistrationNumber(
+                                mockPropertyOwnership.landlordship.registrationNumber,
+                            ),
                         dashboardUrl = URI("https://test.example.com"),
                         newCertificateUrl = URI("https://test.example.com/compliance"),
                         complianceUpdateType = ComplianceUpdateConfirmationEmail.UpdateType.CERTIFICATE_ADDED,
@@ -714,12 +717,15 @@ class PropertyComplianceServiceTests {
             )
 
             verify(mockComplianceUpdateConfirmationSender).sendEmail(
-                eq(mockPropertyOwnership.primaryLandlord.email),
+                eq(mockPropertyOwnership.landlordship.primaryLandlord.email),
                 eq(
                     ComplianceUpdateConfirmationEmail(
-                        landlordName = mockPropertyOwnership.primaryLandlord.name,
-                        multiLineAddress = mockPropertyOwnership.address.toMultiLineAddress(),
-                        registrationNumber = RegistrationNumberDataModel.fromRegistrationNumber(mockPropertyOwnership.registrationNumber),
+                        landlordName = mockPropertyOwnership.landlordship.primaryLandlord.name,
+                        multiLineAddress = mockPropertyOwnership.propertyDetails.address.toMultiLineAddress(),
+                        registrationNumber =
+                            RegistrationNumberDataModel.fromRegistrationNumber(
+                                mockPropertyOwnership.landlordship.registrationNumber,
+                            ),
                         dashboardUrl = URI("https://test.example.com"),
                         newCertificateUrl = URI("https://test.example.com/compliance"),
                         complianceUpdateType = ComplianceUpdateConfirmationEmail.UpdateType.EXPIRED_CERTIFICATE_UNOCCUPIED,
@@ -755,14 +761,14 @@ class PropertyComplianceServiceTests {
             )
 
             verify(mockComplianceUpdateConfirmationSender).sendEmail(
-                eq(occupiedPropertyOwnership.primaryLandlord.email),
+                eq(occupiedPropertyOwnership.landlordship.primaryLandlord.email),
                 eq(
                     ComplianceUpdateConfirmationEmail(
-                        landlordName = occupiedPropertyOwnership.primaryLandlord.name,
-                        multiLineAddress = occupiedPropertyOwnership.address.toMultiLineAddress(),
+                        landlordName = occupiedPropertyOwnership.landlordship.primaryLandlord.name,
+                        multiLineAddress = occupiedPropertyOwnership.propertyDetails.address.toMultiLineAddress(),
                         registrationNumber =
                             RegistrationNumberDataModel.fromRegistrationNumber(
-                                occupiedPropertyOwnership.registrationNumber,
+                                occupiedPropertyOwnership.landlordship.registrationNumber,
                             ),
                         dashboardUrl = URI("https://test.example.com"),
                         newCertificateUrl = URI("https://test.example.com/compliance"),
@@ -794,12 +800,15 @@ class PropertyComplianceServiceTests {
             )
 
             verify(mockComplianceUpdateConfirmationSender).sendEmail(
-                eq(mockPropertyOwnership.primaryLandlord.email),
+                eq(mockPropertyOwnership.landlordship.primaryLandlord.email),
                 eq(
                     ComplianceUpdateConfirmationEmail(
-                        landlordName = mockPropertyOwnership.primaryLandlord.name,
-                        multiLineAddress = mockPropertyOwnership.address.toMultiLineAddress(),
-                        registrationNumber = RegistrationNumberDataModel.fromRegistrationNumber(mockPropertyOwnership.registrationNumber),
+                        landlordName = mockPropertyOwnership.landlordship.primaryLandlord.name,
+                        multiLineAddress = mockPropertyOwnership.propertyDetails.address.toMultiLineAddress(),
+                        registrationNumber =
+                            RegistrationNumberDataModel.fromRegistrationNumber(
+                                mockPropertyOwnership.landlordship.registrationNumber,
+                            ),
                         dashboardUrl = URI("https://test.example.com"),
                         newCertificateUrl = URI("https://test.example.com/compliance"),
                         complianceUpdateType = ComplianceUpdateConfirmationEmail.UpdateType.EXPIRED_CERTIFICATE_UNOCCUPIED,
@@ -833,14 +842,14 @@ class PropertyComplianceServiceTests {
             )
 
             verify(mockComplianceUpdateConfirmationSender).sendEmail(
-                eq(occupiedPropertyOwnership.primaryLandlord.email),
+                eq(occupiedPropertyOwnership.landlordship.primaryLandlord.email),
                 eq(
                     ComplianceUpdateConfirmationEmail(
-                        landlordName = occupiedPropertyOwnership.primaryLandlord.name,
-                        multiLineAddress = occupiedPropertyOwnership.address.toMultiLineAddress(),
+                        landlordName = occupiedPropertyOwnership.landlordship.primaryLandlord.name,
+                        multiLineAddress = occupiedPropertyOwnership.propertyDetails.address.toMultiLineAddress(),
                         registrationNumber =
                             RegistrationNumberDataModel.fromRegistrationNumber(
-                                occupiedPropertyOwnership.registrationNumber,
+                                occupiedPropertyOwnership.landlordship.registrationNumber,
                             ),
                         dashboardUrl = URI("https://test.example.com"),
                         newCertificateUrl = URI("https://test.example.com/compliance"),
@@ -1069,12 +1078,15 @@ class PropertyComplianceServiceTests {
             )
 
             verify(mockComplianceUpdateConfirmationSender).sendEmail(
-                eq(mockPropertyOwnership.primaryLandlord.email),
+                eq(mockPropertyOwnership.landlordship.primaryLandlord.email),
                 eq(
                     ComplianceUpdateConfirmationEmail(
-                        landlordName = mockPropertyOwnership.primaryLandlord.name,
-                        multiLineAddress = mockPropertyOwnership.address.toMultiLineAddress(),
-                        registrationNumber = RegistrationNumberDataModel.fromRegistrationNumber(mockPropertyOwnership.registrationNumber),
+                        landlordName = mockPropertyOwnership.landlordship.primaryLandlord.name,
+                        multiLineAddress = mockPropertyOwnership.propertyDetails.address.toMultiLineAddress(),
+                        registrationNumber =
+                            RegistrationNumberDataModel.fromRegistrationNumber(
+                                mockPropertyOwnership.landlordship.registrationNumber,
+                            ),
                         dashboardUrl = URI("https://test.example.com"),
                         newCertificateUrl = URI("https://test.example.com/compliance"),
                         complianceUpdateType = ComplianceUpdateConfirmationEmail.UpdateType.CERTIFICATE_ADDED,
@@ -1107,12 +1119,15 @@ class PropertyComplianceServiceTests {
             )
 
             verify(mockComplianceUpdateConfirmationSender).sendEmail(
-                eq(mockPropertyOwnership.primaryLandlord.email),
+                eq(mockPropertyOwnership.landlordship.primaryLandlord.email),
                 eq(
                     ComplianceUpdateConfirmationEmail(
-                        landlordName = mockPropertyOwnership.primaryLandlord.name,
-                        multiLineAddress = mockPropertyOwnership.address.toMultiLineAddress(),
-                        registrationNumber = RegistrationNumberDataModel.fromRegistrationNumber(mockPropertyOwnership.registrationNumber),
+                        landlordName = mockPropertyOwnership.landlordship.primaryLandlord.name,
+                        multiLineAddress = mockPropertyOwnership.propertyDetails.address.toMultiLineAddress(),
+                        registrationNumber =
+                            RegistrationNumberDataModel.fromRegistrationNumber(
+                                mockPropertyOwnership.landlordship.registrationNumber,
+                            ),
                         dashboardUrl = URI("https://test.example.com"),
                         newCertificateUrl = URI("https://test.example.com/compliance"),
                         complianceUpdateType = ComplianceUpdateConfirmationEmail.UpdateType.EXPIRED_CERTIFICATE_UNOCCUPIED,
@@ -1148,14 +1163,14 @@ class PropertyComplianceServiceTests {
             )
 
             verify(mockComplianceUpdateConfirmationSender).sendEmail(
-                eq(occupiedPropertyOwnership.primaryLandlord.email),
+                eq(occupiedPropertyOwnership.landlordship.primaryLandlord.email),
                 eq(
                     ComplianceUpdateConfirmationEmail(
-                        landlordName = occupiedPropertyOwnership.primaryLandlord.name,
-                        multiLineAddress = occupiedPropertyOwnership.address.toMultiLineAddress(),
+                        landlordName = occupiedPropertyOwnership.landlordship.primaryLandlord.name,
+                        multiLineAddress = occupiedPropertyOwnership.propertyDetails.address.toMultiLineAddress(),
                         registrationNumber =
                             RegistrationNumberDataModel.fromRegistrationNumber(
-                                occupiedPropertyOwnership.registrationNumber,
+                                occupiedPropertyOwnership.landlordship.registrationNumber,
                             ),
                         dashboardUrl = URI("https://test.example.com"),
                         newCertificateUrl = URI("https://test.example.com/compliance"),
@@ -1187,12 +1202,15 @@ class PropertyComplianceServiceTests {
             )
 
             verify(mockComplianceUpdateConfirmationSender).sendEmail(
-                eq(mockPropertyOwnership.primaryLandlord.email),
+                eq(mockPropertyOwnership.landlordship.primaryLandlord.email),
                 eq(
                     ComplianceUpdateConfirmationEmail(
-                        landlordName = mockPropertyOwnership.primaryLandlord.name,
-                        multiLineAddress = mockPropertyOwnership.address.toMultiLineAddress(),
-                        registrationNumber = RegistrationNumberDataModel.fromRegistrationNumber(mockPropertyOwnership.registrationNumber),
+                        landlordName = mockPropertyOwnership.landlordship.primaryLandlord.name,
+                        multiLineAddress = mockPropertyOwnership.propertyDetails.address.toMultiLineAddress(),
+                        registrationNumber =
+                            RegistrationNumberDataModel.fromRegistrationNumber(
+                                mockPropertyOwnership.landlordship.registrationNumber,
+                            ),
                         dashboardUrl = URI("https://test.example.com"),
                         newCertificateUrl = URI("https://test.example.com/compliance"),
                         complianceUpdateType = ComplianceUpdateConfirmationEmail.UpdateType.EXPIRED_CERTIFICATE_UNOCCUPIED,
@@ -1226,14 +1244,14 @@ class PropertyComplianceServiceTests {
             )
 
             verify(mockComplianceUpdateConfirmationSender).sendEmail(
-                eq(occupiedPropertyOwnership.primaryLandlord.email),
+                eq(occupiedPropertyOwnership.landlordship.primaryLandlord.email),
                 eq(
                     ComplianceUpdateConfirmationEmail(
-                        landlordName = occupiedPropertyOwnership.primaryLandlord.name,
-                        multiLineAddress = occupiedPropertyOwnership.address.toMultiLineAddress(),
+                        landlordName = occupiedPropertyOwnership.landlordship.primaryLandlord.name,
+                        multiLineAddress = occupiedPropertyOwnership.propertyDetails.address.toMultiLineAddress(),
                         registrationNumber =
                             RegistrationNumberDataModel.fromRegistrationNumber(
-                                occupiedPropertyOwnership.registrationNumber,
+                                occupiedPropertyOwnership.landlordship.registrationNumber,
                             ),
                         dashboardUrl = URI("https://test.example.com"),
                         newCertificateUrl = URI("https://test.example.com/compliance"),
@@ -1424,12 +1442,15 @@ class PropertyComplianceServiceTests {
             )
 
             verify(mockComplianceUpdateConfirmationSender).sendEmail(
-                eq(mockPropertyOwnership.primaryLandlord.email),
+                eq(mockPropertyOwnership.landlordship.primaryLandlord.email),
                 eq(
                     ComplianceUpdateConfirmationEmail(
-                        landlordName = mockPropertyOwnership.primaryLandlord.name,
-                        multiLineAddress = mockPropertyOwnership.address.toMultiLineAddress(),
-                        registrationNumber = RegistrationNumberDataModel.fromRegistrationNumber(mockPropertyOwnership.registrationNumber),
+                        landlordName = mockPropertyOwnership.landlordship.primaryLandlord.name,
+                        multiLineAddress = mockPropertyOwnership.propertyDetails.address.toMultiLineAddress(),
+                        registrationNumber =
+                            RegistrationNumberDataModel.fromRegistrationNumber(
+                                mockPropertyOwnership.landlordship.registrationNumber,
+                            ),
                         dashboardUrl = URI("https://test.example.com"),
                         newCertificateUrl = URI("https://test.example.com/compliance"),
                         complianceUpdateType = ComplianceUpdateConfirmationEmail.UpdateType.CERTIFICATE_ADDED,
@@ -1460,12 +1481,15 @@ class PropertyComplianceServiceTests {
             )
 
             verify(mockComplianceUpdateConfirmationSender).sendEmail(
-                eq(mockPropertyOwnership.primaryLandlord.email),
+                eq(mockPropertyOwnership.landlordship.primaryLandlord.email),
                 eq(
                     ComplianceUpdateConfirmationEmail(
-                        landlordName = mockPropertyOwnership.primaryLandlord.name,
-                        multiLineAddress = mockPropertyOwnership.address.toMultiLineAddress(),
-                        registrationNumber = RegistrationNumberDataModel.fromRegistrationNumber(mockPropertyOwnership.registrationNumber),
+                        landlordName = mockPropertyOwnership.landlordship.primaryLandlord.name,
+                        multiLineAddress = mockPropertyOwnership.propertyDetails.address.toMultiLineAddress(),
+                        registrationNumber =
+                            RegistrationNumberDataModel.fromRegistrationNumber(
+                                mockPropertyOwnership.landlordship.registrationNumber,
+                            ),
                         dashboardUrl = URI("https://test.example.com"),
                         newCertificateUrl = URI("https://test.example.com/compliance"),
                         complianceUpdateType = ComplianceUpdateConfirmationEmail.UpdateType.EXPIRED_CERTIFICATE_UNOCCUPIED,
@@ -1499,14 +1523,14 @@ class PropertyComplianceServiceTests {
             )
 
             verify(mockComplianceUpdateConfirmationSender).sendEmail(
-                eq(occupiedPropertyOwnership.primaryLandlord.email),
+                eq(occupiedPropertyOwnership.landlordship.primaryLandlord.email),
                 eq(
                     ComplianceUpdateConfirmationEmail(
-                        landlordName = occupiedPropertyOwnership.primaryLandlord.name,
-                        multiLineAddress = occupiedPropertyOwnership.address.toMultiLineAddress(),
+                        landlordName = occupiedPropertyOwnership.landlordship.primaryLandlord.name,
+                        multiLineAddress = occupiedPropertyOwnership.propertyDetails.address.toMultiLineAddress(),
                         registrationNumber =
                             RegistrationNumberDataModel.fromRegistrationNumber(
-                                occupiedPropertyOwnership.registrationNumber,
+                                occupiedPropertyOwnership.landlordship.registrationNumber,
                             ),
                         dashboardUrl = URI("https://test.example.com"),
                         newCertificateUrl = URI("https://test.example.com/compliance"),

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/PropertyOwnershipServiceTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/PropertyOwnershipServiceTests.kt
@@ -243,7 +243,7 @@ class PropertyOwnershipServiceTests {
 
         val propertyOwnershipCaptor = captor<PropertyOwnership>()
         verify(mockPropertyOwnershipRepository).save(propertyOwnershipCaptor.capture())
-        assertEquals(LocalDate.now(), propertyOwnershipCaptor.value.lastOccupiedDate)
+        assertEquals(LocalDate.now(), propertyOwnershipCaptor.value.tenancyDetails.lastOccupiedDate)
     }
 
     @Test
@@ -279,7 +279,7 @@ class PropertyOwnershipServiceTests {
 
         val propertyOwnershipCaptor = captor<PropertyOwnership>()
         verify(mockPropertyOwnershipRepository).save(propertyOwnershipCaptor.capture())
-        assertEquals(null, propertyOwnershipCaptor.value.lastOccupiedDate)
+        assertEquals(null, propertyOwnershipCaptor.value.tenancyDetails.lastOccupiedDate)
     }
 
     @Nested
@@ -313,7 +313,9 @@ class PropertyOwnershipServiceTests {
         @Test
         fun `Returns a list of Landlords properties in correctly formatted data model from landlords BaseUser_Id`() {
             whenever(
-                mockPropertyOwnershipRepository.findAllByPrimaryLandlord_BaseUser_IdAndIsActiveTrue(landlord.baseUser.id),
+                mockPropertyOwnershipRepository.findAllByLandlordship_PrimaryLandlord_BaseUser_IdAndLandlordship_IsActiveTrue(
+                    landlord.baseUser.id,
+                ),
             ).thenReturn(landlordsProperties)
 
             whenever(mockBackUrlStorageService.storeCurrentUrlReturningKey(REGISTERED_PROPERTIES_FRAGMENT))
@@ -322,10 +324,10 @@ class PropertyOwnershipServiceTests {
             val expectedResults: List<RegisteredPropertyLandlordViewModel> =
                 listOf(
                     RegisteredPropertyLandlordViewModel(
-                        address = propertyOwnership1.address.singleLineAddress,
+                        address = propertyOwnership1.propertyDetails.address.singleLineAddress,
                         registrationNumber =
                             RegistrationNumberDataModel
-                                .fromRegistrationNumber(propertyOwnership1.registrationNumber)
+                                .fromRegistrationNumber(propertyOwnership1.landlordship.registrationNumber)
                                 .toString(),
                         recordLink =
                             PropertyDetailsController
@@ -333,10 +335,10 @@ class PropertyOwnershipServiceTests {
                                 .overrideBackLinkForUrl(expectedCurrentUrlKey),
                     ),
                     RegisteredPropertyLandlordViewModel(
-                        address = propertyOwnership2.address.singleLineAddress,
+                        address = propertyOwnership2.propertyDetails.address.singleLineAddress,
                         registrationNumber =
                             RegistrationNumberDataModel
-                                .fromRegistrationNumber(propertyOwnership2.registrationNumber)
+                                .fromRegistrationNumber(propertyOwnership2.landlordship.registrationNumber)
                                 .toString(),
                         recordLink =
                             PropertyDetailsController
@@ -358,7 +360,7 @@ class PropertyOwnershipServiceTests {
         @Test
         fun `Returns a list of Landlords properties in correctly formatted data model from landlords Id`() {
             whenever(
-                mockPropertyOwnershipRepository.findAllByPrimaryLandlord_IdAndIsActiveTrue(landlord.id),
+                mockPropertyOwnershipRepository.findAllByLandlordship_PrimaryLandlord_IdAndLandlordship_IsActiveTrue(landlord.id),
             ).thenReturn(landlordsProperties)
 
             whenever(mockBackUrlStorageService.storeCurrentUrlReturningKey(REGISTERED_PROPERTIES_FRAGMENT))
@@ -367,10 +369,10 @@ class PropertyOwnershipServiceTests {
             val expectedResults: List<RegisteredPropertyLocalCouncilViewModel> =
                 listOf(
                     RegisteredPropertyLocalCouncilViewModel(
-                        address = propertyOwnership1.address.singleLineAddress,
+                        address = propertyOwnership1.propertyDetails.address.singleLineAddress,
                         registrationNumber =
                             RegistrationNumberDataModel
-                                .fromRegistrationNumber(propertyOwnership1.registrationNumber)
+                                .fromRegistrationNumber(propertyOwnership1.landlordship.registrationNumber)
                                 .toString(),
                         localCouncilName = localCouncil.name,
                         licenseTypeMessageKey = expectedPropertyLicence,
@@ -381,10 +383,10 @@ class PropertyOwnershipServiceTests {
                                 .overrideBackLinkForUrl(expectedCurrentUrlKey),
                     ),
                     RegisteredPropertyLocalCouncilViewModel(
-                        address = propertyOwnership2.address.singleLineAddress,
+                        address = propertyOwnership2.propertyDetails.address.singleLineAddress,
                         registrationNumber =
                             RegistrationNumberDataModel
-                                .fromRegistrationNumber(propertyOwnership2.registrationNumber)
+                                .fromRegistrationNumber(propertyOwnership2.landlordship.registrationNumber)
                                 .toString(),
                         localCouncilName = localCouncil.name,
                         licenseTypeMessageKey = expectedPropertyLicence,
@@ -413,7 +415,7 @@ class PropertyOwnershipServiceTests {
         fun `throws not found error if an active property ownership does not exist`() {
             val invalidId: Long = 1
             val principalName = "landlord"
-            whenever(mockPropertyOwnershipRepository.findByIdAndIsActiveTrue(invalidId)).thenReturn(null)
+            whenever(mockPropertyOwnershipRepository.findByIdAndLandlordship_IsActiveTrue(invalidId)).thenReturn(null)
 
             val errorThrown =
                 assertThrows<ResponseStatusException> {
@@ -426,7 +428,7 @@ class PropertyOwnershipServiceTests {
         fun `throws not found error if user is not primary landlord or an lc user`() {
             val propertyOwnership = MockLandlordData.createPropertyOwnership()
             val principalName = "not-the-landlord"
-            whenever(mockPropertyOwnershipRepository.findByIdAndIsActiveTrue(propertyOwnership.id)).thenReturn(
+            whenever(mockPropertyOwnershipRepository.findByIdAndLandlordship_IsActiveTrue(propertyOwnership.id)).thenReturn(
                 propertyOwnership,
             )
 
@@ -447,7 +449,7 @@ class PropertyOwnershipServiceTests {
                 )
             val principalName = localCouncilUser.baseUser.id
 
-            whenever(mockPropertyOwnershipRepository.findByIdAndIsActiveTrue(propertyOwnership.id)).thenReturn(
+            whenever(mockPropertyOwnershipRepository.findByIdAndLandlordship_IsActiveTrue(propertyOwnership.id)).thenReturn(
                 propertyOwnership,
             )
 
@@ -462,9 +464,9 @@ class PropertyOwnershipServiceTests {
         @Test
         fun `returns property ownership when user is primary landlord`() {
             val propertyOwnership = MockLandlordData.createPropertyOwnership()
-            val principalName = propertyOwnership.primaryLandlord.baseUser.id
+            val principalName = propertyOwnership.landlordship.primaryLandlord.baseUser.id
 
-            whenever(mockPropertyOwnershipRepository.findByIdAndIsActiveTrue(propertyOwnership.id)).thenReturn(
+            whenever(mockPropertyOwnershipRepository.findByIdAndLandlordship_IsActiveTrue(propertyOwnership.id)).thenReturn(
                 propertyOwnership,
             )
 
@@ -490,7 +492,9 @@ class PropertyOwnershipServiceTests {
                         ),
                 )
 
-            whenever(mockPropertyOwnershipRepository.findByIdAndIsActiveTrue(propertyOwnership.id)).thenReturn(propertyOwnership)
+            whenever(
+                mockPropertyOwnershipRepository.findByIdAndLandlordship_IsActiveTrue(propertyOwnership.id),
+            ).thenReturn(propertyOwnership)
 
             val returnedIsPrimaryLandlord = propertyOwnershipService.getIsAuthorizedToEditRecord(propertyOwnership.id, baseUserId)
 
@@ -507,7 +511,9 @@ class PropertyOwnershipServiceTests {
                         ),
                 )
 
-            whenever(mockPropertyOwnershipRepository.findByIdAndIsActiveTrue(propertyOwnership.id)).thenReturn(propertyOwnership)
+            whenever(
+                mockPropertyOwnershipRepository.findByIdAndLandlordship_IsActiveTrue(propertyOwnership.id),
+            ).thenReturn(propertyOwnership)
 
             val returnedIsPrimaryLandlord =
                 propertyOwnershipService.getIsAuthorizedToEditRecord(
@@ -707,11 +713,11 @@ class PropertyOwnershipServiceTests {
         val newLicenceNumber = "newLicenceNumber"
         val updatedLicence = License(newLicensingType, newLicenceNumber)
 
-        whenever(mockPropertyOwnershipRepository.findByIdAndIsActiveTrue(propertyOwnership.id)).thenReturn(
+        whenever(mockPropertyOwnershipRepository.findByIdAndLandlordship_IsActiveTrue(propertyOwnership.id)).thenReturn(
             propertyOwnership,
         )
         whenever(
-            mockLicenseService.updateLicence(propertyOwnership.license, newLicensingType, newLicenceNumber),
+            mockLicenseService.updateLicence(propertyOwnership.landlordship.license, newLicensingType, newLicenceNumber),
         ).thenReturn(updatedLicence)
 
         // Act
@@ -723,7 +729,7 @@ class PropertyOwnershipServiceTests {
         )
 
         // Assert
-        assertEquals(updatedLicence, propertyOwnership.license)
+        assertEquals(updatedLicence, propertyOwnership.landlordship.license)
     }
 
     @Test
@@ -735,7 +741,7 @@ class PropertyOwnershipServiceTests {
                 license = License(LicensingType.SELECTIVE_LICENCE, "licenceNumber"),
             )
 
-        whenever(mockPropertyOwnershipRepository.findByIdAndIsActiveTrue(propertyOwnership.id)).thenReturn(
+        whenever(mockPropertyOwnershipRepository.findByIdAndLandlordship_IsActiveTrue(propertyOwnership.id)).thenReturn(
             propertyOwnership,
         )
 
@@ -765,7 +771,7 @@ class PropertyOwnershipServiceTests {
                 ownershipType = OwnershipType.FREEHOLD,
             )
 
-        whenever(mockPropertyOwnershipRepository.findByIdAndIsActiveTrue(propertyOwnership.id)).thenReturn(
+        whenever(mockPropertyOwnershipRepository.findByIdAndLandlordship_IsActiveTrue(propertyOwnership.id)).thenReturn(
             propertyOwnership,
         )
 
@@ -777,7 +783,7 @@ class PropertyOwnershipServiceTests {
         )
 
         // Assert
-        assertEquals(OwnershipType.LEASEHOLD, propertyOwnership.ownershipType)
+        assertEquals(OwnershipType.LEASEHOLD, propertyOwnership.landlordship.ownershipType)
     }
 
     @Test
@@ -789,7 +795,7 @@ class PropertyOwnershipServiceTests {
                 ownershipType = OwnershipType.FREEHOLD,
             )
 
-        whenever(mockPropertyOwnershipRepository.findByIdAndIsActiveTrue(propertyOwnership.id)).thenReturn(
+        whenever(mockPropertyOwnershipRepository.findByIdAndLandlordship_IsActiveTrue(propertyOwnership.id)).thenReturn(
             propertyOwnership,
         )
 
@@ -820,7 +826,7 @@ class PropertyOwnershipServiceTests {
                     currentNumTenants = 4,
                 )
             val newNumberOfTenants = 5
-            whenever(mockPropertyOwnershipRepository.findByIdAndIsActiveTrue(propertyOwnership.id)).thenReturn(
+            whenever(mockPropertyOwnershipRepository.findByIdAndLandlordship_IsActiveTrue(propertyOwnership.id)).thenReturn(
                 propertyOwnership,
             )
 
@@ -828,26 +834,26 @@ class PropertyOwnershipServiceTests {
             propertyOwnershipService.updateOccupancy(
                 propertyOwnership.id,
                 numberOfPeople = newNumberOfTenants,
-                numberOfHouseholds = propertyOwnership.currentNumHouseholds,
-                numBedrooms = propertyOwnership.numBedrooms,
-                billsIncludedList = propertyOwnership.billsIncludedList,
-                customBillsIncluded = propertyOwnership.customBillsIncluded,
-                furnishedStatus = propertyOwnership.furnishedStatus,
-                rentFrequency = propertyOwnership.rentFrequency,
-                customRentFrequency = propertyOwnership.customRentFrequency,
-                rentAmount = propertyOwnership.rentAmount,
+                numberOfHouseholds = propertyOwnership.tenancyDetails.currentNumHouseholds,
+                numBedrooms = propertyOwnership.propertyDetails.numBedrooms,
+                billsIncludedList = propertyOwnership.tenancyDetails.billsIncludedList,
+                customBillsIncluded = propertyOwnership.tenancyDetails.customBillsIncluded,
+                furnishedStatus = propertyOwnership.tenancyDetails.furnishedStatus,
+                rentFrequency = propertyOwnership.tenancyDetails.rentFrequency,
+                customRentFrequency = propertyOwnership.tenancyDetails.customRentFrequency,
+                rentAmount = propertyOwnership.tenancyDetails.rentAmount,
                 initialLastModifiedDate = propertyOwnership.getMostRecentlyUpdated(),
             )
 
             // Assert
-            assertEquals(newNumberOfTenants, propertyOwnership.currentNumTenants)
+            assertEquals(newNumberOfTenants, propertyOwnership.tenancyDetails.currentNumTenants)
         }
 
         @Test
         fun `updateOccupancy sets lastOccupiedDate when property transitions to occupied`() {
             // Arrange
             val propertyOwnership = MockLandlordData.createPropertyOwnership(id = 1)
-            whenever(mockPropertyOwnershipRepository.findByIdAndIsActiveTrue(propertyOwnership.id)).thenReturn(
+            whenever(mockPropertyOwnershipRepository.findByIdAndLandlordship_IsActiveTrue(propertyOwnership.id)).thenReturn(
                 propertyOwnership,
             )
 
@@ -867,7 +873,7 @@ class PropertyOwnershipServiceTests {
             )
 
             // Assert
-            assertEquals(LocalDate.now(), propertyOwnership.lastOccupiedDate)
+            assertEquals(LocalDate.now(), propertyOwnership.tenancyDetails.lastOccupiedDate)
         }
 
         @Test
@@ -875,28 +881,28 @@ class PropertyOwnershipServiceTests {
             // Arrange
             val propertyOwnership = MockLandlordData.createOccupiedPropertyOwnership(id = 1)
             val existingLastOccupiedDate = LocalDate.now().minusDays(10)
-            ReflectionTestUtils.setField(propertyOwnership, "lastOccupiedDate", existingLastOccupiedDate)
-            whenever(mockPropertyOwnershipRepository.findByIdAndIsActiveTrue(propertyOwnership.id)).thenReturn(
+            ReflectionTestUtils.setField(propertyOwnership.tenancyDetails, "lastOccupiedDate", existingLastOccupiedDate)
+            whenever(mockPropertyOwnershipRepository.findByIdAndLandlordship_IsActiveTrue(propertyOwnership.id)).thenReturn(
                 propertyOwnership,
             )
 
             // Act
             propertyOwnershipService.updateOccupancy(
                 propertyOwnership.id,
-                numberOfPeople = propertyOwnership.currentNumTenants + 1,
-                numberOfHouseholds = propertyOwnership.currentNumHouseholds,
-                numBedrooms = propertyOwnership.numBedrooms,
-                billsIncludedList = propertyOwnership.billsIncludedList,
-                customBillsIncluded = propertyOwnership.customBillsIncluded,
-                furnishedStatus = propertyOwnership.furnishedStatus,
-                rentFrequency = propertyOwnership.rentFrequency,
-                customRentFrequency = propertyOwnership.customRentFrequency,
-                rentAmount = propertyOwnership.rentAmount,
+                numberOfPeople = propertyOwnership.tenancyDetails.currentNumTenants + 1,
+                numberOfHouseholds = propertyOwnership.tenancyDetails.currentNumHouseholds,
+                numBedrooms = propertyOwnership.propertyDetails.numBedrooms,
+                billsIncludedList = propertyOwnership.tenancyDetails.billsIncludedList,
+                customBillsIncluded = propertyOwnership.tenancyDetails.customBillsIncluded,
+                furnishedStatus = propertyOwnership.tenancyDetails.furnishedStatus,
+                rentFrequency = propertyOwnership.tenancyDetails.rentFrequency,
+                customRentFrequency = propertyOwnership.tenancyDetails.customRentFrequency,
+                rentAmount = propertyOwnership.tenancyDetails.rentAmount,
                 initialLastModifiedDate = propertyOwnership.getMostRecentlyUpdated(),
             )
 
             // Assert
-            assertEquals(existingLastOccupiedDate, propertyOwnership.lastOccupiedDate)
+            assertEquals(existingLastOccupiedDate, propertyOwnership.tenancyDetails.lastOccupiedDate)
         }
 
         @Test
@@ -904,8 +910,8 @@ class PropertyOwnershipServiceTests {
             // Arrange
             val propertyOwnership = MockLandlordData.createOccupiedPropertyOwnership(id = 1)
             val existingLastOccupiedDate = LocalDate.now().minusDays(10)
-            ReflectionTestUtils.setField(propertyOwnership, "lastOccupiedDate", existingLastOccupiedDate)
-            whenever(mockPropertyOwnershipRepository.findByIdAndIsActiveTrue(propertyOwnership.id)).thenReturn(
+            ReflectionTestUtils.setField(propertyOwnership.tenancyDetails, "lastOccupiedDate", existingLastOccupiedDate)
+            whenever(mockPropertyOwnershipRepository.findByIdAndLandlordship_IsActiveTrue(propertyOwnership.id)).thenReturn(
                 propertyOwnership,
             )
 
@@ -913,19 +919,19 @@ class PropertyOwnershipServiceTests {
             propertyOwnershipService.updateOccupancy(
                 propertyOwnership.id,
                 numberOfPeople = 0,
-                numberOfHouseholds = propertyOwnership.currentNumHouseholds,
-                numBedrooms = propertyOwnership.numBedrooms,
-                billsIncludedList = propertyOwnership.billsIncludedList,
-                customBillsIncluded = propertyOwnership.customBillsIncluded,
-                furnishedStatus = propertyOwnership.furnishedStatus,
-                rentFrequency = propertyOwnership.rentFrequency,
-                customRentFrequency = propertyOwnership.customRentFrequency,
-                rentAmount = propertyOwnership.rentAmount,
+                numberOfHouseholds = propertyOwnership.tenancyDetails.currentNumHouseholds,
+                numBedrooms = propertyOwnership.propertyDetails.numBedrooms,
+                billsIncludedList = propertyOwnership.tenancyDetails.billsIncludedList,
+                customBillsIncluded = propertyOwnership.tenancyDetails.customBillsIncluded,
+                furnishedStatus = propertyOwnership.tenancyDetails.furnishedStatus,
+                rentFrequency = propertyOwnership.tenancyDetails.rentFrequency,
+                customRentFrequency = propertyOwnership.tenancyDetails.customRentFrequency,
+                rentAmount = propertyOwnership.tenancyDetails.rentAmount,
                 initialLastModifiedDate = propertyOwnership.getMostRecentlyUpdated(),
             )
 
             // Assert
-            assertEquals(existingLastOccupiedDate, propertyOwnership.lastOccupiedDate)
+            assertEquals(existingLastOccupiedDate, propertyOwnership.tenancyDetails.lastOccupiedDate)
         }
 
         @Test
@@ -933,7 +939,7 @@ class PropertyOwnershipServiceTests {
             // Arrange
             val propertyOwnership =
                 MockLandlordData.createOccupiedPropertyOwnership()
-            whenever(mockPropertyOwnershipRepository.findByIdAndIsActiveTrue(propertyOwnership.id)).thenReturn(
+            whenever(mockPropertyOwnershipRepository.findByIdAndLandlordship_IsActiveTrue(propertyOwnership.id)).thenReturn(
                 propertyOwnership,
             )
 
@@ -943,14 +949,14 @@ class PropertyOwnershipServiceTests {
                     propertyOwnershipService.updateOccupancy(
                         propertyOwnership.id,
                         numberOfPeople = 6,
-                        numberOfHouseholds = propertyOwnership.currentNumHouseholds,
-                        numBedrooms = propertyOwnership.numBedrooms,
-                        billsIncludedList = propertyOwnership.billsIncludedList,
-                        customBillsIncluded = propertyOwnership.customBillsIncluded,
-                        furnishedStatus = propertyOwnership.furnishedStatus,
-                        rentFrequency = propertyOwnership.rentFrequency,
-                        customRentFrequency = propertyOwnership.customRentFrequency,
-                        rentAmount = propertyOwnership.rentAmount,
+                        numberOfHouseholds = propertyOwnership.tenancyDetails.currentNumHouseholds,
+                        numBedrooms = propertyOwnership.propertyDetails.numBedrooms,
+                        billsIncludedList = propertyOwnership.tenancyDetails.billsIncludedList,
+                        customBillsIncluded = propertyOwnership.tenancyDetails.customBillsIncluded,
+                        furnishedStatus = propertyOwnership.tenancyDetails.furnishedStatus,
+                        rentFrequency = propertyOwnership.tenancyDetails.rentFrequency,
+                        customRentFrequency = propertyOwnership.tenancyDetails.customRentFrequency,
+                        rentAmount = propertyOwnership.tenancyDetails.rentAmount,
                         initialLastModifiedDate = propertyOwnership.getMostRecentlyUpdated().minus(1, ChronoUnit.MINUTES),
                     )
                 }
@@ -975,7 +981,7 @@ class PropertyOwnershipServiceTests {
                 )
             val newNumberOfHouseholds = 3
             val newNumberOfTenants = 5
-            whenever(mockPropertyOwnershipRepository.findByIdAndIsActiveTrue(propertyOwnership.id)).thenReturn(
+            whenever(mockPropertyOwnershipRepository.findByIdAndLandlordship_IsActiveTrue(propertyOwnership.id)).thenReturn(
                 propertyOwnership,
             )
 
@@ -988,8 +994,8 @@ class PropertyOwnershipServiceTests {
             )
 
             // Assert
-            assertEquals(newNumberOfTenants, propertyOwnership.currentNumTenants)
-            assertEquals(newNumberOfHouseholds, propertyOwnership.currentNumHouseholds)
+            assertEquals(newNumberOfTenants, propertyOwnership.tenancyDetails.currentNumTenants)
+            assertEquals(newNumberOfHouseholds, propertyOwnership.tenancyDetails.currentNumHouseholds)
         }
 
         @Test
@@ -997,7 +1003,7 @@ class PropertyOwnershipServiceTests {
             // Arrange
             val propertyOwnership =
                 MockLandlordData.createOccupiedPropertyOwnership()
-            whenever(mockPropertyOwnershipRepository.findByIdAndIsActiveTrue(propertyOwnership.id)).thenReturn(
+            whenever(mockPropertyOwnershipRepository.findByIdAndLandlordship_IsActiveTrue(propertyOwnership.id)).thenReturn(
                 propertyOwnership,
             )
 
@@ -1030,7 +1036,7 @@ class PropertyOwnershipServiceTests {
                     numberOfBedrooms = 2,
                 )
             val newNumberOfBedrooms = 3
-            whenever(mockPropertyOwnershipRepository.findByIdAndIsActiveTrue(propertyOwnership.id)).thenReturn(
+            whenever(mockPropertyOwnershipRepository.findByIdAndLandlordship_IsActiveTrue(propertyOwnership.id)).thenReturn(
                 propertyOwnership,
             )
 
@@ -1042,7 +1048,7 @@ class PropertyOwnershipServiceTests {
             )
 
             // Assert
-            assertEquals(newNumberOfBedrooms, propertyOwnership.numBedrooms)
+            assertEquals(newNumberOfBedrooms, propertyOwnership.propertyDetails.numBedrooms)
         }
 
         @Test
@@ -1050,7 +1056,7 @@ class PropertyOwnershipServiceTests {
             // Arrange
             val propertyOwnership =
                 MockLandlordData.createOccupiedPropertyOwnership()
-            whenever(mockPropertyOwnershipRepository.findByIdAndIsActiveTrue(propertyOwnership.id)).thenReturn(
+            whenever(mockPropertyOwnershipRepository.findByIdAndLandlordship_IsActiveTrue(propertyOwnership.id)).thenReturn(
                 propertyOwnership,
             )
 
@@ -1084,7 +1090,7 @@ class PropertyOwnershipServiceTests {
                 )
             val newBillsIncludedList = "GAS,BROADBAND,SOMETHING_ELSE"
             val newCustomBillsIncluded = "Dog grooming"
-            whenever(mockPropertyOwnershipRepository.findByIdAndIsActiveTrue(propertyOwnership.id)).thenReturn(
+            whenever(mockPropertyOwnershipRepository.findByIdAndLandlordship_IsActiveTrue(propertyOwnership.id)).thenReturn(
                 propertyOwnership,
             )
 
@@ -1097,8 +1103,8 @@ class PropertyOwnershipServiceTests {
             )
 
             // Assert
-            assertEquals(newCustomBillsIncluded, propertyOwnership.billsIncludedList)
-            assertEquals(newBillsIncludedList, propertyOwnership.customBillsIncluded)
+            assertEquals(newCustomBillsIncluded, propertyOwnership.tenancyDetails.billsIncludedList)
+            assertEquals(newBillsIncludedList, propertyOwnership.tenancyDetails.customBillsIncluded)
         }
 
         @Test
@@ -1112,7 +1118,7 @@ class PropertyOwnershipServiceTests {
                 )
             val newBillsIncludedList = "GAS,BROADBAND,SOMETHING_ELSE"
             val newCustomBillsIncluded = "Dog grooming"
-            whenever(mockPropertyOwnershipRepository.findByIdAndIsActiveTrue(propertyOwnership.id)).thenReturn(
+            whenever(mockPropertyOwnershipRepository.findByIdAndLandlordship_IsActiveTrue(propertyOwnership.id)).thenReturn(
                 propertyOwnership,
             )
 
@@ -1125,8 +1131,8 @@ class PropertyOwnershipServiceTests {
             )
 
             // Assert
-            assertEquals(newCustomBillsIncluded, propertyOwnership.billsIncludedList)
-            assertEquals(newBillsIncludedList, propertyOwnership.customBillsIncluded)
+            assertEquals(newCustomBillsIncluded, propertyOwnership.tenancyDetails.billsIncludedList)
+            assertEquals(newBillsIncludedList, propertyOwnership.tenancyDetails.customBillsIncluded)
         }
 
         @Test
@@ -1134,7 +1140,7 @@ class PropertyOwnershipServiceTests {
             // Arrange
             val propertyOwnership =
                 MockLandlordData.createOccupiedPropertyOwnership()
-            whenever(mockPropertyOwnershipRepository.findByIdAndIsActiveTrue(propertyOwnership.id)).thenReturn(
+            whenever(mockPropertyOwnershipRepository.findByIdAndLandlordship_IsActiveTrue(propertyOwnership.id)).thenReturn(
                 propertyOwnership,
             )
 
@@ -1167,7 +1173,7 @@ class PropertyOwnershipServiceTests {
                     furnishedStatus = FurnishedStatus.FURNISHED,
                 )
             val newFurnishedStatus = FurnishedStatus.PART_FURNISHED
-            whenever(mockPropertyOwnershipRepository.findByIdAndIsActiveTrue(propertyOwnership.id)).thenReturn(
+            whenever(mockPropertyOwnershipRepository.findByIdAndLandlordship_IsActiveTrue(propertyOwnership.id)).thenReturn(
                 propertyOwnership,
             )
 
@@ -1179,7 +1185,7 @@ class PropertyOwnershipServiceTests {
             )
 
             // Assert
-            assertEquals(newFurnishedStatus, propertyOwnership.furnishedStatus)
+            assertEquals(newFurnishedStatus, propertyOwnership.tenancyDetails.furnishedStatus)
         }
 
         @Test
@@ -1187,7 +1193,7 @@ class PropertyOwnershipServiceTests {
             // Arrange
             val propertyOwnership =
                 MockLandlordData.createOccupiedPropertyOwnership()
-            whenever(mockPropertyOwnershipRepository.findByIdAndIsActiveTrue(propertyOwnership.id)).thenReturn(
+            whenever(mockPropertyOwnershipRepository.findByIdAndLandlordship_IsActiveTrue(propertyOwnership.id)).thenReturn(
                 propertyOwnership,
             )
 
@@ -1223,7 +1229,7 @@ class PropertyOwnershipServiceTests {
             val newRentFrequency = RentFrequency.OTHER
             val newCustomRentFrequency = "Every 5 days"
             val newRentAmount = BigDecimal(50)
-            whenever(mockPropertyOwnershipRepository.findByIdAndIsActiveTrue(propertyOwnership.id)).thenReturn(
+            whenever(mockPropertyOwnershipRepository.findByIdAndLandlordship_IsActiveTrue(propertyOwnership.id)).thenReturn(
                 propertyOwnership,
             )
 
@@ -1237,9 +1243,9 @@ class PropertyOwnershipServiceTests {
             )
 
             // Assert
-            assertEquals(newRentFrequency, propertyOwnership.rentFrequency)
-            assertEquals(newCustomRentFrequency, propertyOwnership.customRentFrequency)
-            assertEquals(newRentAmount, propertyOwnership.rentAmount)
+            assertEquals(newRentFrequency, propertyOwnership.tenancyDetails.rentFrequency)
+            assertEquals(newCustomRentFrequency, propertyOwnership.tenancyDetails.customRentFrequency)
+            assertEquals(newRentAmount, propertyOwnership.tenancyDetails.rentAmount)
         }
 
         @Test
@@ -1247,7 +1253,7 @@ class PropertyOwnershipServiceTests {
             // Arrange
             val propertyOwnership =
                 MockLandlordData.createOccupiedPropertyOwnership()
-            whenever(mockPropertyOwnershipRepository.findByIdAndIsActiveTrue(propertyOwnership.id)).thenReturn(
+            whenever(mockPropertyOwnershipRepository.findByIdAndLandlordship_IsActiveTrue(propertyOwnership.id)).thenReturn(
                 propertyOwnership,
             )
 
@@ -1299,7 +1305,7 @@ class PropertyOwnershipServiceTests {
         val baseUserId = "user-id"
 
         whenever(
-            mockPropertyOwnershipRepository.findAllByPrimaryLandlord_BaseUser_IdAndIsActiveTrue(baseUserId),
+            mockPropertyOwnershipRepository.findAllByLandlordship_PrimaryLandlord_BaseUser_IdAndLandlordship_IsActiveTrue(baseUserId),
         ).thenReturn(expectedPropertyOwnerships)
 
         // Act
@@ -1328,7 +1334,9 @@ class PropertyOwnershipServiceTests {
             val unoccupiedProperty = MockLandlordData.createPropertyOwnership(currentNumTenants = 0)
 
             whenever(
-                mockPropertyOwnershipRepository.findAllByPrimaryLandlord_BaseUser_IdAndIsActiveTrue(principalName),
+                mockPropertyOwnershipRepository.findAllByLandlordship_PrimaryLandlord_BaseUser_IdAndLandlordship_IsActiveTrue(
+                    principalName,
+                ),
             ).thenReturn(listOf(unoccupiedProperty, occupiedPropertyWithCompliance, occupiedPropertyWithoutCompliance))
 
             // Act
@@ -1342,7 +1350,9 @@ class PropertyOwnershipServiceTests {
         fun `returns 0 if there are no incomplete compliances for a landlord`() {
             // Arrange
             whenever(
-                mockPropertyOwnershipRepository.findAllByPrimaryLandlord_BaseUser_IdAndIsActiveTrue(principalName),
+                mockPropertyOwnershipRepository.findAllByLandlordship_PrimaryLandlord_BaseUser_IdAndLandlordship_IsActiveTrue(
+                    principalName,
+                ),
             ).thenReturn(emptyList())
 
             // Act
@@ -1359,7 +1369,7 @@ class PropertyOwnershipServiceTests {
 
         @Test
         fun `returns the count from the repository`() {
-            whenever(mockPropertyOwnershipRepository.countByPrimaryLandlord_BaseUser_Id(baseUserId)).thenReturn(3)
+            whenever(mockPropertyOwnershipRepository.countByLandlordship_PrimaryLandlord_BaseUser_Id(baseUserId)).thenReturn(3)
 
             assertEquals(3L, propertyOwnershipService.getPropertyCountForLandlord(baseUserId))
         }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/PropertyRegistrationServiceTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/PropertyRegistrationServiceTests.kt
@@ -77,7 +77,7 @@ class PropertyRegistrationServiceTests {
 
         whenever(mockLandlordRepository.findByBaseUser_Id("baseUserId")).thenReturn(landlord)
         whenever(
-            mockPropertyOwnershipRepository.existsByIsActiveTrueAndAddress_Uprn(registeredAddress.uprn!!),
+            mockPropertyOwnershipRepository.existsByLandlordship_IsActiveTrueAndPropertyDetails_Address_Uprn(registeredAddress.uprn!!),
         ).thenReturn(true)
 
         val errorThrown =
@@ -355,9 +355,9 @@ class PropertyRegistrationServiceTests {
                 registrationNumber = registrationNumber,
             )
 
-        whenever(mockAddressService.findOrCreateAddress(any())).thenReturn(expectedPropertyOwnership.address)
+        whenever(mockAddressService.findOrCreateAddress(any())).thenReturn(expectedPropertyOwnership.propertyDetails.address)
         whenever(mockLandlordRepository.findByBaseUser_Id(any())).thenReturn(landlord)
-        whenever(mockLicenseService.createLicense(any(), any())).thenReturn(expectedPropertyOwnership.license)
+        whenever(mockLicenseService.createLicense(any(), any())).thenReturn(expectedPropertyOwnership.landlordship.license)
         whenever(
             mockPropertyOwnershipService.createPropertyOwnership(
                 ownershipType = any(),
@@ -384,7 +384,7 @@ class PropertyRegistrationServiceTests {
 
         // Act
         propertyRegistrationService.registerProperty(
-            AddressDataModel.fromAddress(expectedPropertyOwnership.address),
+            AddressDataModel.fromAddress(expectedPropertyOwnership.propertyDetails.address),
             PropertyType.DETACHED_HOUSE,
             LicensingType.SELECTIVE_LICENCE,
             "Licence",
@@ -407,9 +407,9 @@ class PropertyRegistrationServiceTests {
             eq(landlord.email),
             argThat<PropertyRegistrationConfirmationEmail> { email ->
                 email.prn == RegistrationNumberDataModel.fromRegistrationNumber(registrationNumber).toString() &&
-                    email.singleLineAddress == expectedPropertyOwnership.address.singleLineAddress &&
+                    email.singleLineAddress == expectedPropertyOwnership.propertyDetails.address.singleLineAddress &&
                     email.prsdUrl == dashboardUri.toString() &&
-                    email.isOccupied == (expectedPropertyOwnership.currentNumTenants > 0)
+                    email.isOccupied == (expectedPropertyOwnership.tenancyDetails.currentNumTenants > 0)
             },
         )
 

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/VirusNotificationEmailHandlerTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/VirusNotificationEmailHandlerTests.kt
@@ -130,7 +130,7 @@ class VirusNotificationEmailHandlerTests {
         val complianceUri = URI("http://example.com/compliance/1")
         whenever(absoluteUrlProvider.buildComplianceInformationUri(ownership.id)).thenReturn(complianceUri)
 
-        whenever(propertyOwnershipRepository.findByIdAndIsActiveTrue(ownership.id)).thenReturn(ownership)
+        whenever(propertyOwnershipRepository.findByIdAndLandlordship_IsActiveTrue(ownership.id)).thenReturn(ownership)
 
         return Pair(
             ownership.id,

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/urlProviders/LandlordDashboardUrlTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/urlProviders/LandlordDashboardUrlTests.kt
@@ -183,7 +183,7 @@ class LandlordDashboardUrlTests(
                 propertyComplianceService = mock(),
             )
 
-        whenever(mockLandlordRepository.findByBaseUser_Id(any())).thenReturn(propertyOwnership.primaryLandlord)
+        whenever(mockLandlordRepository.findByBaseUser_Id(any())).thenReturn(propertyOwnership.landlordship.primaryLandlord)
         whenever(
             mockPropertyOwnershipService.createPropertyOwnership(
                 anyOrNull(),
@@ -213,22 +213,22 @@ class LandlordDashboardUrlTests(
 
         // Act
         propertyRegistrationService.registerProperty(
-            addressModel = AddressDataModel.fromAddress(propertyOwnership.address),
-            propertyType = propertyOwnership.propertyBuildType,
-            customPropertyType = propertyOwnership.customPropertyType,
-            licenseType = propertyOwnership.license?.licenseType ?: LicensingType.NO_LICENSING,
-            licenceNumber = propertyOwnership.license?.licenseNumber ?: "",
-            ownershipType = propertyOwnership.ownershipType,
-            numberOfHouseholds = propertyOwnership.currentNumHouseholds,
-            numberOfPeople = propertyOwnership.currentNumTenants,
-            baseUserId = propertyOwnership.primaryLandlord.baseUser.id,
-            numBedrooms = propertyOwnership.numBedrooms,
-            billsIncludedList = propertyOwnership.billsIncludedList,
-            customBillsIncluded = propertyOwnership.customBillsIncluded,
-            furnishedStatus = propertyOwnership.furnishedStatus,
-            rentFrequency = propertyOwnership.rentFrequency,
-            customRentFrequency = propertyOwnership.customRentFrequency,
-            rentAmount = propertyOwnership.rentAmount,
+            addressModel = AddressDataModel.fromAddress(propertyOwnership.propertyDetails.address),
+            propertyType = propertyOwnership.propertyDetails.propertyBuildType,
+            customPropertyType = propertyOwnership.propertyDetails.customPropertyType,
+            licenseType = propertyOwnership.landlordship.license?.licenseType ?: LicensingType.NO_LICENSING,
+            licenceNumber = propertyOwnership.landlordship.license?.licenseNumber ?: "",
+            ownershipType = propertyOwnership.landlordship.ownershipType,
+            numberOfHouseholds = propertyOwnership.tenancyDetails.currentNumHouseholds,
+            numberOfPeople = propertyOwnership.tenancyDetails.currentNumTenants,
+            baseUserId = propertyOwnership.landlordship.primaryLandlord.baseUser.id,
+            numBedrooms = propertyOwnership.propertyDetails.numBedrooms,
+            billsIncludedList = propertyOwnership.tenancyDetails.billsIncludedList,
+            customBillsIncluded = propertyOwnership.tenancyDetails.customBillsIncluded,
+            furnishedStatus = propertyOwnership.tenancyDetails.furnishedStatus,
+            rentFrequency = propertyOwnership.tenancyDetails.rentFrequency,
+            customRentFrequency = propertyOwnership.tenancyDetails.customRentFrequency,
+            rentAmount = propertyOwnership.tenancyDetails.rentAmount,
         )
 
         // Assert


### PR DESCRIPTION
## Ticket number

PDJB-NONE

## Goal of change

Improve separation of concerns within the PropertyOwnership entity by decomposing its fields into focused @Embeddable value objects.

## Description of main change(s)

- Extracts ownership-related fields (ownershipType, isActive, registrationNumber, primaryLandlord, license) into a new `Landlordship` @Embeddable class
- Extracts property characteristic fields (address, propertyBuildType, numBedrooms, customPropertyType) into a new `PropertyDetails` @Embeddable class
- Extracts tenancy/rent fields (currentNumHouseholds, currentNumTenants, lastOccupiedDate, furnishedStatus, rentFrequency, rentAmount, etc.) into a new `TenancyDetails` @Embeddable class
- Updates all repository query method names to use embedded path notation (e.g. `existsByLandlordship_IsActiveTrueAndPropertyDetails_Address_Uprn`)
- Updates all service, controller, and view model field access paths throughout the codebase
- No database migration required — @Embeddable does not change the table structure

## Anything you'd like to highlight to the reviewer?

This is PR 1 of 2 for the property entity decomposition. PR 2 will decompose PropertyCompliance similarly.

The PropertyOwnership constructor signature is preserved for backward compatibility — it delegates internally to the embeddable constructors.

## Checklist

- [x] Test suite has been run in full locally and is passing
- [x] Branch has been rebased onto main and run locally, with everything working as expected