### PR TITLE
PDJB-317: confirm property deregistration page

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyDeregistration/PropertyDeregistrationJourneyFactory.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyDeregistration/PropertyDeregistrationJourneyFactory.kt
@@ -20,6 +20,7 @@ import uk.gov.communities.prsdb.webapp.journeys.isComplete
 import uk.gov.communities.prsdb.webapp.journeys.propertyDeregistration.stepConfig.AreYouSureMode
 import uk.gov.communities.prsdb.webapp.journeys.propertyDeregistration.stepConfig.AreYouSureStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyDeregistration.stepConfig.CheckPendingInvitationsStep
+import uk.gov.communities.prsdb.webapp.journeys.propertyDeregistration.stepConfig.ConfirmStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyDeregistration.stepConfig.DeregisterInfoStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyDeregistration.stepConfig.HasPendingInvitationsMode
 import uk.gov.communities.prsdb.webapp.journeys.propertyDeregistration.stepConfig.HasPendingInvitationsStep
@@ -48,7 +49,7 @@ class PropertyDeregistrationJourneyFactory(
                 nextStep { mode ->
                     when (mode) {
                         HasPendingInvitationsMode.YES -> journey.checkPendingInvitationsStep
-                        HasPendingInvitationsMode.NO -> journey.reasonStep
+                        HasPendingInvitationsMode.NO -> journey.confirmStep
                     }
                 }
             }
@@ -59,10 +60,10 @@ class PropertyDeregistrationJourneyFactory(
                     DeregisterPropertyController.getPropertyDeregistrationBasePath(propertyOwnershipId) +
                         "/${DeregisterInfoStep.ROUTE_SEGMENT}"
                 }
-                nextStep { journey.reasonStep }
+                nextStep { journey.confirmStep }
             }
