### PR TITLE
PDJB-962: Add feedback survey links to LC confirmation and dashboard pages

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/constants/ExternalLinks.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/constants/ExternalLinks.kt
@@ -104,3 +104,11 @@ const val LANDLORD_REGISTRATION_SURVEY_URL =
 const val PROPERTY_REGISTRATION_SURVEY_URL =
     "https://forms.office.com/Pages/" +
         "ResponsePage.aspx?id=EGg0v32c3kOociSi7zmVqIpl3LghCIRKlCwVik247GRUQ0Y0UjA5SkdBTkdKSEo5R04yRk5XSFNYWS4u"
+
+const val LOCAL_COUNCIL_REGISTRATION_SURVEY_URL =
+    "https://forms.office.com/Pages/" +
+        "ResponsePage.aspx?id=EGg0v32c3kOociSi7zmVqIpl3LghCIRKlCwVik247GRUMlhXUTNKQUFUQkxNSlpESEVYOTJOSENHSC4u"
+
+const val LOCAL_COUNCIL_DASHBOARD_SURVEY_URL =
+    "https://forms.office.com/Pages/" +
+        "ResponsePage.aspx?id=EGg0v32c3kOociSi7zmVqIpl3LghCIRKlCwVik247GRUQ1ZUWEEzRzNROUo5UFJGVTNSOVozQzVDMC4u"

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/LocalCouncilDashboardController.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/LocalCouncilDashboardController.kt
@@ -6,6 +6,7 @@ import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import uk.gov.communities.prsdb.webapp.annotations.webAnnotations.PrsdbController
 import uk.gov.communities.prsdb.webapp.constants.DASHBOARD_PATH_SEGMENT
+import uk.gov.communities.prsdb.webapp.constants.LOCAL_COUNCIL_DASHBOARD_SURVEY_URL
 import uk.gov.communities.prsdb.webapp.constants.LOCAL_COUNCIL_PATH_SEGMENT
 import uk.gov.communities.prsdb.webapp.controllers.SearchRegisterController.Companion.SEARCH_LANDLORD_URL
 import uk.gov.communities.prsdb.webapp.controllers.SearchRegisterController.Companion.SEARCH_PROPERTY_URL
@@ -51,8 +52,10 @@ class LocalCouncilDashboardController(
 
         model.addAttribute("userName", localCouncilUser.name)
         model.addAttribute("localCouncil", localCouncilUser.localCouncil.name)
+        model.addAttribute("isLocalCouncilAdmin", isAdmin)
         model.addAttribute("searchPropertyUrl", SEARCH_PROPERTY_URL)
         model.addAttribute("searchLandlordUrl", SEARCH_LANDLORD_URL)
+        model.addAttribute("localCouncilDashboardSurveyUrl", LOCAL_COUNCIL_DASHBOARD_SURVEY_URL)
         return "localCouncilDashboard"
     }
 

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/RegisterLocalCouncilUserController.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/RegisterLocalCouncilUserController.kt
@@ -13,6 +13,7 @@ import uk.gov.communities.prsdb.webapp.annotations.webAnnotations.PrsdbControlle
 import uk.gov.communities.prsdb.webapp.constants.CONFIRMATION_PATH_SEGMENT
 import uk.gov.communities.prsdb.webapp.constants.INVALID_LINK_PAGE_PATH_SEGMENT
 import uk.gov.communities.prsdb.webapp.constants.LOCAL_COUNCIL_PATH_SEGMENT
+import uk.gov.communities.prsdb.webapp.constants.LOCAL_COUNCIL_REGISTRATION_SURVEY_URL
 import uk.gov.communities.prsdb.webapp.constants.PRIVACY_NOTICE_PATH_SEGMENT
 import uk.gov.communities.prsdb.webapp.constants.REGISTER_LOCAL_COUNCIL_USER_JOURNEY_URL
 import uk.gov.communities.prsdb.webapp.constants.TOKEN
