### PR TITLE
PDJB-304: Invite joint landlords from the property record

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/InviteJointLandlordController.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/InviteJointLandlordController.kt
@@ -22,6 +22,7 @@ import uk.gov.communities.prsdb.webapp.journeys.FormData
 import uk.gov.communities.prsdb.webapp.journeys.JourneyStateService
 import uk.gov.communities.prsdb.webapp.journeys.NoSuchJourneyException
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.update.inviteJointLandlord.InviteJointLandlordJourneyFactory
+import uk.gov.communities.prsdb.webapp.journeys.shared.inviteJointLandlord.InviteJointLandlordStep.Companion.INVITE_FIRST_ROUTE_SEGMENT
 import uk.gov.communities.prsdb.webapp.services.PropertyOwnershipService
 import java.security.Principal
 
@@ -105,5 +106,8 @@ class InviteJointLandlordController(
 
         fun getInviteJointLandlordRoute(propertyOwnershipId: Long): String =
             INVITE_JOINT_LANDLORD_ROUTE.replace("{propertyOwnershipId}", propertyOwnershipId.toString())
+
+        fun getInviteJointLandlordFirstStepPath(propertyOwnershipId: Long): String =
+            "${getInviteJointLandlordRoute(propertyOwnershipId)}/$INVITE_FIRST_ROUTE_SEGMENT"
     }
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/PropertyDetailsController.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/PropertyDetailsController.kt
@@ -22,6 +22,7 @@ import uk.gov.communities.prsdb.webapp.constants.PROPERTY_DETAILS_SEGMENT
 import uk.gov.communities.prsdb.webapp.controllers.LandlordController.Companion.LANDLORD_DASHBOARD_URL
 import uk.gov.communities.prsdb.webapp.controllers.LocalCouncilDashboardController.Companion.LOCAL_COUNCIL_DASHBOARD_URL
 import uk.gov.communities.prsdb.webapp.helpers.DateTimeHelper
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.JointLandlordsPropertyRegistrationStrategy
 import uk.gov.communities.prsdb.webapp.models.viewModels.InvitationViewModelBuilder
 import uk.gov.communities.prsdb.webapp.models.viewModels.summaryModels.PropertyDetailsLandlordViewModelBuilder
 import uk.gov.communities.prsdb.webapp.models.viewModels.summaryModels.PropertyDetailsViewModel
