### PR TITLE
PDJB-300: Fix dividers to be after all elements

### DIFF
--- a/src/main/resources/templates/propertyDetailsView.html
+++ b/src/main/resources/templates/propertyDetailsView.html
@@ -101,7 +101,6 @@
                             </summary>
                             <div class="govuk-details__text">
                                 <th:block th:each="invitation, iterStat : ${pendingInvitations}">
-                                    <hr th:unless="${iterStat.first}" class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
                                     <div class="govuk-!-margin-bottom-4">
                                         <p class="govuk-body govuk-!-margin-bottom-1" th:text="${invitation.email}">invitation.email</p>
                                         <p class="govuk-hint govuk-!-margin-bottom-1"
@@ -137,6 +136,7 @@
                                             </li>
                                         </ul>
                                     </div>
+                                    <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
                                 </th:block>
                             </div>
                         </details>
@@ -150,7 +150,6 @@
                             </summary>
                             <div class="govuk-details__text">
                                 <th:block th:each="invitation, iterStat : ${expiredInvitations}">
-                                    <hr th:unless="${iterStat.first}" class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
                                     <div class="govuk-!-margin-bottom-4">
                                         <p class="govuk-body govuk-!-margin-bottom-1" th:text="${invitation.email}">invitation.email</p>
                                         <p class="govuk-hint govuk-!-margin-bottom-1"
@@ -168,6 +167,7 @@
                                             </li>
                                         </ul>
                                     </div>
+                                    <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
                                 </th:block>
                             </div>
                         </details>


### PR DESCRIPTION
## Ticket number

[PDJB-300](https://mhclgdigital.atlassian.net/browse/PDJB-300)

## Goal of change

add a divider after the last item in the invitations

<img alt="pending and expired invitations view" src="https://github.com/user-attachments/assets/05a5ada8-f646-42e1-93c3-fef261fadc83" />

## Checklist

Delete any that are not applicable, and add explanation below for any that are applicable but haven't been done

- [x] Screenshots of any UI changes have been added
- [x] Test suite has been run in full locally and is passing
- [x] Branch has been rebased onto main and run locally, with everything working as expected (both for your new feature
  and any related functionality)
- [x] QA instructions have been added to the ticket (particularly if this is the last PR required to complete the ticket)