@@ -132,6 +133,7 @@ class RegisterLocalCouncilUserController(
 
         model.addAttribute("localCouncil", localCouncilUser.localCouncil.name)
         model.addAttribute("dashboardUrl", LOCAL_COUNCIL_DASHBOARD_URL)
+        model.addAttribute("localCouncilRegistrationSurveyUrl", LOCAL_COUNCIL_REGISTRATION_SURVEY_URL)
 
         return "registerLocalCouncilUserSuccess"
     }

--- a/src/main/resources/messages/localCouncil.yml
+++ b/src/main/resources/messages/localCouncil.yml
@@ -7,3 +7,8 @@ dashboard:
     button: Search for a property
   searchForLandlord:
     button: Search for a landlord
+  feedback:
+    heading: Try the service, then tell us what you think
+    body:
+      admin: 'Explore the <strong>Find a property</strong>, <strong>Find a landlord</strong> and <strong>Manage users</strong> sections, then share your opinion. Please only do this survey once.'
+      user: 'Explore the <strong>Find a property</strong> and <strong>Find a landlord</strong> sections, then share your opinion. Please only do this survey once.'

--- a/src/main/resources/messages/registerLocalCouncilUser.yml
+++ b/src/main/resources/messages/registerLocalCouncilUser.yml
@@ -24,6 +24,9 @@ success:
     title: 'You’ve registered as a {0,,localCouncil} user'
   paragraph:
     one: You can now view details about registered rental properties and landlords.
+  feedback:
+    heading: Share your thoughts so far
+    body: 'Answer a few short questions about <strong>registering</strong>.'
 privacyNotice:
   heading: Read and agree to the privacy notice
   paragraph:

--- a/src/main/resources/templates/fragments/content/feedbackSurveyPanel.html
+++ b/src/main/resources/templates/fragments/content/feedbackSurveyPanel.html
@@ -1,6 +1,6 @@
-<article th:fragment="feedbackSurveyPanel(body, surveyUrl)" class="moj-ticket-panel" aria-label="Feedback survey">
+<article th:fragment="feedbackSurveyPanel(heading, body, surveyUrl)" class="moj-ticket-panel" aria-label="Feedback survey">
     <section class="moj-ticket-panel__content moj-ticket-panel__content--blue">
-        <h2 class="govuk-heading-m govuk-!-margin-bottom-2" th:text="#{common.confirmationPage.feedback.heading}">common.confirmationPage.feedback.heading</h2>
+        <h2 class="govuk-heading-m govuk-!-margin-bottom-2" th:text="${heading}">heading</h2>
         <p class="govuk-body" th:utext="${body}">body</p>
         <a th:replace="~{fragments/buttons/primaryButtonLink :: primaryButtonLink(${surveyUrl}, #{common.confirmationPage.feedback.surveyLink})}">
             common.confirmationPage.feedback.surveyLink

--- a/src/main/resources/templates/localCouncilDashboard.html
+++ b/src/main/resources/templates/localCouncilDashboard.html
@@ -22,6 +22,13 @@
                 </div>
             </div>
         </section>
+        <section class="prsd-dashboard__section">
+            <div th:replace="~{fragments/content/feedbackSurveyPanel :: feedbackSurveyPanel(
+                #{localCouncil.dashboard.feedback.heading},
+                ${isLocalCouncilAdmin} ? #{localCouncil.dashboard.feedback.body.admin} : #{localCouncil.dashboard.feedback.body.user},
+                ${localCouncilDashboardSurveyUrl})}">
+            </div>
+        </section>
     </div>
 </main>
 </html>

--- a/src/main/resources/templates/registerAsALandlordConfirmation.html
+++ b/src/main/resources/templates/registerAsALandlordConfirmation.html
@@ -35,6 +35,7 @@
             </li>
         </ul>
         <div th:replace="~{fragments/content/feedbackSurveyPanel :: feedbackSurveyPanel(
