### PR TITLE
PDJB-302: Fix banner body class

### DIFF
--- a/src/main/resources/templates/propertyDetailsView.html
+++ b/src/main/resources/templates/propertyDetailsView.html
@@ -9,7 +9,7 @@
                      th:replace="~{fragments/banners/notificationBanner ::
                     notificationBanner(#{propertyDetails.landlordDetails.invitations.expiredInvitations.removedBanner.title}, ~{::#invite-removed-banner/content()})}"
                      th:with="isSuccess=true">
-                    <p class="govuk-body" th:text="#{propertyDetails.landlordDetails.invitations.expiredInvitations.removedBanner.content}">
+                    <p class="govuk-notification-banner__heading" th:text="#{propertyDetails.landlordDetails.invitations.expiredInvitations.removedBanner.content}">
                         propertyDetails.landlordDetails.invitations.expiredInvitations.removedBanner.content
                     </p>
                 </div>


### PR DESCRIPTION
## Ticket number

[PDJB-302](https://mhclgdigital.atlassian.net/browse/PDJB-302)

## Goal of change

makes the text in the removed banner match figma (it is a notification banner heading)
<img alt="removed expired invitation notification box" src="https://github.com/user-attachments/assets/047d8cc3-e8d9-40a6-b3cb-2473714026fb" />

## Checklist

Delete any that are not applicable, and add explanation below for any that are applicable but haven't been done

- [x] Screenshots of any UI changes have been added
- [x] Test suite has been run in full locally and is passing
- [x] Branch has been rebased onto main and run locally, with everything working as expected (both for your new feature
  and any related functionality)
- [x] QA instructions have been added to the ticket (particularly if this is the last PR required to complete the ticket)
