### PR TITLE
PDJB-1035: Add Plausible analytics journey completion rate metrics

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -205,7 +205,7 @@
         "filename": "src\\main\\resources\\application-local.yml",
         "hashed_secret": "ce8c74ce64b55dc94183540aac1aee68fd6d27ad",
         "is_verified": false,
-        "line_number": 133,
+        "line_number": 135,
         "is_secret": false
       }
     ],
@@ -220,5 +220,5 @@
       }
     ]
   },
-  "generated_at": "2026-05-27T09:16:34Z"
+  "generated_at": "2026-06-12T14:05:15Z"
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/clients/PlausibleClient.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/clients/PlausibleClient.kt
@@ -1,0 +1,22 @@
+package uk.gov.communities.prsdb.webapp.clients
+
+import org.springframework.beans.factory.annotation.Qualifier
+import org.springframework.web.client.RestClient
+import org.springframework.web.client.body
+import uk.gov.communities.prsdb.webapp.annotations.webAnnotations.PrsdbWebService
+import uk.gov.communities.prsdb.webapp.models.dataModels.plausible.PlausibleQuery
+import uk.gov.communities.prsdb.webapp.models.dataModels.plausible.PlausibleQueryResponse
+
+@PrsdbWebService
+class PlausibleClient(
+    @Qualifier("plausible-stats-client") private val client: RestClient,
+) {
+    fun query(query: PlausibleQuery): PlausibleQueryResponse =
+        client
+            .post()
+            .uri("/api/v2/query")
+            .body(query)
+            .retrieve()
+            .body<PlausibleQueryResponse>()
+            ?: PlausibleQueryResponse()
+}

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/config/PlausibleApiConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/config/PlausibleApiConfig.kt
@@ -1,0 +1,25 @@
+package uk.gov.communities.prsdb.webapp.config
+
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.annotation.Bean
+import org.springframework.web.client.RestClient
+import uk.gov.communities.prsdb.webapp.annotations.webAnnotations.PrsdbWebConfiguration
+
+@PrsdbWebConfiguration
+class PlausibleApiConfig {
+    @Value("\${plausible.base-url}")
+    lateinit var baseUrl: String
+
+    @Value("\${plausible.api-key}")
+    lateinit var apiKey: String
+
+    @Bean("plausible-stats-client")
+    fun plausibleStatsClient(): RestClient =
+        RestClient
+            .builder()
+            .baseUrl(baseUrl)
+            .requestInterceptor { request, body, execution ->
+                request.headers.setBearerAuth(apiKey)
+                execution.execute(request, body)
+            }.build()
+}

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/MetricsController.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/MetricsController.kt
@@ -11,11 +11,13 @@ import org.springframework.web.bind.annotation.RequestMapping
 import uk.gov.communities.prsdb.webapp.annotations.webAnnotations.PrsdbController
 import uk.gov.communities.prsdb.webapp.constants.METRICS_PATH_SEGMENT
 import uk.gov.communities.prsdb.webapp.constants.SYSTEM_OPERATOR_PATH_SEGMENT
+import uk.gov.communities.prsdb.webapp.models.dataModels.JourneyCompletionRatesDataModel
 import uk.gov.communities.prsdb.webapp.models.dataModels.MetricsDataModel
 import uk.gov.communities.prsdb.webapp.models.dataModels.ReportingPeriod
 import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.MetricsDateRangeFormModel
 import uk.gov.communities.prsdb.webapp.models.viewModels.summaryModels.SummaryListRowViewModel
 import uk.gov.communities.prsdb.webapp.services.MetricsService
+import uk.gov.communities.prsdb.webapp.services.PlausibleMetricsService
 import java.text.NumberFormat
 import java.time.Duration
 import java.util.Locale