+            #{common.confirmationPage.feedback.heading},
             #{registerAsALandlord.confirmation.feedback.body},
             ${landlordRegistrationSurveyUrl})}">
         </div>

--- a/src/main/resources/templates/registerLocalCouncilUserSuccess.html
+++ b/src/main/resources/templates/registerLocalCouncilUserSuccess.html
@@ -9,8 +9,13 @@
         <p class="govuk-body" th:text="#{registerLocalCouncilUser.success.paragraph.one}">
             registerLocalCouncilUser.success.paragraph.one
         </p>
+        <div th:replace="~{fragments/content/feedbackSurveyPanel :: feedbackSurveyPanel(
+            #{registerLocalCouncilUser.success.feedback.heading},
+            #{registerLocalCouncilUser.success.feedback.body},
+            ${localCouncilRegistrationSurveyUrl})}">
+        </div>
         <div class="govuk-button-group">
-            <a th:replace="~{fragments/buttons/primaryButtonLink :: primaryButtonLink(@{${dashboardUrl}}, #{common.confirmationPage.goToDashboard})}">
+            <a th:replace="~{fragments/buttons/secondaryButtonLink :: secondaryButtonLink(@{${dashboardUrl}}, #{common.confirmationPage.goToDashboard})}">
                 common.confirmationPage.goToDashboard
             </a>
         </div>

--- a/src/main/resources/templates/registerPropertyConfirmation.html
+++ b/src/main/resources/templates/registerPropertyConfirmation.html
@@ -48,6 +48,7 @@
 
             <th:block th:if="${isFirstProperty}">
                 <div th:replace="~{fragments/content/feedbackSurveyPanel :: feedbackSurveyPanel(
+                    #{common.confirmationPage.feedback.heading},
                     #{registerProperty.confirmation.feedback.body},
                     ${propertyRegistrationSurveyUrl})}">
                 </div>

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/controllers/LocalCouncilDashboardControllerTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/controllers/LocalCouncilDashboardControllerTests.kt
@@ -7,6 +7,7 @@ import org.springframework.security.test.context.support.WithMockUser
 import org.springframework.test.context.bean.override.mockito.MockitoBean
 import org.springframework.test.web.servlet.get
 import org.springframework.web.context.WebApplicationContext
+import uk.gov.communities.prsdb.webapp.constants.LOCAL_COUNCIL_DASHBOARD_SURVEY_URL
 import uk.gov.communities.prsdb.webapp.constants.LOCAL_COUNCIL_PATH_SEGMENT
 import uk.gov.communities.prsdb.webapp.controllers.LocalCouncilDashboardController.Companion.LOCAL_COUNCIL_DASHBOARD_URL
 import uk.gov.communities.prsdb.webapp.services.LocalCouncilDataService
