### PR TITLE
PDJB-1033: Add database performance metrics to the metrics dashboard

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/MetricsController.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/MetricsController.kt
@@ -11,17 +11,25 @@ import org.springframework.web.bind.annotation.RequestMapping
 import uk.gov.communities.prsdb.webapp.annotations.webAnnotations.PrsdbController
 import uk.gov.communities.prsdb.webapp.constants.METRICS_PATH_SEGMENT
 import uk.gov.communities.prsdb.webapp.constants.SYSTEM_OPERATOR_PATH_SEGMENT
+import uk.gov.communities.prsdb.webapp.models.dataModels.MetricsDataModel
+import uk.gov.communities.prsdb.webapp.models.dataModels.ReportingPeriod
 import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.MetricsDateRangeFormModel
 import uk.gov.communities.prsdb.webapp.models.viewModels.summaryModels.SummaryListRowViewModel
+import uk.gov.communities.prsdb.webapp.services.MetricsService
+import java.text.NumberFormat
+import java.time.Duration
+import java.util.Locale
 
 @PreAuthorize("hasRole('SYSTEM_OPERATOR')")
 @PrsdbController
 @RequestMapping(MetricsController.METRICS_URL)
-class MetricsController {
+class MetricsController(
+    private val metricsService: MetricsService,
+) {
     @GetMapping
     fun getMetrics(model: Model): String {
         model.addAttribute("formModel", MetricsDateRangeFormModel())
-        addMetricRows(model)
+        model.addAttribute("metricRows", emptyList<SummaryListRowViewModel>())
         return "metrics"
     }
 
@@ -31,12 +39,62 @@ class MetricsController {
         bindingResult: BindingResult,
         model: Model,
     ): String {
-        addMetricRows(model)
+        val metricRows =
+            getReportingPeriodOrNull(bindingResult, formModel)
+                ?.let { period -> getMetricRows(metricsService.getMetrics(period)) }
+                ?: emptyList()
+        model.addAttribute("metricRows", metricRows)
         return "metrics"
     }
 
-    private fun addMetricRows(model: Model) {
-        model.addAttribute("metricRows", emptyList<SummaryListRowViewModel>())
+    private fun getReportingPeriodOrNull(
+        bindingResult: BindingResult,
+        formModel: MetricsDateRangeFormModel,
+    ): ReportingPeriod? {
+        if (bindingResult.hasErrors()) return null
+        val from = formModel.fromLocalDateOrNull() ?: return null
+        val to = formModel.toLocalDateOrNull() ?: return null
+        return ReportingPeriod.fromDateRange(from, to)
+    }
+
+    private fun getMetricRows(metrics: MetricsDataModel): List<SummaryListRowViewModel> =
+        listOf(
+            countRow("metrics.rows.landlordRegistrations", metrics.numberOfLandlordRegistrations),
+            countRow("metrics.rows.properties", metrics.numberOfProperties),
+            countRow("metrics.rows.landlordsWithProperty", metrics.numberOfLandlordsWithAProperty),
+            averageTimeRow(metrics.averageTimeToFirstProperty),
+        )
+
+    private fun countRow(
+        headingKey: String,
+        count: Long,
+    ): SummaryListRowViewModel =
+        SummaryListRowViewModel(
+            fieldHeading = headingKey,
+            fieldValue = NumberFormat.getIntegerInstance(Locale.UK).format(count),
+        )
+
+    private fun averageTimeRow(duration: Duration?): SummaryListRowViewModel {
+        val (valueKey, valueParam) =
+            when {
+                duration == null -> "metrics.saveAndReturn.noData" to null
+                duration.toDays() >= 1 -> pluralisedKey("day", duration.toDays())
+                duration.toHours() >= 1 -> pluralisedKey("hour", duration.toHours())
+                else -> pluralisedKey("minute", duration.toMinutes())
+            }
+        return SummaryListRowViewModel(
+            fieldHeading = "metrics.rows.averageTimeToFirstProperty",
+            fieldValue = valueKey,
+            optionalFieldValueParam = valueParam,
+        )
+    }
+
+    private fun pluralisedKey(
+        unit: String,
+        amount: Long,
+    ): Pair<String, Long> {
+        val key = if (amount == 1L) "metrics.saveAndReturn.$unit" else "metrics.saveAndReturn.${unit}s"
+        return key to amount
     }
 
     companion object {

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/MetricsController.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/MetricsController.kt
@@ -63,7 +63,9 @@ class MetricsController(
             countRow("metrics.rows.verifiedLandlords", metrics.numberOfVerifiedLandlords),
             countRow("metrics.rows.properties", metrics.numberOfProperties),
             countRow("metrics.rows.landlordsWithProperty", metrics.numberOfLandlordsWithAProperty),
-            averageTimeRow(metrics.averageTimeToFirstProperty),
+            durationRow("metrics.rows.medianTimeToFirstProperty", metrics.medianTimeToFirstProperty),
+            durationRow("metrics.rows.p90TimeToFirstProperty", metrics.p90TimeToFirstProperty),
+            durationRow("metrics.rows.p95TimeToFirstProperty", metrics.p95TimeToFirstProperty),
         )
 
     private fun countRow(
@@ -75,7 +77,10 @@ class MetricsController(
             fieldValue = NumberFormat.getIntegerInstance(Locale.UK).format(count),
         )
 
-    private fun averageTimeRow(duration: Duration?): SummaryListRowViewModel {
+    private fun durationRow(
+        headingKey: String,
+        duration: Duration?,
+    ): SummaryListRowViewModel {
         val (valueKey, valueParam) =
             when {
                 duration == null -> "metrics.saveAndReturn.noData" to null
@@ -84,7 +89,7 @@ class MetricsController(
                 else -> pluralisedKey("minute", duration.toMinutes())
             }
         return SummaryListRowViewModel(
-            fieldHeading = "metrics.rows.averageTimeToFirstProperty",
+            fieldHeading = headingKey,
             fieldValue = valueKey,
             optionalFieldValueParam = valueParam,
         )

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/MetricsController.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/MetricsController.kt
@@ -60,6 +60,7 @@ class MetricsController(
     private fun getMetricRows(metrics: MetricsDataModel): List<SummaryListRowViewModel> =
         listOf(
             countRow("metrics.rows.landlordRegistrations", metrics.numberOfLandlordRegistrations),
+            countRow("metrics.rows.verifiedLandlords", metrics.numberOfVerifiedLandlords),
             countRow("metrics.rows.properties", metrics.numberOfProperties),
             countRow("metrics.rows.landlordsWithProperty", metrics.numberOfLandlordsWithAProperty),
             averageTimeRow(metrics.averageTimeToFirstProperty),

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/database/repository/LandlordRepository.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/database/repository/LandlordRepository.kt
@@ -2,6 +2,7 @@ package uk.gov.communities.prsdb.webapp.database.repository
 
 import org.springframework.data.jpa.repository.JpaRepository
 import uk.gov.communities.prsdb.webapp.database.entity.Landlord
+import java.time.Instant
 
 // The underscore tells JPA to access fields relating to the referenced table
 @Suppress("ktlint:standard:function-naming")
@@ -13,4 +14,9 @@ interface LandlordRepository :
     fun findByBaseUser_Id(subjectId: String): Landlord?
 
     fun deleteByBaseUser_Id(subjectId: String)
+
+    fun countByCreatedDateBetween(
+        start: Instant,
+        end: Instant,
+    ): Long
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/database/repository/LandlordRepository.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/database/repository/LandlordRepository.kt
@@ -19,4 +19,9 @@ interface LandlordRepository :
         start: Instant,
         end: Instant,
     ): Long
+
+    fun countByIsVerifiedTrueAndCreatedDateBetween(
+        start: Instant,
+        end: Instant,
+    ): Long
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/database/repository/PropertyOwnershipRepository.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/database/repository/PropertyOwnershipRepository.kt
@@ -48,7 +48,6 @@ interface PropertyOwnershipRepository :
     @Query(
         "SELECT l.createdDate, MIN(po.createdDate) FROM PropertyOwnership po " +
             "JOIN po.landlords l " +
-            "WHERE l.createdDate BETWEEN :start AND :end " +
             "GROUP BY l.id, l.createdDate " +
             "HAVING MIN(po.createdDate) BETWEEN :start AND :end",
     )

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/database/repository/PropertyOwnershipRepository.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/database/repository/PropertyOwnershipRepository.kt
@@ -1,7 +1,10 @@
 package uk.gov.communities.prsdb.webapp.database.repository
 
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
 import uk.gov.communities.prsdb.webapp.database.entity.PropertyOwnership
+import java.time.Instant
 
 // The underscore tells JPA to access fields relating to the referenced table
 @Suppress("ktlint:standard:function-naming")
@@ -26,4 +29,30 @@ interface PropertyOwnershipRepository :
     ): Boolean
 
     fun countByLandlords_BaseUser_Id(userId: String): Long
+
+    fun countByCreatedDateBetween(
+        start: Instant,
+        end: Instant,
+    ): Long
+
+    @Query(
+        "SELECT COUNT(DISTINCT l.id) FROM PropertyOwnership po " +
+            "JOIN po.landlords l " +
+            "WHERE po.createdDate <= :end",
+    )
+    fun countDistinctLandlordsWithPropertyCreatedOnOrBefore(
+        @Param("end") end: Instant,
+    ): Long
+
+    @Query(
+        "SELECT l.createdDate, MIN(po.createdDate) FROM PropertyOwnership po " +
+            "JOIN po.landlords l " +
+            "WHERE l.createdDate BETWEEN :start AND :end " +
+            "GROUP BY l.id, l.createdDate " +
+            "HAVING MIN(po.createdDate) BETWEEN :start AND :end",
+    )
+    fun findLandlordAndFirstPropertyCreatedDates(
+        @Param("start") start: Instant,
+        @Param("end") end: Instant,
+    ): List<Array<Instant>>
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/database/repository/PropertyOwnershipRepository.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/database/repository/PropertyOwnershipRepository.kt
@@ -38,9 +38,10 @@ interface PropertyOwnershipRepository :
     @Query(
         "SELECT COUNT(DISTINCT l.id) FROM PropertyOwnership po " +
             "JOIN po.landlords l " +
-            "WHERE po.createdDate <= :end",
+            "WHERE po.createdDate BETWEEN :start AND :end",
     )
-    fun countDistinctLandlordsWithPropertyCreatedOnOrBefore(
+    fun countDistinctLandlordsWithPropertyCreatedBetween(
+        @Param("start") start: Instant,
         @Param("end") end: Instant,
     ): Long
 

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/dataModels/MetricsDataModel.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/dataModels/MetricsDataModel.kt
@@ -7,5 +7,7 @@ data class MetricsDataModel(
     val numberOfVerifiedLandlords: Long,
     val numberOfProperties: Long,
     val numberOfLandlordsWithAProperty: Long,
-    val averageTimeToFirstProperty: Duration?,
+    val medianTimeToFirstProperty: Duration?,
+    val p90TimeToFirstProperty: Duration?,
+    val p95TimeToFirstProperty: Duration?,
 )

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/dataModels/MetricsDataModel.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/dataModels/MetricsDataModel.kt
@@ -4,6 +4,7 @@ import java.time.Duration
 
 data class MetricsDataModel(
     val numberOfLandlordRegistrations: Long,
+    val numberOfVerifiedLandlords: Long,
     val numberOfProperties: Long,
     val numberOfLandlordsWithAProperty: Long,
     val averageTimeToFirstProperty: Duration?,

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/dataModels/MetricsDataModel.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/dataModels/MetricsDataModel.kt
@@ -1,0 +1,10 @@
+package uk.gov.communities.prsdb.webapp.models.dataModels
+
+import java.time.Duration
+
+data class MetricsDataModel(
+    val numberOfLandlordRegistrations: Long,
+    val numberOfProperties: Long,
+    val numberOfLandlordsWithAProperty: Long,
+    val averageTimeToFirstProperty: Duration?,
+)

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/MetricsService.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/MetricsService.kt
@@ -27,7 +27,7 @@ class MetricsService(
             numberOfProperties =
                 propertyOwnershipRepository.countByCreatedDateBetween(period.start, period.end),
             numberOfLandlordsWithAProperty =
-                propertyOwnershipRepository.countDistinctLandlordsWithPropertyCreatedOnOrBefore(period.end),
+                propertyOwnershipRepository.countDistinctLandlordsWithPropertyCreatedBetween(period.start, period.end),
             medianTimeToFirstProperty = percentile(timesToFirstProperty, 0.5),
             p90TimeToFirstProperty = percentile(timesToFirstProperty, 0.9),
             p95TimeToFirstProperty = percentile(timesToFirstProperty, 0.95),

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/MetricsService.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/MetricsService.kt
@@ -1,0 +1,40 @@
+package uk.gov.communities.prsdb.webapp.services
+
+import jakarta.transaction.Transactional
+import uk.gov.communities.prsdb.webapp.annotations.webAnnotations.PrsdbWebService
+import uk.gov.communities.prsdb.webapp.database.repository.LandlordRepository
+import uk.gov.communities.prsdb.webapp.database.repository.PropertyOwnershipRepository
+import uk.gov.communities.prsdb.webapp.models.dataModels.MetricsDataModel
+import uk.gov.communities.prsdb.webapp.models.dataModels.ReportingPeriod
+import java.time.Duration
+
+@PrsdbWebService
+class MetricsService(
+    private val landlordRepository: LandlordRepository,
+    private val propertyOwnershipRepository: PropertyOwnershipRepository,
+) {
+    @Transactional
+    fun getMetrics(period: ReportingPeriod): MetricsDataModel =
+        MetricsDataModel(
+            numberOfLandlordRegistrations =
+                landlordRepository.countByCreatedDateBetween(period.start, period.end),
+            numberOfProperties =
+                propertyOwnershipRepository.countByCreatedDateBetween(period.start, period.end),
+            numberOfLandlordsWithAProperty =
+                propertyOwnershipRepository.countDistinctLandlordsWithPropertyCreatedOnOrBefore(period.end),
+            averageTimeToFirstProperty = getAverageTimeToFirstProperty(period),
+        )
+
+    private fun getAverageTimeToFirstProperty(period: ReportingPeriod): Duration? {
+        val registrationAndFirstPropertyDates =
+            propertyOwnershipRepository.findLandlordAndFirstPropertyCreatedDates(period.start, period.end)
+        if (registrationAndFirstPropertyDates.isEmpty()) {
+            return null
+        }
+        val totalSeconds =
+            registrationAndFirstPropertyDates.sumOf { (landlordCreatedDate, firstPropertyCreatedDate) ->
+                Duration.between(landlordCreatedDate, firstPropertyCreatedDate).seconds
+            }
+        return Duration.ofSeconds(totalSeconds / registrationAndFirstPropertyDates.size)
+    }
+}

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/MetricsService.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/MetricsService.kt
@@ -7,6 +7,9 @@ import uk.gov.communities.prsdb.webapp.database.repository.PropertyOwnershipRepo
 import uk.gov.communities.prsdb.webapp.models.dataModels.MetricsDataModel
 import uk.gov.communities.prsdb.webapp.models.dataModels.ReportingPeriod
 import java.time.Duration
+import kotlin.math.ceil
+import kotlin.math.floor
+import kotlin.math.roundToLong
 
 @PrsdbWebService
 class MetricsService(
@@ -14,8 +17,9 @@ class MetricsService(
     private val propertyOwnershipRepository: PropertyOwnershipRepository,
 ) {
     @Transactional
-    fun getMetrics(period: ReportingPeriod): MetricsDataModel =
-        MetricsDataModel(
+    fun getMetrics(period: ReportingPeriod): MetricsDataModel {
+        val timesToFirstProperty = getTimesToFirstProperty(period)
+        return MetricsDataModel(
             numberOfLandlordRegistrations =
                 landlordRepository.countByCreatedDateBetween(period.start, period.end),
             numberOfVerifiedLandlords =
@@ -24,19 +28,34 @@ class MetricsService(
                 propertyOwnershipRepository.countByCreatedDateBetween(period.start, period.end),
             numberOfLandlordsWithAProperty =
                 propertyOwnershipRepository.countDistinctLandlordsWithPropertyCreatedOnOrBefore(period.end),
-            averageTimeToFirstProperty = getAverageTimeToFirstProperty(period),
+            medianTimeToFirstProperty = percentile(timesToFirstProperty, 0.5),
+            p90TimeToFirstProperty = percentile(timesToFirstProperty, 0.9),
+            p95TimeToFirstProperty = percentile(timesToFirstProperty, 0.95),
         )
+    }
 
-    private fun getAverageTimeToFirstProperty(period: ReportingPeriod): Duration? {
-        val registrationAndFirstPropertyDates =
-            propertyOwnershipRepository.findLandlordAndFirstPropertyCreatedDates(period.start, period.end)
-        if (registrationAndFirstPropertyDates.isEmpty()) {
-            return null
-        }
-        val totalSeconds =
-            registrationAndFirstPropertyDates.sumOf { (landlordCreatedDate, firstPropertyCreatedDate) ->
-                Duration.between(landlordCreatedDate, firstPropertyCreatedDate).seconds
+    private fun getTimesToFirstProperty(period: ReportingPeriod): List<Duration> =
+        propertyOwnershipRepository
+            .findLandlordAndFirstPropertyCreatedDates(period.start, period.end)
+            .map { (landlordCreatedDate, firstPropertyCreatedDate) ->
+                Duration.between(landlordCreatedDate, firstPropertyCreatedDate)
             }
-        return Duration.ofSeconds(totalSeconds / registrationAndFirstPropertyDates.size)
+
+    private fun percentile(
+        durations: List<Duration>,
+        fraction: Double,
+    ): Duration? {
+        if (durations.isEmpty()) return null
+        val sortedSeconds = durations.map { it.seconds }.sorted()
+        val rank = fraction * (sortedSeconds.size - 1)
+        val lowerIndex = floor(rank).toInt()
+        val upperIndex = ceil(rank).toInt()
+        if (lowerIndex == upperIndex) {
+            return Duration.ofSeconds(sortedSeconds[lowerIndex])
+        }
+        val lowerValue = sortedSeconds[lowerIndex]
+        val upperValue = sortedSeconds[upperIndex]
+        val interpolated = lowerValue + (rank - lowerIndex) * (upperValue - lowerValue)
+        return Duration.ofSeconds(interpolated.roundToLong())
     }
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/MetricsService.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/MetricsService.kt
@@ -18,6 +18,8 @@ class MetricsService(
         MetricsDataModel(
             numberOfLandlordRegistrations =
                 landlordRepository.countByCreatedDateBetween(period.start, period.end),
+            numberOfVerifiedLandlords =
+                landlordRepository.countByIsVerifiedTrueAndCreatedDateBetween(period.start, period.end),
             numberOfProperties =
                 propertyOwnershipRepository.countByCreatedDateBetween(period.start, period.end),
             numberOfLandlordsWithAProperty =

--- a/src/main/resources/messages/metrics.yml
+++ b/src/main/resources/messages/metrics.yml
@@ -17,9 +17,9 @@ rows:
   verifiedLandlords: Landlords verified by One Login
   properties: Number of properties
   landlordsWithProperty: Number of landlords with at least 1 property
-  medianTimeToFirstProperty: Median time between registration and first property
-  p90TimeToFirstProperty: 90th percentile time between registration and first property
-  p95TimeToFirstProperty: 95th percentile time between registration and first property
+  medianTimeToFirstProperty: Median time between registration and first property (does not account for joint landlords)
+  p90TimeToFirstProperty: 90th percentile time between registration and first property (does not account for joint landlords)
+  p95TimeToFirstProperty: 95th percentile time between registration and first property (does not account for joint landlords)
 saveAndReturn:
   day: '{0} day'
   days: '{0} days'

--- a/src/main/resources/messages/metrics.yml
+++ b/src/main/resources/messages/metrics.yml
@@ -17,7 +17,9 @@ rows:
   verifiedLandlords: Landlords verified by One Login
   properties: Number of properties
   landlordsWithProperty: Number of landlords with at least 1 property
-  averageTimeToFirstProperty: Average time between registration and first property
+  medianTimeToFirstProperty: Median time between registration and first property
+  p90TimeToFirstProperty: 90th percentile time between registration and first property
+  p95TimeToFirstProperty: 95th percentile time between registration and first property
 saveAndReturn:
   day: '{0} day'
   days: '{0} days'

--- a/src/main/resources/messages/metrics.yml
+++ b/src/main/resources/messages/metrics.yml
@@ -12,3 +12,16 @@ refreshButton: Refresh
 dateRange:
   error:
     toBeforeFrom: The ‘to’ date must be the same as or after the ‘from’ date
+rows:
+  landlordRegistrations: Number of registrations (landlords)
+  properties: Number of properties
+  landlordsWithProperty: Number of landlords with at least 1 property
+  averageTimeToFirstProperty: Average time between registration and first property
+saveAndReturn:
+  day: '{0} day'
+  days: '{0} days'
+  hour: '{0} hour'
+  hours: '{0} hours'
+  minute: '{0} minute'
+  minutes: '{0} minutes'
+  noData: No data

--- a/src/main/resources/messages/metrics.yml
+++ b/src/main/resources/messages/metrics.yml
@@ -14,6 +14,7 @@ dateRange:
     toBeforeFrom: The ‘to’ date must be the same as or after the ‘from’ date
 rows:
   landlordRegistrations: Number of registrations (landlords)
+  verifiedLandlords: Landlords verified by One Login
   properties: Number of properties
   landlordsWithProperty: Number of landlords with at least 1 property
   averageTimeToFirstProperty: Average time between registration and first property

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/controllers/MetricsControllerTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/controllers/MetricsControllerTests.kt
@@ -120,6 +120,7 @@ class MetricsControllerTests(
         whenever(metricsService.getMetrics(any())).thenReturn(
             MetricsDataModel(
                 numberOfLandlordRegistrations = 0L,
+                numberOfVerifiedLandlords = 0L,
                 numberOfProperties = 0L,
                 numberOfLandlordsWithAProperty = 0L,
                 averageTimeToFirstProperty = null,
@@ -147,10 +148,11 @@ class MetricsControllerTests(
 
     @Test
     @WithMockUser(roles = ["SYSTEM_OPERATOR"])
-    fun `submitMetrics populates four metric rows for a valid date range`() {
+    fun `submitMetrics populates five metric rows for a valid date range`() {
         whenever(metricsService.getMetrics(any())).thenReturn(
             MetricsDataModel(
                 numberOfLandlordRegistrations = 5L,
+                numberOfVerifiedLandlords = 4L,
                 numberOfProperties = 3L,
                 numberOfLandlordsWithAProperty = 2L,
                 averageTimeToFirstProperty = Duration.ofDays(4),
@@ -171,7 +173,7 @@ class MetricsControllerTests(
                 status { isOk() }
                 view { name("metrics") }
                 model {
-                    attribute("metricRows", hasSize<Any>(4))
+                    attribute("metricRows", hasSize<Any>(5))
                 }
             }
     }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/controllers/MetricsControllerTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/controllers/MetricsControllerTests.kt
@@ -123,7 +123,9 @@ class MetricsControllerTests(
                 numberOfVerifiedLandlords = 0L,
                 numberOfProperties = 0L,
                 numberOfLandlordsWithAProperty = 0L,
-                averageTimeToFirstProperty = null,
+                medianTimeToFirstProperty = null,
+                p90TimeToFirstProperty = null,
+                p95TimeToFirstProperty = null,
             ),
         )
 
@@ -148,14 +150,16 @@ class MetricsControllerTests(
 
     @Test
     @WithMockUser(roles = ["SYSTEM_OPERATOR"])
-    fun `submitMetrics populates five metric rows for a valid date range`() {
+    fun `submitMetrics populates seven metric rows for a valid date range`() {
         whenever(metricsService.getMetrics(any())).thenReturn(
             MetricsDataModel(
                 numberOfLandlordRegistrations = 5L,
                 numberOfVerifiedLandlords = 4L,
                 numberOfProperties = 3L,
                 numberOfLandlordsWithAProperty = 2L,
-                averageTimeToFirstProperty = Duration.ofDays(4),
+                medianTimeToFirstProperty = Duration.ofDays(4),
+                p90TimeToFirstProperty = Duration.ofDays(10),
+                p95TimeToFirstProperty = Duration.ofDays(20),
             ),
         )
 
@@ -173,7 +177,7 @@ class MetricsControllerTests(
                 status { isOk() }
                 view { name("metrics") }
                 model {
-                    attribute("metricRows", hasSize<Any>(5))
+                    attribute("metricRows", hasSize<Any>(7))
                 }
             }
     }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/controllers/MetricsControllerTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/controllers/MetricsControllerTests.kt
@@ -1,20 +1,30 @@
 package uk.gov.communities.prsdb.webapp.controllers
 
+import org.hamcrest.Matchers.hasSize
+import org.mockito.kotlin.any
+import org.mockito.kotlin.whenever
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
 import org.springframework.http.MediaType
 import org.springframework.security.test.context.support.WithMockUser
 import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf
+import org.springframework.test.context.bean.override.mockito.MockitoBean
 import org.springframework.test.web.servlet.get
 import org.springframework.test.web.servlet.post
 import org.springframework.web.context.WebApplicationContext
 import uk.gov.communities.prsdb.webapp.controllers.MetricsController.Companion.METRICS_URL
+import uk.gov.communities.prsdb.webapp.models.dataModels.MetricsDataModel
+import uk.gov.communities.prsdb.webapp.services.MetricsService
+import java.time.Duration
 import kotlin.test.Test
 
 @WebMvcTest(MetricsController::class)
 class MetricsControllerTests(
     @Autowired val webContext: WebApplicationContext,
 ) : ControllerTest(webContext) {
+    @MockitoBean
+    lateinit var metricsService: MetricsService
+
     @Test
     fun `getMetrics returns a redirect for unauthenticated user`() {
         mvc
@@ -107,6 +117,15 @@ class MetricsControllerTests(
     @Test
     @WithMockUser(roles = ["SYSTEM_OPERATOR"])
     fun `submitMetrics re-renders the page without errors for a valid date range`() {
+        whenever(metricsService.getMetrics(any())).thenReturn(
+            MetricsDataModel(
+                numberOfLandlordRegistrations = 0L,
+                numberOfProperties = 0L,
+                numberOfLandlordsWithAProperty = 0L,
+                averageTimeToFirstProperty = null,
+            ),
+        )
+
         mvc
             .post(METRICS_URL) {
                 contentType = MediaType.APPLICATION_FORM_URLENCODED
@@ -122,6 +141,58 @@ class MetricsControllerTests(
                 view { name("metrics") }
                 model {
                     attributeHasNoErrors("formModel")
+                }
+            }
+    }
+
+    @Test
+    @WithMockUser(roles = ["SYSTEM_OPERATOR"])
+    fun `submitMetrics populates four metric rows for a valid date range`() {
+        whenever(metricsService.getMetrics(any())).thenReturn(
+            MetricsDataModel(
+                numberOfLandlordRegistrations = 5L,
+                numberOfProperties = 3L,
+                numberOfLandlordsWithAProperty = 2L,
+                averageTimeToFirstProperty = Duration.ofDays(4),
+            ),
+        )
+
+        mvc
+            .post(METRICS_URL) {
+                contentType = MediaType.APPLICATION_FORM_URLENCODED
+                param("fromDay", "10")
+                param("fromMonth", "1")
+                param("fromYear", "2025")
+                param("toDay", "20")
+                param("toMonth", "1")
+                param("toYear", "2025")
+                with(csrf())
+            }.andExpect {
+                status { isOk() }
+                view { name("metrics") }
+                model {
+                    attribute("metricRows", hasSize<Any>(4))
+                }
+            }
+    }
+
+    @Test
+    @WithMockUser(roles = ["SYSTEM_OPERATOR"])
+    fun `submitMetrics leaves metric rows empty for an invalid date range`() {
+        mvc
+            .post(METRICS_URL) {
+                contentType = MediaType.APPLICATION_FORM_URLENCODED
+                param("fromDay", "20")
+                param("fromMonth", "1")
+                param("fromYear", "2025")
+                param("toDay", "10")
+                param("toMonth", "1")
+                param("toYear", "2025")
+                with(csrf())
+            }.andExpect {
+                status { isOk() }
+                model {
+                    attribute("metricRows", hasSize<Any>(0))
                 }
             }
     }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/MetricsSinglePageTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/MetricsSinglePageTests.kt
@@ -54,15 +54,16 @@ class MetricsSinglePageTests : IntegrationTestWithImmutableData("data-local.sql"
     }
 
     @Test
-    fun `submitting a valid date range renders the four metrics computed from the seeded data`(page: Page) {
+    fun `submitting a valid date range renders the five metrics computed from the seeded data`(page: Page) {
         val metricsPage = navigator.goToMetricsPage()
 
         metricsPage.submitDateRange("1", "9", "2024", "30", "6", "2025")
 
         val reloadedPage = assertPageIs(page, MetricsPage::class)
         assertThat(reloadedPage.metricsList.rowValue(0)).containsText("33")
-        assertThat(reloadedPage.metricsList.rowValue(1)).containsText("36")
-        assertThat(reloadedPage.metricsList.rowValue(2)).containsText("3")
-        assertThat(reloadedPage.metricsList.rowValue(3)).containsText("124 days")
+        assertThat(reloadedPage.metricsList.rowValue(1)).containsText("33")
+        assertThat(reloadedPage.metricsList.rowValue(2)).containsText("36")
+        assertThat(reloadedPage.metricsList.rowValue(3)).containsText("3")
+        assertThat(reloadedPage.metricsList.rowValue(4)).containsText("124 days")
     }
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/MetricsSinglePageTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/MetricsSinglePageTests.kt
@@ -54,7 +54,7 @@ class MetricsSinglePageTests : IntegrationTestWithImmutableData("data-local.sql"
     }
 
     @Test
-    fun `submitting a valid date range renders the five metrics computed from the seeded data`(page: Page) {
+    fun `submitting a valid date range renders the seven metrics computed from the seeded data`(page: Page) {
         val metricsPage = navigator.goToMetricsPage()
 
         metricsPage.submitDateRange("1", "9", "2024", "30", "6", "2025")
@@ -65,5 +65,7 @@ class MetricsSinglePageTests : IntegrationTestWithImmutableData("data-local.sql"
         assertThat(reloadedPage.metricsList.rowValue(2)).containsText("36")
         assertThat(reloadedPage.metricsList.rowValue(3)).containsText("3")
         assertThat(reloadedPage.metricsList.rowValue(4)).containsText("124 days")
+        assertThat(reloadedPage.metricsList.rowValue(5)).containsText("124 days")
+        assertThat(reloadedPage.metricsList.rowValue(6)).containsText("124 days")
     }
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/MetricsSinglePageTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/MetricsSinglePageTests.kt
@@ -52,4 +52,17 @@ class MetricsSinglePageTests : IntegrationTestWithImmutableData("data-local.sql"
         val reloadedPage = assertPageIs(page, MetricsPage::class)
         BaseComponent.assertThat(reloadedPage.errorSummary).not().isVisible()
     }
+
+    @Test
+    fun `submitting a valid date range renders the four metrics computed from the seeded data`(page: Page) {
+        val metricsPage = navigator.goToMetricsPage()
+
+        metricsPage.submitDateRange("1", "9", "2024", "30", "6", "2025")
+
+        val reloadedPage = assertPageIs(page, MetricsPage::class)
+        assertThat(reloadedPage.metricsList.rowValue(0)).containsText("33")
+        assertThat(reloadedPage.metricsList.rowValue(1)).containsText("36")
+        assertThat(reloadedPage.metricsList.rowValue(2)).containsText("3")
+        assertThat(reloadedPage.metricsList.rowValue(3)).containsText("124 days")
+    }
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/MetricsPage.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/MetricsPage.kt
@@ -5,6 +5,7 @@ import uk.gov.communities.prsdb.webapp.controllers.MetricsController
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.Button
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.ErrorSummary
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.PostForm
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.SummaryList
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.TextInput
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages.BasePage
 
@@ -14,6 +15,7 @@ class MetricsPage(
     val form = MetricsForm(page)
     val errorSummary = ErrorSummary(page)
     val refreshButton = Button.byText(page, "Refresh")
+    val metricsList = MetricsSummaryList(page)
 
     fun submitDateRange(
         fromDay: String,
@@ -41,5 +43,13 @@ class MetricsPage(
         val toDay = TextInput.textByFieldName(locator, "toDay")
         val toMonth = TextInput.textByFieldName(locator, "toMonth")
         val toYear = TextInput.textByFieldName(locator, "toYear")
+    }
+
+    class MetricsSummaryList(
+        page: Page,
+    ) : SummaryList(page) {
+        fun rowKey(index: Int) = getRow(index).key
+
+        fun rowValue(index: Int) = getRow(index).value
     }
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/MetricsServiceTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/MetricsServiceTests.kt
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.InjectMocks
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
 import org.mockito.kotlin.whenever
 import uk.gov.communities.prsdb.webapp.database.repository.LandlordRepository
 import uk.gov.communities.prsdb.webapp.database.repository.PropertyOwnershipRepository
@@ -29,59 +30,86 @@ class MetricsServiceTests {
     private val end = Instant.parse("2025-01-31T23:59:59Z")
     private val period = ReportingPeriod(start, end)
 
-    @Test
-    fun `getMetrics returns the four computed metrics over the period`() {
-        whenever(landlordRepository.countByCreatedDateBetween(start, end)).thenReturn(7L)
-        whenever(propertyOwnershipRepository.countByCreatedDateBetween(start, end)).thenReturn(4L)
-        whenever(propertyOwnershipRepository.countDistinctLandlordsWithPropertyCreatedOnOrBefore(end)).thenReturn(3L)
-        whenever(propertyOwnershipRepository.findLandlordAndFirstPropertyCreatedDates(start, end))
-            .thenReturn(
-                listOf(
-                    // 2 days
-                    arrayOf(Instant.parse("2025-01-01T00:00:00Z"), Instant.parse("2025-01-03T00:00:00Z")),
-                    // 4 days
-                    arrayOf(Instant.parse("2025-01-05T00:00:00Z"), Instant.parse("2025-01-09T00:00:00Z")),
-                ),
-            )
-
-        val metrics = metricsService.getMetrics(period)
-
-        assertEquals(7L, metrics.numberOfLandlordRegistrations)
-        assertEquals(4L, metrics.numberOfProperties)
-        assertEquals(3L, metrics.numberOfLandlordsWithAProperty)
-        assertEquals(Duration.ofDays(3), metrics.averageTimeToFirstProperty) // mean of 2 and 4 days
+    private fun stubCounts() {
+        whenever(landlordRepository.countByCreatedDateBetween(any(), any())).thenReturn(0L)
+        whenever(landlordRepository.countByIsVerifiedTrueAndCreatedDateBetween(any(), any())).thenReturn(0L)
+        whenever(propertyOwnershipRepository.countByCreatedDateBetween(any(), any())).thenReturn(0L)
+        whenever(propertyOwnershipRepository.countDistinctLandlordsWithPropertyCreatedOnOrBefore(any())).thenReturn(0L)
     }
 
+    private fun durationsOfDays(vararg days: Long): List<Array<Instant>> = days.map { arrayOf(start, start.plus(Duration.ofDays(it))) }
+
     @Test
-    fun `getMetrics returns a null average when no landlords qualify`() {
-        whenever(landlordRepository.countByCreatedDateBetween(start, end)).thenReturn(0L)
-        whenever(propertyOwnershipRepository.countByCreatedDateBetween(start, end)).thenReturn(0L)
-        whenever(propertyOwnershipRepository.countDistinctLandlordsWithPropertyCreatedOnOrBefore(end)).thenReturn(0L)
+    fun `getMetrics returns the counts computed over the period`() {
+        whenever(landlordRepository.countByCreatedDateBetween(start, end)).thenReturn(7L)
+        whenever(landlordRepository.countByIsVerifiedTrueAndCreatedDateBetween(start, end)).thenReturn(5L)
+        whenever(propertyOwnershipRepository.countByCreatedDateBetween(start, end)).thenReturn(4L)
+        whenever(propertyOwnershipRepository.countDistinctLandlordsWithPropertyCreatedOnOrBefore(end)).thenReturn(3L)
         whenever(propertyOwnershipRepository.findLandlordAndFirstPropertyCreatedDates(start, end))
             .thenReturn(emptyList())
 
         val metrics = metricsService.getMetrics(period)
 
-        assertNull(metrics.averageTimeToFirstProperty)
+        assertEquals(7L, metrics.numberOfLandlordRegistrations)
+        assertEquals(5L, metrics.numberOfVerifiedLandlords)
+        assertEquals(4L, metrics.numberOfProperties)
+        assertEquals(3L, metrics.numberOfLandlordsWithAProperty)
     }
 
     @Test
-    fun `getMetrics averages sub-day durations`() {
-        whenever(landlordRepository.countByCreatedDateBetween(start, end)).thenReturn(1L)
-        whenever(propertyOwnershipRepository.countByCreatedDateBetween(start, end)).thenReturn(1L)
-        whenever(propertyOwnershipRepository.countDistinctLandlordsWithPropertyCreatedOnOrBefore(end)).thenReturn(1L)
-        whenever(propertyOwnershipRepository.findLandlordAndFirstPropertyCreatedDates(start, end))
+    fun `getMetrics returns null time-to-first-property percentiles when there is no data`() {
+        stubCounts()
+        whenever(propertyOwnershipRepository.findLandlordAndFirstPropertyCreatedDates(any(), any()))
+            .thenReturn(emptyList())
+
+        val metrics = metricsService.getMetrics(period)
+
+        assertNull(metrics.medianTimeToFirstProperty)
+        assertNull(metrics.p90TimeToFirstProperty)
+        assertNull(metrics.p95TimeToFirstProperty)
+    }
+
+    @Test
+    fun `getMetrics returns the single value for every percentile when there is one data point`() {
+        stubCounts()
+        whenever(propertyOwnershipRepository.findLandlordAndFirstPropertyCreatedDates(any(), any()))
+            .thenReturn(durationsOfDays(7))
+
+        val metrics = metricsService.getMetrics(period)
+
+        assertEquals(Duration.ofDays(7), metrics.medianTimeToFirstProperty)
+        assertEquals(Duration.ofDays(7), metrics.p90TimeToFirstProperty)
+        assertEquals(Duration.ofDays(7), metrics.p95TimeToFirstProperty)
+    }
+
+    @Test
+    fun `getMetrics computes median p90 and p95 with linear interpolation`() {
+        stubCounts()
+        // Eleven values 10,20,...,110 days, supplied unsorted to confirm sorting.
+        whenever(propertyOwnershipRepository.findLandlordAndFirstPropertyCreatedDates(any(), any()))
+            .thenReturn(durationsOfDays(110, 30, 70, 10, 90, 50, 20, 100, 40, 80, 60))
+
+        val metrics = metricsService.getMetrics(period)
+
+        // rank = fraction * (n - 1) = fraction * 10
+        assertEquals(Duration.ofDays(60), metrics.medianTimeToFirstProperty) // rank 5 -> 60
+        assertEquals(Duration.ofDays(100), metrics.p90TimeToFirstProperty) // rank 9 -> 100
+        assertEquals(Duration.ofDays(105), metrics.p95TimeToFirstProperty) // rank 9.5 -> midway 100..110
+    }
+
+    @Test
+    fun `getMetrics computes sub-day percentiles`() {
+        stubCounts()
+        whenever(propertyOwnershipRepository.findLandlordAndFirstPropertyCreatedDates(any(), any()))
             .thenReturn(
                 listOf(
-                    // 2 hours
-                    arrayOf(Instant.parse("2025-01-01T00:00:00Z"), Instant.parse("2025-01-01T02:00:00Z")),
-                    // 6 hours
-                    arrayOf(Instant.parse("2025-01-02T00:00:00Z"), Instant.parse("2025-01-02T06:00:00Z")),
+                    arrayOf(start, start.plus(Duration.ofHours(2))),
+                    arrayOf(start, start.plus(Duration.ofHours(6))),
                 ),
             )
 
         val metrics = metricsService.getMetrics(period)
 
-        assertEquals(Duration.ofHours(4), metrics.averageTimeToFirstProperty)
+        assertEquals(Duration.ofHours(4), metrics.medianTimeToFirstProperty) // midway between 2h and 6h
     }
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/MetricsServiceTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/MetricsServiceTests.kt
@@ -1,0 +1,87 @@
+package uk.gov.communities.prsdb.webapp.services
+
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.InjectMocks
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.whenever
+import uk.gov.communities.prsdb.webapp.database.repository.LandlordRepository
+import uk.gov.communities.prsdb.webapp.database.repository.PropertyOwnershipRepository
+import uk.gov.communities.prsdb.webapp.models.dataModels.ReportingPeriod
+import java.time.Duration
+import java.time.Instant
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+@ExtendWith(MockitoExtension::class)
+class MetricsServiceTests {
+    @Mock
+    private lateinit var landlordRepository: LandlordRepository
+
+    @Mock
+    private lateinit var propertyOwnershipRepository: PropertyOwnershipRepository
+
+    @InjectMocks
+    private lateinit var metricsService: MetricsService
+
+    private val start = Instant.parse("2025-01-01T00:00:00Z")
+    private val end = Instant.parse("2025-01-31T23:59:59Z")
+    private val period = ReportingPeriod(start, end)
+
+    @Test
+    fun `getMetrics returns the four computed metrics over the period`() {
+        whenever(landlordRepository.countByCreatedDateBetween(start, end)).thenReturn(7L)
+        whenever(propertyOwnershipRepository.countByCreatedDateBetween(start, end)).thenReturn(4L)
+        whenever(propertyOwnershipRepository.countDistinctLandlordsWithPropertyCreatedOnOrBefore(end)).thenReturn(3L)
+        whenever(propertyOwnershipRepository.findLandlordAndFirstPropertyCreatedDates(start, end))
+            .thenReturn(
+                listOf(
+                    // 2 days
+                    arrayOf(Instant.parse("2025-01-01T00:00:00Z"), Instant.parse("2025-01-03T00:00:00Z")),
+                    // 4 days
+                    arrayOf(Instant.parse("2025-01-05T00:00:00Z"), Instant.parse("2025-01-09T00:00:00Z")),
+                ),
+            )
+
+        val metrics = metricsService.getMetrics(period)
+
+        assertEquals(7L, metrics.numberOfLandlordRegistrations)
+        assertEquals(4L, metrics.numberOfProperties)
+        assertEquals(3L, metrics.numberOfLandlordsWithAProperty)
+        assertEquals(Duration.ofDays(3), metrics.averageTimeToFirstProperty) // mean of 2 and 4 days
+    }
+
+    @Test
+    fun `getMetrics returns a null average when no landlords qualify`() {
+        whenever(landlordRepository.countByCreatedDateBetween(start, end)).thenReturn(0L)
+        whenever(propertyOwnershipRepository.countByCreatedDateBetween(start, end)).thenReturn(0L)
+        whenever(propertyOwnershipRepository.countDistinctLandlordsWithPropertyCreatedOnOrBefore(end)).thenReturn(0L)
+        whenever(propertyOwnershipRepository.findLandlordAndFirstPropertyCreatedDates(start, end))
+            .thenReturn(emptyList())
+
+        val metrics = metricsService.getMetrics(period)
+
+        assertNull(metrics.averageTimeToFirstProperty)
+    }
+
+    @Test
+    fun `getMetrics averages sub-day durations`() {
+        whenever(landlordRepository.countByCreatedDateBetween(start, end)).thenReturn(1L)
+        whenever(propertyOwnershipRepository.countByCreatedDateBetween(start, end)).thenReturn(1L)
+        whenever(propertyOwnershipRepository.countDistinctLandlordsWithPropertyCreatedOnOrBefore(end)).thenReturn(1L)
+        whenever(propertyOwnershipRepository.findLandlordAndFirstPropertyCreatedDates(start, end))
+            .thenReturn(
+                listOf(
+                    // 2 hours
+                    arrayOf(Instant.parse("2025-01-01T00:00:00Z"), Instant.parse("2025-01-01T02:00:00Z")),
+                    // 6 hours
+                    arrayOf(Instant.parse("2025-01-02T00:00:00Z"), Instant.parse("2025-01-02T06:00:00Z")),
+                ),
+            )
+
+        val metrics = metricsService.getMetrics(period)
+
+        assertEquals(Duration.ofHours(4), metrics.averageTimeToFirstProperty)
+    }
+}

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/MetricsServiceTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/MetricsServiceTests.kt
@@ -98,18 +98,25 @@ class MetricsServiceTests {
     }
 
     @Test
-    fun `getMetrics computes sub-day percentiles`() {
+    fun `getMetrics computes percentiles for realistic mixed minute hour and day durations`() {
         stubCounts()
+        // Three landlords whose first property followed registration after 27 minutes,
+        // 1 day 3 hours 42 minutes, and 2 days 12 hours 38 minutes respectively.
         whenever(propertyOwnershipRepository.findLandlordAndFirstPropertyCreatedDates(any(), any()))
             .thenReturn(
                 listOf(
-                    arrayOf(start, start.plus(Duration.ofHours(2))),
-                    arrayOf(start, start.plus(Duration.ofHours(6))),
+                    arrayOf(start, start.plus(Duration.ofMinutes(27))),
+                    arrayOf(start, start.plus(Duration.ofDays(1)).plus(Duration.ofHours(3)).plus(Duration.ofMinutes(42))),
+                    arrayOf(start, start.plus(Duration.ofDays(2)).plus(Duration.ofHours(12)).plus(Duration.ofMinutes(38))),
                 ),
             )
 
         val metrics = metricsService.getMetrics(period)
 
-        assertEquals(Duration.ofHours(4), metrics.medianTimeToFirstProperty) // midway between 2h and 6h
+        // Median (rank 1 of 3) lands exactly on the middle data point.
+        assertEquals(
+            Duration.ofDays(1).plusHours(3).plusMinutes(42),
+            metrics.medianTimeToFirstProperty,
+        )
     }
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/MetricsServiceTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/MetricsServiceTests.kt
@@ -34,7 +34,7 @@ class MetricsServiceTests {
         whenever(landlordRepository.countByCreatedDateBetween(any(), any())).thenReturn(0L)
         whenever(landlordRepository.countByIsVerifiedTrueAndCreatedDateBetween(any(), any())).thenReturn(0L)
         whenever(propertyOwnershipRepository.countByCreatedDateBetween(any(), any())).thenReturn(0L)
-        whenever(propertyOwnershipRepository.countDistinctLandlordsWithPropertyCreatedOnOrBefore(any())).thenReturn(0L)
+        whenever(propertyOwnershipRepository.countDistinctLandlordsWithPropertyCreatedBetween(any(), any())).thenReturn(0L)
     }
 
     private fun durationsOfDays(vararg days: Long): List<Array<Instant>> = days.map { arrayOf(start, start.plus(Duration.ofDays(it))) }
@@ -44,7 +44,7 @@ class MetricsServiceTests {
         whenever(landlordRepository.countByCreatedDateBetween(start, end)).thenReturn(7L)
         whenever(landlordRepository.countByIsVerifiedTrueAndCreatedDateBetween(start, end)).thenReturn(5L)
         whenever(propertyOwnershipRepository.countByCreatedDateBetween(start, end)).thenReturn(4L)
-        whenever(propertyOwnershipRepository.countDistinctLandlordsWithPropertyCreatedOnOrBefore(end)).thenReturn(3L)
+        whenever(propertyOwnershipRepository.countDistinctLandlordsWithPropertyCreatedBetween(start, end)).thenReturn(3L)
         whenever(propertyOwnershipRepository.findLandlordAndFirstPropertyCreatedDates(start, end))
             .thenReturn(emptyList())
 


### PR DESCRIPTION
## Ticket number

PDJB-1033

## Goal of change

Populate the system-operator metrics dashboard with four database-performance metrics computed over the user-selected reporting period.

## Description of main change(s)

- Adds a `MetricsService` that computes four metrics for a `ReportingPeriod`:
  - **Landlord registrations** — landlords created within the period.
  - **Properties** — property ownerships created within the period.
  - **Landlords with a property** — distinct landlords who had at least one property by the **end** of the period.
  - **Average time to first property** — mean gap between a landlord's registration and their first-ever property, for landlords whose registration and first property both fall in the period (`No data` when none qualify).
- Wires the service into `MetricsController` so the four rows render on a valid date-range submission (and no rows on an invalid submission).
- Adds the supporting repository query methods and message keys for the row labels and the humanised average (days/hours/minutes).

## Anything you'd like to highlight to the reviewer?

- Metrics 3 and 4 count **all** landlords on a property (joint landlords included) via `po.landlords` — `primaryLandlord` is no longer a persistent attribute after the recent `landlords` many-to-many refactor, so it can't be used in JPQL. The current seed has no joint landlords, so values are unaffected.
- The integration test asserts exact values (33 / 36 / 3 / 124 days) derived from `data-local.sql`.

## Checklist

- [x] Unit tests for new logic (e.g. new service methods) have been added
- [x] Controller tests for any new endpoints, including testing the relevant permissions
- [x] Single page integration tests have been added for any unhappy-flow UI features, e.g. validation errors
- [x] Branch has been rebased onto main and run locally, with everything working as expected (both for your new feature and any related functionality)
- [x] TODO comments referencing this JIRA ticket have been searched for and removed
- [x] Test suite has been run in full locally and is passing 
- [ ] QA instructions have been added to the ticket (particularly if this is the last PR required to complete the ticket)
