### PR TITLE
PDJB-261: multiline address in email

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/acceptOrRejectJointLandlordInvitation/steps/SendRejectionEmailsStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/acceptOrRejectJointLandlordInvitation/steps/SendRejectionEmailsStepConfig.kt
@@ -20,7 +20,7 @@ class SendRejectionEmailsStepConfig(
 
     override fun afterStepIsReached(state: AcceptOrRejectJointLandlordInvitationJourneyState) {
         val invitation = invitationService.getInvitationForJourney(state.journeyId)
-        val propertyAddress = invitation.registeredOwnership.address.singleLineAddress
+        val propertyAddress = invitation.registeredOwnership.address.toMultiLineAddress()
         val propertyRecordUrl =
             absoluteUrlProvider.buildPropertyDetailsUri(invitation.registeredOwnership.id).toString()
 

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/acceptOrRejectJointLandlordInvitation/steps/SendRejectionEmailsStepConfigTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/acceptOrRejectJointLandlordInvitation/steps/SendRejectionEmailsStepConfigTests.kt
@@ -49,7 +49,7 @@ class SendRejectionEmailsStepConfigTests {
         whenever(landlord2.email).thenReturn("clark@example.com")
 
         val mockAddress = mock<Address>()
-        whenever(mockAddress.singleLineAddress).thenReturn("Flat 1, 11 Elm Drive, London, NW8 2DK")
+        whenever(mockAddress.toMultiLineAddress()).thenReturn("Flat 1\n11 Elm Drive\nLondon\nNW8 2DK")
 
         val mockPropertyOwnership = mock<PropertyOwnership>()
         whenever(mockPropertyOwnership.address).thenReturn(mockAddress)
@@ -74,7 +74,7 @@ class SendRejectionEmailsStepConfigTests {
                 JointLandlordInvitationRejectionEmail(
                     recipientName = "Lois Lane",
                     inviteeEmail = "invitee@example.com",
-                    propertyAddress = "Flat 1, 11 Elm Drive, London, NW8 2DK",
+                    propertyAddress = "Flat 1\n11 Elm Drive\nLondon\nNW8 2DK",
                     propertyRecordUrl = "http://localhost/property/42",
                 ),
             ),
@@ -85,7 +85,7 @@ class SendRejectionEmailsStepConfigTests {
                 JointLandlordInvitationRejectionEmail(
                     recipientName = "Clark Kent",
                     inviteeEmail = "invitee@example.com",
-                    propertyAddress = "Flat 1, 11 Elm Drive, London, NW8 2DK",
+                    propertyAddress = "Flat 1\n11 Elm Drive\nLondon\nNW8 2DK",
                     propertyRecordUrl = "http://localhost/property/42",
                 ),
             ),
@@ -98,7 +98,7 @@ class SendRejectionEmailsStepConfigTests {
         val stepConfig = setupStepConfig()
 
         val mockAddress = mock<Address>()
-        whenever(mockAddress.singleLineAddress).thenReturn("Flat 1, 11 Elm Drive, London, NW8 2DK")
+        whenever(mockAddress.toMultiLineAddress()).thenReturn("Flat 1\n11 Elm Drive\nLondon\nNW8 2DK")
 
         val landlord = mock<Landlord>()
         whenever(landlord.name).thenReturn("Lois Lane")
@@ -122,7 +122,7 @@ class SendRejectionEmailsStepConfigTests {
 
         // Assert
         verify(mockInvitationService).addRejectedPropertyAddressToSession(
-            "Flat 1, 11 Elm Drive, London, NW8 2DK",
+            "Flat 1\n11 Elm Drive\nLondon\nNW8 2DK",
         )
     }
 


### PR DESCRIPTION
## Ticket number

PDJB-261

## Goal of change

One liner to multiline the address in the landlord rejected your invite email

## Description of main change(s)

changes singleLineAddress to multiline address

## Checklist

Delete any that are not applicable, and add explanation below for any that are applicable but haven't been done

- [ ] Test suite has been run in full locally and is passing
- [ ] Branch has been rebased onto main and run locally, with everything working as expected (both for your new feature
  and any related functionality)