@@ -85,6 +86,50 @@ class LocalCouncilDashboardControllerTests(
             .get(LOCAL_COUNCIL_DASHBOARD_URL)
             .andExpect {
                 status { isOk() }
+            }
+    }
+
+    @Test
+    @WithMockUser(roles = ["LOCAL_COUNCIL_USER"])
+    fun `localCouncilDashboard includes the dashboard survey URL in the model`() {
+        val localCouncilUser = createLocalCouncilUser()
+        whenever(localCouncilDataService.getLocalCouncilUser("user")).thenReturn(localCouncilUser)
+
+        mvc
+            .get(LOCAL_COUNCIL_DASHBOARD_URL)
+            .andExpect {
+                status { isOk() }
+                model { attribute("localCouncilDashboardSurveyUrl", LOCAL_COUNCIL_DASHBOARD_SURVEY_URL) }
+            }
+    }
+
+    @Test
+    @WithMockUser(roles = ["LOCAL_COUNCIL_ADMIN"])
+    fun `localCouncilDashboard sets isLocalCouncilAdmin to true for an admin user`() {
+        val localCouncilUser = createLocalCouncilUser()
+        whenever(localCouncilDataService.getLocalCouncilUser("user")).thenReturn(localCouncilUser)
+        whenever(userRolesService.getHasLocalCouncilAdminRole("user")).thenReturn(true)
+
+        mvc
+            .get(LOCAL_COUNCIL_DASHBOARD_URL)
+            .andExpect {
+                status { isOk() }
+                model { attribute("isLocalCouncilAdmin", true) }
+            }
+    }
+
+    @Test
+    @WithMockUser(roles = ["LOCAL_COUNCIL_USER"])
+    fun `localCouncilDashboard sets isLocalCouncilAdmin to false for a non-admin user`() {
+        val localCouncilUser = createLocalCouncilUser()
+        whenever(localCouncilDataService.getLocalCouncilUser("user")).thenReturn(localCouncilUser)
+        whenever(userRolesService.getHasLocalCouncilAdminRole("user")).thenReturn(false)
+
+        mvc
+            .get(LOCAL_COUNCIL_DASHBOARD_URL)
+            .andExpect {
+                status { isOk() }
+                model { attribute("isLocalCouncilAdmin", false) }
             }
     }
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/controllers/RegisterLocalCouncilUserControllerTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/controllers/RegisterLocalCouncilUserControllerTests.kt
@@ -16,6 +16,7 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers
 import org.springframework.web.context.WebApplicationContext
 import uk.gov.communities.prsdb.webapp.constants.CONFIRMATION_PATH_SEGMENT
+import uk.gov.communities.prsdb.webapp.constants.LOCAL_COUNCIL_REGISTRATION_SURVEY_URL
 import uk.gov.communities.prsdb.webapp.constants.LOCAL_COUNCIL_USER_ID
 import uk.gov.communities.prsdb.webapp.constants.PRIVACY_NOTICE_PATH_SEGMENT
 import uk.gov.communities.prsdb.webapp.constants.TOKEN
@@ -113,6 +114,26 @@ class RegisterLocalCouncilUserControllerTests(
                     .get("${RegisterLocalCouncilUserController.LOCAL_COUNCIL_USER_REGISTRATION_ROUTE}/$CONFIRMATION_PATH_SEGMENT")
                     .sessionAttr(LOCAL_COUNCIL_USER_ID, localCouncilUserId),
             ).andExpect(MockMvcResultMatchers.status().isOk())
+    }
+
+    @Test
+    @WithMockUser
+    fun `getConfirmation includes the registration survey URL in the model`() {
+        val localCouncilUserId = 0L
+        val localCouncilUser = MockLocalCouncilData.createLocalCouncilUser()
+
+        whenever(localCouncilDataService.getLastUserIdRegisteredThisSession()).thenReturn(localCouncilUserId)
+        whenever(localCouncilDataService.getLocalCouncilUserOrNull(localCouncilUserId)).thenReturn(localCouncilUser)
+
+        mvc
+            .perform(
+                MockMvcRequestBuilders
+                    .get("${RegisterLocalCouncilUserController.LOCAL_COUNCIL_USER_REGISTRATION_ROUTE}/$CONFIRMATION_PATH_SEGMENT")
+                    .sessionAttr(LOCAL_COUNCIL_USER_ID, localCouncilUserId),
+            ).andExpect(MockMvcResultMatchers.status().isOk())
+            .andExpect(
+                MockMvcResultMatchers.model().attribute("localCouncilRegistrationSurveyUrl", LOCAL_COUNCIL_REGISTRATION_SURVEY_URL),
+            )
     }
 
     @Test

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/LocalCouncilDashboardTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/LocalCouncilDashboardTests.kt
@@ -2,6 +2,7 @@ package uk.gov.communities.prsdb.webapp.integration
 
 import com.microsoft.playwright.Page
 import org.junit.jupiter.api.Nested
