### PR TITLE
PDJB-300: Add 'Expires today' copy for JL pending invite

### DIFF
--- a/src/main/resources/messages/propertyDetails.yml
+++ b/src/main/resources/messages/propertyDetails.yml
@@ -19,6 +19,7 @@ landlordDetails:
       heading: 'Pending invitations ({0})'
       expiresIn: 'Expires in {0} days ({1})'
       expiresInSingular: 'Expires in 1 day ({0})'
+      expiresToday: 'Expires today ({0})'
       sentOn: 'Sent on {0}'
       sendNewInvitationEmail: Send a new email invitation
       cancelInvitation: Cancel invitation

--- a/src/main/resources/templates/propertyDetailsView.html
+++ b/src/main/resources/templates/propertyDetailsView.html
@@ -90,7 +90,7 @@
                                     <div class="govuk-!-margin-bottom-4">
                                         <p class="govuk-body govuk-!-margin-bottom-1" th:text="${invitation.email}">invitation.email</p>
                                         <p class="govuk-hint govuk-!-margin-bottom-1"
-                                           th:if="${invitation.expiresInDays != 1}"
+                                          th:if="${invitation.expiresInDays > 1}"
                                            th:text="#{propertyDetails.landlordDetails.invitations.pendingInvitations.expiresIn(${invitation.expiresInDays}, ${invitation.expiryDate})}">
                                             propertyDetails.landlordDetails.invitations.pendingInvitations.expiresIn
                                         </p>
@@ -98,6 +98,11 @@
                                            th:if="${invitation.expiresInDays == 1}"
                                            th:text="#{propertyDetails.landlordDetails.invitations.pendingInvitations.expiresInSingular(${invitation.expiryDate})}">
                                             propertyDetails.landlordDetails.invitations.pendingInvitations.expiresInSingular
+                                        </p>
+                                        <p class="govuk-hint govuk-!-margin-bottom-1"
+                                           th:if="${invitation.expiresInDays == 0}"
+                                           th:text="#{propertyDetails.landlordDetails.invitations.pendingInvitations.expiresToday(${invitation.expiryDate})}">
+                                            propertyDetails.landlordDetails.invitations.pendingInvitations.expiresToday
                                         </p>
                                         <p class="govuk-hint govuk-!-margin-bottom-1"
                                            th:text="#{propertyDetails.landlordDetails.invitations.pendingInvitations.sentOn(${invitation.sentDate})}">


### PR DESCRIPTION
## Ticket number

[PDJB-300](https://mhclgdigital.atlassian.net/browse/PDJB-300)

## Goal of change

replace 'Expires in 0 days' with 'Expires today' as requested by design

<img alt="pending invite with one saying expires today" src="https://github.com/user-attachments/assets/dd8a0a75-a17b-49ca-8435-50c56ad2c31d" />

## Anything you'd like to highlight to the reviewer?

does this make sense? 'Expires today' meaning at midnight tonight the invite will stop being valid

## Checklist

Delete any that are not applicable, and add explanation below for any that are applicable but haven't been done

- [x] Screenshots of any UI changes have been added
- [x] Test suite has been run in full locally and is passing
- [x] Branch has been rebased onto main and run locally, with everything working as expected (both for your new feature
  and any related functionality)
- [ ] QA instructions have been added to the ticket (particularly if this is the last PR required to complete the ticket) (this is hard to test and minor enough to not matter)