-            step(journey.reasonStep) {
-                routeSegment(ReasonStep.ROUTE_SEGMENT)
+            step(journey.confirmStep) {
+                routeSegment(ConfirmStep.ROUTE_SEGMENT)
                 parents {
                     OrParents(
                         journey.hasPendingInvitationsStep.hasOutcome(HasPendingInvitationsMode.NO),
@@ -142,6 +143,7 @@ class PropertyDeregistrationJourney(
     override val deregisterInfoStep: DeregisterInfoStep,
     override val hasPendingInvitationsStep: HasPendingInvitationsStep,
     override val checkPendingInvitationsStep: CheckPendingInvitationsStep,
+    override val confirmStep: ConfirmStep,
     override val reasonStep: ReasonStep,
     journeyStateService: JourneyStateService,
 ) : AbstractJourneyState(journeyStateService),
@@ -168,6 +170,7 @@ interface PropertyDeregistrationJourneyState : JourneyState {
     val deregisterInfoStep: DeregisterInfoStep
     val hasPendingInvitationsStep: HasPendingInvitationsStep
     val checkPendingInvitationsStep: CheckPendingInvitationsStep
+    val confirmStep: ConfirmStep
     val reasonStep: ReasonStep
     var propertyOwnershipId: Long
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyDeregistration/stepConfig/ConfirmStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyDeregistration/stepConfig/ConfirmStepConfig.kt
@@ -7,7 +7,6 @@ import uk.gov.communities.prsdb.webapp.journeys.Destination
 import uk.gov.communities.prsdb.webapp.journeys.JourneyStep.RequestableStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyDeregistration.PropertyDeregistrationJourneyState
 import uk.gov.communities.prsdb.webapp.journeys.shared.Complete
-import uk.gov.communities.prsdb.webapp.models.dataModels.RegistrationNumberDataModel
 import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.NoInputFormModel
 import uk.gov.communities.prsdb.webapp.models.viewModels.emailModels.PropertyDeregistrationConfirmationEmail
 import uk.gov.communities.prsdb.webapp.services.EmailNotificationService
@@ -38,23 +37,18 @@ class ConfirmStepConfig(
     override fun mode(state: PropertyDeregistrationJourneyState): Complete? = getFormModelFromStateOrNull(state)?.let { Complete.COMPLETE }
 
     override fun afterStepDataIsAdded(state: PropertyDeregistrationJourneyState) {
-        val propertyOwnership = propertyOwnershipService.getPropertyOwnership(state.propertyOwnershipId)
-
-        // TODO PDJB-319 - do not use primary landlord
-        val primaryLandlordEmailAddress = propertyOwnership.primaryLandlord.email
-        val propertyRegistrationNumber = propertyOwnership.registrationNumber
-        val propertyAddress = propertyOwnership.address.singleLineAddress
-
-        propertyDeregistrationService.deregisterProperty(state.propertyOwnershipId)
+        val emailDetails = propertyDeregistrationService.deregisterProperty(state.propertyOwnershipId)
         propertyDeregistrationService.addDeregisteredPropertyOwnershipIdToSession(state.propertyOwnershipId)
 
-        confirmationEmailSender.sendEmail(
-            primaryLandlordEmailAddress,
-            PropertyDeregistrationConfirmationEmail(
-                RegistrationNumberDataModel.fromRegistrationNumber(propertyRegistrationNumber).toString(),
-                propertyAddress,
-            ),
-        )
+        // PDJB-318: Use new email here
+        for (landlordEmail in emailDetails.landlordEmailAddresses)
+            confirmationEmailSender.sendEmail(
+                landlordEmail,
+                PropertyDeregistrationConfirmationEmail(
+                    emailDetails.prn,
+                    emailDetails.singleLineAddress,
+                ),
+            )
     }
 
     override fun resolveNextDestination(

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyDeregistration/stepConfig/ConfirmStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyDeregistration/stepConfig/ConfirmStepConfig.kt
@@ -1,0 +1,77 @@
+package uk.gov.communities.prsdb.webapp.journeys.propertyDeregistration.stepConfig
+
+import uk.gov.communities.prsdb.webapp.annotations.webAnnotations.JourneyFrameworkComponent
+import uk.gov.communities.prsdb.webapp.controllers.PropertyDetailsController
+import uk.gov.communities.prsdb.webapp.journeys.AbstractRequestableStepConfig
+import uk.gov.communities.prsdb.webapp.journeys.Destination
+import uk.gov.communities.prsdb.webapp.journeys.JourneyStep.RequestableStep
+import uk.gov.communities.prsdb.webapp.journeys.propertyDeregistration.PropertyDeregistrationJourneyState
+import uk.gov.communities.prsdb.webapp.journeys.shared.Complete
+import uk.gov.communities.prsdb.webapp.models.dataModels.RegistrationNumberDataModel
+import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.NoInputFormModel
+import uk.gov.communities.prsdb.webapp.models.viewModels.emailModels.PropertyDeregistrationConfirmationEmail
+import uk.gov.communities.prsdb.webapp.services.EmailNotificationService
+import uk.gov.communities.prsdb.webapp.services.PropertyDeregistrationService
+import uk.gov.communities.prsdb.webapp.services.PropertyOwnershipService
+
+@JourneyFrameworkComponent
+class ConfirmStepConfig(
+    private val propertyOwnershipService: PropertyOwnershipService,
+    private val propertyDeregistrationService: PropertyDeregistrationService,
+    private val confirmationEmailSender: EmailNotificationService<PropertyDeregistrationConfirmationEmail>,
+) : AbstractRequestableStepConfig<Complete, NoInputFormModel, PropertyDeregistrationJourneyState>() {
+    override val formModelClass = NoInputFormModel::class
+
+    override fun getStepSpecificContent(state: PropertyDeregistrationJourneyState) =
+        mapOf(
+            "address" to
+                propertyOwnershipService
+                    .getPropertyOwnership(state.propertyOwnershipId)
+                    .address
+                    .toMultiLineAddress()
+                    .split("\n"),
+            "cancelLinkUrl" to PropertyDetailsController.getPropertyDetailsPath(state.propertyOwnershipId),
+        )
+
+    override fun chooseTemplate(state: PropertyDeregistrationJourneyState) = "forms/confirmPropertyDeregistrationForm"
+
+    override fun mode(state: PropertyDeregistrationJourneyState): Complete? = getFormModelFromStateOrNull(state)?.let { Complete.COMPLETE }
+
+    override fun afterStepDataIsAdded(state: PropertyDeregistrationJourneyState) {
+        val propertyOwnership = propertyOwnershipService.getPropertyOwnership(state.propertyOwnershipId)
+
+        // TODO PDJB-319 - do not use primary landlord
+        val primaryLandlordEmailAddress = propertyOwnership.primaryLandlord.email
+        val propertyRegistrationNumber = propertyOwnership.registrationNumber
+        val propertyAddress = propertyOwnership.address.singleLineAddress
+
+        propertyDeregistrationService.deregisterProperty(state.propertyOwnershipId)
+        propertyDeregistrationService.addDeregisteredPropertyOwnershipIdToSession(state.propertyOwnershipId)
+
+        confirmationEmailSender.sendEmail(
+            primaryLandlordEmailAddress,
+            PropertyDeregistrationConfirmationEmail(
+                RegistrationNumberDataModel.fromRegistrationNumber(propertyRegistrationNumber).toString(),
+                propertyAddress,
+            ),
+        )
+    }
+
+    override fun resolveNextDestination(
+        state: PropertyDeregistrationJourneyState,
+        defaultDestination: Destination,
+    ): Destination {
+        // Clean up journey state from session after all business logic completes
+        state.deleteJourney()
+        return defaultDestination
+    }
+}
+
+@JourneyFrameworkComponent
+final class ConfirmStep(
+    stepConfig: ConfirmStepConfig,
+) : RequestableStep<Complete, NoInputFormModel, PropertyDeregistrationJourneyState>(stepConfig) {
+    companion object {
+        const val ROUTE_SEGMENT = "confirm"
+    }
+}

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/dataModels/PropertyDeregistrationEmailDetails.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/dataModels/PropertyDeregistrationEmailDetails.kt
@@ -1,0 +1,7 @@
+package uk.gov.communities.prsdb.webapp.models.dataModels
+
+data class PropertyDeregistrationEmailDetails(
+    val landlordEmailAddresses: List<String>,
+    val prn: String,
+    val singleLineAddress: String,
+)

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/PropertyDeregistrationService.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/PropertyDeregistrationService.kt
@@ -1,16 +1,28 @@
 package uk.gov.communities.prsdb.webapp.services
 
 import jakarta.servlet.http.HttpSession
+import jakarta.transaction.Transactional
 import uk.gov.communities.prsdb.webapp.annotations.webAnnotations.PrsdbWebService
 import uk.gov.communities.prsdb.webapp.constants.PROPERTIES_DEREGISTERED_THIS_SESSION
+import uk.gov.communities.prsdb.webapp.models.dataModels.PropertyDeregistrationEmailDetails
+import uk.gov.communities.prsdb.webapp.models.dataModels.RegistrationNumberDataModel
 
 @PrsdbWebService
 class PropertyDeregistrationService(
     private val propertyOwnershipService: PropertyOwnershipService,
     private val session: HttpSession,
 ) {
-    fun deregisterProperty(propertyOwnershipId: Long) {
+    @Transactional
+    fun deregisterProperty(propertyOwnershipId: Long): PropertyDeregistrationEmailDetails {
+        val propertyOwnership = propertyOwnershipService.getPropertyOwnership(propertyOwnershipId)
+        val emailDetails =
+            PropertyDeregistrationEmailDetails(
+                landlordEmailAddresses = propertyOwnership.landlords.map { it.email },
+                prn = RegistrationNumberDataModel.fromRegistrationNumber(propertyOwnership.registrationNumber).toString(),
+                singleLineAddress = propertyOwnership.address.singleLineAddress,
+            )
         propertyOwnershipService.deletePropertyOwnership(propertyOwnershipId)
+        return emailDetails
     }
 
     fun addDeregisteredPropertyOwnershipIdToSession(propertyOwnershipId: Long) =

--- a/src/main/resources/messages/deregisterProperty.yml
+++ b/src/main/resources/messages/deregisterProperty.yml
@@ -16,6 +16,12 @@ checkInvitations:
     body: "We’ll cancel these invitations to joint landlords to register onto the property:"
     sentOn: "Sent on {0}"
   cancelLink: Cancel (go back to property record)
+confirm:
+  heading: Confirm property deregistration
+  body: "This property will be deregistered:"
+  warning: You cannot undo this action. Only continue if the property will no longer be rented out.
+  confirmButton: Confirm and deregister property
+  cancelLink: Cancel (go back to property record)
 confirmation:
   banner:
     heading: You have deleted a property

--- a/src/main/resources/templates/forms/confirmPropertyDeregistrationForm.html
+++ b/src/main/resources/templates/forms/confirmPropertyDeregistrationForm.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html>
+<th:block id="main-content"
+          th:replace="~{fragments/layout :: layout(#{deregisterProperty.title}, ~{::#main-content/content()}, false)}">
+    <a href="#" th:replace="~{fragments/forms/backLink :: backLink(${backUrl})}">Back link</a>
+    <main class="govuk-main-wrapper" id="main-content">
+        <div id="page-contents"
+             th:replace="~{fragments/layouts/twoThirdsLayout :: twoThirdsLayout(~{::#page-contents/content()})}">
+            <h1 class="govuk-heading-l" th:text="#{deregisterProperty.confirm.heading}">
+                deregisterProperty.confirm.heading
+            </h1>
+            <p class="govuk-body" th:text="#{deregisterProperty.confirm.body}">
+                deregisterProperty.confirm.body
+            </p>
+            <p class="govuk-body">
+                <th:block th:replace="~{fragments/multiLineText :: multiLineText(${address})}"></th:block>
+            </p>
+            <div th:replace="~{fragments/warningText :: warningText(#{deregisterProperty.confirm.warning})}"></div>
+            <form th:action="@{''}" method="post" novalidate>
+                <div class="govuk-button-group">
+                    <button th:replace="~{fragments/buttons/warningButton :: warningButton(#{deregisterProperty.confirm.confirmButton})}"></button>
+                    <a th:href="@{${cancelLinkUrl}}" class="govuk-link" th:text="#{deregisterProperty.confirm.cancelLink}">
+                        deregisterProperty.confirm.cancelLink
+                    </a>
+                </div>
+            </form>
+        </div>
+    </main>
+</th:block>
+</html>

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/PropertyDeregistrationJourneyTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/PropertyDeregistrationJourneyTests.kt
@@ -10,6 +10,7 @@ import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.LandlordDas
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.PropertyDetailsPageLandlordView
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages.BasePage.Companion.assertPageIs
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyDeregistrationJourneyPages.CheckInvitationsPage
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyDeregistrationJourneyPages.ConfirmPagePropertyDeregistration
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyDeregistrationJourneyPages.ConfirmationPagePropertyDeregistration
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyDeregistrationJourneyPages.ReasonPagePropertyDeregistration
 
@@ -21,13 +22,13 @@ class PropertyDeregistrationJourneyTests : IntegrationTestWithMutableData("data-
         assertThat(deregisterPropertyInfoPage.heading).containsText("1, Example Road, EG")
         deregisterPropertyInfoPage.submitContinue()
 
-        val reasonPage =
+        val confirmPage =
             assertPageIs(
                 page,
-                ReasonPagePropertyDeregistration::class,
+                ConfirmPagePropertyDeregistration::class,
                 mapOf("propertyOwnershipId" to propertyOwnershipId.toString()),
             )
-        reasonPage.submitReason("No longer own this property")
+        confirmPage.submitConfirm()
 
         val confirmationPage =
             assertPageIs(
@@ -55,13 +56,13 @@ class PropertyDeregistrationJourneyTests : IntegrationTestWithMutableData("data-
             )
         checkInvitationsPage.submitContinue()
 
-        val reasonPage =
+        val confirmPage =
             assertPageIs(
                 page,
-                ReasonPagePropertyDeregistration::class,
+                ConfirmPagePropertyDeregistration::class,
                 mapOf("propertyOwnershipId" to propertyOwnershipId.toString()),
             )
-        reasonPage.submitReason("No longer own this property")
+        confirmPage.submitConfirm()
 
         val confirmationPage =
             assertPageIs(
@@ -76,12 +77,12 @@ class PropertyDeregistrationJourneyTests : IntegrationTestWithMutableData("data-
     }
 
     @Nested
-    inner class ReasonStep {
+    inner class ConfirmStep {
         @Test
-        fun `Reason page can be submitted without being filled in`(page: Page) {
+        fun `Confirm page deregisters the property and reaches confirmation`(page: Page) {
             val propertyOwnershipId = 1.toLong()
-            val deregisterPropertyReasonPage = navigator.skipToPropertyDeregistrationReasonPage(propertyOwnershipId)
-            deregisterPropertyReasonPage.form.submit()
+            val confirmPage = navigator.skipToPropertyDeregistrationConfirmPage(propertyOwnershipId)
+            confirmPage.submitConfirm()
             assertPageIs(
                 page,
                 ConfirmationPagePropertyDeregistration::class,

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/PropertyDeregistrationSinglePageTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/PropertyDeregistrationSinglePageTests.kt
@@ -4,8 +4,11 @@ import com.microsoft.playwright.Page
 import com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import uk.gov.communities.prsdb.webapp.constants.JOINT_LANDLORDS
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.PropertyDetailsPageLandlordView
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages.BasePage
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages.BasePage.Companion.assertPageIs
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyDeregistrationJourneyPages.ReasonPagePropertyDeregistration
 
 class PropertyDeregistrationSinglePageTests : IntegrationTestWithImmutableData("data-local.sql") {
     @Nested
@@ -71,17 +74,44 @@ class PropertyDeregistrationSinglePageTests : IntegrationTestWithImmutableData("
     }
 
     @Nested
-    inner class ReasonStep {
+    inner class ConfirmStep {
         @Test
-        fun `Submitting with a reason longer than 200 characters returns an error`(page: Page) {
-            val longReason =
-                "This is my life story, it is far too long to go in this field.  " +
-                    "This is my life story, it is far too long to go in this field." +
-                    "This is my life story, it is far too long to go in this field." +
-                    "This is my life story, it is far too long to go in this field."
-            val deregisterPropertyReasonPage = navigator.skipToPropertyDeregistrationReasonPage(1.toLong())
-            deregisterPropertyReasonPage.submitReason(longReason)
-            assertThat(deregisterPropertyReasonPage.form.getErrorMessage("reason"))
+        fun `Page displays heading, address and warning`(page: Page) {
+            val confirmPage = navigator.skipToPropertyDeregistrationConfirmPage(1L)
+            assertThat(confirmPage.heading).containsText("Confirm property deregistration")
+            assertThat(confirmPage.bodyText).containsText("This property will be deregistered")
+            assertThat(confirmPage.warningText).containsText("You cannot undo this action")
+        }
+
+        @Test
+        fun `User is returned to the property details page if they click the cancel link`(page: Page) {
+            val propertyOwnershipId = 1
+            val confirmPage = navigator.skipToPropertyDeregistrationConfirmPage(propertyOwnershipId.toLong())
+            confirmPage.cancelLink.clickAndWait()
+            BasePage.assertPageIs(
+                page,
+                PropertyDetailsPageLandlordView::class,
+                mapOf("propertyOwnershipId" to propertyOwnershipId.toString()),
+            )
+        }
+    }
+
+    @Nested
+    inner class ReasonStepWhenJointLandlordsFlagIsDisabled {
+        @Test
+        fun `Submitting a reason longer than 200 characters returns an error`(page: Page) {
+            featureFlagManager.disableFeature(JOINT_LANDLORDS)
+            val areYouSurePage = navigator.goToDeregisterPropertyAreYouSurePage(1L)
+            areYouSurePage.submitWantsToProceed()
+            val reasonPage =
+                assertPageIs(
+                    page,
+                    ReasonPagePropertyDeregistration::class,
+                    mapOf("propertyOwnershipId" to "1"),
+                )
+            val longReason = "x".repeat(201)
+            reasonPage.submitReason(longReason)
+            assertThat(reasonPage.form.getErrorMessage("reason"))
                 .containsText("Your reason for deleting this property must be 200 characters or fewer")
         }
     }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/Navigator.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/Navigator.kt
@@ -104,8 +104,8 @@ import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.localCounci
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.localCouncilUserRegistrationJourneyPages.PrivacyNoticePageLocalCouncilUserRegistration
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyDeregistrationJourneyPages.AreYouSurePagePropertyDeregistration
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyDeregistrationJourneyPages.CheckInvitationsPage
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyDeregistrationJourneyPages.ConfirmPagePropertyDeregistration
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyDeregistrationJourneyPages.DeregisterPropertyInfoPage
-import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyDeregistrationJourneyPages.ReasonPagePropertyDeregistration
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyDetailsUpdateJourneyPages.CheckOccupancyAnswersPagePropertyDetailsUpdate
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyDetailsUpdateJourneyPages.OccupancyFormPagePropertyDetailsUpdate
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyDetailsUpdateJourneyPages.OwnershipTypeFormPagePropertyDetailsUpdate
@@ -218,7 +218,7 @@ import uk.gov.communities.prsdb.webapp.testHelpers.builders.PropertyStateSession
 import uk.gov.communities.prsdb.webapp.testHelpers.builders.UpdateOccupancyJourneyStateSessionBuilder
 import java.util.UUID
 import kotlin.test.assertTrue
-import uk.gov.communities.prsdb.webapp.journeys.propertyDeregistration.stepConfig.ReasonStep as DeregistrationReasonStep
+import uk.gov.communities.prsdb.webapp.journeys.propertyDeregistration.stepConfig.ConfirmStep as DeregistrationConfirmStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.EpcExpiredStep as RegistrationEpcExpiredStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.EpcMissingStep as RegistrationEpcMissingStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.LowEnergyRatingStep as RegistrationLowEnergyRatingStep
@@ -918,17 +918,17 @@ class Navigator(
         )
     }
 
-    fun skipToPropertyDeregistrationReasonPage(propertyOwnershipId: Long): ReasonPagePropertyDeregistration {
+    fun skipToPropertyDeregistrationConfirmPage(propertyOwnershipId: Long): ConfirmPagePropertyDeregistration {
         setJourneyStateInSession(
             PropertyDeregistrationStateSessionBuilder.beforePropertyDeregistrationReasonViaInfo().build(),
         )
         navigate(
             DeregisterPropertyController.getPropertyDeregistrationBasePath(propertyOwnershipId) +
-                "/${DeregistrationReasonStep.ROUTE_SEGMENT}?journeyId=$TEST_JOURNEY_ID",
+                "/${DeregistrationConfirmStep.ROUTE_SEGMENT}?journeyId=$TEST_JOURNEY_ID",
         )
         return createValidPage(
             page,
-            ReasonPagePropertyDeregistration::class,
+            ConfirmPagePropertyDeregistration::class,
             mapOf("propertyOwnershipId" to propertyOwnershipId.toString()),
         )
     }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/propertyDeregistrationJourneyPages/ConfirmPagePropertyDeregistration.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/propertyDeregistrationJourneyPages/ConfirmPagePropertyDeregistration.kt
@@ -1,0 +1,35 @@
+package uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyDeregistrationJourneyPages
+
+import com.microsoft.playwright.Page
+import uk.gov.communities.prsdb.webapp.controllers.DeregisterPropertyController
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.BackLink
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.Button
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.Link
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages.BasePage
+import uk.gov.communities.prsdb.webapp.journeys.propertyDeregistration.stepConfig.ConfirmStep
+
+class ConfirmPagePropertyDeregistration(
+    page: Page,
+    urlArguments: Map<String, String>,
+) : BasePage(
+        page,
+        DeregisterPropertyController.getPropertyDeregistrationBasePath(urlArguments["propertyOwnershipId"]!!.toLong()) +
+            "/${ConfirmStep.ROUTE_SEGMENT}",
+    ) {
+    val heading
+        get() = page.locator("h1")
+
+    val bodyText
+        get() = page.locator("main .govuk-body").first()
+
+    val warningText
+        get() = page.locator(".govuk-warning-text__text")
+
+    val confirmButton = Button(page.locator("button.govuk-button--warning"))
+    val cancelLink = Link.byText(page, "Cancel")
+    val backLink = BackLink.default(page)
+
+    fun submitConfirm() {
+        confirmButton.clickAndWait()
+    }
+}

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyDeregistration/stepConfig/ConfirmStepConfigTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyDeregistration/stepConfig/ConfirmStepConfigTests.kt
@@ -10,12 +10,12 @@ import org.mockito.kotlin.eq
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import uk.gov.communities.prsdb.webapp.journeys.propertyDeregistration.PropertyDeregistrationJourneyState
+import uk.gov.communities.prsdb.webapp.models.dataModels.PropertyDeregistrationEmailDetails
 import uk.gov.communities.prsdb.webapp.models.viewModels.emailModels.PropertyDeregistrationConfirmationEmail
 import uk.gov.communities.prsdb.webapp.services.EmailNotificationService
 import uk.gov.communities.prsdb.webapp.services.PropertyDeregistrationService
 import uk.gov.communities.prsdb.webapp.services.PropertyOwnershipService
 import uk.gov.communities.prsdb.webapp.testHelpers.mockObjects.AlwaysTrueValidator
-import uk.gov.communities.prsdb.webapp.testHelpers.mockObjects.MockLandlordData
 
 @ExtendWith(MockitoExtension::class)
 class ConfirmStepConfigTests {
@@ -36,9 +36,9 @@ class ConfirmStepConfigTests {
     @Test
     fun `afterStepDataIsAdded deregisters the property`() {
         val stepConfig = setupStepConfig()
-        val propertyOwnership = MockLandlordData.createPropertyOwnership(id = propertyOwnershipId)
         whenever(mockState.propertyOwnershipId).thenReturn(propertyOwnershipId)
-        whenever(mockPropertyOwnershipService.getPropertyOwnership(propertyOwnershipId)).thenReturn(propertyOwnership)
+        whenever(mockPropertyDeregistrationService.deregisterProperty(propertyOwnershipId))
+            .thenReturn(emailDetails())
 
         stepConfig.afterStepDataIsAdded(mockState)
 
@@ -48,9 +48,9 @@ class ConfirmStepConfigTests {
     @Test
     fun `afterStepDataIsAdded adds deregistered property ownership id to session`() {
         val stepConfig = setupStepConfig()
-        val propertyOwnership = MockLandlordData.createPropertyOwnership(id = propertyOwnershipId)
         whenever(mockState.propertyOwnershipId).thenReturn(propertyOwnershipId)
-        whenever(mockPropertyOwnershipService.getPropertyOwnership(propertyOwnershipId)).thenReturn(propertyOwnership)
+        whenever(mockPropertyDeregistrationService.deregisterProperty(propertyOwnershipId))
+            .thenReturn(emailDetails())
 
         stepConfig.afterStepDataIsAdded(mockState)
 
@@ -58,13 +58,12 @@ class ConfirmStepConfigTests {
     }
 
     @Test
-    fun `afterStepDataIsAdded sends confirmation email to primary landlord`() {
+    fun `afterStepDataIsAdded sends confirmation email to each landlord`() {
         val stepConfig = setupStepConfig()
         val landlordEmail = "landlord@example.com"
-        val landlord = MockLandlordData.createLandlord(email = landlordEmail)
-        val propertyOwnership = MockLandlordData.createPropertyOwnership(id = propertyOwnershipId, primaryLandlord = landlord)
         whenever(mockState.propertyOwnershipId).thenReturn(propertyOwnershipId)
-        whenever(mockPropertyOwnershipService.getPropertyOwnership(propertyOwnershipId)).thenReturn(propertyOwnership)
+        whenever(mockPropertyDeregistrationService.deregisterProperty(propertyOwnershipId))
+            .thenReturn(emailDetails(landlordEmailAddresses = listOf(landlordEmail)))
 
         stepConfig.afterStepDataIsAdded(mockState)
 
@@ -75,10 +74,9 @@ class ConfirmStepConfigTests {
     fun `afterStepDataIsAdded sends confirmation email with correct property address`() {
         val stepConfig = setupStepConfig()
         val propertyAddress = "123 Test Street, AB1 2CD"
-        val address = MockLandlordData.createAddress(singleLineAddress = propertyAddress)
-        val propertyOwnership = MockLandlordData.createPropertyOwnership(id = propertyOwnershipId, address = address)
         whenever(mockState.propertyOwnershipId).thenReturn(propertyOwnershipId)
-        whenever(mockPropertyOwnershipService.getPropertyOwnership(propertyOwnershipId)).thenReturn(propertyOwnership)
+        whenever(mockPropertyDeregistrationService.deregisterProperty(propertyOwnershipId))
+            .thenReturn(emailDetails(singleLineAddress = propertyAddress))
 
         stepConfig.afterStepDataIsAdded(mockState)
 
@@ -87,6 +85,12 @@ class ConfirmStepConfigTests {
             argThat<PropertyDeregistrationConfirmationEmail> { this.singleLineAddress == propertyAddress },
         )
     }
+
+    private fun emailDetails(
+        landlordEmailAddresses: List<String> = listOf("landlord@example.com"),
+        prn: String = "P1234",
+        singleLineAddress: String = "123 Test Street, AB1 2CD",
+    ) = PropertyDeregistrationEmailDetails(landlordEmailAddresses, prn, singleLineAddress)
 
     private fun setupStepConfig(): ConfirmStepConfig {
         val stepConfig =

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyDeregistration/stepConfig/ConfirmStepConfigTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyDeregistration/stepConfig/ConfirmStepConfigTests.kt
@@ -1,0 +1,102 @@
+package uk.gov.communities.prsdb.webapp.journeys.propertyDeregistration.stepConfig
+
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argThat
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import uk.gov.communities.prsdb.webapp.journeys.propertyDeregistration.PropertyDeregistrationJourneyState
+import uk.gov.communities.prsdb.webapp.models.viewModels.emailModels.PropertyDeregistrationConfirmationEmail
+import uk.gov.communities.prsdb.webapp.services.EmailNotificationService
+import uk.gov.communities.prsdb.webapp.services.PropertyDeregistrationService
+import uk.gov.communities.prsdb.webapp.services.PropertyOwnershipService
+import uk.gov.communities.prsdb.webapp.testHelpers.mockObjects.AlwaysTrueValidator
+import uk.gov.communities.prsdb.webapp.testHelpers.mockObjects.MockLandlordData
+
+@ExtendWith(MockitoExtension::class)
+class ConfirmStepConfigTests {
+    @Mock
+    lateinit var mockPropertyOwnershipService: PropertyOwnershipService
+
+    @Mock
+    lateinit var mockPropertyDeregistrationService: PropertyDeregistrationService
+
+    @Mock
+    lateinit var mockConfirmationEmailSender: EmailNotificationService<PropertyDeregistrationConfirmationEmail>
+
+    @Mock
+    lateinit var mockState: PropertyDeregistrationJourneyState
+
+    val propertyOwnershipId = 123L
+
+    @Test
+    fun `afterStepDataIsAdded deregisters the property`() {
+        val stepConfig = setupStepConfig()
+        val propertyOwnership = MockLandlordData.createPropertyOwnership(id = propertyOwnershipId)
+        whenever(mockState.propertyOwnershipId).thenReturn(propertyOwnershipId)
+        whenever(mockPropertyOwnershipService.getPropertyOwnership(propertyOwnershipId)).thenReturn(propertyOwnership)
+
+        stepConfig.afterStepDataIsAdded(mockState)
+
+        verify(mockPropertyDeregistrationService).deregisterProperty(propertyOwnershipId)
+    }
+
+    @Test
+    fun `afterStepDataIsAdded adds deregistered property ownership id to session`() {
+        val stepConfig = setupStepConfig()
+        val propertyOwnership = MockLandlordData.createPropertyOwnership(id = propertyOwnershipId)
+        whenever(mockState.propertyOwnershipId).thenReturn(propertyOwnershipId)
+        whenever(mockPropertyOwnershipService.getPropertyOwnership(propertyOwnershipId)).thenReturn(propertyOwnership)
+
+        stepConfig.afterStepDataIsAdded(mockState)
+
+        verify(mockPropertyDeregistrationService).addDeregisteredPropertyOwnershipIdToSession(propertyOwnershipId)
+    }
+
+    @Test
+    fun `afterStepDataIsAdded sends confirmation email to primary landlord`() {
+        val stepConfig = setupStepConfig()
+        val landlordEmail = "landlord@example.com"
+        val landlord = MockLandlordData.createLandlord(email = landlordEmail)
+        val propertyOwnership = MockLandlordData.createPropertyOwnership(id = propertyOwnershipId, primaryLandlord = landlord)
+        whenever(mockState.propertyOwnershipId).thenReturn(propertyOwnershipId)
+        whenever(mockPropertyOwnershipService.getPropertyOwnership(propertyOwnershipId)).thenReturn(propertyOwnership)
+
+        stepConfig.afterStepDataIsAdded(mockState)
+
+        verify(mockConfirmationEmailSender).sendEmail(eq(landlordEmail), any<PropertyDeregistrationConfirmationEmail>())
+    }
+
+    @Test
+    fun `afterStepDataIsAdded sends confirmation email with correct property address`() {
+        val stepConfig = setupStepConfig()
+        val propertyAddress = "123 Test Street, AB1 2CD"
+        val address = MockLandlordData.createAddress(singleLineAddress = propertyAddress)
+        val propertyOwnership = MockLandlordData.createPropertyOwnership(id = propertyOwnershipId, address = address)
+        whenever(mockState.propertyOwnershipId).thenReturn(propertyOwnershipId)
+        whenever(mockPropertyOwnershipService.getPropertyOwnership(propertyOwnershipId)).thenReturn(propertyOwnership)
+
+        stepConfig.afterStepDataIsAdded(mockState)
+
+        verify(mockConfirmationEmailSender).sendEmail(
+            any(),
+            argThat<PropertyDeregistrationConfirmationEmail> { this.singleLineAddress == propertyAddress },
+        )
+    }
+
+    private fun setupStepConfig(): ConfirmStepConfig {
+        val stepConfig =
+            ConfirmStepConfig(
+                mockPropertyOwnershipService,
+                mockPropertyDeregistrationService,
+                mockConfirmationEmailSender,
+            )
+        stepConfig.routeSegment = ConfirmStep.ROUTE_SEGMENT
+        stepConfig.validator = AlwaysTrueValidator()
+        return stepConfig
+    }
+}

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/PropertyDeregistrationServiceTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/PropertyDeregistrationServiceTests.kt
@@ -9,6 +9,7 @@ import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import uk.gov.communities.prsdb.webapp.constants.PROPERTIES_DEREGISTERED_THIS_SESSION
+import uk.gov.communities.prsdb.webapp.testHelpers.mockObjects.MockLandlordData
 import kotlin.test.assertEquals
 
 @ExtendWith(MockitoExtension::class)
@@ -26,12 +27,38 @@ class PropertyDeregistrationServiceTests {
     fun `deregisterProperty deletes the property ownership`() {
         // Arrange
         val propertyOwnershipId = 1L
+        val propertyOwnership = MockLandlordData.createPropertyOwnership(id = propertyOwnershipId)
+        whenever(mockPropertyOwnershipService.getPropertyOwnership(propertyOwnershipId)).thenReturn(propertyOwnership)
 
         // Act
         propertyDeregistrationService.deregisterProperty(propertyOwnershipId)
 
         // Assert
         verify(mockPropertyOwnershipService).deletePropertyOwnership(propertyOwnershipId)
+    }
+
+    @Test
+    fun `deregisterProperty returns the email details for the deregistered property`() {
+        // Arrange
+        val propertyOwnershipId = 1L
+        val landlordEmail = "landlord@example.com"
+        val landlord = MockLandlordData.createLandlord(email = landlordEmail)
+        val singleLineAddress = "123 Test Street, AB1 2CD"
+        val address = MockLandlordData.createAddress(singleLineAddress = singleLineAddress)
+        val propertyOwnership =
+            MockLandlordData.createPropertyOwnership(
+                id = propertyOwnershipId,
+                primaryLandlord = landlord,
+                address = address,
+            )
+        whenever(mockPropertyOwnershipService.getPropertyOwnership(propertyOwnershipId)).thenReturn(propertyOwnership)
+
+        // Act
+        val result = propertyDeregistrationService.deregisterProperty(propertyOwnershipId)
+
+        // Assert
+        assertEquals(listOf(landlordEmail), result.landlordEmailAddresses)
+        assertEquals(singleLineAddress, result.singleLineAddress)
     }
 
     @Test


### PR DESCRIPTION
## Ticket number

PDJB-317

## Goal of change

Adds the confirm property deletion page

## Description of main change(s)

<img width="985" height="589" alt="image" src="https://github.com/user-attachments/assets/a03cb728-3c78-41a8-81f0-ffbf4cd966c1" />
Adds the confirm property deletion page

## Anything you'd like to highlight to the reviewer?

This hasn't touched any of the existing email sending logic, but it has moved it to the confirm page (as it replaced the reason page)

## Checklist

Delete any that are not applicable, and add explanation below for any that are applicable but haven't been done

- [x] Screenshots of any UI changes have been added
- [x] Unit tests for new logic (e.g. new service methods) have been added
- [x] Single page integration tests have been added for any unhappy-flow UI features, e.g. validation errors
- [x] Test suite has been run in full locally and is passing
- [x] Branch has been rebased onto main and run locally, with everything working as expected (both for your new feature
  and any related functionality)
- [x] TODO comments referencing this JIRA ticket have been searched for and removed - if a future PR will address them,
  mention that here
- [x] QA instructions have been added to the ticket (particularly if this is the last PR required to complete the ticket)