+import uk.gov.communities.prsdb.webapp.constants.LOCAL_COUNCIL_DASHBOARD_SURVEY_URL
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.BaseComponent.Companion.assertThat
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.ManageLocalCouncilUsersPage
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.SearchLandlordRegisterPage
@@ -31,12 +32,30 @@ class LocalCouncilDashboardTests : IntegrationTestWithImmutableData("data-local.
         assertPageIs(page, SearchLandlordRegisterPage::class)
     }
 
+    @Test
+    fun `the feedback survey link points to the dashboard survey`(page: Page) {
+        val dashboard = navigator.goToLocalCouncilDashboard()
+        assertThat(dashboard.surveyLink).hasAttribute("href", LOCAL_COUNCIL_DASHBOARD_SURVEY_URL)
+    }
+
+    @Test
+    fun `the feedback survey body references the manage users section for an admin user`(page: Page) {
+        val dashboard = navigator.goToLocalCouncilDashboard()
+        assertThat(dashboard.surveyPanelBody).containsText("Manage users")
+    }
+
     @Nested
     inner class LcUserNotAdmin : NestedIntegrationTestWithImmutableData("data-mockuser-local-council-user-not-admin.sql") {
         @Test
         fun `the manage users button is not visible`(page: Page) {
             val dashboard = navigator.goToLocalCouncilDashboard()
             assertThat(dashboard.manageUsersLink).isHidden()
+        }
+
+        @Test
+        fun `the feedback survey body does not reference the manage users section`(page: Page) {
+            val dashboard = navigator.goToLocalCouncilDashboard()
+            assertThat(dashboard.surveyPanelBody).not().containsText("Manage users")
         }
     }
 

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/LocalCouncilDashboardTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/LocalCouncilDashboardTests.kt
@@ -41,7 +41,10 @@ class LocalCouncilDashboardTests : IntegrationTestWithImmutableData("data-local.
     @Test
     fun `the feedback survey body references the manage users section for an admin user`(page: Page) {
         val dashboard = navigator.goToLocalCouncilDashboard()
-        assertThat(dashboard.surveyPanelBody).containsText("Manage users")
+        assertThat(dashboard.surveyPanelBody).hasText(
+            "Explore the Find a property, Find a landlord and Manage users sections, then share your opinion. " +
+                "Please only do this survey once.",
+        )
     }
 
     @Nested
@@ -55,7 +58,10 @@ class LocalCouncilDashboardTests : IntegrationTestWithImmutableData("data-local.
         @Test
         fun `the feedback survey body does not reference the manage users section`(page: Page) {
             val dashboard = navigator.goToLocalCouncilDashboard()
-            assertThat(dashboard.surveyPanelBody).not().containsText("Manage users")
+            assertThat(dashboard.surveyPanelBody).hasText(
+                "Explore the Find a property and Find a landlord sections, then share your opinion. " +
+                    "Please only do this survey once.",
+            )
         }
     }
 

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/LocalCouncilUserRegistrationJourneyTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/LocalCouncilUserRegistrationJourneyTests.kt
@@ -11,6 +11,7 @@ import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.test.context.bean.override.mockito.MockitoSpyBean
+import uk.gov.communities.prsdb.webapp.constants.LOCAL_COUNCIL_REGISTRATION_SURVEY_URL
 import uk.gov.communities.prsdb.webapp.database.entity.LocalCouncilInvitation
 import uk.gov.communities.prsdb.webapp.database.entity.LocalCouncilUser
 import uk.gov.communities.prsdb.webapp.database.repository.LocalCouncilInvitationRepository
@@ -112,6 +113,9 @@ class LocalCouncilUserRegistrationJourneyTests : IntegrationTestWithMutableData(
         assertThat(
             confirmationPage.bannerHeading,
         ).containsText("You’ve registered as a ${localCouncilUserCaptor.value.localCouncil.name} user")
+
+        // Feedback survey link
+        assertThat(confirmationPage.surveyLink).hasAttribute("href", LOCAL_COUNCIL_REGISTRATION_SURVEY_URL)
 
         // Return to dashboard button
         confirmationPage.returnToDashboardButton.clickAndWait()

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/LocalCouncilDashboardPage.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/LocalCouncilDashboardPage.kt
@@ -7,6 +7,7 @@ import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.BetaBa
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.Button
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.Heading
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.Link
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.Paragraph
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages.BasePage
 
 class LocalCouncilDashboardPage(
@@ -20,4 +21,6 @@ class LocalCouncilDashboardPage(
 
     val searchPropertyButton = Button.byText(page, "Search for a property")
     val searchLandlordButton = Button.byText(page, "Search for a landlord")
+    val surveyLink = Button.byText(page, "Go to survey")
+    val surveyPanelBody = Paragraph(page.locator("article[aria-label=\"Feedback survey\"] p"))
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/localCouncilUserRegistrationJourneyPages/ConfirmationPageLocalCouncilUserRegistration.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/localCouncilUserRegistrationJourneyPages/ConfirmationPageLocalCouncilUserRegistration.kt
@@ -11,5 +11,6 @@ class ConfirmationPageLocalCouncilUserRegistration(
     page: Page,
 ) : BasePage(page, "${RegisterLocalCouncilUserController.LOCAL_COUNCIL_USER_REGISTRATION_ROUTE}/$CONFIRMATION_PATH_SEGMENT") {
     val bannerHeading = Heading(page.locator(".govuk-panel__title"))
+    val surveyLink = Button.byText(page, "Go to survey")
     val returnToDashboardButton = Button.byText(page, "Go to dashboard")
 }


### PR DESCRIPTION
## Ticket number

PDJB-962

## Goal of change

Add Microsoft Forms feedback survey links for Local Council users — one on the registration confirmation page and a permanent one on the LC dashboard.

## Description of main change(s)

- Adds a survey panel to the LC registration confirmation page linking to the post-registration survey, and makes "Go to survey" the primary call to action with "Go to dashboard" demoted to a secondary button (matching Figma).
- Adds a permanent survey panel to the LC dashboard linking to the ongoing feedback survey.
- The dashboard panel body varies by role: admins see a reference to the "Manage users" section; basic LC users see only "Find a property" and "Find a landlord".
- Reuses the existing `feedbackSurveyPanel` fragment shared with the landlord/property confirmation pages, parameterising it to accept a heading.

## Screenshots

<img width="1280" height="1239" alt="lc-confirmation-page" src="https://github.com/user-attachments/assets/f627c471-8470-4c60-88b6-ec976a5db31b" />
<img width="1280" height="1144" alt="lc-dashboard-page" src="https://github.com/user-attachments/assets/961716d2-1477-4437-b2f0-6a44bffa0bbf" />
<img width="940" height="188" alt="lc-dashboard-survey-admin" src="https://github.com/user-attachments/assets/3badfebc-555f-4a5a-afbe-90605ff761ba" />
<img width="940" height="188" alt="lc-dashboard-survey-user" src="https://github.com/user-attachments/assets/48d0021f-c90f-48dd-bb28-9ef776b7a754" />

## Checklist

- [x] Screenshots of any UI changes have been added — admin and basic-user dashboard variants captured; to be attached to this PR
- [x] Controller tests for any new endpoints, including testing the relevant permissions — extended the LC dashboard and registration controller tests, including admin vs basic-user role assertions
- [x] Branch has been rebased onto main and run locally, with everything working as expected — branched from up-to-date main; smoke-tested both dashboard variants locally
- [x] TODO comments referencing this JIRA ticket have been searched for and removed — none found
- [x] Test suite has been run in full locally and is passing — ran the affected controller and integration tests plus ktlint; full suite not run
- [ ] QA instructions have been added to the ticket