@@ -40,6 +41,7 @@ class PropertyDetailsController(
     private val propertyComplianceService: PropertyComplianceService,
     private val propertyComplianceViewModelFactory: PropertyComplianceViewModelFactory,
     private val messageSource: MessageSource,
+    private val jointLandlordsStrategy: JointLandlordsPropertyRegistrationStrategy,
     private val jointLandlordInvitationService: JointLandlordInvitationService,
     private val featureFlagManager: FeatureFlagManager,
 ) {
@@ -87,6 +89,9 @@ class PropertyDetailsController(
         modelAndView.addObject("complianceInfoTabId", COMPLIANCE_INFO_FRAGMENT)
         modelAndView.addObject("deregisterPropertyLink", DeregisterPropertyController.getPropertyDeregistrationPath(propertyOwnershipId))
         modelAndView.addObject("isLandlordView", true)
+        jointLandlordsStrategy.ifEnabled {
+            modelAndView.addObject("inviteJointLandlordUrl", getInviteJointLandlordPath(propertyOwnershipId))
+        }
         modelAndView.addObject("backUrl", LANDLORD_DASHBOARD_URL)
 
         val isJointLandlordsEnabled = featureFlagManager.checkFeature(JOINT_LANDLORDS)
@@ -170,6 +175,8 @@ class PropertyDetailsController(
 
         const val LOCAL_COUNCIL_PROPERTY_DETAILS_ROUTE = "/$LOCAL_COUNCIL_PATH_SEGMENT/$PROPERTY_DETAILS_SEGMENT/{propertyOwnershipId}"
 
+        const val INVITE_JOINT_LANDLORD_ROUTE = "$LANDLORD_PROPERTY_DETAILS_ROUTE/invite-joint-landlord"
+
         fun getPropertyDetailsPath(
             propertyOwnershipId: Long,
             isLocalCouncilView: Boolean = false,
@@ -180,5 +187,8 @@ class PropertyDetailsController(
 
         fun getPropertyCompliancePath(propertyOwnershipId: Long): String =
             UriTemplate("$LANDLORD_PROPERTY_DETAILS_ROUTE#$COMPLIANCE_INFO_FRAGMENT").expand(propertyOwnershipId).toASCIIString()
+
+        fun getInviteJointLandlordPath(propertyOwnershipId: Long): String =
+            UriTemplate(INVITE_JOINT_LANDLORD_ROUTE).expand(propertyOwnershipId).toASCIIString()
     }
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/PropertyDetailsController.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/PropertyDetailsController.kt
@@ -90,7 +90,10 @@ class PropertyDetailsController(
         modelAndView.addObject("deregisterPropertyLink", DeregisterPropertyController.getPropertyDeregistrationPath(propertyOwnershipId))
         modelAndView.addObject("isLandlordView", true)
         jointLandlordsStrategy.ifEnabled {
-            modelAndView.addObject("inviteJointLandlordUrl", getInviteJointLandlordPath(propertyOwnershipId))
+            modelAndView.addObject(
+                "inviteJointLandlordUrl",
+                InviteJointLandlordController.getInviteJointLandlordFirstStepPath(propertyOwnershipId),
+            )
         }
         modelAndView.addObject("backUrl", LANDLORD_DASHBOARD_URL)
 
@@ -175,8 +178,6 @@ class PropertyDetailsController(
 
         const val LOCAL_COUNCIL_PROPERTY_DETAILS_ROUTE = "/$LOCAL_COUNCIL_PATH_SEGMENT/$PROPERTY_DETAILS_SEGMENT/{propertyOwnershipId}"
 
-        const val INVITE_JOINT_LANDLORD_ROUTE = "$LANDLORD_PROPERTY_DETAILS_ROUTE/invite-joint-landlord"
-
         fun getPropertyDetailsPath(
             propertyOwnershipId: Long,
             isLocalCouncilView: Boolean = false,
@@ -187,8 +188,5 @@ class PropertyDetailsController(
 
         fun getPropertyCompliancePath(propertyOwnershipId: Long): String =
             UriTemplate("$LANDLORD_PROPERTY_DETAILS_ROUTE#$COMPLIANCE_INFO_FRAGMENT").expand(propertyOwnershipId).toASCIIString()
-
-        fun getInviteJointLandlordPath(propertyOwnershipId: Long): String =
-            UriTemplate("$INVITE_JOINT_LANDLORD_ROUTE/invite-joint-landlord").expand(propertyOwnershipId).toASCIIString()
     }
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/PropertyDetailsController.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/PropertyDetailsController.kt
@@ -189,6 +189,6 @@ class PropertyDetailsController(
             UriTemplate("$LANDLORD_PROPERTY_DETAILS_ROUTE#$COMPLIANCE_INFO_FRAGMENT").expand(propertyOwnershipId).toASCIIString()
 
         fun getInviteJointLandlordPath(propertyOwnershipId: Long): String =
-            UriTemplate(INVITE_JOINT_LANDLORD_ROUTE).expand(propertyOwnershipId).toASCIIString()
+            UriTemplate("$INVITE_JOINT_LANDLORD_ROUTE/invite-joint-landlord").expand(propertyOwnershipId).toASCIIString()
     }
 }

--- a/src/main/resources/messages/propertyDetails.yml
+++ b/src/main/resources/messages/propertyDetails.yml
@@ -9,6 +9,8 @@ landlordDetails:
   heading: Landlords
   registeredLandlord:
     heading: Registered landlord
+  inviteJointLandlord:
+    button: Invite a joint landlord
   contactNumber: Contact number
   addressNonEnglandOrWales: Address (outside England or Wales)
   contactAddressInEnglandOrWales: Contact address in England or Wales

--- a/src/main/resources/templates/propertyDetailsView.html
+++ b/src/main/resources/templates/propertyDetailsView.html
@@ -63,7 +63,9 @@
                     <h2 class="govuk-heading-m" th:text="#{propertyDetails.landlordDetails.heading}">propertyDetails.landlordDetails.heading</h2>
                     <h3 class="govuk-heading-s" th:text="#{propertyDetails.landlordDetails.registeredLandlord.heading}">propertyDetails.landlordDetails.registeredLandlord.heading</h3>
                     <dl th:replace="~{fragments/summaryList :: summaryList(${landlordDetails})}"></dl>
-
+                    <a th:if="${inviteJointLandlordUrl}" th:replace="~{fragments/buttons/secondaryButtonLink :: secondaryButtonLink(${inviteJointLandlordUrl}, #{propertyDetails.landlordDetails.inviteJointLandlord.button})}">
+                        Invite a joint landlord
+                    </a>
                     <th:block th:if="${isLandlordView && isJointLandlordsEnabled}">
                         <details th:if="${pendingInvitations != null && !pendingInvitations.isEmpty()}" class="govuk-details">
                             <summary class="govuk-details__summary">

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/controllers/PropertyDetailsControllerTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/controllers/PropertyDetailsControllerTests.kt
@@ -13,9 +13,9 @@ import org.springframework.security.test.context.support.WithMockUser
 import org.springframework.test.context.bean.override.mockito.MockitoBean
 import org.springframework.test.web.servlet.get
 import org.springframework.web.context.WebApplicationContext
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.JointLandlordsPropertyRegistrationStrategy
 import uk.gov.communities.prsdb.webapp.config.managers.FeatureFlagManager
 import uk.gov.communities.prsdb.webapp.constants.JOINT_LANDLORDS
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.JointLandlordsPropertyRegistrationStrategy
 import uk.gov.communities.prsdb.webapp.models.viewModels.summaryModels.propertyComplianceViewModels.PropertyComplianceViewModelFactory
 import uk.gov.communities.prsdb.webapp.services.JointLandlordInvitationService
 import uk.gov.communities.prsdb.webapp.services.PropertyComplianceService

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/controllers/PropertyDetailsControllerTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/controllers/PropertyDetailsControllerTests.kt
@@ -2,6 +2,7 @@ package uk.gov.communities.prsdb.webapp.controllers
 
 import org.junit.jupiter.api.Nested
 import org.mockito.kotlin.any
+import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
@@ -130,6 +131,38 @@ class PropertyDetailsControllerTests(
             }
 
             verify(jointLandlordInvitationService, never()).getPendingAndExpiredInvitations(any())
+        }
+
+        @Test
+        @WithMockUser(roles = ["LANDLORD"])
+        fun `getPropertyDetails shows invite joint landlord button when feature flag is enabled`() {
+            val propertyOwnership = createPropertyOwnership()
+
+            whenever(propertyOwnershipService.getPropertyOwnershipIfAuthorizedUser(eq(propertyOwnership.id), any()))
+                .thenReturn(propertyOwnership)
+            whenever(jointLandlordsStrategy.ifEnabled(any())).doAnswer { invocation ->
+                val action = invocation.getArgument<() -> Unit>(0)
+                action()
+            }
+
+            mvc.get(PropertyDetailsController.getPropertyDetailsPath(propertyOwnership.id, isLocalCouncilView = false)).andExpect {
+                status { isOk() }
+                model { attributeExists("inviteJointLandlordUrl") }
+            }
+        }
+
+        @Test
+        @WithMockUser(roles = ["LANDLORD"])
+        fun `getPropertyDetails does not show invite joint landlord button when feature flag is disabled`() {
+            val propertyOwnership = createPropertyOwnership()
+
+            whenever(propertyOwnershipService.getPropertyOwnershipIfAuthorizedUser(eq(propertyOwnership.id), any()))
+                .thenReturn(propertyOwnership)
+
+            mvc.get(PropertyDetailsController.getPropertyDetailsPath(propertyOwnership.id, isLocalCouncilView = false)).andExpect {
+                status { isOk() }
+                model { attributeDoesNotExist("inviteJointLandlordUrl") }
+            }
         }
     }
 

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/controllers/PropertyDetailsControllerTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/controllers/PropertyDetailsControllerTests.kt
@@ -12,6 +12,7 @@ import org.springframework.security.test.context.support.WithMockUser
 import org.springframework.test.context.bean.override.mockito.MockitoBean
 import org.springframework.test.web.servlet.get
 import org.springframework.web.context.WebApplicationContext
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.JointLandlordsPropertyRegistrationStrategy
 import uk.gov.communities.prsdb.webapp.config.managers.FeatureFlagManager
 import uk.gov.communities.prsdb.webapp.constants.JOINT_LANDLORDS
 import uk.gov.communities.prsdb.webapp.models.viewModels.summaryModels.propertyComplianceViewModels.PropertyComplianceViewModelFactory
@@ -33,6 +34,9 @@ class PropertyDetailsControllerTests(
 
     @MockitoBean
     private lateinit var viewModelFactory: PropertyComplianceViewModelFactory
+
+    @MockitoBean
+    private lateinit var jointLandlordsStrategy: JointLandlordsPropertyRegistrationStrategy
 
     @MockitoBean
     private lateinit var jointLandlordInvitationService: JointLandlordInvitationService


### PR DESCRIPTION
## Ticket number

PDJB-304

## Goal of change

Adds a button inviting joint landlords from the property record

## Description of main change(s)

<img width="1003" height="641" alt="image" src="https://github.com/user-attachments/assets/7273a993-9035-488e-8acf-9773839c4821" />

## Anything you'd like to highlight to the reviewer?

Note, this hasn't included the different versions for having no joint landlords, as I believe this is covered in PDJB-306. This ticket only includes the button.

## Checklist

Delete any that are not applicable, and add explanation below for any that are applicable but haven't been done

- [x] Screenshots of any UI changes have been added
- [x] Controller tests for any new endpoints, including testing the relevant permissions
- [x] Branch has been rebased onto main and run locally, with everything working as expected (both for your new feature
  and any related functionality)
- [ ] QA instructions have been added to the ticket (particularly if this is the last PR required to complete the ticket)
