### PR TITLE
[PR 1 of 2] PDJB-318: deregister property confirmation page

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/constants/SessionAttributes.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/constants/SessionAttributes.kt
@@ -6,7 +6,7 @@ const val LOCAL_COUNCIL_USER_ID = "local-council-user-id"
 
 const val PROPERTY_REGISTRATION_NUMBER = "propertyRegistrationNumber"
 
-const val PROPERTIES_DEREGISTERED_THIS_SESSION = "propertiesDeregisteredThisSession"
+const val PROPERTIES_DEREGISTERED_THIS_SESSION = "propertiesDeregisteredThisSessionWithAddresses"
 
 const val LANDLORD_HAD_ACTIVE_PROPERTIES = "landlordHadActiveProperties"
 

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/constants/SessionAttributes.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/constants/SessionAttributes.kt
@@ -6,7 +6,7 @@ const val LOCAL_COUNCIL_USER_ID = "local-council-user-id"
 
 const val PROPERTY_REGISTRATION_NUMBER = "propertyRegistrationNumber"
 
-const val PROPERTIES_DEREGISTERED_THIS_SESSION = "propertiesDeregisteredThisSessionWithAddresses"
+const val PROPERTIES_DEREGISTERED_THIS_SESSION_WITH_ADDRESSES = "propertiesDeregisteredThisSessionWithAddresses"
 
 const val LANDLORD_HAD_ACTIVE_PROPERTIES = "landlordHadActiveProperties"
 

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/constants/SessionAttributes.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/constants/SessionAttributes.kt
@@ -6,7 +6,7 @@ const val LOCAL_COUNCIL_USER_ID = "local-council-user-id"
 
 const val PROPERTY_REGISTRATION_NUMBER = "propertyRegistrationNumber"
 
-const val PROPERTY_DEREGISTERED_THIS_SESSION = "propertyDeregisteredThisSession"
+const val PROPERTIES_DEREGISTERED_THIS_SESSION_WITH_ADDRESSES = "propertiesDeregisteredThisSessionWithAddresses"
 
 const val LANDLORD_HAD_ACTIVE_PROPERTIES = "landlordHadActiveProperties"
 

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/constants/SessionAttributes.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/constants/SessionAttributes.kt
@@ -6,7 +6,7 @@ const val LOCAL_COUNCIL_USER_ID = "local-council-user-id"
 
 const val PROPERTY_REGISTRATION_NUMBER = "propertyRegistrationNumber"
 
