### PR TITLE
PDJB-432: Fix joint landlord view property permissions

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/PropertyOwnershipService.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/PropertyOwnershipService.kt
@@ -116,7 +116,7 @@ class PropertyOwnershipService(
     fun getIsAuthorizedToEditRecord(
         propertyOwnershipId: Long,
         baseUserId: String,
-    ): Boolean = getPropertyOwnership(propertyOwnershipId).primaryLandlord.baseUser.id == baseUserId
+    ): Boolean = getPropertyOwnership(propertyOwnershipId).landlords.any { it.baseUser.id == baseUserId }
 
     fun getIsPrimaryLandlord(
         propertyOwnershipId: Long,

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/PropertyOwnershipService.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/PropertyOwnershipService.kt
@@ -94,9 +94,9 @@ class PropertyOwnershipService(
 
         val isLocalCouncil = localCouncilDataService.getIsLocalCouncilUser(baseUserId)
 
-        val isPrimaryLandlord = propertyOwnership.primaryLandlord.baseUser.id == baseUserId
+        val isLandlord = propertyOwnership.landlords.any { it.baseUser.id == baseUserId }
 
-        if (!isLocalCouncil && !isPrimaryLandlord) {
+        if (!isLocalCouncil && !isLandlord) {
             throw ResponseStatusException(
                 HttpStatus.NOT_FOUND,
                 "The current user is not authorised to view property ownership $propertyOwnershipId",

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/PropertyOwnershipServiceTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/PropertyOwnershipServiceTests.kt
@@ -507,7 +507,7 @@ class PropertyOwnershipServiceTests {
     @Nested
     inner class GetIsAuthorizedToEditRecord {
         @Test
-        fun `returns true when the user is the property's primary landlord`() {
+        fun `returns true when the user is the only landlord`() {
             val baseUserId = "baseUserId"
             val propertyOwnership =
                 MockLandlordData.createPropertyOwnership(
@@ -525,7 +525,24 @@ class PropertyOwnershipServiceTests {
         }
 
         @Test
-        fun `returns false when the user is not the property's primary landlord`() {
+        fun `returns true when the user is a joint landlord`() {
+            val jointLandlord =
+                MockLandlordData.createLandlord(
+                    baseUser = MockLandlordData.createPrsdbUser("joint-landlord"),
+                )
+            val propertyOwnership = MockLandlordData.createPropertyOwnership()
+            propertyOwnership.landlords.add(jointLandlord)
+
+            whenever(mockPropertyOwnershipRepository.findByIdAndIsActiveTrue(propertyOwnership.id)).thenReturn(propertyOwnership)
+
+            val result =
+                propertyOwnershipService.getIsAuthorizedToEditRecord(propertyOwnership.id, jointLandlord.baseUser.id)
+
+            assertTrue(result)
+        }
+
+        @Test
+        fun `returns false when the user is not a landlord of the property`() {
             val propertyOwnership =
                 MockLandlordData.createPropertyOwnership(
                     primaryLandlord =
@@ -536,13 +553,13 @@ class PropertyOwnershipServiceTests {
 
             whenever(mockPropertyOwnershipRepository.findByIdAndIsActiveTrue(propertyOwnership.id)).thenReturn(propertyOwnership)
 
-            val returnedIsPrimaryLandlord =
+            val result =
                 propertyOwnershipService.getIsAuthorizedToEditRecord(
                     propertyOwnership.id,
                     "differentBaseUserId",
                 )
 
-            assertFalse(returnedIsPrimaryLandlord)
+            assertFalse(result)
         }
 
         @Test

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/PropertyOwnershipServiceTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/PropertyOwnershipServiceTests.kt
@@ -423,7 +423,7 @@ class PropertyOwnershipServiceTests {
         }
 
         @Test
-        fun `throws not found error if user is not primary landlord or an lc user`() {
+        fun `throws not found error if user is not a landlord or an lc user`() {
             val propertyOwnership = MockLandlordData.createPropertyOwnership()
             val principalName = "not-the-landlord"
             whenever(mockPropertyOwnershipRepository.findByIdAndIsActiveTrue(propertyOwnership.id)).thenReturn(
@@ -460,9 +460,36 @@ class PropertyOwnershipServiceTests {
         }
 
         @Test
-        fun `returns property ownership when user is primary landlord`() {
+        fun `returns property ownership when user is only landlord`() {
             val propertyOwnership = MockLandlordData.createPropertyOwnership()
-            val principalName = propertyOwnership.primaryLandlord.baseUser.id
+            val principalName =
+                propertyOwnership
+                    .landlords
+                    .first()
+                    .baseUser
+                    .id
+
+            whenever(mockPropertyOwnershipRepository.findByIdAndIsActiveTrue(propertyOwnership.id)).thenReturn(
+                propertyOwnership,
+            )
+
+            whenever(mockLocalCouncilDataService.getIsLocalCouncilUser(principalName)).thenReturn(false)
+
+            val result =
+                propertyOwnershipService.getPropertyOwnershipIfAuthorizedUser(propertyOwnership.id, principalName)
+
+            assertEquals(result, propertyOwnership)
+        }
+
+        @Test
+        fun `returns property ownership when user is a joint landlord`() {
+            val jointLandlord =
+                MockLandlordData.createLandlord(
+                    baseUser = MockLandlordData.createPrsdbUser("joint-landlord"),
+                )
+            val propertyOwnership = MockLandlordData.createPropertyOwnership()
+            propertyOwnership.landlords.add(jointLandlord)
+            val principalName = jointLandlord.baseUser.id
 
             whenever(mockPropertyOwnershipRepository.findByIdAndIsActiveTrue(propertyOwnership.id)).thenReturn(
                 propertyOwnership,


### PR DESCRIPTION
## Ticket number

[PDJB-432](https://mhclgdigital.atlassian.net/browse/PDJB-432)

## Goal of change

fixes it so landlords can view and edit any properties they're associated with

## Description of main change(s)

updates the relevant methods in PropertyOwnershipService

this means that we can test flows properly on integration that require another landlord to be added to the property. right now you can only test this if you are the lowest ID landlord as that's the primaryLandlord fallback

## Checklist

Delete any that are not applicable, and add explanation below for any that are applicable but haven't been done

- [x] Unit tests for new logic (e.g. new service methods) have been added
- [ ] Test suite has been run in full locally and is passing
- [x] Branch has been rebased onto main and run locally, with everything working as expected (both for your new feature
  and any related functionality)
