### PR TITLE
PDJB-268/PDJB-269: Remove feature flags from regular jobs

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/JointLandlordInvitationDeletionService.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/JointLandlordInvitationDeletionService.kt
@@ -1,10 +1,7 @@
 package uk.gov.communities.prsdb.webapp.services
 
 import jakarta.transaction.Transactional
-import org.springframework.context.annotation.Primary
 import uk.gov.communities.prsdb.webapp.annotations.taskAnnotations.PrsdbTaskService
-import uk.gov.communities.prsdb.webapp.annotations.webAnnotations.PrsdbFlip
-import uk.gov.communities.prsdb.webapp.constants.JOINT_LANDLORDS
 import uk.gov.communities.prsdb.webapp.constants.JOINT_LANDLORD_INVITATION_DELETION_GRACE_PERIOD_IN_DAYS
 import uk.gov.communities.prsdb.webapp.constants.JOINT_LANDLORD_INVITATION_LIFETIME_IN_DAYS
 import uk.gov.communities.prsdb.webapp.constants.enums.JointLandlordInvitationStatus
@@ -12,23 +9,12 @@ import uk.gov.communities.prsdb.webapp.database.repository.JointLandlordInvitati
 import java.time.Instant
 import java.time.temporal.ChronoUnit
 
-@PrsdbFlip(name = JOINT_LANDLORDS, alterBean = "jl-invitation-deletion-flag-on")
-interface JointLandlordInvitationDeletionService {
-    fun deleteExpiredInvitations(): List<Long>
-}
-
-@Primary
-@PrsdbTaskService("jl-invitation-deletion-flag-off")
-class JointLandlordInvitationDeletionServiceImplFlagOff : JointLandlordInvitationDeletionService {
-    override fun deleteExpiredInvitations(): List<Long> = emptyList()
-}
-
-@PrsdbTaskService("jl-invitation-deletion-flag-on")
-class JointLandlordInvitationDeletionServiceImplFlagOn(
+@PrsdbTaskService
+class JointLandlordInvitationDeletionService(
     private val invitationRepository: JointLandlordInvitationRepository,
-) : JointLandlordInvitationDeletionService {
+) {
     @Transactional
-    override fun deleteExpiredInvitations(): List<Long> {
+    fun deleteExpiredInvitations(): List<Long> {
         val totalGracePeriodInDays =
             (JOINT_LANDLORD_INVITATION_LIFETIME_IN_DAYS + JOINT_LANDLORD_INVITATION_DELETION_GRACE_PERIOD_IN_DAYS).toLong()
         val cutoffDate = Instant.now().minus(totalGracePeriodInDays, ChronoUnit.DAYS)

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/JointLandlordInvitationExpiryEmailService.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/JointLandlordInvitationExpiryEmailService.kt
@@ -1,9 +1,7 @@
 package uk.gov.communities.prsdb.webapp.services
 
-import org.springframework.context.annotation.Primary
+import jakarta.transaction.Transactional
 import uk.gov.communities.prsdb.webapp.annotations.taskAnnotations.PrsdbTaskService
-import uk.gov.communities.prsdb.webapp.annotations.webAnnotations.PrsdbFlip
-import uk.gov.communities.prsdb.webapp.constants.JOINT_LANDLORDS
 import uk.gov.communities.prsdb.webapp.constants.JOINT_LANDLORD_INVITATION_LIFETIME_IN_DAYS
 import uk.gov.communities.prsdb.webapp.constants.enums.JointLandlordInvitationStatus
 import uk.gov.communities.prsdb.webapp.database.entity.JointLandlordInvitation
@@ -12,27 +10,14 @@ import uk.gov.communities.prsdb.webapp.exceptions.PersistentEmailSendException
 import uk.gov.communities.prsdb.webapp.exceptions.TransientEmailSentException
 import uk.gov.communities.prsdb.webapp.models.viewModels.emailModels.JointLandlordInvitationExpiryEmail
 
-@PrsdbFlip(name = JOINT_LANDLORDS, alterBean = "joint-landlord-invitation-expiry-email-flag-on")
-interface JointLandlordInvitationExpiryEmailService {
-    fun sendExpiryEmailsForExpiredInvitations(): List<Long>
-}
-
-@Primary
-@PrsdbTaskService("joint-landlord-invitation-expiry-email-flag-off")
-class JointLandlordInvitationExpiryEmailServiceImplFlagOff : JointLandlordInvitationExpiryEmailService {
-    override fun sendExpiryEmailsForExpiredInvitations(): List<Long> {
-        // No-op: the joint-landlords feature is disabled, so we do not send expiry emails.
-        return emptyList()
-    }
-}
-
-@PrsdbTaskService("joint-landlord-invitation-expiry-email-flag-on")
-class JointLandlordInvitationExpiryEmailServiceImplFlagOn(
+@PrsdbTaskService
+class JointLandlordInvitationExpiryEmailService(
     private val invitationRepository: JointLandlordInvitationRepository,
     private val expiryEmailNotificationService: EmailNotificationService<JointLandlordInvitationExpiryEmail>,
     private val absoluteUrlProvider: AbsoluteUrlProvider,
-) : JointLandlordInvitationExpiryEmailService {
-    override fun sendExpiryEmailsForExpiredInvitations(): List<Long> {
+) {
+    @Transactional
+    fun sendExpiryEmailsForExpiredInvitations(): List<Long> {
         val expiredInvitations =
             invitationRepository
                 .findAllByInvitationExpiredEmailSentFalse()

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/applications/PrsdbTaskApplicationTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/applications/PrsdbTaskApplicationTests.kt
@@ -30,6 +30,8 @@ import uk.gov.communities.prsdb.webapp.services.AbsoluteUrlProvider
 import uk.gov.communities.prsdb.webapp.services.AwsS3DequarantiningFileCopier
 import uk.gov.communities.prsdb.webapp.services.AwsS3QuarantinedFileDeleter
 import uk.gov.communities.prsdb.webapp.services.IncompletePropertiesService
+import uk.gov.communities.prsdb.webapp.services.JointLandlordInvitationDeletionService
+import uk.gov.communities.prsdb.webapp.services.JointLandlordInvitationExpiryEmailService
 import uk.gov.communities.prsdb.webapp.services.NgdAddressLoader
 import uk.gov.communities.prsdb.webapp.services.NotifyEmailNotificationService
 import uk.gov.communities.prsdb.webapp.services.NotifyIdService
@@ -85,12 +87,8 @@ class PrsdbTaskApplicationTests {
                 LandlordSearchRepositoryImpl::class.simpleBeanName,
                 IncompletePropertiesService::class.simpleBeanName,
                 AuditingConfig::class.simpleBeanName,
-                // when the feature flagged variant is removed the name overrides from JointLandlordInvitationExpiryEmailService can be removed.
-                // then, this can be replaced by JointLandlordInvitationExpiryEmailService::class.simpleBeanName
-                "joint-landlord-invitation-expiry-email-flag-off",
-                "joint-landlord-invitation-expiry-email-flag-on",
-                "jl-invitation-deletion-flag-off",
-                "jl-invitation-deletion-flag-on",
+                JointLandlordInvitationExpiryEmailService::class.simpleBeanName,
+                JointLandlordInvitationDeletionService::class.simpleBeanName,
             ).map { it.lowercase() }.toSet()
 
         val beanNames = ApplicationTestHelper.getAvailableBeanNames(context!!)

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/JointLandlordInvitationDeletionServiceTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/JointLandlordInvitationDeletionServiceTests.kt
@@ -4,13 +4,11 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.mockito.Mockito.mock
-import org.mockito.Mockito.never
 import org.mockito.Mockito.verify
 import org.mockito.kotlin.any
 import org.mockito.kotlin.whenever
 import uk.gov.communities.prsdb.webapp.constants.JOINT_LANDLORD_INVITATION_DELETION_GRACE_PERIOD_IN_DAYS
 import uk.gov.communities.prsdb.webapp.constants.JOINT_LANDLORD_INVITATION_LIFETIME_IN_DAYS
-import uk.gov.communities.prsdb.webapp.database.entity.JointLandlordInvitation
 import uk.gov.communities.prsdb.webapp.database.repository.JointLandlordInvitationRepository
 import uk.gov.communities.prsdb.webapp.testHelpers.mockObjects.MockJointLandlordData
 import java.time.Instant
@@ -18,7 +16,7 @@ import java.time.temporal.ChronoUnit
 
 class JointLandlordInvitationDeletionServiceTests {
     private lateinit var mockInvitationRepository: JointLandlordInvitationRepository
-    private lateinit var deletionService: JointLandlordInvitationDeletionServiceImplFlagOn
+    private lateinit var deletionService: JointLandlordInvitationDeletionService
 
     private val expiredAndPastGracePeriodCreatedDate: Instant =
         Instant.now().minus(
@@ -29,7 +27,7 @@ class JointLandlordInvitationDeletionServiceTests {
     @BeforeEach
     fun setup() {
         mockInvitationRepository = mock()
-        deletionService = JointLandlordInvitationDeletionServiceImplFlagOn(mockInvitationRepository)
+        deletionService = JointLandlordInvitationDeletionService(mockInvitationRepository)
     }
 
     @Test
@@ -94,16 +92,5 @@ class JointLandlordInvitationDeletionServiceTests {
 
         assertEquals(listOf(1L, 2L, 3L), deletedIds)
         verify(mockInvitationRepository).deleteAll(invitations)
-    }
-
-    @Test
-    fun `flag-off implementation does nothing`() {
-        val flagOff = JointLandlordInvitationDeletionServiceImplFlagOff()
-
-        val result = flagOff.deleteExpiredInvitations()
-
-        assertEquals(emptyList<Long>(), result)
-        verify(mockInvitationRepository, never()).findAllByCreatedDateBefore(any())
-        verify(mockInvitationRepository, never()).deleteAll(any<List<JointLandlordInvitation>>())
     }
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/JointLandlordInvitationExpiryEmailServiceTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/JointLandlordInvitationExpiryEmailServiceTests.kt
@@ -26,7 +26,7 @@ class JointLandlordInvitationExpiryEmailServiceTests {
     private lateinit var mockJointLandlordInvitationRepository: JointLandlordInvitationRepository
     private lateinit var mockExpiryEmailNotificationService: EmailNotificationService<JointLandlordInvitationExpiryEmail>
     private lateinit var mockAbsoluteUrlProvider: AbsoluteUrlProvider
-    private lateinit var expiryService: JointLandlordInvitationExpiryEmailServiceImplFlagOn
+    private lateinit var expiryService: JointLandlordInvitationExpiryEmailService
 
     private val expiredCreatedDate: Instant =
         Instant.now().minus(JOINT_LANDLORD_INVITATION_LIFETIME_IN_DAYS.toLong() + 1, ChronoUnit.DAYS)
@@ -37,7 +37,7 @@ class JointLandlordInvitationExpiryEmailServiceTests {
         mockExpiryEmailNotificationService = mock()
         mockAbsoluteUrlProvider = mock()
         expiryService =
-            JointLandlordInvitationExpiryEmailServiceImplFlagOn(
+            JointLandlordInvitationExpiryEmailService(
                 mockJointLandlordInvitationRepository,
                 mockExpiryEmailNotificationService,
                 mockAbsoluteUrlProvider,
@@ -155,15 +155,5 @@ class JointLandlordInvitationExpiryEmailServiceTests {
         assert(!failingInvitation.invitationExpiredEmailSent) { "Expected failing invitation to not be marked as expired" }
         verify(mockJointLandlordInvitationRepository).save(succeedingInvitation)
         assert(succeedingInvitation.invitationExpiredEmailSent) { "Expected succeeding invitation to be marked as expired" }
-    }
-
-    @Test
-    fun `flag-off implementation does nothing`() {
-        val flagOff = JointLandlordInvitationExpiryEmailServiceImplFlagOff()
-
-        flagOff.sendExpiryEmailsForExpiredInvitations()
-
-        verify(mockExpiryEmailNotificationService, never()).sendEmail(any(), any())
-        verify(mockJointLandlordInvitationRepository, never()).save(any<JointLandlordInvitation>())
     }
 }


### PR DESCRIPTION
## Ticket number

[PDJB-268](https://mhclgdigital.atlassian.net/browse/PDJB-268) / [PDJB-269](https://mhclgdigital.atlassian.net/browse/PDJB-269)

## Goal of change

removes feature flag flipping from regular jobs

## Description of main change(s)

there is something that is preventing this from work properly, see slack.

needs more investigation into why the previous implementation didn't work, for now since the regular jobs don't strictly need to be feature flagged (there's no JL invitations in the db for them to act on) this is fine

## Anything you'd like to highlight to the reviewer?

Include e.g. anything unusual about the PR, where there was some debate over how to implement it, or anywhere you were
unsure of the approach to take and would like specific feedback.

## Checklist

Delete any that are not applicable, and add explanation below for any that are applicable but haven't been done

- [ ] Test suite has been run in full locally and is passing
- [x] Branch has been rebased onto main and run locally, with everything working as expected (both for your new feature
  and any related functionality)