-const val PROPERTIES_DEREGISTERED_THIS_SESSION_WITH_ADDRESSES = "propertiesDeregisteredThisSessionWithAddresses"
+const val PROPERTY_DEREGISTERED_THIS_SESSION = "propertyDeregisteredThisSession"
 
 const val LANDLORD_HAD_ACTIVE_PROPERTIES = "landlordHadActiveProperties"
 

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/DeregisterPropertyController.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/DeregisterPropertyController.kt
@@ -106,7 +106,7 @@ class DeregisterPropertyController(
         model.addAttribute("landlordDashboardUrl", LANDLORD_DASHBOARD_URL)
 
         return if (featureFlagManager.checkFeature(JOINT_LANDLORDS)) {
-            model.addAttribute("address", propertyDeregistrationService.getDeregisteredPropertyAddress())
+            model.addAttribute("address", propertyDeregistrationService.getDeregisteredPropertyAddress(propertyOwnershipId))
             "deregisterPropertyConfirmationJune26Redesign"
         } else {
             // TODO PDJB-319: Remove
@@ -134,10 +134,10 @@ class DeregisterPropertyController(
             .getIsPrimaryLandlord(propertyOwnershipId, principal.name)
 
     private fun checkPropertyHasBeenDeregisteredInThisSession(propertyOwnershipId: Long) {
-        if (propertyOwnershipId != propertyDeregistrationService.getDeregisteredPropertyOwnershipIdFromSession()) {
+        if (propertyOwnershipId !in propertyDeregistrationService.getDeregisteredPropertyOwnershipIdsFromSession()) {
             throw ResponseStatusException(
                 HttpStatus.NOT_FOUND,
-                "PropertyOwnershipId $propertyOwnershipId was not the property deregistered in the session",
+                "PropertyOwnershipId $propertyOwnershipId was not found in the list of deregistered propertyOwnershipIds in the session",
             )
         }
 

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/DeregisterPropertyController.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/DeregisterPropertyController.kt
@@ -105,7 +105,13 @@ class DeregisterPropertyController(
 
         model.addAttribute("landlordDashboardUrl", LANDLORD_DASHBOARD_URL)
 
-        return "deregisterPropertyConfirmation"
+        return if (featureFlagManager.checkFeature(JOINT_LANDLORDS)) {
+            model.addAttribute("address", propertyDeregistrationService.getDeregisteredPropertyAddress(propertyOwnershipId))
+            "deregisterPropertyConfirmation"
+        } else {
+            // TODO PDJB-319: Remove
+            "deregisterPropertyConfirmationOld"
+        }
     }
 
     private fun throwExceptionIfCurrentUserIsUnauthorizedToDeregisterProperty(

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/DeregisterPropertyController.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/DeregisterPropertyController.kt
@@ -107,7 +107,7 @@ class DeregisterPropertyController(
 
         return if (featureFlagManager.checkFeature(JOINT_LANDLORDS)) {
             model.addAttribute("address", propertyDeregistrationService.getDeregisteredPropertyAddress(propertyOwnershipId))
-            "deregisterPropertyConfirmation"
+            "deregisterPropertyConfirmationJune26Redesign"
         } else {
             // TODO PDJB-319: Remove
             "deregisterPropertyConfirmationOld"

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/DeregisterPropertyController.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/DeregisterPropertyController.kt
@@ -106,7 +106,7 @@ class DeregisterPropertyController(
         model.addAttribute("landlordDashboardUrl", LANDLORD_DASHBOARD_URL)
 
         return if (featureFlagManager.checkFeature(JOINT_LANDLORDS)) {
-            model.addAttribute("address", propertyDeregistrationService.getDeregisteredPropertyAddress(propertyOwnershipId))
+            model.addAttribute("address", propertyDeregistrationService.getDeregisteredPropertyAddress())
             "deregisterPropertyConfirmationJune26Redesign"
         } else {
             // TODO PDJB-319: Remove
@@ -134,10 +134,10 @@ class DeregisterPropertyController(
             .getIsPrimaryLandlord(propertyOwnershipId, principal.name)
 
     private fun checkPropertyHasBeenDeregisteredInThisSession(propertyOwnershipId: Long) {
-        if (propertyOwnershipId !in propertyDeregistrationService.getDeregisteredPropertyOwnershipIdsFromSession()) {
+        if (propertyOwnershipId != propertyDeregistrationService.getDeregisteredPropertyOwnershipIdFromSession()) {
             throw ResponseStatusException(
                 HttpStatus.NOT_FOUND,
-                "PropertyOwnershipId $propertyOwnershipId was not found in the list of deregistered propertyOwnershipIds in the session",
+                "PropertyOwnershipId $propertyOwnershipId was not the property deregistered in the session",
             )
         }
 

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyDeregistration/stepConfig/ConfirmStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyDeregistration/stepConfig/ConfirmStepConfig.kt
@@ -38,7 +38,10 @@ class ConfirmStepConfig(
 
     override fun afterStepDataIsAdded(state: PropertyDeregistrationJourneyState) {
         val emailDetails = propertyDeregistrationService.deregisterProperty(state.propertyOwnershipId)
-        propertyDeregistrationService.addDeregisteredPropertyOwnershipIdToSession(state.propertyOwnershipId)
+        propertyDeregistrationService.addDeregisteredPropertyOwnershipIdToSession(
+            state.propertyOwnershipId,
+            emailDetails.singleLineAddress,
+        )
 
         // PDJB-318: Use new email here
         for (landlordEmail in emailDetails.landlordEmailAddresses)

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyDeregistration/stepConfig/ConfirmStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyDeregistration/stepConfig/ConfirmStepConfig.kt
@@ -38,7 +38,7 @@ class ConfirmStepConfig(
 
     override fun afterStepDataIsAdded(state: PropertyDeregistrationJourneyState) {
         val emailDetails = propertyDeregistrationService.deregisterProperty(state.propertyOwnershipId)
-        propertyDeregistrationService.setDeregisteredPropertyInSession(
+        propertyDeregistrationService.addDeregisteredPropertyOwnershipIdToSession(
             state.propertyOwnershipId,
             emailDetails.singleLineAddress,
         )

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyDeregistration/stepConfig/ConfirmStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyDeregistration/stepConfig/ConfirmStepConfig.kt
@@ -38,7 +38,7 @@ class ConfirmStepConfig(
 
     override fun afterStepDataIsAdded(state: PropertyDeregistrationJourneyState) {
         val emailDetails = propertyDeregistrationService.deregisterProperty(state.propertyOwnershipId)
-        propertyDeregistrationService.addDeregisteredPropertyOwnershipIdToSession(
+        propertyDeregistrationService.setDeregisteredPropertyInSession(
             state.propertyOwnershipId,
             emailDetails.singleLineAddress,
         )

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyDeregistration/stepConfig/ReasonStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyDeregistration/stepConfig/ReasonStepConfig.kt
@@ -41,7 +41,8 @@ class ReasonStepConfig(
         val propertyAddress = propertyOwnership.address.singleLineAddress
 
         propertyDeregistrationService.deregisterProperty(state.propertyOwnershipId)
-        propertyDeregistrationService.setDeregisteredPropertyInSession(state.propertyOwnershipId)
+        // The old confirmation page does not display the address, so only the deregistered id is stored
+        propertyDeregistrationService.addDeregisteredPropertyOwnershipIdToSession(state.propertyOwnershipId)
 
         confirmationEmailSender.sendEmail(
             primaryLandlordEmailAddress,

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyDeregistration/stepConfig/ReasonStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyDeregistration/stepConfig/ReasonStepConfig.kt
@@ -41,8 +41,7 @@ class ReasonStepConfig(
         val propertyAddress = propertyOwnership.address.singleLineAddress
 
         propertyDeregistrationService.deregisterProperty(state.propertyOwnershipId)
-        // The old confirmation page does not display the address, so a placeholder is stored against the deregistered id
-        propertyDeregistrationService.setDeregisteredPropertyInSession(state.propertyOwnershipId, "")
+        propertyDeregistrationService.setDeregisteredPropertyInSession(state.propertyOwnershipId)
 
         confirmationEmailSender.sendEmail(
             primaryLandlordEmailAddress,

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyDeregistration/stepConfig/ReasonStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyDeregistration/stepConfig/ReasonStepConfig.kt
@@ -41,7 +41,8 @@ class ReasonStepConfig(
         val propertyAddress = propertyOwnership.address.singleLineAddress
 
         propertyDeregistrationService.deregisterProperty(state.propertyOwnershipId)
-        propertyDeregistrationService.addDeregisteredPropertyOwnershipIdToSession(state.propertyOwnershipId, propertyAddress)
+        // The old confirmation page does not display the address, so a placeholder is stored against the deregistered id
+        propertyDeregistrationService.addDeregisteredPropertyOwnershipIdToSession(state.propertyOwnershipId, "")
 
         confirmationEmailSender.sendEmail(
             primaryLandlordEmailAddress,

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyDeregistration/stepConfig/ReasonStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyDeregistration/stepConfig/ReasonStepConfig.kt
@@ -42,7 +42,7 @@ class ReasonStepConfig(
 
         propertyDeregistrationService.deregisterProperty(state.propertyOwnershipId)
         // The old confirmation page does not display the address, so a placeholder is stored against the deregistered id
-        propertyDeregistrationService.addDeregisteredPropertyOwnershipIdToSession(state.propertyOwnershipId, "")
+        propertyDeregistrationService.setDeregisteredPropertyInSession(state.propertyOwnershipId, "")
 
         confirmationEmailSender.sendEmail(
             primaryLandlordEmailAddress,

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyDeregistration/stepConfig/ReasonStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyDeregistration/stepConfig/ReasonStepConfig.kt
@@ -41,7 +41,7 @@ class ReasonStepConfig(
         val propertyAddress = propertyOwnership.address.singleLineAddress
 
         propertyDeregistrationService.deregisterProperty(state.propertyOwnershipId)
-        propertyDeregistrationService.addDeregisteredPropertyOwnershipIdToSession(state.propertyOwnershipId)
+        propertyDeregistrationService.addDeregisteredPropertyOwnershipIdToSession(state.propertyOwnershipId, propertyAddress)
 
         confirmationEmailSender.sendEmail(
             primaryLandlordEmailAddress,

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/PropertyDeregistrationService.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/PropertyDeregistrationService.kt
@@ -3,7 +3,7 @@ package uk.gov.communities.prsdb.webapp.services
 import jakarta.servlet.http.HttpSession
 import jakarta.transaction.Transactional
 import uk.gov.communities.prsdb.webapp.annotations.webAnnotations.PrsdbWebService
-import uk.gov.communities.prsdb.webapp.constants.PROPERTIES_DEREGISTERED_THIS_SESSION
+import uk.gov.communities.prsdb.webapp.constants.PROPERTIES_DEREGISTERED_THIS_SESSION_WITH_ADDRESSES
 import uk.gov.communities.prsdb.webapp.models.dataModels.PropertyDeregistrationEmailDetails
 import uk.gov.communities.prsdb.webapp.models.dataModels.RegistrationNumberDataModel
 
@@ -29,7 +29,7 @@ class PropertyDeregistrationService(
         propertyOwnershipId: Long,
         singleLineAddress: String,
     ) = session.setAttribute(
-        PROPERTIES_DEREGISTERED_THIS_SESSION,
+        PROPERTIES_DEREGISTERED_THIS_SESSION_WITH_ADDRESSES,
         getDeregisteredPropertiesFromSession() + (propertyOwnershipId to singleLineAddress),
     )
 
@@ -39,6 +39,6 @@ class PropertyDeregistrationService(
 
     @Suppress("UNCHECKED_CAST")
     private fun getDeregisteredPropertiesFromSession(): MutableMap<Long, String> =
-        session.getAttribute(PROPERTIES_DEREGISTERED_THIS_SESSION) as MutableMap<Long, String>?
+        session.getAttribute(PROPERTIES_DEREGISTERED_THIS_SESSION_WITH_ADDRESSES) as MutableMap<Long, String>?
             ?: mutableMapOf()
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/PropertyDeregistrationService.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/PropertyDeregistrationService.kt
@@ -3,7 +3,7 @@ package uk.gov.communities.prsdb.webapp.services
 import jakarta.servlet.http.HttpSession
 import jakarta.transaction.Transactional
 import uk.gov.communities.prsdb.webapp.annotations.webAnnotations.PrsdbWebService
-import uk.gov.communities.prsdb.webapp.constants.PROPERTY_DEREGISTERED_THIS_SESSION
+import uk.gov.communities.prsdb.webapp.constants.PROPERTIES_DEREGISTERED_THIS_SESSION_WITH_ADDRESSES
 import uk.gov.communities.prsdb.webapp.models.dataModels.PropertyDeregistrationEmailDetails
 import uk.gov.communities.prsdb.webapp.models.dataModels.RegistrationNumberDataModel
 
@@ -25,19 +25,20 @@ class PropertyDeregistrationService(
         return emailDetails
     }
 
-    fun setDeregisteredPropertyInSession(
+    fun addDeregisteredPropertyOwnershipIdToSession(
         propertyOwnershipId: Long,
         singleLineAddress: String? = null,
     ) = session.setAttribute(
-        PROPERTY_DEREGISTERED_THIS_SESSION,
-        propertyOwnershipId to singleLineAddress,
+        PROPERTIES_DEREGISTERED_THIS_SESSION_WITH_ADDRESSES,
+        getDeregisteredPropertiesFromSession() + (propertyOwnershipId to singleLineAddress),
     )
 
-    fun getDeregisteredPropertyOwnershipIdFromSession(): Long? = getDeregisteredPropertyFromSession()?.first
+    fun getDeregisteredPropertyOwnershipIdsFromSession(): MutableList<Long> = getDeregisteredPropertiesFromSession().keys.toMutableList()
 
-    fun getDeregisteredPropertyAddress(): String? = getDeregisteredPropertyFromSession()?.second
+    fun getDeregisteredPropertyAddress(propertyOwnershipId: Long): String? = getDeregisteredPropertiesFromSession()[propertyOwnershipId]
 
     @Suppress("UNCHECKED_CAST")
-    private fun getDeregisteredPropertyFromSession(): Pair<Long, String?>? =
-        session.getAttribute(PROPERTY_DEREGISTERED_THIS_SESSION) as Pair<Long, String?>?
+    private fun getDeregisteredPropertiesFromSession(): MutableMap<Long, String?> =
+        session.getAttribute(PROPERTIES_DEREGISTERED_THIS_SESSION_WITH_ADDRESSES) as MutableMap<Long, String?>?
+            ?: mutableMapOf()
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/PropertyDeregistrationService.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/PropertyDeregistrationService.kt
@@ -27,7 +27,7 @@ class PropertyDeregistrationService(
 
     fun setDeregisteredPropertyInSession(
         propertyOwnershipId: Long,
-        singleLineAddress: String,
+        singleLineAddress: String? = null,
     ) = session.setAttribute(
         PROPERTY_DEREGISTERED_THIS_SESSION,
         propertyOwnershipId to singleLineAddress,
@@ -38,6 +38,6 @@ class PropertyDeregistrationService(
     fun getDeregisteredPropertyAddress(): String? = getDeregisteredPropertyFromSession()?.second
 
     @Suppress("UNCHECKED_CAST")
-    private fun getDeregisteredPropertyFromSession(): Pair<Long, String>? =
-        session.getAttribute(PROPERTY_DEREGISTERED_THIS_SESSION) as Pair<Long, String>?
+    private fun getDeregisteredPropertyFromSession(): Pair<Long, String?>? =
+        session.getAttribute(PROPERTY_DEREGISTERED_THIS_SESSION) as Pair<Long, String?>?
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/PropertyDeregistrationService.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/PropertyDeregistrationService.kt
@@ -3,7 +3,7 @@ package uk.gov.communities.prsdb.webapp.services
 import jakarta.servlet.http.HttpSession
 import jakarta.transaction.Transactional
 import uk.gov.communities.prsdb.webapp.annotations.webAnnotations.PrsdbWebService
-import uk.gov.communities.prsdb.webapp.constants.PROPERTIES_DEREGISTERED_THIS_SESSION_WITH_ADDRESSES
+import uk.gov.communities.prsdb.webapp.constants.PROPERTY_DEREGISTERED_THIS_SESSION
 import uk.gov.communities.prsdb.webapp.models.dataModels.PropertyDeregistrationEmailDetails
 import uk.gov.communities.prsdb.webapp.models.dataModels.RegistrationNumberDataModel
 
@@ -25,20 +25,19 @@ class PropertyDeregistrationService(
         return emailDetails
     }
 
-    fun addDeregisteredPropertyOwnershipIdToSession(
+    fun setDeregisteredPropertyInSession(
         propertyOwnershipId: Long,
         singleLineAddress: String,
     ) = session.setAttribute(
-        PROPERTIES_DEREGISTERED_THIS_SESSION_WITH_ADDRESSES,
-        getDeregisteredPropertiesFromSession() + (propertyOwnershipId to singleLineAddress),
+        PROPERTY_DEREGISTERED_THIS_SESSION,
+        propertyOwnershipId to singleLineAddress,
     )
 
-    fun getDeregisteredPropertyOwnershipIdsFromSession(): MutableList<Long> = getDeregisteredPropertiesFromSession().keys.toMutableList()
+    fun getDeregisteredPropertyOwnershipIdFromSession(): Long? = getDeregisteredPropertyFromSession()?.first
 
-    fun getDeregisteredPropertyAddress(propertyOwnershipId: Long): String? = getDeregisteredPropertiesFromSession()[propertyOwnershipId]
+    fun getDeregisteredPropertyAddress(): String? = getDeregisteredPropertyFromSession()?.second
 
     @Suppress("UNCHECKED_CAST")
-    private fun getDeregisteredPropertiesFromSession(): MutableMap<Long, String> =
-        session.getAttribute(PROPERTIES_DEREGISTERED_THIS_SESSION_WITH_ADDRESSES) as MutableMap<Long, String>?
-            ?: mutableMapOf()
+    private fun getDeregisteredPropertyFromSession(): Pair<Long, String>? =
+        session.getAttribute(PROPERTY_DEREGISTERED_THIS_SESSION) as Pair<Long, String>?
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/PropertyDeregistrationService.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/PropertyDeregistrationService.kt
@@ -25,14 +25,20 @@ class PropertyDeregistrationService(
         return emailDetails
     }
 
-    fun addDeregisteredPropertyOwnershipIdToSession(propertyOwnershipId: Long) =
-        session.setAttribute(
-            PROPERTIES_DEREGISTERED_THIS_SESSION,
-            getDeregisteredPropertyOwnershipIdsFromSession() + propertyOwnershipId,
-        )
+    fun addDeregisteredPropertyOwnershipIdToSession(
+        propertyOwnershipId: Long,
+        singleLineAddress: String,
+    ) = session.setAttribute(
+        PROPERTIES_DEREGISTERED_THIS_SESSION,
+        getDeregisteredPropertiesFromSession() + (propertyOwnershipId to singleLineAddress),
+    )
+
+    fun getDeregisteredPropertyOwnershipIdsFromSession(): MutableList<Long> = getDeregisteredPropertiesFromSession().keys.toMutableList()
+
+    fun getDeregisteredPropertyAddress(propertyOwnershipId: Long): String? = getDeregisteredPropertiesFromSession()[propertyOwnershipId]
 
     @Suppress("UNCHECKED_CAST")
-    fun getDeregisteredPropertyOwnershipIdsFromSession(): MutableList<Long> =
-        session.getAttribute(PROPERTIES_DEREGISTERED_THIS_SESSION) as MutableList<Long>?
-            ?: mutableListOf()
+    private fun getDeregisteredPropertiesFromSession(): MutableMap<Long, String> =
+        session.getAttribute(PROPERTIES_DEREGISTERED_THIS_SESSION) as MutableMap<Long, String>?
+            ?: mutableMapOf()
 }

--- a/src/main/resources/messages/deregisterProperty.yml
+++ b/src/main/resources/messages/deregisterProperty.yml
@@ -29,3 +29,9 @@ confirmation:
     paragraph:
       one: This property has been removed from the database and your landlord record.
       two: We’ve sent a confirmation email about the deleted property to your email address.
+  panel:
+    title: "Deregistered {0}"
+    body: This property is no longer registered as a rental property
+  body:
+    one: We’ve sent you a confirmation email.
+    two: This property’s details have been removed from the service.

--- a/src/main/resources/templates/deregisterPropertyConfirmation.html
+++ b/src/main/resources/templates/deregisterPropertyConfirmation.html
@@ -1,21 +1,32 @@
 <!DOCTYPE html>
 <html th:replace="~{fragments/layout :: layout(#{deregisterProperty.title}, ~{::main}, false)}">
-<main class="govuk-main-wrapper" id="main-content">
-    <div id="page-contents"
-         th:replace="~{fragments/layouts/twoThirdsLayout :: twoThirdsLayout(~{::#page-contents/content()})}">
-        <div id="confirmation-banner"
-             th:replace="~{fragments/banners/confirmationPageBanner :: confirmationPageBanner(#{deregisterProperty.confirmation.banner.heading}, null)}">
+    <main class="govuk-main-wrapper" id="main-content">
+        <div id="page-contents" th:replace="~{fragments/layouts/twoThirdsLayout :: twoThirdsLayout(~{::#page-contents/content()})}">
+
+            <div class="govuk-panel govuk-panel--confirmation">
+                <h1 class="govuk-panel__title"
+                    th:text="#{deregisterProperty.confirmation.panel.title(${address})}">
+                    deregisterProperty.confirmation.panel.title
+                </h1>
+                <div class="govuk-panel__body"
+                     th:text="#{deregisterProperty.confirmation.panel.body}">
+                    deregisterProperty.confirmation.panel.body
+                </div>
+            </div>
+
+            <p class="govuk-body" th:text="#{deregisterProperty.confirmation.body.one}">
+                deregisterProperty.confirmation.body.one
+            </p>
+            <p class="govuk-body" th:text="#{deregisterProperty.confirmation.body.two}">
+                deregisterProperty.confirmation.body.two
+            </p>
+
+            <p class="govuk-body">
+                <a class="govuk-link"
+                   th:href="@{${landlordDashboardUrl}}"
+                   th:text="#{common.confirmationPage.goToDashboard}">common.confirmationPage.goToDashboard</a>
+            </p>
+
         </div>
-        <h1 class="govuk-heading-l" th:text="#{common.confirmationPage.whatHappensNext}">common.whatHappensNext</h1>
-        <p class="govuk-body" th:text="#{deregisterProperty.confirmation.whatHappensNext.paragraph.one}">
-            deregisterProperty.confirmation.whatHappensNext.paragraph.one
-        </p>
-        <p class="govuk-body" th:text="#{deregisterProperty.confirmation.whatHappensNext.paragraph.two}">
-            deregisterProperty.confirmation.whatHappensNext.paragraph.two
-        </p>
-        <a th:replace="~{fragments/buttons/primaryButtonLink :: primaryButtonLink(@{${landlordDashboardUrl}}, #{common.confirmationPage.goToDashboard})}">
-            common.confirmationPage.goToDashboard
-        </a>
-    </div>
-</main>
+    </main>
 </html>

--- a/src/main/resources/templates/deregisterPropertyConfirmationJune26Redesign.html
+++ b/src/main/resources/templates/deregisterPropertyConfirmationJune26Redesign.html
@@ -2,7 +2,6 @@
 <html th:replace="~{fragments/layout :: layout(#{deregisterProperty.title}, ~{::main}, false)}">
     <main class="govuk-main-wrapper" id="main-content">
         <div id="page-contents" th:replace="~{fragments/layouts/twoThirdsLayout :: twoThirdsLayout(~{::#page-contents/content()})}">
-
             <div class="govuk-panel govuk-panel--confirmation">
                 <h1 class="govuk-panel__title"
                     th:text="#{deregisterProperty.confirmation.panel.title(${address})}">
@@ -26,7 +25,6 @@
                    th:href="@{${landlordDashboardUrl}}"
                    th:text="#{common.confirmationPage.goToDashboard}">common.confirmationPage.goToDashboard</a>
             </p>
-
         </div>
     </main>
 </html>

--- a/src/main/resources/templates/deregisterPropertyConfirmationOld.html
+++ b/src/main/resources/templates/deregisterPropertyConfirmationOld.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html th:replace="~{fragments/layout :: layout(#{deregisterProperty.title}, ~{::main}, false)}">
+<main class="govuk-main-wrapper" id="main-content">
+    <div id="page-contents"
+         th:replace="~{fragments/layouts/twoThirdsLayout :: twoThirdsLayout(~{::#page-contents/content()})}">
+        <div id="confirmation-banner"
+             th:replace="~{fragments/banners/confirmationPageBanner :: confirmationPageBanner(#{deregisterProperty.confirmation.banner.heading}, null)}">
+        </div>
+        <h1 class="govuk-heading-l" th:text="#{common.confirmationPage.whatHappensNext}">common.whatHappensNext</h1>
+        <p class="govuk-body" th:text="#{deregisterProperty.confirmation.whatHappensNext.paragraph.one}">
+            deregisterProperty.confirmation.whatHappensNext.paragraph.one
+        </p>
+        <p class="govuk-body" th:text="#{deregisterProperty.confirmation.whatHappensNext.paragraph.two}">
+            deregisterProperty.confirmation.whatHappensNext.paragraph.two
+        </p>
+        <a th:replace="~{fragments/buttons/primaryButtonLink :: primaryButtonLink(@{${landlordDashboardUrl}}, #{common.confirmationPage.goToDashboard})}">
+            common.confirmationPage.goToDashboard
+        </a>
+    </div>
+</main>
+</html>

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/controllers/DeregisterPropertyControllerTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/controllers/DeregisterPropertyControllerTests.kt
@@ -314,4 +314,43 @@ class DeregisterPropertyControllerTests(
                 status { is5xxServerError() }
             }
     }
+
+    @Test
+    @WithMockUser(roles = ["LANDLORD"])
+    fun `getConfirmation returns the new confirmation view with the address when joint landlords is enabled`() {
+        val propertyOwnershipId = 1.toLong()
+        whenever(featureFlagManager.checkFeature(JOINT_LANDLORDS)).thenReturn(true)
+        whenever(
+            propertyDeregistrationService.getDeregisteredPropertyOwnershipIdsFromSession(),
+        ).thenReturn(mutableListOf(propertyOwnershipId))
+        whenever(propertyOwnershipService.retrievePropertyOwnershipById(propertyOwnershipId)).thenReturn(null)
+        whenever(propertyDeregistrationService.getDeregisteredPropertyAddress(propertyOwnershipId))
+            .thenReturn("1, Example Road, EG")
+
+        mvc
+            .get("${getPropertyDeregistrationBasePath(propertyOwnershipId)}/$CONFIRMATION_PATH_SEGMENT")
+            .andExpect {
+                status { isOk() }
+                view { name("deregisterPropertyConfirmation") }
+                model { attribute("address", "1, Example Road, EG") }
+            }
+    }
+
+    @Test
+    @WithMockUser(roles = ["LANDLORD"])
+    fun `getConfirmation returns the old confirmation view when joint landlords is disabled`() {
+        val propertyOwnershipId = 1.toLong()
+        whenever(featureFlagManager.checkFeature(JOINT_LANDLORDS)).thenReturn(false)
+        whenever(
+            propertyDeregistrationService.getDeregisteredPropertyOwnershipIdsFromSession(),
+        ).thenReturn(mutableListOf(propertyOwnershipId))
+        whenever(propertyOwnershipService.retrievePropertyOwnershipById(propertyOwnershipId)).thenReturn(null)
+
+        mvc
+            .get("${getPropertyDeregistrationBasePath(propertyOwnershipId)}/$CONFIRMATION_PATH_SEGMENT")
+            .andExpect {
+                status { isOk() }
+                view { name("deregisterPropertyConfirmationOld") }
+            }
+    }
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/controllers/DeregisterPropertyControllerTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/controllers/DeregisterPropertyControllerTests.kt
@@ -258,9 +258,7 @@ class DeregisterPropertyControllerTests(
     @WithMockUser(roles = ["LANDLORD"])
     fun `getConfirmation returns 200 if the property ownership was deregistered in the session`() {
         val propertyOwnershipId = 1.toLong()
-        whenever(
-            propertyDeregistrationService.getDeregisteredPropertyOwnershipIdsFromSession(),
-        ).thenReturn(mutableListOf(propertyOwnershipId))
+        whenever(propertyDeregistrationService.getDeregisteredPropertyOwnershipIdFromSession()).thenReturn(propertyOwnershipId)
         whenever(propertyOwnershipService.retrievePropertyOwnershipById(propertyOwnershipId)).thenReturn(null)
 
         mvc
@@ -284,10 +282,9 @@ class DeregisterPropertyControllerTests(
 
     @Test
     @WithMockUser(roles = ["LANDLORD"])
-    fun `getConfirmation returns 404 if the propertyOwnershipId is not in the list of deregistered propertyOwnershipIds in the session`() {
+    fun `getConfirmation returns 404 if the propertyOwnershipId is not the deregistered property in the session`() {
         val propertyOwnershipId = 1.toLong()
-        whenever(propertyDeregistrationService.getDeregisteredPropertyOwnershipIdsFromSession())
-            .thenReturn(mutableListOf(2, 3))
+        whenever(propertyDeregistrationService.getDeregisteredPropertyOwnershipIdFromSession()).thenReturn(2L)
 
         mvc
             .get("${getPropertyDeregistrationBasePath(propertyOwnershipId)}/$CONFIRMATION_PATH_SEGMENT")
@@ -302,9 +299,7 @@ class DeregisterPropertyControllerTests(
         // Arrange
         val propertyOwnership = MockLandlordData.createPropertyOwnership()
         val propertyOwnershipId = propertyOwnership.id
-        whenever(
-            propertyDeregistrationService.getDeregisteredPropertyOwnershipIdsFromSession(),
-        ).thenReturn(mutableListOf(propertyOwnershipId))
+        whenever(propertyDeregistrationService.getDeregisteredPropertyOwnershipIdFromSession()).thenReturn(propertyOwnershipId)
         whenever(propertyOwnershipService.retrievePropertyOwnershipById(propertyOwnershipId)).thenReturn(propertyOwnership)
 
         // Act, Assert
@@ -320,11 +315,9 @@ class DeregisterPropertyControllerTests(
     fun `getConfirmation returns the new confirmation view with the address when joint landlords is enabled`() {
         val propertyOwnershipId = 1.toLong()
         whenever(featureFlagManager.checkFeature(JOINT_LANDLORDS)).thenReturn(true)
-        whenever(
-            propertyDeregistrationService.getDeregisteredPropertyOwnershipIdsFromSession(),
-        ).thenReturn(mutableListOf(propertyOwnershipId))
+        whenever(propertyDeregistrationService.getDeregisteredPropertyOwnershipIdFromSession()).thenReturn(propertyOwnershipId)
         whenever(propertyOwnershipService.retrievePropertyOwnershipById(propertyOwnershipId)).thenReturn(null)
-        whenever(propertyDeregistrationService.getDeregisteredPropertyAddress(propertyOwnershipId))
+        whenever(propertyDeregistrationService.getDeregisteredPropertyAddress())
             .thenReturn("1, Example Road, EG")
 
         mvc
@@ -341,9 +334,7 @@ class DeregisterPropertyControllerTests(
     fun `getConfirmation returns the old confirmation view when joint landlords is disabled`() {
         val propertyOwnershipId = 1.toLong()
         whenever(featureFlagManager.checkFeature(JOINT_LANDLORDS)).thenReturn(false)
-        whenever(
-            propertyDeregistrationService.getDeregisteredPropertyOwnershipIdsFromSession(),
-        ).thenReturn(mutableListOf(propertyOwnershipId))
+        whenever(propertyDeregistrationService.getDeregisteredPropertyOwnershipIdFromSession()).thenReturn(propertyOwnershipId)
         whenever(propertyOwnershipService.retrievePropertyOwnershipById(propertyOwnershipId)).thenReturn(null)
 
         mvc

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/controllers/DeregisterPropertyControllerTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/controllers/DeregisterPropertyControllerTests.kt
@@ -258,7 +258,9 @@ class DeregisterPropertyControllerTests(
     @WithMockUser(roles = ["LANDLORD"])
     fun `getConfirmation returns 200 if the property ownership was deregistered in the session`() {
         val propertyOwnershipId = 1.toLong()
-        whenever(propertyDeregistrationService.getDeregisteredPropertyOwnershipIdFromSession()).thenReturn(propertyOwnershipId)
+        whenever(
+            propertyDeregistrationService.getDeregisteredPropertyOwnershipIdsFromSession(),
+        ).thenReturn(mutableListOf(propertyOwnershipId))
         whenever(propertyOwnershipService.retrievePropertyOwnershipById(propertyOwnershipId)).thenReturn(null)
 
         mvc
@@ -282,9 +284,10 @@ class DeregisterPropertyControllerTests(
 
     @Test
     @WithMockUser(roles = ["LANDLORD"])
-    fun `getConfirmation returns 404 if the propertyOwnershipId is not the deregistered property in the session`() {
+    fun `getConfirmation returns 404 if the propertyOwnershipId is not in the list of deregistered propertyOwnershipIds in the session`() {
         val propertyOwnershipId = 1.toLong()
-        whenever(propertyDeregistrationService.getDeregisteredPropertyOwnershipIdFromSession()).thenReturn(2L)
+        whenever(propertyDeregistrationService.getDeregisteredPropertyOwnershipIdsFromSession())
+            .thenReturn(mutableListOf(2, 3))
 
         mvc
             .get("${getPropertyDeregistrationBasePath(propertyOwnershipId)}/$CONFIRMATION_PATH_SEGMENT")
@@ -299,7 +302,9 @@ class DeregisterPropertyControllerTests(
         // Arrange
         val propertyOwnership = MockLandlordData.createPropertyOwnership()
         val propertyOwnershipId = propertyOwnership.id
-        whenever(propertyDeregistrationService.getDeregisteredPropertyOwnershipIdFromSession()).thenReturn(propertyOwnershipId)
+        whenever(
+            propertyDeregistrationService.getDeregisteredPropertyOwnershipIdsFromSession(),
+        ).thenReturn(mutableListOf(propertyOwnershipId))
         whenever(propertyOwnershipService.retrievePropertyOwnershipById(propertyOwnershipId)).thenReturn(propertyOwnership)
 
         // Act, Assert
@@ -315,9 +320,11 @@ class DeregisterPropertyControllerTests(
     fun `getConfirmation returns the new confirmation view with the address when joint landlords is enabled`() {
         val propertyOwnershipId = 1.toLong()
         whenever(featureFlagManager.checkFeature(JOINT_LANDLORDS)).thenReturn(true)
-        whenever(propertyDeregistrationService.getDeregisteredPropertyOwnershipIdFromSession()).thenReturn(propertyOwnershipId)
+        whenever(
+            propertyDeregistrationService.getDeregisteredPropertyOwnershipIdsFromSession(),
+        ).thenReturn(mutableListOf(propertyOwnershipId))
         whenever(propertyOwnershipService.retrievePropertyOwnershipById(propertyOwnershipId)).thenReturn(null)
-        whenever(propertyDeregistrationService.getDeregisteredPropertyAddress())
+        whenever(propertyDeregistrationService.getDeregisteredPropertyAddress(propertyOwnershipId))
             .thenReturn("1, Example Road, EG")
 
         mvc
@@ -334,7 +341,9 @@ class DeregisterPropertyControllerTests(
     fun `getConfirmation returns the old confirmation view when joint landlords is disabled`() {
         val propertyOwnershipId = 1.toLong()
         whenever(featureFlagManager.checkFeature(JOINT_LANDLORDS)).thenReturn(false)
-        whenever(propertyDeregistrationService.getDeregisteredPropertyOwnershipIdFromSession()).thenReturn(propertyOwnershipId)
+        whenever(
+            propertyDeregistrationService.getDeregisteredPropertyOwnershipIdsFromSession(),
+        ).thenReturn(mutableListOf(propertyOwnershipId))
         whenever(propertyOwnershipService.retrievePropertyOwnershipById(propertyOwnershipId)).thenReturn(null)
 
         mvc

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/controllers/DeregisterPropertyControllerTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/controllers/DeregisterPropertyControllerTests.kt
@@ -331,7 +331,7 @@ class DeregisterPropertyControllerTests(
             .get("${getPropertyDeregistrationBasePath(propertyOwnershipId)}/$CONFIRMATION_PATH_SEGMENT")
             .andExpect {
                 status { isOk() }
-                view { name("deregisterPropertyConfirmation") }
+                view { name("deregisterPropertyConfirmationJune26Redesign") }
                 model { attribute("address", "1, Example Road, EG") }
             }
     }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/PropertyDeregistrationJourneyTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/PropertyDeregistrationJourneyTests.kt
@@ -12,6 +12,7 @@ import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages.B
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyDeregistrationJourneyPages.CheckInvitationsPage
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyDeregistrationJourneyPages.ConfirmPagePropertyDeregistration
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyDeregistrationJourneyPages.ConfirmationPagePropertyDeregistration
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyDeregistrationJourneyPages.ConfirmationPagePropertyDeregistrationOld
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyDeregistrationJourneyPages.ReasonPagePropertyDeregistration
 
 class PropertyDeregistrationJourneyTests : IntegrationTestWithMutableData("data-local.sql") {
@@ -36,9 +37,9 @@ class PropertyDeregistrationJourneyTests : IntegrationTestWithMutableData("data-
                 ConfirmationPagePropertyDeregistration::class,
                 mapOf("propertyOwnershipId" to propertyOwnershipId.toString()),
             )
-        BaseComponent.assertThat(confirmationPage.confirmationBanner).containsText("You have deleted a property")
+        BaseComponent.assertThat(confirmationPage.confirmationBanner).containsText("Deregistered 1, Example Road, EG1 1AA")
 
-        confirmationPage.goToDashboardButton.clickAndWait()
+        confirmationPage.goToDashboardLink.clickAndWait()
         assertPageIs(page, LandlordDashboardPage::class)
     }
 
@@ -70,9 +71,9 @@ class PropertyDeregistrationJourneyTests : IntegrationTestWithMutableData("data-
                 ConfirmationPagePropertyDeregistration::class,
                 mapOf("propertyOwnershipId" to propertyOwnershipId.toString()),
             )
-        BaseComponent.assertThat(confirmationPage.confirmationBanner).containsText("You have deleted a property")
+        BaseComponent.assertThat(confirmationPage.confirmationBanner).containsText("Deregistered 1 PRSDB Square, EG1 2AA")
 
-        confirmationPage.goToDashboardButton.clickAndWait()
+        confirmationPage.goToDashboardLink.clickAndWait()
         assertPageIs(page, LandlordDashboardPage::class)
     }
 
@@ -111,7 +112,7 @@ class PropertyDeregistrationJourneyTests : IntegrationTestWithMutableData("data-
             val confirmationPage =
                 assertPageIs(
                     page,
-                    ConfirmationPagePropertyDeregistration::class,
+                    ConfirmationPagePropertyDeregistrationOld::class,
                     mapOf("propertyOwnershipId" to propertyOwnershipId.toString()),
                 )
             BaseComponent.assertThat(confirmationPage.confirmationBanner).containsText("You have deleted a property")

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/propertyDeregistrationJourneyPages/ConfirmationPagePropertyDeregistrationOld.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/propertyDeregistrationJourneyPages/ConfirmationPagePropertyDeregistrationOld.kt
@@ -3,11 +3,11 @@ package uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyDe
 import com.microsoft.playwright.Page
 import uk.gov.communities.prsdb.webapp.constants.CONFIRMATION_PATH_SEGMENT
 import uk.gov.communities.prsdb.webapp.controllers.DeregisterPropertyController
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.Button
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.ConfirmationBanner
-import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.Link
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages.BasePage
 
-class ConfirmationPagePropertyDeregistration(
+class ConfirmationPagePropertyDeregistrationOld(
     page: Page,
     urlArguments: Map<String, String>,
 ) : BasePage(
@@ -16,5 +16,5 @@ class ConfirmationPagePropertyDeregistration(
             "/$CONFIRMATION_PATH_SEGMENT",
     ) {
     val confirmationBanner = ConfirmationBanner(page)
-    val goToDashboardLink = Link.byText(page, "Go to dashboard")
+    val goToDashboardButton = Button.byText(page, "Go to Dashboard")
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyDeregistration/stepConfig/ConfirmStepConfigTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyDeregistration/stepConfig/ConfirmStepConfigTests.kt
@@ -55,7 +55,7 @@ class ConfirmStepConfigTests {
 
         stepConfig.afterStepDataIsAdded(mockState)
 
-        verify(mockPropertyDeregistrationService).setDeregisteredPropertyInSession(propertyOwnershipId, propertyAddress)
+        verify(mockPropertyDeregistrationService).addDeregisteredPropertyOwnershipIdToSession(propertyOwnershipId, propertyAddress)
     }
 
     @Test

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyDeregistration/stepConfig/ConfirmStepConfigTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyDeregistration/stepConfig/ConfirmStepConfigTests.kt
@@ -46,15 +46,16 @@ class ConfirmStepConfigTests {
     }
 
     @Test
-    fun `afterStepDataIsAdded adds deregistered property ownership id to session`() {
+    fun `afterStepDataIsAdded adds deregistered property ownership id and address to session`() {
         val stepConfig = setupStepConfig()
+        val propertyAddress = "123 Test Street, AB1 2CD"
         whenever(mockState.propertyOwnershipId).thenReturn(propertyOwnershipId)
         whenever(mockPropertyDeregistrationService.deregisterProperty(propertyOwnershipId))
-            .thenReturn(emailDetails())
+            .thenReturn(emailDetails(singleLineAddress = propertyAddress))
 
         stepConfig.afterStepDataIsAdded(mockState)
 
-        verify(mockPropertyDeregistrationService).addDeregisteredPropertyOwnershipIdToSession(propertyOwnershipId)
+        verify(mockPropertyDeregistrationService).addDeregisteredPropertyOwnershipIdToSession(propertyOwnershipId, propertyAddress)
     }
 
     @Test

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyDeregistration/stepConfig/ConfirmStepConfigTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyDeregistration/stepConfig/ConfirmStepConfigTests.kt
@@ -55,7 +55,7 @@ class ConfirmStepConfigTests {
 
         stepConfig.afterStepDataIsAdded(mockState)
 
-        verify(mockPropertyDeregistrationService).addDeregisteredPropertyOwnershipIdToSession(propertyOwnershipId, propertyAddress)
+        verify(mockPropertyDeregistrationService).setDeregisteredPropertyInSession(propertyOwnershipId, propertyAddress)
     }
 
     @Test

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyDeregistration/stepConfig/ReasonStepConfigTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyDeregistration/stepConfig/ReasonStepConfigTests.kt
@@ -62,7 +62,7 @@ class ReasonStepConfigTests {
         stepConfig.afterStepDataIsAdded(mockState)
 
         // Assert
-        verify(mockPropertyDeregistrationService).setDeregisteredPropertyInSession(propertyOwnershipId, "")
+        verify(mockPropertyDeregistrationService).setDeregisteredPropertyInSession(propertyOwnershipId, null)
     }
 
     @Test

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyDeregistration/stepConfig/ReasonStepConfigTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyDeregistration/stepConfig/ReasonStepConfigTests.kt
@@ -49,10 +49,12 @@ class ReasonStepConfigTests {
     }
 
     @Test
-    fun `afterStepDataIsAdded adds deregistered property ownership id to session`() {
+    fun `afterStepDataIsAdded adds deregistered property ownership id and address to session`() {
         // Arrange
         val stepConfig = setupStepConfig()
-        val propertyOwnership = MockLandlordData.createPropertyOwnership(id = propertyOwnershipId)
+        val propertyAddress = "123 Test Street, AB1 2CD"
+        val address = MockLandlordData.createAddress(singleLineAddress = propertyAddress)
+        val propertyOwnership = MockLandlordData.createPropertyOwnership(id = propertyOwnershipId, address = address)
         whenever(mockState.propertyOwnershipId).thenReturn(propertyOwnershipId)
         whenever(mockPropertyOwnershipService.getPropertyOwnership(propertyOwnershipId)).thenReturn(propertyOwnership)
 
@@ -60,7 +62,7 @@ class ReasonStepConfigTests {
         stepConfig.afterStepDataIsAdded(mockState)
 
         // Assert
-        verify(mockPropertyDeregistrationService).addDeregisteredPropertyOwnershipIdToSession(propertyOwnershipId)
+        verify(mockPropertyDeregistrationService).addDeregisteredPropertyOwnershipIdToSession(propertyOwnershipId, propertyAddress)
     }
 
     @Test

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyDeregistration/stepConfig/ReasonStepConfigTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyDeregistration/stepConfig/ReasonStepConfigTests.kt
@@ -49,7 +49,7 @@ class ReasonStepConfigTests {
     }
 
     @Test
-    fun `afterStepDataIsAdded adds deregistered property ownership id and address to session`() {
+    fun `afterStepDataIsAdded stores the deregistered property ownership id in the session`() {
         // Arrange
         val stepConfig = setupStepConfig()
         val propertyAddress = "123 Test Street, AB1 2CD"
@@ -62,7 +62,7 @@ class ReasonStepConfigTests {
         stepConfig.afterStepDataIsAdded(mockState)
 
         // Assert
-        verify(mockPropertyDeregistrationService).addDeregisteredPropertyOwnershipIdToSession(propertyOwnershipId, propertyAddress)
+        verify(mockPropertyDeregistrationService).setDeregisteredPropertyInSession(propertyOwnershipId, "")
     }
 
     @Test

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyDeregistration/stepConfig/ReasonStepConfigTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyDeregistration/stepConfig/ReasonStepConfigTests.kt
@@ -62,7 +62,7 @@ class ReasonStepConfigTests {
         stepConfig.afterStepDataIsAdded(mockState)
 
         // Assert
-        verify(mockPropertyDeregistrationService).setDeregisteredPropertyInSession(propertyOwnershipId, null)
+        verify(mockPropertyDeregistrationService).addDeregisteredPropertyOwnershipIdToSession(propertyOwnershipId, null)
     }
 
     @Test

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/PropertyDeregistrationServiceTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/PropertyDeregistrationServiceTests.kt
@@ -8,7 +8,7 @@ import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
-import uk.gov.communities.prsdb.webapp.constants.PROPERTIES_DEREGISTERED_THIS_SESSION_WITH_ADDRESSES
+import uk.gov.communities.prsdb.webapp.constants.PROPERTY_DEREGISTERED_THIS_SESSION
 import uk.gov.communities.prsdb.webapp.testHelpers.mockObjects.MockLandlordData
 import kotlin.test.assertEquals
 
@@ -62,70 +62,64 @@ class PropertyDeregistrationServiceTests {
     }
 
     @Test
-    fun `addDeregisteredPropertyOwnershipIdToSession adds the id and address to the ones stored in the session`() {
+    fun `setDeregisteredPropertyInSession stores the id and address in the session`() {
         // Arrange
         val propertyOwnershipId = 123.toLong()
         val address = "Flat 1, 1 Elm Street, London, NE1 2GB"
-        val existingDeregisteredProperties = mutableMapOf(456L to "456 Road", 789L to "789 Road")
-        whenever(
-            mockHttpSession.getAttribute(PROPERTIES_DEREGISTERED_THIS_SESSION_WITH_ADDRESSES),
-        ).thenReturn(existingDeregisteredProperties)
 
         // Act
-        propertyDeregistrationService.addDeregisteredPropertyOwnershipIdToSession(propertyOwnershipId, address)
+        propertyDeregistrationService.setDeregisteredPropertyInSession(propertyOwnershipId, address)
 
         // Assert
         verify(mockHttpSession).setAttribute(
-            PROPERTIES_DEREGISTERED_THIS_SESSION_WITH_ADDRESSES,
-            existingDeregisteredProperties + (propertyOwnershipId to address),
+            PROPERTY_DEREGISTERED_THIS_SESSION,
+            propertyOwnershipId to address,
         )
     }
 
     @Test
-    fun `getDeregisteredPropertyOwnershipIdsFromSession returns a list of property ownership Ids in the session`() {
+    fun `getDeregisteredPropertyOwnershipIdFromSession returns the id stored in the session`() {
         // Arrange
-        val deregisteredProperties = mutableMapOf(456L to "456 Road", 789L to "789 Road")
-        whenever(mockHttpSession.getAttribute(PROPERTIES_DEREGISTERED_THIS_SESSION_WITH_ADDRESSES)).thenReturn(deregisteredProperties)
+        whenever(mockHttpSession.getAttribute(PROPERTY_DEREGISTERED_THIS_SESSION)).thenReturn(456L to "456 Road")
 
         // Act
-        val results = propertyDeregistrationService.getDeregisteredPropertyOwnershipIdsFromSession()
+        val result = propertyDeregistrationService.getDeregisteredPropertyOwnershipIdFromSession()
 
         // Assert
-        assertEquals(mutableListOf(456L, 789L), results)
+        assertEquals(456L, result)
     }
 
     @Test
-    fun `getDeregisteredPropertyOwnershipIdsFromSession returns empty list if no property ownerships were deregistered in the session`() {
+    fun `getDeregisteredPropertyOwnershipIdFromSession returns null if no property was deregistered in the session`() {
         // Arrange
-        whenever(mockHttpSession.getAttribute(PROPERTIES_DEREGISTERED_THIS_SESSION_WITH_ADDRESSES)).thenReturn(null)
+        whenever(mockHttpSession.getAttribute(PROPERTY_DEREGISTERED_THIS_SESSION)).thenReturn(null)
 
         // Act
-        val results = propertyDeregistrationService.getDeregisteredPropertyOwnershipIdsFromSession()
+        val result = propertyDeregistrationService.getDeregisteredPropertyOwnershipIdFromSession()
 
         // Assert
-        assertEquals(emptyList(), results)
+        assertEquals(null, result)
     }
 
     @Test
-    fun `getDeregisteredPropertyAddress returns the stored address for the property ownership Id`() {
+    fun `getDeregisteredPropertyAddress returns the stored address`() {
         // Arrange
-        val deregisteredProperties = mutableMapOf(456L to "456 Road", 789L to "789 Road")
-        whenever(mockHttpSession.getAttribute(PROPERTIES_DEREGISTERED_THIS_SESSION_WITH_ADDRESSES)).thenReturn(deregisteredProperties)
+        whenever(mockHttpSession.getAttribute(PROPERTY_DEREGISTERED_THIS_SESSION)).thenReturn(456L to "456 Road")
 
         // Act
-        val result = propertyDeregistrationService.getDeregisteredPropertyAddress(456L)
+        val result = propertyDeregistrationService.getDeregisteredPropertyAddress()
 
         // Assert
         assertEquals("456 Road", result)
     }
 
     @Test
-    fun `getDeregisteredPropertyAddress returns null if the property ownership Id is not in the session`() {
+    fun `getDeregisteredPropertyAddress returns null if no property was deregistered in the session`() {
         // Arrange
-        whenever(mockHttpSession.getAttribute(PROPERTIES_DEREGISTERED_THIS_SESSION_WITH_ADDRESSES)).thenReturn(null)
+        whenever(mockHttpSession.getAttribute(PROPERTY_DEREGISTERED_THIS_SESSION)).thenReturn(null)
 
         // Act
-        val result = propertyDeregistrationService.getDeregisteredPropertyAddress(456L)
+        val result = propertyDeregistrationService.getDeregisteredPropertyAddress()
 
         // Assert
         assertEquals(null, result)

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/PropertyDeregistrationServiceTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/PropertyDeregistrationServiceTests.kt
@@ -62,30 +62,34 @@ class PropertyDeregistrationServiceTests {
     }
 
     @Test
-    fun `addDeregisteredPropertyAndOwnershipIdsToSession adds a property ownership Id to the ones stored in the session`() {
+    fun `addDeregisteredPropertyOwnershipIdToSession adds the id and address to the ones stored in the session`() {
         // Arrange
         val propertyOwnershipId = 123.toLong()
-        val existingPropertyOwnershipIds = mutableListOf(456, 789)
-        whenever(mockHttpSession.getAttribute(PROPERTIES_DEREGISTERED_THIS_SESSION)).thenReturn(existingPropertyOwnershipIds)
+        val address = "Flat 1, 1 Elm Street, London, NE1 2GB"
+        val existingDeregisteredProperties = mutableMapOf(456L to "456 Road", 789L to "789 Road")
+        whenever(mockHttpSession.getAttribute(PROPERTIES_DEREGISTERED_THIS_SESSION)).thenReturn(existingDeregisteredProperties)
 
         // Act
-        propertyDeregistrationService.addDeregisteredPropertyOwnershipIdToSession(propertyOwnershipId)
+        propertyDeregistrationService.addDeregisteredPropertyOwnershipIdToSession(propertyOwnershipId, address)
 
         // Assert
-        verify(mockHttpSession).setAttribute(PROPERTIES_DEREGISTERED_THIS_SESSION, existingPropertyOwnershipIds + propertyOwnershipId)
+        verify(mockHttpSession).setAttribute(
+            PROPERTIES_DEREGISTERED_THIS_SESSION,
+            existingDeregisteredProperties + (propertyOwnershipId to address),
+        )
     }
 
     @Test
     fun `getDeregisteredPropertyOwnershipIdsFromSession returns a list of property ownership Ids in the session`() {
         // Arrange
-        val deregisteredPropertyOwnershipIds = mutableListOf(456L, 789L)
-        whenever(mockHttpSession.getAttribute(PROPERTIES_DEREGISTERED_THIS_SESSION)).thenReturn(deregisteredPropertyOwnershipIds)
+        val deregisteredProperties = mutableMapOf(456L to "456 Road", 789L to "789 Road")
+        whenever(mockHttpSession.getAttribute(PROPERTIES_DEREGISTERED_THIS_SESSION)).thenReturn(deregisteredProperties)
 
         // Act
         val results = propertyDeregistrationService.getDeregisteredPropertyOwnershipIdsFromSession()
 
         // Assert
-        assertEquals(deregisteredPropertyOwnershipIds, results)
+        assertEquals(mutableListOf(456L, 789L), results)
     }
 
     @Test
@@ -98,5 +102,30 @@ class PropertyDeregistrationServiceTests {
 
         // Assert
         assertEquals(emptyList(), results)
+    }
+
+    @Test
+    fun `getDeregisteredPropertyAddress returns the stored address for the property ownership Id`() {
+        // Arrange
+        val deregisteredProperties = mutableMapOf(456L to "456 Road", 789L to "789 Road")
+        whenever(mockHttpSession.getAttribute(PROPERTIES_DEREGISTERED_THIS_SESSION)).thenReturn(deregisteredProperties)
+
+        // Act
+        val result = propertyDeregistrationService.getDeregisteredPropertyAddress(456L)
+
+        // Assert
+        assertEquals("456 Road", result)
+    }
+
+    @Test
+    fun `getDeregisteredPropertyAddress returns null if the property ownership Id is not in the session`() {
+        // Arrange
+        whenever(mockHttpSession.getAttribute(PROPERTIES_DEREGISTERED_THIS_SESSION)).thenReturn(null)
+
+        // Act
+        val result = propertyDeregistrationService.getDeregisteredPropertyAddress(456L)
+
+        // Assert
+        assertEquals(null, result)
     }
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/PropertyDeregistrationServiceTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/PropertyDeregistrationServiceTests.kt
@@ -8,7 +8,7 @@ import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
-import uk.gov.communities.prsdb.webapp.constants.PROPERTY_DEREGISTERED_THIS_SESSION
+import uk.gov.communities.prsdb.webapp.constants.PROPERTIES_DEREGISTERED_THIS_SESSION_WITH_ADDRESSES
 import uk.gov.communities.prsdb.webapp.testHelpers.mockObjects.MockLandlordData
 import kotlin.test.assertEquals
 
@@ -62,64 +62,89 @@ class PropertyDeregistrationServiceTests {
     }
 
     @Test
-    fun `setDeregisteredPropertyInSession stores the id and address in the session`() {
+    fun `addDeregisteredPropertyOwnershipIdToSession adds the id and address to the ones stored in the session`() {
         // Arrange
         val propertyOwnershipId = 123.toLong()
         val address = "Flat 1, 1 Elm Street, London, NE1 2GB"
+        val existingDeregisteredProperties = mutableMapOf(456L to "456 Road", 789L to "789 Road")
+        whenever(
+            mockHttpSession.getAttribute(PROPERTIES_DEREGISTERED_THIS_SESSION_WITH_ADDRESSES),
+        ).thenReturn(existingDeregisteredProperties)
 
         // Act
-        propertyDeregistrationService.setDeregisteredPropertyInSession(propertyOwnershipId, address)
+        propertyDeregistrationService.addDeregisteredPropertyOwnershipIdToSession(propertyOwnershipId, address)
 
         // Assert
         verify(mockHttpSession).setAttribute(
-            PROPERTY_DEREGISTERED_THIS_SESSION,
-            propertyOwnershipId to address,
+            PROPERTIES_DEREGISTERED_THIS_SESSION_WITH_ADDRESSES,
+            existingDeregisteredProperties + (propertyOwnershipId to address),
         )
     }
 
     @Test
-    fun `getDeregisteredPropertyOwnershipIdFromSession returns the id stored in the session`() {
+    fun `addDeregisteredPropertyOwnershipIdToSession adds the id with a null address when no address is given`() {
         // Arrange
-        whenever(mockHttpSession.getAttribute(PROPERTY_DEREGISTERED_THIS_SESSION)).thenReturn(456L to "456 Road")
+        val propertyOwnershipId = 123.toLong()
+        val existingDeregisteredProperties = mutableMapOf<Long, String?>(456L to "456 Road", 789L to "789 Road")
+        whenever(
+            mockHttpSession.getAttribute(PROPERTIES_DEREGISTERED_THIS_SESSION_WITH_ADDRESSES),
+        ).thenReturn(existingDeregisteredProperties)
 
         // Act
-        val result = propertyDeregistrationService.getDeregisteredPropertyOwnershipIdFromSession()
+        propertyDeregistrationService.addDeregisteredPropertyOwnershipIdToSession(propertyOwnershipId)
 
         // Assert
-        assertEquals(456L, result)
+        verify(mockHttpSession).setAttribute(
+            PROPERTIES_DEREGISTERED_THIS_SESSION_WITH_ADDRESSES,
+            existingDeregisteredProperties + (propertyOwnershipId to null),
+        )
     }
 
     @Test
-    fun `getDeregisteredPropertyOwnershipIdFromSession returns null if no property was deregistered in the session`() {
+    fun `getDeregisteredPropertyOwnershipIdsFromSession returns a list of property ownership Ids in the session`() {
         // Arrange
-        whenever(mockHttpSession.getAttribute(PROPERTY_DEREGISTERED_THIS_SESSION)).thenReturn(null)
+        val deregisteredProperties = mutableMapOf(456L to "456 Road", 789L to "789 Road")
+        whenever(mockHttpSession.getAttribute(PROPERTIES_DEREGISTERED_THIS_SESSION_WITH_ADDRESSES)).thenReturn(deregisteredProperties)
 
         // Act
-        val result = propertyDeregistrationService.getDeregisteredPropertyOwnershipIdFromSession()
+        val results = propertyDeregistrationService.getDeregisteredPropertyOwnershipIdsFromSession()
 
         // Assert
-        assertEquals(null, result)
+        assertEquals(mutableListOf(456L, 789L), results)
     }
 
     @Test
-    fun `getDeregisteredPropertyAddress returns the stored address`() {
+    fun `getDeregisteredPropertyOwnershipIdsFromSession returns empty list if no property ownerships were deregistered in the session`() {
         // Arrange
-        whenever(mockHttpSession.getAttribute(PROPERTY_DEREGISTERED_THIS_SESSION)).thenReturn(456L to "456 Road")
+        whenever(mockHttpSession.getAttribute(PROPERTIES_DEREGISTERED_THIS_SESSION_WITH_ADDRESSES)).thenReturn(null)
 
         // Act
-        val result = propertyDeregistrationService.getDeregisteredPropertyAddress()
+        val results = propertyDeregistrationService.getDeregisteredPropertyOwnershipIdsFromSession()
+
+        // Assert
+        assertEquals(emptyList(), results)
+    }
+
+    @Test
+    fun `getDeregisteredPropertyAddress returns the stored address for the property ownership Id`() {
+        // Arrange
+        val deregisteredProperties = mutableMapOf(456L to "456 Road", 789L to "789 Road")
+        whenever(mockHttpSession.getAttribute(PROPERTIES_DEREGISTERED_THIS_SESSION_WITH_ADDRESSES)).thenReturn(deregisteredProperties)
+
+        // Act
+        val result = propertyDeregistrationService.getDeregisteredPropertyAddress(456L)
 
         // Assert
         assertEquals("456 Road", result)
     }
 
     @Test
-    fun `getDeregisteredPropertyAddress returns null if no property was deregistered in the session`() {
+    fun `getDeregisteredPropertyAddress returns null if the property ownership Id is not in the session`() {
         // Arrange
-        whenever(mockHttpSession.getAttribute(PROPERTY_DEREGISTERED_THIS_SESSION)).thenReturn(null)
+        whenever(mockHttpSession.getAttribute(PROPERTIES_DEREGISTERED_THIS_SESSION_WITH_ADDRESSES)).thenReturn(null)
 
         // Act
-        val result = propertyDeregistrationService.getDeregisteredPropertyAddress()
+        val result = propertyDeregistrationService.getDeregisteredPropertyAddress(456L)
 
         // Assert
         assertEquals(null, result)

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/PropertyDeregistrationServiceTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/PropertyDeregistrationServiceTests.kt
@@ -8,7 +8,7 @@ import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
-import uk.gov.communities.prsdb.webapp.constants.PROPERTIES_DEREGISTERED_THIS_SESSION
+import uk.gov.communities.prsdb.webapp.constants.PROPERTIES_DEREGISTERED_THIS_SESSION_WITH_ADDRESSES
 import uk.gov.communities.prsdb.webapp.testHelpers.mockObjects.MockLandlordData
 import kotlin.test.assertEquals
 
@@ -67,14 +67,16 @@ class PropertyDeregistrationServiceTests {
         val propertyOwnershipId = 123.toLong()
         val address = "Flat 1, 1 Elm Street, London, NE1 2GB"
         val existingDeregisteredProperties = mutableMapOf(456L to "456 Road", 789L to "789 Road")
-        whenever(mockHttpSession.getAttribute(PROPERTIES_DEREGISTERED_THIS_SESSION)).thenReturn(existingDeregisteredProperties)
+        whenever(
+            mockHttpSession.getAttribute(PROPERTIES_DEREGISTERED_THIS_SESSION_WITH_ADDRESSES),
+        ).thenReturn(existingDeregisteredProperties)
 
         // Act
         propertyDeregistrationService.addDeregisteredPropertyOwnershipIdToSession(propertyOwnershipId, address)
 
         // Assert
         verify(mockHttpSession).setAttribute(
-            PROPERTIES_DEREGISTERED_THIS_SESSION,
+            PROPERTIES_DEREGISTERED_THIS_SESSION_WITH_ADDRESSES,
             existingDeregisteredProperties + (propertyOwnershipId to address),
         )
     }
@@ -83,7 +85,7 @@ class PropertyDeregistrationServiceTests {
     fun `getDeregisteredPropertyOwnershipIdsFromSession returns a list of property ownership Ids in the session`() {
         // Arrange
         val deregisteredProperties = mutableMapOf(456L to "456 Road", 789L to "789 Road")
-        whenever(mockHttpSession.getAttribute(PROPERTIES_DEREGISTERED_THIS_SESSION)).thenReturn(deregisteredProperties)
+        whenever(mockHttpSession.getAttribute(PROPERTIES_DEREGISTERED_THIS_SESSION_WITH_ADDRESSES)).thenReturn(deregisteredProperties)
 
         // Act
         val results = propertyDeregistrationService.getDeregisteredPropertyOwnershipIdsFromSession()
@@ -95,7 +97,7 @@ class PropertyDeregistrationServiceTests {
     @Test
     fun `getDeregisteredPropertyOwnershipIdsFromSession returns empty list if no property ownerships were deregistered in the session`() {
         // Arrange
-        whenever(mockHttpSession.getAttribute(PROPERTIES_DEREGISTERED_THIS_SESSION)).thenReturn(null)
+        whenever(mockHttpSession.getAttribute(PROPERTIES_DEREGISTERED_THIS_SESSION_WITH_ADDRESSES)).thenReturn(null)
 
         // Act
         val results = propertyDeregistrationService.getDeregisteredPropertyOwnershipIdsFromSession()
@@ -108,7 +110,7 @@ class PropertyDeregistrationServiceTests {
     fun `getDeregisteredPropertyAddress returns the stored address for the property ownership Id`() {
         // Arrange
         val deregisteredProperties = mutableMapOf(456L to "456 Road", 789L to "789 Road")
-        whenever(mockHttpSession.getAttribute(PROPERTIES_DEREGISTERED_THIS_SESSION)).thenReturn(deregisteredProperties)
+        whenever(mockHttpSession.getAttribute(PROPERTIES_DEREGISTERED_THIS_SESSION_WITH_ADDRESSES)).thenReturn(deregisteredProperties)
 
         // Act
         val result = propertyDeregistrationService.getDeregisteredPropertyAddress(456L)
@@ -120,7 +122,7 @@ class PropertyDeregistrationServiceTests {
     @Test
     fun `getDeregisteredPropertyAddress returns null if the property ownership Id is not in the session`() {
         // Arrange
-        whenever(mockHttpSession.getAttribute(PROPERTIES_DEREGISTERED_THIS_SESSION)).thenReturn(null)
+        whenever(mockHttpSession.getAttribute(PROPERTIES_DEREGISTERED_THIS_SESSION_WITH_ADDRESSES)).thenReturn(null)
 
         // Act
         val result = propertyDeregistrationService.getDeregisteredPropertyAddress(456L)


### PR DESCRIPTION
## Ticket number

PDJB-318

## Goal of change

Adds the deregister property confirm page

## Description of main change(s)

<img width="979" height="682" alt="image" src="https://github.com/user-attachments/assets/763d2028-4687-42bc-898c-98f2c7a237c8" />

Adds the confirm page.
Doesn't add any emails

## Checklist

Delete any that are not applicable, and add explanation below for any that are applicable but haven't been done

- [x] Screenshots of any UI changes have been added
- [x] Unit tests for new logic (e.g. new service methods) have been added
- [x] Test suite has been run in full locally and is passing
- [x] Branch has been rebased onto main and run locally, with everything working as expected (both for your new feature
  and any related functionality)
- [x] TODO comments referencing this JIRA ticket have been searched for and removed - if a future PR will address them,
  mention that here
- [ ] QA instructions have been added to the ticket (particularly if this is the last PR required to complete the ticket)