@@ -25,6 +27,7 @@ import java.util.Locale
 @RequestMapping(MetricsController.METRICS_URL)
 class MetricsController(
     private val metricsService: MetricsService,
+    private val plausibleMetricsService: PlausibleMetricsService,
 ) {
     @GetMapping
     fun getMetrics(model: Model): String {
@@ -41,7 +44,12 @@ class MetricsController(
     ): String {
         val metricRows =
             getReportingPeriodOrNull(bindingResult, formModel)
-                ?.let { period -> getMetricRows(metricsService.getMetrics(period)) }
+                ?.let { period ->
+                    getMetricRows(
+                        metricsService.getMetrics(period),
+                        plausibleMetricsService.getCompletionRates(period),
+                    )
+                }
                 ?: emptyList()
         model.addAttribute("metricRows", metricRows)
         return "metrics"
@@ -57,7 +65,10 @@ class MetricsController(
         return ReportingPeriod.fromDateRange(from, to)
     }
 
-    private fun getMetricRows(metrics: MetricsDataModel): List<SummaryListRowViewModel> =
+    private fun getMetricRows(
+        metrics: MetricsDataModel,
+        completionRates: JourneyCompletionRatesDataModel,
+    ): List<SummaryListRowViewModel> =
         listOf(
             countRow("metrics.rows.landlordRegistrations", metrics.numberOfLandlordRegistrations),
             countRow("metrics.rows.verifiedLandlords", metrics.numberOfVerifiedLandlords),
@@ -66,6 +77,21 @@ class MetricsController(
             durationRow("metrics.rows.medianTimeToFirstProperty", metrics.medianTimeToFirstProperty),
             durationRow("metrics.rows.p90TimeToFirstProperty", metrics.p90TimeToFirstProperty),
             durationRow("metrics.rows.p95TimeToFirstProperty", metrics.p95TimeToFirstProperty),
+            completionRateRow("metrics.rows.landlordRegistrationCompletionRate", completionRates.landlordRegistration),
+            completionRateRow("metrics.rows.propertyRegistrationCompletionRate", completionRates.propertyRegistration),
+            completionRateRow(
+                "metrics.rows.localCouncilUserRegistrationCompletionRate",
+                completionRates.localCouncilUserRegistration,
+            ),
+        )
+
+    private fun completionRateRow(
+        headingKey: String,
+        rate: Double?,
+    ): SummaryListRowViewModel =
+        SummaryListRowViewModel(
+            fieldHeading = headingKey,
+            fieldValue = rate?.let { String.format(Locale.UK, "%.2f%%", it) } ?: "metrics.saveAndReturn.noData",
         )
 
     private fun countRow(

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/local/api/controllers/MockPlausibleController.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/local/api/controllers/MockPlausibleController.kt
@@ -26,17 +26,18 @@ class MockPlausibleController {
         PlausibleQueryResponse(
             results =
                 listOf(
-                    row(LANDLORD_REGISTRATION_START_PAGE_ROUTE, 1000.0),
-                    row(LANDLORD_REGISTRATION_CONFIRMATION_ROUTE, 732.0),
-                    row(PROPERTY_REGISTRATION_ROUTE, 80.0),
-                    row(PROPERTY_REGISTRATION_CONFIRMATION_ROUTE, 20.0),
-                    row(LOCAL_COUNCIL_USER_REGISTRATION_PRIVACY_NOTICE_ROUTE, 3.0),
-                    row(LOCAL_COUNCIL_USER_REGISTRATION_CONFIRMATION_ROUTE, 1.0),
+                    row(LANDLORD_REGISTRATION_START_PAGE_ROUTE, visitors = 1000.0, pageViews = 1200.0),
+                    row(LANDLORD_REGISTRATION_CONFIRMATION_ROUTE, visitors = 732.0, pageViews = 800.0),
+                    row(PROPERTY_REGISTRATION_ROUTE, visitors = 60.0, pageViews = 80.0),
+                    row(PROPERTY_REGISTRATION_CONFIRMATION_ROUTE, visitors = 18.0, pageViews = 20.0),
+                    row(LOCAL_COUNCIL_USER_REGISTRATION_PRIVACY_NOTICE_ROUTE, visitors = 3.0, pageViews = 4.0),
+                    row(LOCAL_COUNCIL_USER_REGISTRATION_CONFIRMATION_ROUTE, visitors = 1.0, pageViews = 2.0),
                 ),
         )
 
     private fun row(
         page: String,
+        visitors: Double,
         pageViews: Double,
-    ) = PlausibleResultRow(metrics = listOf(pageViews), dimensions = listOf(page))
+    ) = PlausibleResultRow(metrics = listOf(visitors, pageViews), dimensions = listOf(page))
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/local/api/controllers/MockPlausibleController.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/local/api/controllers/MockPlausibleController.kt
@@ -37,6 +37,6 @@ class MockPlausibleController {
 
     private fun row(
         page: String,
-        visitors: Double,
-    ) = PlausibleResultRow(metrics = listOf(visitors), dimensions = listOf(page))
+        pageViews: Double,
+    ) = PlausibleResultRow(metrics = listOf(pageViews), dimensions = listOf(page))
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/local/api/controllers/MockPlausibleController.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/local/api/controllers/MockPlausibleController.kt
@@ -1,0 +1,42 @@
+package uk.gov.communities.prsdb.webapp.local.api.controllers
+
+import org.springframework.context.annotation.Profile
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import uk.gov.communities.prsdb.webapp.annotations.webAnnotations.PrsdbRestController
+import uk.gov.communities.prsdb.webapp.controllers.RegisterLandlordController.Companion.LANDLORD_REGISTRATION_CONFIRMATION_ROUTE
+import uk.gov.communities.prsdb.webapp.controllers.RegisterLandlordController.Companion.LANDLORD_REGISTRATION_START_PAGE_ROUTE
+import uk.gov.communities.prsdb.webapp.controllers.RegisterPropertyController.Companion.PROPERTY_REGISTRATION_ROUTE
+import uk.gov.communities.prsdb.webapp.models.dataModels.plausible.PlausibleQuery
+import uk.gov.communities.prsdb.webapp.models.dataModels.plausible.PlausibleQueryResponse
+import uk.gov.communities.prsdb.webapp.models.dataModels.plausible.PlausibleResultRow
+import uk.gov.communities.prsdb.webapp.services.PlausibleMetricsService.Companion.LOCAL_COUNCIL_USER_REGISTRATION_CONFIRMATION_ROUTE
+import uk.gov.communities.prsdb.webapp.services.PlausibleMetricsService.Companion.LOCAL_COUNCIL_USER_REGISTRATION_PRIVACY_NOTICE_ROUTE
+import uk.gov.communities.prsdb.webapp.services.PlausibleMetricsService.Companion.PROPERTY_REGISTRATION_CONFIRMATION_ROUTE
+
+@Profile("local")
+@PrsdbRestController
+@RequestMapping("/local/plausible")
+class MockPlausibleController {
+    @PostMapping("/api/v2/query")
+    fun query(
+        @RequestBody query: PlausibleQuery,
+    ): PlausibleQueryResponse =
+        PlausibleQueryResponse(
+            results =
+                listOf(
+                    row(LANDLORD_REGISTRATION_START_PAGE_ROUTE, 1000.0),
+                    row(LANDLORD_REGISTRATION_CONFIRMATION_ROUTE, 732.0),
+                    row(PROPERTY_REGISTRATION_ROUTE, 80.0),
+                    row(PROPERTY_REGISTRATION_CONFIRMATION_ROUTE, 20.0),
+                    row(LOCAL_COUNCIL_USER_REGISTRATION_PRIVACY_NOTICE_ROUTE, 3.0),
+                    row(LOCAL_COUNCIL_USER_REGISTRATION_CONFIRMATION_ROUTE, 1.0),
+                ),
+        )
+
+    private fun row(
+        page: String,
+        visitors: Double,
+    ) = PlausibleResultRow(metrics = listOf(visitors), dimensions = listOf(page))
+}

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/dataModels/JourneyCompletionRatesDataModel.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/dataModels/JourneyCompletionRatesDataModel.kt
@@ -1,0 +1,7 @@
+package uk.gov.communities.prsdb.webapp.models.dataModels
+
+data class JourneyCompletionRatesDataModel(
+    val landlordRegistration: Double?,
+    val propertyRegistration: Double?,
+    val localCouncilUserRegistration: Double?,
+)

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/dataModels/plausible/PlausibleQuery.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/dataModels/plausible/PlausibleQuery.kt
@@ -1,0 +1,11 @@
+package uk.gov.communities.prsdb.webapp.models.dataModels.plausible
+
+import com.fasterxml.jackson.annotation.JsonProperty
+
+data class PlausibleQuery(
+    @get:JsonProperty("site_id") val siteId: String,
+    @get:JsonProperty("date_range") val dateRange: List<String>,
+    val metrics: List<String>,
+    val dimensions: List<String>,
+    val filters: List<List<Any>>,
+)

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/dataModels/plausible/PlausibleQueryResponse.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/dataModels/plausible/PlausibleQueryResponse.kt
@@ -1,0 +1,14 @@
+package uk.gov.communities.prsdb.webapp.models.dataModels.plausible
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class PlausibleQueryResponse(
+    val results: List<PlausibleResultRow> = emptyList(),
+)
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class PlausibleResultRow(
+    val metrics: List<Double> = emptyList(),
+    val dimensions: List<String> = emptyList(),
+)

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/PlausibleMetricsService.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/PlausibleMetricsService.kt
@@ -26,18 +26,18 @@ class PlausibleMetricsService(
     fun getCompletionRates(period: ReportingPeriod): JourneyCompletionRatesDataModel =
         try {
             val response = plausibleClient.query(buildQuery(period))
-            val visitorsByPage =
+            val pageViewsByPage =
                 response.results
                     .filter { it.dimensions.isNotEmpty() && it.metrics.isNotEmpty() }
                     .associate { it.dimensions.first() to it.metrics.first() }
             JourneyCompletionRatesDataModel(
                 landlordRegistration =
-                    completionRate(visitorsByPage, LANDLORD_REGISTRATION_START_PAGE_ROUTE, LANDLORD_REGISTRATION_CONFIRMATION_ROUTE),
+                    completionRate(pageViewsByPage, LANDLORD_REGISTRATION_START_PAGE_ROUTE, LANDLORD_REGISTRATION_CONFIRMATION_ROUTE),
                 propertyRegistration =
-                    completionRate(visitorsByPage, PROPERTY_REGISTRATION_ROUTE, PROPERTY_REGISTRATION_CONFIRMATION_ROUTE),
+                    completionRate(pageViewsByPage, PROPERTY_REGISTRATION_ROUTE, PROPERTY_REGISTRATION_CONFIRMATION_ROUTE),
                 localCouncilUserRegistration =
                     completionRate(
-                        visitorsByPage,
+                        pageViewsByPage,
                         LOCAL_COUNCIL_USER_REGISTRATION_PRIVACY_NOTICE_ROUTE,
                         LOCAL_COUNCIL_USER_REGISTRATION_CONFIRMATION_ROUTE,
                     ),
@@ -51,21 +51,21 @@ class PlausibleMetricsService(
         PlausibleQuery(
             siteId = siteId,
             dateRange = listOf(period.start.toUkDate(), period.end.toUkDate()),
-            metrics = listOf("visitors"),
+            metrics = listOf("pageviews"),
             dimensions = listOf("event:page"),
             filters = listOf(listOf("is", "event:page", ALL_PAGES)),
         )
 
     private fun completionRate(
-        visitorsByPage: Map<String, Double>,
+        pageViewsByPage: Map<String, Double>,
         startPage: String,
         confirmationPage: String,
     ): Double? {
-        val startVisitors = visitorsByPage[startPage] ?: return null
-        if (startVisitors == 0.0) return null
-        val confirmationVisitors = visitorsByPage[confirmationPage] ?: 0.0
+        val startPageViews = pageViewsByPage[startPage] ?: return null
+        if (startPageViews == 0.0) return null
+        val confirmationPageViews = pageViewsByPage[confirmationPage] ?: 0.0
         return BigDecimal
-            .valueOf(confirmationVisitors / startVisitors * 100)
+            .valueOf(confirmationPageViews / startPageViews * 100)
             .setScale(2, RoundingMode.HALF_UP)
             .toDouble()
             .coerceAtMost(100.0)

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/PlausibleMetricsService.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/PlausibleMetricsService.kt
@@ -49,6 +49,8 @@ class PlausibleMetricsService(
             JourneyCompletionRatesDataModel(null, null, null)
         }
 
+    // TODO PDJB-1055: Add pagination handling for Plausible queries. This query is currently bounded to a fixed set of
+    //  pages, but pagination will need to be addressed if a query ever returns more than 10,000 entries from Plausible.
     private fun buildQuery(period: ReportingPeriod): PlausibleQuery =
         PlausibleQuery(
             siteId = siteId,

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/PlausibleMetricsService.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/PlausibleMetricsService.kt
@@ -72,7 +72,6 @@ class PlausibleMetricsService(
             .valueOf(confirmationCount / startCount * 100)
             .setScale(2, RoundingMode.HALF_UP)
             .toDouble()
-            .coerceAtMost(100.0)
     }
 
     private fun Instant.toUkDate(): String = DateTimeFormatter.ISO_LOCAL_DATE.format(this.atZone(UK_ZONE).toLocalDate())

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/PlausibleMetricsService.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/PlausibleMetricsService.kt
@@ -26,18 +26,20 @@ class PlausibleMetricsService(
     fun getCompletionRates(period: ReportingPeriod): JourneyCompletionRatesDataModel =
         try {
             val response = plausibleClient.query(buildQuery(period))
-            val pageViewsByPage =
+            val metricsByPage =
                 response.results
-                    .filter { it.dimensions.isNotEmpty() && it.metrics.isNotEmpty() }
-                    .associate { it.dimensions.first() to it.metrics.first() }
+                    .filter { it.dimensions.isNotEmpty() && it.metrics.size >= METRICS.size }
+                    .associate { it.dimensions.first() to it.metrics }
+            val visitorsByPage = metricsByPage.mapValues { it.value[VISITORS_INDEX] }
+            val pageViewsByPage = metricsByPage.mapValues { it.value[PAGE_VIEWS_INDEX] }
             JourneyCompletionRatesDataModel(
                 landlordRegistration =
-                    completionRate(pageViewsByPage, LANDLORD_REGISTRATION_START_PAGE_ROUTE, LANDLORD_REGISTRATION_CONFIRMATION_ROUTE),
+                    completionRate(visitorsByPage, LANDLORD_REGISTRATION_START_PAGE_ROUTE, LANDLORD_REGISTRATION_CONFIRMATION_ROUTE),
                 propertyRegistration =
                     completionRate(pageViewsByPage, PROPERTY_REGISTRATION_ROUTE, PROPERTY_REGISTRATION_CONFIRMATION_ROUTE),
                 localCouncilUserRegistration =
                     completionRate(
-                        pageViewsByPage,
+                        visitorsByPage,
                         LOCAL_COUNCIL_USER_REGISTRATION_PRIVACY_NOTICE_ROUTE,
                         LOCAL_COUNCIL_USER_REGISTRATION_CONFIRMATION_ROUTE,
                     ),
@@ -51,21 +53,21 @@ class PlausibleMetricsService(
         PlausibleQuery(
             siteId = siteId,
             dateRange = listOf(period.start.toUkDate(), period.end.toUkDate()),
-            metrics = listOf("pageviews"),
+            metrics = METRICS,
             dimensions = listOf("event:page"),
             filters = listOf(listOf("is", "event:page", ALL_PAGES)),
         )
 
     private fun completionRate(
-        pageViewsByPage: Map<String, Double>,
+        countsByPage: Map<String, Double>,
         startPage: String,
         confirmationPage: String,
     ): Double? {
-        val startPageViews = pageViewsByPage[startPage] ?: return null
-        if (startPageViews == 0.0) return null
-        val confirmationPageViews = pageViewsByPage[confirmationPage] ?: 0.0
+        val startCount = countsByPage[startPage] ?: return null
+        if (startCount == 0.0) return null
+        val confirmationCount = countsByPage[confirmationPage] ?: 0.0
         return BigDecimal
-            .valueOf(confirmationPageViews / startPageViews * 100)
+            .valueOf(confirmationCount / startCount * 100)
             .setScale(2, RoundingMode.HALF_UP)
             .toDouble()
             .coerceAtMost(100.0)
@@ -75,6 +77,12 @@ class PlausibleMetricsService(
 
     companion object {
         private val UK_ZONE = ZoneId.of("Europe/London")
+
+        // Visitors are used for one-off-per-user journeys (landlord and local council registration); page views are
+        // used for property registration, where a single landlord may register multiple properties.
+        private val METRICS = listOf("visitors", "pageviews")
+        private const val VISITORS_INDEX = 0
+        private const val PAGE_VIEWS_INDEX = 1
 
         const val PROPERTY_REGISTRATION_CONFIRMATION_ROUTE = "$PROPERTY_REGISTRATION_ROUTE/$CONFIRMATION_PATH_SEGMENT"
         const val LOCAL_COUNCIL_USER_REGISTRATION_PRIVACY_NOTICE_ROUTE =

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/PlausibleMetricsService.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/PlausibleMetricsService.kt
@@ -1,0 +1,92 @@
+package uk.gov.communities.prsdb.webapp.services
+
+import org.springframework.beans.factory.annotation.Value
+import uk.gov.communities.prsdb.webapp.annotations.webAnnotations.PrsdbWebService
+import uk.gov.communities.prsdb.webapp.clients.PlausibleClient
+import uk.gov.communities.prsdb.webapp.constants.CONFIRMATION_PATH_SEGMENT
+import uk.gov.communities.prsdb.webapp.constants.PRIVACY_NOTICE_PATH_SEGMENT
+import uk.gov.communities.prsdb.webapp.controllers.RegisterLandlordController.Companion.LANDLORD_REGISTRATION_CONFIRMATION_ROUTE
+import uk.gov.communities.prsdb.webapp.controllers.RegisterLandlordController.Companion.LANDLORD_REGISTRATION_START_PAGE_ROUTE
+import uk.gov.communities.prsdb.webapp.controllers.RegisterLocalCouncilUserController.Companion.LOCAL_COUNCIL_USER_REGISTRATION_ROUTE
+import uk.gov.communities.prsdb.webapp.controllers.RegisterPropertyController.Companion.PROPERTY_REGISTRATION_ROUTE
+import uk.gov.communities.prsdb.webapp.models.dataModels.JourneyCompletionRatesDataModel
+import uk.gov.communities.prsdb.webapp.models.dataModels.ReportingPeriod
+import uk.gov.communities.prsdb.webapp.models.dataModels.plausible.PlausibleQuery
+import java.math.BigDecimal
+import java.math.RoundingMode
+import java.time.Instant
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+
+@PrsdbWebService
+class PlausibleMetricsService(
+    private val plausibleClient: PlausibleClient,
+    @Value("\${plausible.site-id}") private val siteId: String,
+) {
+    fun getCompletionRates(period: ReportingPeriod): JourneyCompletionRatesDataModel =
+        try {
+            val response = plausibleClient.query(buildQuery(period))
+            val visitorsByPage =
+                response.results
+                    .filter { it.dimensions.isNotEmpty() && it.metrics.isNotEmpty() }
+                    .associate { it.dimensions.first() to it.metrics.first() }
+            JourneyCompletionRatesDataModel(
+                landlordRegistration =
+                    completionRate(visitorsByPage, LANDLORD_REGISTRATION_START_PAGE_ROUTE, LANDLORD_REGISTRATION_CONFIRMATION_ROUTE),
+                propertyRegistration =
+                    completionRate(visitorsByPage, PROPERTY_REGISTRATION_ROUTE, PROPERTY_REGISTRATION_CONFIRMATION_ROUTE),
+                localCouncilUserRegistration =
+                    completionRate(
+                        visitorsByPage,
+                        LOCAL_COUNCIL_USER_REGISTRATION_PRIVACY_NOTICE_ROUTE,
+                        LOCAL_COUNCIL_USER_REGISTRATION_CONFIRMATION_ROUTE,
+                    ),
+            )
+        } catch (e: Exception) {
+            JourneyCompletionRatesDataModel(null, null, null)
+        }
+
+    private fun buildQuery(period: ReportingPeriod): PlausibleQuery =
+        PlausibleQuery(
+            siteId = siteId,
+            dateRange = listOf(period.start.toUkDate(), period.end.toUkDate()),
+            metrics = listOf("visitors"),
+            dimensions = listOf("event:page"),
+            filters = listOf(listOf("is", "event:page", ALL_PAGES)),
+        )
+
+    private fun completionRate(
+        visitorsByPage: Map<String, Double>,
+        startPage: String,
+        confirmationPage: String,
+    ): Double? {
+        val startVisitors = visitorsByPage[startPage] ?: return null
+        if (startVisitors == 0.0) return null
+        val confirmationVisitors = visitorsByPage[confirmationPage] ?: 0.0
+        return BigDecimal(confirmationVisitors / startVisitors * 100)
+            .setScale(2, RoundingMode.HALF_UP)
+            .toDouble()
+    }
+
+    private fun Instant.toUkDate(): String = DateTimeFormatter.ISO_LOCAL_DATE.format(this.atZone(UK_ZONE).toLocalDate())
+
+    companion object {
+        private val UK_ZONE = ZoneId.of("Europe/London")
+
+        const val PROPERTY_REGISTRATION_CONFIRMATION_ROUTE = "$PROPERTY_REGISTRATION_ROUTE/$CONFIRMATION_PATH_SEGMENT"
+        const val LOCAL_COUNCIL_USER_REGISTRATION_PRIVACY_NOTICE_ROUTE =
+            "$LOCAL_COUNCIL_USER_REGISTRATION_ROUTE/$PRIVACY_NOTICE_PATH_SEGMENT"
+        const val LOCAL_COUNCIL_USER_REGISTRATION_CONFIRMATION_ROUTE =
+            "$LOCAL_COUNCIL_USER_REGISTRATION_ROUTE/$CONFIRMATION_PATH_SEGMENT"
+
+        private val ALL_PAGES =
+            listOf(
+                LANDLORD_REGISTRATION_START_PAGE_ROUTE,
+                LANDLORD_REGISTRATION_CONFIRMATION_ROUTE,
+                PROPERTY_REGISTRATION_ROUTE,
+                PROPERTY_REGISTRATION_CONFIRMATION_ROUTE,
+                LOCAL_COUNCIL_USER_REGISTRATION_PRIVACY_NOTICE_ROUTE,
+                LOCAL_COUNCIL_USER_REGISTRATION_CONFIRMATION_ROUTE,
+            )
+    }
+}

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/PlausibleMetricsService.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/PlausibleMetricsService.kt
@@ -1,5 +1,6 @@
 package uk.gov.communities.prsdb.webapp.services
 
+import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value
 import uk.gov.communities.prsdb.webapp.annotations.webAnnotations.PrsdbWebService
 import uk.gov.communities.prsdb.webapp.clients.PlausibleClient
@@ -43,6 +44,7 @@ class PlausibleMetricsService(
                     ),
             )
         } catch (e: Exception) {
+            logger.warn("Failed to fetch journey completion rates from Plausible; displaying no data", e)
             JourneyCompletionRatesDataModel(null, null, null)
         }
 
@@ -63,14 +65,18 @@ class PlausibleMetricsService(
         val startVisitors = visitorsByPage[startPage] ?: return null
         if (startVisitors == 0.0) return null
         val confirmationVisitors = visitorsByPage[confirmationPage] ?: 0.0
-        return BigDecimal(confirmationVisitors / startVisitors * 100)
+        return BigDecimal
+            .valueOf(confirmationVisitors / startVisitors * 100)
             .setScale(2, RoundingMode.HALF_UP)
             .toDouble()
+            .coerceAtMost(100.0)
     }
 
     private fun Instant.toUkDate(): String = DateTimeFormatter.ISO_LOCAL_DATE.format(this.atZone(UK_ZONE).toLocalDate())
 
     companion object {
+        private val logger = LoggerFactory.getLogger(PlausibleMetricsService::class.java)
+
         private val UK_ZONE = ZoneId.of("Europe/London")
 
         const val PROPERTY_REGISTRATION_CONFIRMATION_ROUTE = "$PROPERTY_REGISTRATION_ROUTE/$CONFIRMATION_PATH_SEGMENT"

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/PlausibleMetricsService.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/PlausibleMetricsService.kt
@@ -1,6 +1,5 @@
 package uk.gov.communities.prsdb.webapp.services
 
-import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Value
 import uk.gov.communities.prsdb.webapp.annotations.webAnnotations.PrsdbWebService
 import uk.gov.communities.prsdb.webapp.clients.PlausibleClient
@@ -44,7 +43,7 @@ class PlausibleMetricsService(
                     ),
             )
         } catch (e: Exception) {
-            logger.warn("Failed to fetch journey completion rates from Plausible; displaying no data", e)
+            println("Failed to fetch journey completion rates from Plausible: ${e.message}")
             JourneyCompletionRatesDataModel(null, null, null)
         }
 
@@ -75,8 +74,6 @@ class PlausibleMetricsService(
     private fun Instant.toUkDate(): String = DateTimeFormatter.ISO_LOCAL_DATE.format(this.atZone(UK_ZONE).toLocalDate())
 
     companion object {
-        private val logger = LoggerFactory.getLogger(PlausibleMetricsService::class.java)
-
         private val UK_ZONE = ZoneId.of("Europe/London")
 
         const val PROPERTY_REGISTRATION_CONFIRMATION_ROUTE = "$PROPERTY_REGISTRATION_ROUTE/$CONFIRMATION_PATH_SEGMENT"

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -88,6 +88,8 @@ management:
 
 plausible:
   site-id: local-no-analytics
+  base-url: https://plausible.io
+  api-key: ${PLAUSIBLE_API_KEY:}
 
 beta-feedback:
   team-email-address: Team-PRSDB@Softwire.com

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -89,7 +89,7 @@ management:
 plausible:
   site-id: local-no-analytics
   base-url: http://localhost:${server.port}/local/plausible
-  api-key: ${PLAUSIBLE_API_KEY:}
+  api-key: local-no-analytics
 
 beta-feedback:
   team-email-address: Team-PRSDB@Softwire.com

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -88,7 +88,7 @@ management:
 
 plausible:
   site-id: local-no-analytics
-  base-url: https://plausible.io
+  base-url: http://localhost:${server.port}/local/plausible
   api-key: ${PLAUSIBLE_API_KEY:}
 
 beta-feedback:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -82,7 +82,7 @@ base-url:
 plausible:
   site-id: ${PLAUSIBLE_SITE_ID}
   base-url: https://plausible.io
-  api-key: ${PLAUSIBLE_API_KEY:}
+  api-key: ${PLAUSIBLE_API_KEY}
 
 beta-feedback:
   team-email-address: ${BETA_FEEDBACK_TEAM_EMAIL_ADDRESS}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -81,6 +81,8 @@ base-url:
 
 plausible:
   site-id: ${PLAUSIBLE_SITE_ID}
+  base-url: ${PLAUSIBLE_BASE_URL:https://plausible.io}
+  api-key: ${PLAUSIBLE_API_KEY:}
 
 beta-feedback:
   team-email-address: ${BETA_FEEDBACK_TEAM_EMAIL_ADDRESS}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -81,7 +81,7 @@ base-url:
 
 plausible:
   site-id: ${PLAUSIBLE_SITE_ID}
-  base-url: ${PLAUSIBLE_BASE_URL:https://plausible.io}
+  base-url: https://plausible.io
   api-key: ${PLAUSIBLE_API_KEY:}
 
 beta-feedback:

--- a/src/main/resources/messages/metrics.yml
+++ b/src/main/resources/messages/metrics.yml
@@ -23,6 +23,7 @@ rows:
   landlordRegistrationCompletionRate: Landlord registration completion rate
   propertyRegistrationCompletionRate: Property registration completion rate
   localCouncilUserRegistrationCompletionRate: Local council user registration completion rate
+completionRateExplanation: Completion rates for landlord and local council user registration are based on unique visitors. Property registration completion rate is based on page views, as a single landlord may register multiple properties.
 saveAndReturn:
   day: '{0} day'
   days: '{0} days'

--- a/src/main/resources/messages/metrics.yml
+++ b/src/main/resources/messages/metrics.yml
@@ -20,6 +20,9 @@ rows:
   medianTimeToFirstProperty: Median time between registration and first property (does not account for joint landlords)
   p90TimeToFirstProperty: 90th percentile time between registration and first property (does not account for joint landlords)
   p95TimeToFirstProperty: 95th percentile time between registration and first property (does not account for joint landlords)
+  landlordRegistrationCompletionRate: Landlord registration completion rate
+  propertyRegistrationCompletionRate: Property registration completion rate
+  localCouncilUserRegistrationCompletionRate: Local council user registration completion rate
 saveAndReturn:
   day: '{0} day'
   days: '{0} days'

--- a/src/main/resources/templates/metrics.html
+++ b/src/main/resources/templates/metrics.html
@@ -9,6 +9,9 @@
                 <div th:replace="~{fragments/forms/errorSummary :: errorSummary()}">Error Summary</div>
                 <h1 class="govuk-heading-l" th:text="#{metrics.heading}">Metrics</h1>
                 <dl th:if="${!#lists.isEmpty(metricRows)}" th:replace="~{fragments/summaryList :: summaryList(${metricRows})}"></dl>
+                <th:block th:if="${!#lists.isEmpty(metricRows)}">
+                    <div th:replace="~{fragments/insetText :: insetText('metrics.completionRateExplanation')}"></div>
+                </th:block>
                 <h2 class="govuk-heading-m" th:text="#{metrics.reportingPeriod.heading}">Reporting period</h2>
                 <th:block th:replace="~{fragments/forms/dateInputScoped :: dateInputScoped('fromDate', 'fromDay', 'fromMonth', 'fromYear', #{metrics.fromDate.fieldSetHeading}, #{metrics.fromDate.fieldSetHint})}"></th:block>
                 <th:block th:replace="~{fragments/forms/dateInputScoped :: dateInputScoped('toDate', 'toDay', 'toMonth', 'toYear', #{metrics.toDate.fieldSetHeading}, #{metrics.toDate.fieldSetHint})}"></th:block>

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/controllers/MetricsControllerTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/controllers/MetricsControllerTests.kt
@@ -1,6 +1,8 @@
 package uk.gov.communities.prsdb.webapp.controllers
 
+import org.hamcrest.Matchers.containsString
 import org.hamcrest.Matchers.hasSize
+import org.hamcrest.Matchers.not
 import org.mockito.kotlin.any
 import org.mockito.kotlin.whenever
 import org.springframework.beans.factory.annotation.Autowired
@@ -190,6 +192,51 @@ class MetricsControllerTests(
                 model {
                     attribute("metricRows", hasSize<Any>(10))
                 }
+            }
+    }
+
+    @Test
+    @WithMockUser(roles = ["SYSTEM_OPERATOR"])
+    fun `getMetrics does not render the completion rate explanation when there are no metric rows`() {
+        mvc
+            .get(METRICS_URL)
+            .andExpect {
+                status { isOk() }
+                content { string(not(containsString("metrics.completionRateExplanation"))) }
+            }
+    }
+
+    @Test
+    @WithMockUser(roles = ["SYSTEM_OPERATOR"])
+    fun `submitMetrics renders the completion rate explanation when metric rows are populated`() {
+        whenever(metricsService.getMetrics(any())).thenReturn(
+            MetricsDataModel(
+                numberOfLandlordRegistrations = 5L,
+                numberOfVerifiedLandlords = 4L,
+                numberOfProperties = 3L,
+                numberOfLandlordsWithAProperty = 2L,
+                medianTimeToFirstProperty = Duration.ofDays(4),
+                p90TimeToFirstProperty = Duration.ofDays(10),
+                p95TimeToFirstProperty = Duration.ofDays(20),
+            ),
+        )
+        whenever(plausibleMetricsService.getCompletionRates(any())).thenReturn(
+            JourneyCompletionRatesDataModel(73.24, 25.0, null),
+        )
+
+        mvc
+            .post(METRICS_URL) {
+                contentType = MediaType.APPLICATION_FORM_URLENCODED
+                param("fromDay", "10")
+                param("fromMonth", "1")
+                param("fromYear", "2025")
+                param("toDay", "20")
+                param("toMonth", "1")
+                param("toYear", "2025")
+                with(csrf())
+            }.andExpect {
+                status { isOk() }
+                content { string(containsString("metrics.completionRateExplanation")) }
             }
     }
 

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/controllers/MetricsControllerTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/controllers/MetricsControllerTests.kt
@@ -13,8 +13,10 @@ import org.springframework.test.web.servlet.get
 import org.springframework.test.web.servlet.post
 import org.springframework.web.context.WebApplicationContext
 import uk.gov.communities.prsdb.webapp.controllers.MetricsController.Companion.METRICS_URL
+import uk.gov.communities.prsdb.webapp.models.dataModels.JourneyCompletionRatesDataModel
 import uk.gov.communities.prsdb.webapp.models.dataModels.MetricsDataModel
 import uk.gov.communities.prsdb.webapp.services.MetricsService
+import uk.gov.communities.prsdb.webapp.services.PlausibleMetricsService
 import java.time.Duration
 import kotlin.test.Test
 
@@ -24,6 +26,9 @@ class MetricsControllerTests(
 ) : ControllerTest(webContext) {
     @MockitoBean
     lateinit var metricsService: MetricsService
+
+    @MockitoBean
+    lateinit var plausibleMetricsService: PlausibleMetricsService
 
     @Test
     fun `getMetrics returns a redirect for unauthenticated user`() {
@@ -128,6 +133,9 @@ class MetricsControllerTests(
                 p95TimeToFirstProperty = null,
             ),
         )
+        whenever(plausibleMetricsService.getCompletionRates(any())).thenReturn(
+            JourneyCompletionRatesDataModel(null, null, null),
+        )
 
         mvc
             .post(METRICS_URL) {
@@ -150,7 +158,7 @@ class MetricsControllerTests(
 
     @Test
     @WithMockUser(roles = ["SYSTEM_OPERATOR"])
-    fun `submitMetrics populates seven metric rows for a valid date range`() {
+    fun `submitMetrics populates ten metric rows for a valid date range`() {
         whenever(metricsService.getMetrics(any())).thenReturn(
             MetricsDataModel(
                 numberOfLandlordRegistrations = 5L,
@@ -161,6 +169,9 @@ class MetricsControllerTests(
                 p90TimeToFirstProperty = Duration.ofDays(10),
                 p95TimeToFirstProperty = Duration.ofDays(20),
             ),
+        )
+        whenever(plausibleMetricsService.getCompletionRates(any())).thenReturn(
+            JourneyCompletionRatesDataModel(73.24, 25.0, null),
         )
 
         mvc
@@ -177,7 +188,7 @@ class MetricsControllerTests(
                 status { isOk() }
                 view { name("metrics") }
                 model {
-                    attribute("metricRows", hasSize<Any>(7))
+                    attribute("metricRows", hasSize<Any>(10))
                 }
             }
     }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/PlausibleMetricsServiceTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/PlausibleMetricsServiceTests.kt
@@ -105,7 +105,7 @@ class PlausibleMetricsServiceTests {
     }
 
     @Test
-    fun `getCompletionRates caps the rate at 100 percent when confirmations exceed starts`() {
+    fun `getCompletionRates does not cap the rate at 100 percent when confirmations exceed starts`() {
         whenever(plausibleClient.query(any())).thenReturn(
             PlausibleQueryResponse(
                 listOf(
@@ -115,7 +115,7 @@ class PlausibleMetricsServiceTests {
             ),
         )
 
-        assertEquals(100.0, service().getCompletionRates(period).propertyRegistration)
+        assertEquals(150.0, service().getCompletionRates(period).propertyRegistration)
     }
 
     @Test

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/PlausibleMetricsServiceTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/PlausibleMetricsServiceTests.kt
@@ -34,8 +34,8 @@ class PlausibleMetricsServiceTests {
 
     private fun row(
         page: String,
-        visitors: Double,
-    ) = PlausibleResultRow(metrics = listOf(visitors), dimensions = listOf(page))
+        pageViews: Double,
+    ) = PlausibleResultRow(metrics = listOf(pageViews), dimensions = listOf(page))
 
     @Test
     fun `getCompletionRates computes a rate per journey rounded to two decimals`() {
@@ -60,7 +60,7 @@ class PlausibleMetricsServiceTests {
     }
 
     @Test
-    fun `getCompletionRates returns null for a journey with zero start visitors`() {
+    fun `getCompletionRates returns null for a journey with zero start page views`() {
         whenever(plausibleClient.query(any())).thenReturn(
             PlausibleQueryResponse(
                 listOf(row("/landlord/register-as-a-landlord/start", 0.0)),
@@ -82,7 +82,7 @@ class PlausibleMetricsServiceTests {
     }
 
     @Test
-    fun `getCompletionRates returns zero when there are start visitors but no confirmations`() {
+    fun `getCompletionRates returns zero when there are start page views but no confirmations`() {
         whenever(plausibleClient.query(any())).thenReturn(
             PlausibleQueryResponse(
                 listOf(row("/landlord/register-property", 50.0)),
@@ -118,7 +118,7 @@ class PlausibleMetricsServiceTests {
     }
 
     @Test
-    fun `getCompletionRates queries Plausible with UK date range, visitors metric and page filter`() {
+    fun `getCompletionRates queries Plausible with UK date range, pageViews metric and page filter`() {
         whenever(plausibleClient.query(any())).thenReturn(PlausibleQueryResponse(emptyList()))
 
         service().getCompletionRates(period)
@@ -128,7 +128,7 @@ class PlausibleMetricsServiceTests {
         val query = captor.firstValue
         assertEquals(siteId, query.siteId)
         assertEquals(listOf("2025-01-10", "2025-01-20"), query.dateRange)
-        assertEquals(listOf("visitors"), query.metrics)
+        assertEquals(listOf("pageviews"), query.metrics)
         assertEquals(listOf("event:page"), query.dimensions)
         val filter = query.filters.single()
         assertEquals("is", filter[0])

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/PlausibleMetricsServiceTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/PlausibleMetricsServiceTests.kt
@@ -34,20 +34,21 @@ class PlausibleMetricsServiceTests {
 
     private fun row(
         page: String,
-        pageViews: Double,
-    ) = PlausibleResultRow(metrics = listOf(pageViews), dimensions = listOf(page))
+        visitors: Double,
+        pageViews: Double = visitors,
+    ) = PlausibleResultRow(metrics = listOf(visitors, pageViews), dimensions = listOf(page))
 
     @Test
-    fun `getCompletionRates computes a rate per journey rounded to two decimals`() {
+    fun `getCompletionRates uses visitors for landlord and council and pageViews for property`() {
         whenever(plausibleClient.query(any())).thenReturn(
             PlausibleQueryResponse(
                 listOf(
-                    row("/landlord/register-as-a-landlord/start", 1000.0),
-                    row("/landlord/register-as-a-landlord/confirmation", 732.0),
-                    row("/landlord/register-property", 80.0),
-                    row("/landlord/register-property/confirmation", 20.0),
-                    row("/local-council/register-local-council-user/privacy-notice", 3.0),
-                    row("/local-council/register-local-council-user/confirmation", 1.0),
+                    row("/landlord/register-as-a-landlord/start", visitors = 1000.0, pageViews = 9999.0),
+                    row("/landlord/register-as-a-landlord/confirmation", visitors = 732.0, pageViews = 9999.0),
+                    row("/landlord/register-property", visitors = 9999.0, pageViews = 80.0),
+                    row("/landlord/register-property/confirmation", visitors = 9999.0, pageViews = 20.0),
+                    row("/local-council/register-local-council-user/privacy-notice", visitors = 3.0, pageViews = 9999.0),
+                    row("/local-council/register-local-council-user/confirmation", visitors = 1.0, pageViews = 9999.0),
                 ),
             ),
         )
@@ -60,10 +61,10 @@ class PlausibleMetricsServiceTests {
     }
 
     @Test
-    fun `getCompletionRates returns null for a journey with zero start page views`() {
+    fun `getCompletionRates returns null for a journey with zero start visitors`() {
         whenever(plausibleClient.query(any())).thenReturn(
             PlausibleQueryResponse(
-                listOf(row("/landlord/register-as-a-landlord/start", 0.0)),
+                listOf(row("/landlord/register-as-a-landlord/start", visitors = 0.0)),
             ),
         )
 
@@ -85,7 +86,7 @@ class PlausibleMetricsServiceTests {
     fun `getCompletionRates returns zero when there are start page views but no confirmations`() {
         whenever(plausibleClient.query(any())).thenReturn(
             PlausibleQueryResponse(
-                listOf(row("/landlord/register-property", 50.0)),
+                listOf(row("/landlord/register-property", visitors = 0.0, pageViews = 50.0)),
             ),
         )
 
@@ -108,8 +109,8 @@ class PlausibleMetricsServiceTests {
         whenever(plausibleClient.query(any())).thenReturn(
             PlausibleQueryResponse(
                 listOf(
-                    row("/landlord/register-property", 50.0),
-                    row("/landlord/register-property/confirmation", 75.0),
+                    row("/landlord/register-property", visitors = 0.0, pageViews = 50.0),
+                    row("/landlord/register-property/confirmation", visitors = 0.0, pageViews = 75.0),
                 ),
             ),
         )
@@ -118,7 +119,7 @@ class PlausibleMetricsServiceTests {
     }
 
     @Test
-    fun `getCompletionRates queries Plausible with UK date range, pageViews metric and page filter`() {
+    fun `getCompletionRates queries Plausible with UK date range, visitors and pageViews metrics and page filter`() {
         whenever(plausibleClient.query(any())).thenReturn(PlausibleQueryResponse(emptyList()))
 
         service().getCompletionRates(period)
@@ -128,7 +129,7 @@ class PlausibleMetricsServiceTests {
         val query = captor.firstValue
         assertEquals(siteId, query.siteId)
         assertEquals(listOf("2025-01-10", "2025-01-20"), query.dateRange)
-        assertEquals(listOf("pageviews"), query.metrics)
+        assertEquals(listOf("visitors", "pageviews"), query.metrics)
         assertEquals(listOf("event:page"), query.dimensions)
         val filter = query.filters.single()
         assertEquals("is", filter[0])

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/PlausibleMetricsServiceTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/PlausibleMetricsServiceTests.kt
@@ -104,6 +104,20 @@ class PlausibleMetricsServiceTests {
     }
 
     @Test
+    fun `getCompletionRates caps the rate at 100 percent when confirmations exceed starts`() {
+        whenever(plausibleClient.query(any())).thenReturn(
+            PlausibleQueryResponse(
+                listOf(
+                    row("/landlord/register-property", 50.0),
+                    row("/landlord/register-property/confirmation", 75.0),
+                ),
+            ),
+        )
+
+        assertEquals(100.0, service().getCompletionRates(period).propertyRegistration)
+    }
+
+    @Test
     fun `getCompletionRates queries Plausible with UK date range, visitors metric and page filter`() {
         whenever(plausibleClient.query(any())).thenReturn(PlausibleQueryResponse(emptyList()))
 

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/PlausibleMetricsServiceTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/PlausibleMetricsServiceTests.kt
@@ -1,0 +1,127 @@
+package uk.gov.communities.prsdb.webapp.services
+
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import uk.gov.communities.prsdb.webapp.clients.PlausibleClient
+import uk.gov.communities.prsdb.webapp.models.dataModels.ReportingPeriod
+import uk.gov.communities.prsdb.webapp.models.dataModels.plausible.PlausibleQuery
+import uk.gov.communities.prsdb.webapp.models.dataModels.plausible.PlausibleQueryResponse
+import uk.gov.communities.prsdb.webapp.models.dataModels.plausible.PlausibleResultRow
+import java.time.Instant
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+@ExtendWith(MockitoExtension::class)
+class PlausibleMetricsServiceTests {
+    @Mock
+    private lateinit var plausibleClient: PlausibleClient
+
+    private val siteId = "test-site-id"
+    private val period =
+        ReportingPeriod(
+            Instant.parse("2025-01-10T00:00:00Z"),
+            Instant.parse("2025-01-20T23:59:59Z"),
+        )
+
+    private fun service() = PlausibleMetricsService(plausibleClient, siteId)
+
+    private fun row(
+        page: String,
+        visitors: Double,
+    ) = PlausibleResultRow(metrics = listOf(visitors), dimensions = listOf(page))
+
+    @Test
+    fun `getCompletionRates computes a rate per journey rounded to two decimals`() {
+        whenever(plausibleClient.query(any())).thenReturn(
+            PlausibleQueryResponse(
+                listOf(
+                    row("/landlord/register-as-a-landlord/start", 1000.0),
+                    row("/landlord/register-as-a-landlord/confirmation", 732.0),
+                    row("/landlord/register-property", 80.0),
+                    row("/landlord/register-property/confirmation", 20.0),
+                    row("/local-council/register-local-council-user/privacy-notice", 3.0),
+                    row("/local-council/register-local-council-user/confirmation", 1.0),
+                ),
+            ),
+        )
+
+        val rates = service().getCompletionRates(period)
+
+        assertEquals(73.20, rates.landlordRegistration)
+        assertEquals(25.00, rates.propertyRegistration)
+        assertEquals(33.33, rates.localCouncilUserRegistration)
+    }
+
+    @Test
+    fun `getCompletionRates returns null for a journey with zero start visitors`() {
+        whenever(plausibleClient.query(any())).thenReturn(
+            PlausibleQueryResponse(
+                listOf(row("/landlord/register-as-a-landlord/start", 0.0)),
+            ),
+        )
+
+        assertNull(service().getCompletionRates(period).landlordRegistration)
+    }
+
+    @Test
+    fun `getCompletionRates returns null for a journey missing from the results`() {
+        whenever(plausibleClient.query(any())).thenReturn(PlausibleQueryResponse(emptyList()))
+
+        val rates = service().getCompletionRates(period)
+
+        assertNull(rates.landlordRegistration)
+        assertNull(rates.propertyRegistration)
+        assertNull(rates.localCouncilUserRegistration)
+    }
+
+    @Test
+    fun `getCompletionRates returns zero when there are start visitors but no confirmations`() {
+        whenever(plausibleClient.query(any())).thenReturn(
+            PlausibleQueryResponse(
+                listOf(row("/landlord/register-property", 50.0)),
+            ),
+        )
+
+        assertEquals(0.0, service().getCompletionRates(period).propertyRegistration)
+    }
+
+    @Test
+    fun `getCompletionRates returns all null rates when the client throws`() {
+        whenever(plausibleClient.query(any())).thenThrow(RuntimeException("boom"))
+
+        val rates = service().getCompletionRates(period)
+
+        assertNull(rates.landlordRegistration)
+        assertNull(rates.propertyRegistration)
+        assertNull(rates.localCouncilUserRegistration)
+    }
+
+    @Test
+    fun `getCompletionRates queries Plausible with UK date range, visitors metric and page filter`() {
+        whenever(plausibleClient.query(any())).thenReturn(PlausibleQueryResponse(emptyList()))
+
+        service().getCompletionRates(period)
+
+        val captor = argumentCaptor<PlausibleQuery>()
+        verify(plausibleClient).query(captor.capture())
+        val query = captor.firstValue
+        assertEquals(siteId, query.siteId)
+        assertEquals(listOf("2025-01-10", "2025-01-20"), query.dateRange)
+        assertEquals(listOf("visitors"), query.metrics)
+        assertEquals(listOf("event:page"), query.dimensions)
+        val filter = query.filters.single()
+        assertEquals("is", filter[0])
+        assertEquals("event:page", filter[1])
+        @Suppress("UNCHECKED_CAST")
+        val pages = filter[2] as List<String>
+        assertEquals(6, pages.size)
+        assertTrue(pages.contains("/landlord/register-as-a-landlord/confirmation"))
+    }
+}

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -35,6 +35,8 @@ aws:
 
 plausible:
   site-id: test-site-id
+  base-url: https://plausible.test
+  api-key: test-api-key
 
 beta-feedback:
   team-email-address: feedback@example.com


### PR DESCRIPTION
## Ticket number

PDJB-1035

## Goal of change

Surface journey completion rates (landlord registration, property registration, local council user registration) on the system operator metrics dashboard, sourced from Plausible analytics.

## Description of main change(s)

- Adds a Plausible analytics integration (`PlausibleClient` + `PlausibleApiConfig`) that queries the Plausible Stats API for per-page visitor counts.
- Adds three completion-rate rows to the metrics dashboard: confirmation-page visitors as a percentage of start-page visitors for each registration journey.
- Rates degrade gracefully to "No data" on API failure (now logged at `warn`) and are capped at 100%.
- Adds a local stub (`MockPlausibleController`, `@Profile("local")`) so local dev exercises the real client/parsing path without an outbound call or API key.

## Anything you'd like to highlight to the reviewer?

- This branch was rebased onto main after PDJB-1033 merged. PDJB-1033 evolved during its review (single `averageTimeToFirstProperty` row → median/p90/p95 percentile rows), so the rebase keeps main's percentile rows and layers the new completion-rate rows on top — the metrics list is now 10 rows.

## Checklist

- [x] Unit tests for new logic (e.g. new service methods) have been added
- [x] Controller tests for any new endpoints, including testing the relevant permissions
- [x] Branch has been rebased onto main and run locally, with everything working as expected (both for your new feature
  and any related functionality)
- [x] TODO comments referencing this JIRA ticket have been searched for and removed - if a future PR will address them,
  mention that here
- [x] Test suite has been run in full locally and is passing
- [ ] QA instructions have been added to the ticket (particularly if this is the last PR required to complete the ticket)
