### PR TITLE
PDJB-268/PDJB-269: Move the transaction away from exitProcess

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/application/DeleteExpiredJointLandlordInvitationsTaskApplicationRunner.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/application/DeleteExpiredJointLandlordInvitationsTaskApplicationRunner.kt
@@ -6,20 +6,19 @@ import org.springframework.boot.ApplicationRunner
 import org.springframework.boot.SpringApplication
 import org.springframework.context.ApplicationContext
 import uk.gov.communities.prsdb.webapp.annotations.taskAnnotations.PrsdbScheduledTask
+import uk.gov.communities.prsdb.webapp.annotations.taskAnnotations.PrsdbTaskService
 import uk.gov.communities.prsdb.webapp.services.JointLandlordInvitationDeletionService
 import kotlin.system.exitProcess
 
 @PrsdbScheduledTask("jl-invitation-deletion-scheduled-task")
 class DeleteExpiredJointLandlordInvitationsTaskApplicationRunner(
     private val context: ApplicationContext,
-    private val jointLandlordInvitationDeletionService: JointLandlordInvitationDeletionService,
+    private val taskLogic: DeleteExpiredJointLandlordInvitationsTaskLogic,
 ) : ApplicationRunner {
-    @Transactional
     override fun run(args: ApplicationArguments?) {
         println("Executing delete expired joint landlord invitations scheduled task")
 
-        // Separating into its own method to allow this to be tested without "exitProcess" being called
-        deleteExpiredJointLandlordInvitationsTaskLogic()
+        taskLogic.deleteExpiredJointLandlordInvitations()
 
         val code =
             SpringApplication.exit(context, { 0 }).also {
@@ -27,8 +26,14 @@ class DeleteExpiredJointLandlordInvitationsTaskApplicationRunner(
             }
         exitProcess(code)
     }
+}
 
-    private fun deleteExpiredJointLandlordInvitationsTaskLogic() {
+@PrsdbTaskService
+class DeleteExpiredJointLandlordInvitationsTaskLogic(
+    private val jointLandlordInvitationDeletionService: JointLandlordInvitationDeletionService,
+) {
+    @Transactional
+    fun deleteExpiredJointLandlordInvitations() {
         val deletedIds = jointLandlordInvitationDeletionService.deleteExpiredInvitations()
 
         deletedIds.forEach { id ->
@@ -36,9 +41,5 @@ class DeleteExpiredJointLandlordInvitationsTaskApplicationRunner(
         }
 
         println("Deleted ${deletedIds.size} expired joint landlord invitations.")
-    }
-
-    companion object {
-        const val DELETE_EXPIRED_JL_INVITATIONS_TASK_METHOD_NAME = "deleteExpiredJointLandlordInvitationsTaskLogic"
     }
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/application/DeleteIncompletePropertiesTaskApplicationRunner.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/application/DeleteIncompletePropertiesTaskApplicationRunner.kt
@@ -1,23 +1,24 @@
 package uk.gov.communities.prsdb.webapp.application
 
+import jakarta.transaction.Transactional
 import org.springframework.boot.ApplicationArguments
 import org.springframework.boot.ApplicationRunner
 import org.springframework.boot.SpringApplication
 import org.springframework.context.ApplicationContext
 import uk.gov.communities.prsdb.webapp.annotations.taskAnnotations.PrsdbScheduledTask
+import uk.gov.communities.prsdb.webapp.annotations.taskAnnotations.PrsdbTaskService
 import uk.gov.communities.prsdb.webapp.services.IncompletePropertiesService
 import kotlin.system.exitProcess
 
 @PrsdbScheduledTask("delete-incomplete-properties-scheduled-task")
 class DeleteIncompletePropertiesTaskApplicationRunner(
     private val context: ApplicationContext,
-    private val incompletePropertiesService: IncompletePropertiesService,
+    private val taskLogic: DeleteIncompletePropertiesTaskLogic,
 ) : ApplicationRunner {
     override fun run(args: ApplicationArguments) {
         println("Executing delete incomplete properties scheduled task")
 
-        // Separating into its own method to allow this to be tested without "exitProcess" being called
-        deleteIncompletePropertiesTaskLogic()
+        taskLogic.deleteIncompleteProperties()
 
         val code =
             SpringApplication.exit(context, { 0 }).also {
@@ -25,13 +26,15 @@ class DeleteIncompletePropertiesTaskApplicationRunner(
             }
         exitProcess(code)
     }
+}
 
-    private fun deleteIncompletePropertiesTaskLogic() {
+@PrsdbTaskService
+class DeleteIncompletePropertiesTaskLogic(
+    private val incompletePropertiesService: IncompletePropertiesService,
+) {
+    @Transactional
+    fun deleteIncompleteProperties() {
         val numberOfRecordsDeleted = incompletePropertiesService.deleteIncompletePropertiesOlderThan28Days()
         println("Deleted $numberOfRecordsDeleted incomplete properties.")
-    }
-
-    companion object {
-        const val DELETE_INCOMPLETE_PROPERTIES_TASK_METHOD_NAME = "deleteIncompletePropertiesTaskLogic"
     }
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/application/IncompletePropertiesReminderTaskApplicationRunner.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/application/IncompletePropertiesReminderTaskApplicationRunner.kt
@@ -1,5 +1,6 @@
 package uk.gov.communities.prsdb.webapp.application
 
+import jakarta.transaction.Transactional
 import kotlinx.datetime.daysUntil
 import kotlinx.datetime.toKotlinLocalDate
 import org.springframework.boot.ApplicationArguments
@@ -7,6 +8,7 @@ import org.springframework.boot.ApplicationRunner
 import org.springframework.boot.SpringApplication
 import org.springframework.context.ApplicationContext
 import uk.gov.communities.prsdb.webapp.annotations.taskAnnotations.PrsdbScheduledTask
+import uk.gov.communities.prsdb.webapp.annotations.taskAnnotations.PrsdbTaskService
 import uk.gov.communities.prsdb.webapp.constants.INCOMPLETE_PROPERTY_AGE_WHEN_REMINDER_EMAIL_DUE_IN_DAYS
 import uk.gov.communities.prsdb.webapp.exceptions.PersistentEmailSendException
 import uk.gov.communities.prsdb.webapp.exceptions.TrackEmailSentException
@@ -24,15 +26,12 @@ import kotlin.system.exitProcess
 @PrsdbScheduledTask("incomplete-property-reminder-scheduled-task")
 class IncompletePropertiesReminderTaskApplicationRunner(
     private val context: ApplicationContext,
-    private val emailSender: EmailNotificationService<IncompletePropertyReminderEmail>,
-    private val absoluteUrlProvider: AbsoluteUrlProvider,
-    private val incompletePropertiesService: IncompletePropertiesService,
+    private val taskLogic: IncompletePropertiesReminderTaskLogic,
 ) : ApplicationRunner {
     override fun run(args: ApplicationArguments?) {
         println("Executing incomplete properties reminder scheduled task")
 
-        // Separating into its own method to allow this to be tested without "exitProcess" being called
-        incompletePropertiesReminderTaskLogic()
+        taskLogic.sendIncompletePropertyReminders()
 
         val code =
             SpringApplication.exit(context, { 0 }).also {
@@ -40,8 +39,16 @@ class IncompletePropertiesReminderTaskApplicationRunner(
             }
         exitProcess(code)
     }
+}
 
-    private fun incompletePropertiesReminderTaskLogic() {
+@PrsdbTaskService
+class IncompletePropertiesReminderTaskLogic(
+    private val emailSender: EmailNotificationService<IncompletePropertyReminderEmail>,
+    private val absoluteUrlProvider: AbsoluteUrlProvider,
+    private val incompletePropertiesService: IncompletePropertiesService,
+) {
+    @Transactional
+    fun sendIncompletePropertyReminders() {
         val prsdUrl = absoluteUrlProvider.buildLandlordDashboardUri().toString()
         val cutoffDate =
             DateTimeHelper.getJavaInstantFromLocalDate(
@@ -99,9 +106,5 @@ class IncompletePropertiesReminderTaskApplicationRunner(
         println(statusMessage)
         println("Exception message: ${ex.message}")
         println("Stack trace: ${ex.stackTraceToString()}")
-    }
-
-    companion object {
-        const val INCOMPLETE_PROPERTY_REMINDER_TASK_METHOD_NAME = "incompletePropertiesReminderTaskLogic"
     }
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/application/JointLandlordInvitationExpiryEmailTaskApplicationRunner.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/application/JointLandlordInvitationExpiryEmailTaskApplicationRunner.kt
@@ -6,20 +6,19 @@ import org.springframework.boot.ApplicationRunner
 import org.springframework.boot.SpringApplication
 import org.springframework.context.ApplicationContext
 import uk.gov.communities.prsdb.webapp.annotations.taskAnnotations.PrsdbScheduledTask
+import uk.gov.communities.prsdb.webapp.annotations.taskAnnotations.PrsdbTaskService
 import uk.gov.communities.prsdb.webapp.services.JointLandlordInvitationExpiryEmailService
 import kotlin.system.exitProcess
 
 @PrsdbScheduledTask("jl-invitation-expiry-email-scheduled-task")
 class JointLandlordInvitationExpiryEmailTaskApplicationRunner(
     private val context: ApplicationContext,
-    private val jointLandlordInvitationExpiryEmailService: JointLandlordInvitationExpiryEmailService,
+    private val taskLogic: JointLandlordInvitationExpiryEmailTaskLogic,
 ) : ApplicationRunner {
-    @Transactional
     override fun run(args: ApplicationArguments?) {
         println("Executing joint landlord invitation expiry email scheduled task")
 
-        // Separating into its own method to allow this to be tested without "exitProcess" being called
-        sendJointLandlordInvitationExpiryEmailsTaskLogic()
+        taskLogic.sendJointLandlordInvitationExpiryEmails()
 
         val code =
             SpringApplication.exit(context, { 0 }).also {
@@ -27,8 +26,14 @@ class JointLandlordInvitationExpiryEmailTaskApplicationRunner(
             }
         exitProcess(code)
     }
+}
 
-    private fun sendJointLandlordInvitationExpiryEmailsTaskLogic() {
+@PrsdbTaskService
+class JointLandlordInvitationExpiryEmailTaskLogic(
+    private val jointLandlordInvitationExpiryEmailService: JointLandlordInvitationExpiryEmailService,
+) {
+    @Transactional
+    fun sendJointLandlordInvitationExpiryEmails() {
         val processedIds = jointLandlordInvitationExpiryEmailService.sendExpiryEmailsForExpiredInvitations()
 
         processedIds.forEach { id ->
@@ -36,9 +41,5 @@ class JointLandlordInvitationExpiryEmailTaskApplicationRunner(
         }
 
         println("Sent expiry emails for ${processedIds.size} joint landlord invitations.")
-    }
-
-    companion object {
-        const val SEND_JOINT_LANDLORD_INVITATION_EXPIRY_EMAILS_TASK_METHOD_NAME = "sendJointLandlordInvitationExpiryEmailsTaskLogic"
     }
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/applications/PrsdbTaskApplicationTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/applications/PrsdbTaskApplicationTests.kt
@@ -13,6 +13,10 @@ import software.amazon.awssdk.services.s3.S3Client
 import software.amazon.awssdk.transfer.s3.S3TransferManager
 import uk.gov.communities.prsdb.webapp.PrsdbWebappApplication
 import uk.gov.communities.prsdb.webapp.TestcontainersConfiguration
+import uk.gov.communities.prsdb.webapp.application.DeleteExpiredJointLandlordInvitationsTaskLogic
+import uk.gov.communities.prsdb.webapp.application.DeleteIncompletePropertiesTaskLogic
+import uk.gov.communities.prsdb.webapp.application.IncompletePropertiesReminderTaskLogic
+import uk.gov.communities.prsdb.webapp.application.JointLandlordInvitationExpiryEmailTaskLogic
 import uk.gov.communities.prsdb.webapp.clients.OsDownloadsClient
 import uk.gov.communities.prsdb.webapp.config.AuditingConfig
 import uk.gov.communities.prsdb.webapp.config.FeatureFlagConfig
@@ -91,6 +95,10 @@ class PrsdbTaskApplicationTests {
                 "joint-landlord-invitation-expiry-email-flag-on",
                 "jl-invitation-deletion-flag-off",
                 "jl-invitation-deletion-flag-on",
+                IncompletePropertiesReminderTaskLogic::class.simpleBeanName,
+                DeleteIncompletePropertiesTaskLogic::class.simpleBeanName,
+                JointLandlordInvitationExpiryEmailTaskLogic::class.simpleBeanName,
+                DeleteExpiredJointLandlordInvitationsTaskLogic::class.simpleBeanName,
             ).map { it.lowercase() }.toSet()
 
         val beanNames = ApplicationTestHelper.getAvailableBeanNames(context!!)

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/scheduledTaskRunners/DeleteExpiredJointLandlordInvitationsTaskApplicationRunnerTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/scheduledTaskRunners/DeleteExpiredJointLandlordInvitationsTaskApplicationRunnerTests.kt
@@ -6,32 +6,21 @@ import org.mockito.InjectMocks
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.verify
-import org.springframework.context.ApplicationContext
-import uk.gov.communities.prsdb.webapp.application.DeleteExpiredJointLandlordInvitationsTaskApplicationRunner
-import uk.gov.communities.prsdb.webapp.application.DeleteExpiredJointLandlordInvitationsTaskApplicationRunner.Companion.DELETE_EXPIRED_JL_INVITATIONS_TASK_METHOD_NAME
+import uk.gov.communities.prsdb.webapp.application.DeleteExpiredJointLandlordInvitationsTaskLogic
 import uk.gov.communities.prsdb.webapp.services.JointLandlordInvitationDeletionService
 
 @ExtendWith(MockitoExtension::class)
 class DeleteExpiredJointLandlordInvitationsTaskApplicationRunnerTests {
     @Mock
-    private lateinit var context: ApplicationContext
-
-    @Mock
     private lateinit var jointLandlordInvitationDeletionService: JointLandlordInvitationDeletionService
 
     @InjectMocks
-    private lateinit var runner: DeleteExpiredJointLandlordInvitationsTaskApplicationRunner
+    private lateinit var taskLogic: DeleteExpiredJointLandlordInvitationsTaskLogic
 
     @Test
-    fun `deleteExpiredJointLandlordInvitationsTaskLogic calls service to delete expired invitations`() {
-        // Arrange
-        val method =
-            DeleteExpiredJointLandlordInvitationsTaskApplicationRunner::class.java
-                .getDeclaredMethod(DELETE_EXPIRED_JL_INVITATIONS_TASK_METHOD_NAME)
-        method.isAccessible = true
-
+    fun `deleteExpiredJointLandlordInvitations calls service to delete expired invitations`() {
         // Act
-        method.invoke(runner)
+        taskLogic.deleteExpiredJointLandlordInvitations()
 
         // Assert
         verify(jointLandlordInvitationDeletionService).deleteExpiredInvitations()

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/scheduledTaskRunners/DeleteIncompletePropertiesTaskApplicationRunnerTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/scheduledTaskRunners/DeleteIncompletePropertiesTaskApplicationRunnerTests.kt
@@ -6,32 +6,21 @@ import org.mockito.InjectMocks
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.verify
-import org.springframework.context.ApplicationContext
-import uk.gov.communities.prsdb.webapp.application.DeleteIncompletePropertiesTaskApplicationRunner
-import uk.gov.communities.prsdb.webapp.application.DeleteIncompletePropertiesTaskApplicationRunner.Companion.DELETE_INCOMPLETE_PROPERTIES_TASK_METHOD_NAME
+import uk.gov.communities.prsdb.webapp.application.DeleteIncompletePropertiesTaskLogic
 import uk.gov.communities.prsdb.webapp.services.IncompletePropertiesService
 
 @ExtendWith(MockitoExtension::class)
 class DeleteIncompletePropertiesTaskApplicationRunnerTests {
     @Mock
-    private lateinit var context: ApplicationContext
-
-    @Mock
     private lateinit var incompletePropertiesService: IncompletePropertiesService
 
     @InjectMocks
-    private lateinit var runner: DeleteIncompletePropertiesTaskApplicationRunner
+    private lateinit var taskLogic: DeleteIncompletePropertiesTaskLogic
 
     @Test
-    fun `deleteIncompletePropertiesTaskLogic calls service to delete incomplete properties older than 28 days`() {
-        // Arrange
-        val method =
-            DeleteIncompletePropertiesTaskApplicationRunner::class.java
-                .getDeclaredMethod(DELETE_INCOMPLETE_PROPERTIES_TASK_METHOD_NAME)
-        method.isAccessible = true
-
+    fun `deleteIncompleteProperties calls service to delete incomplete properties older than 28 days`() {
         // Act
-        method.invoke(runner)
+        taskLogic.deleteIncompleteProperties()
 
         // Assert
         verify(incompletePropertiesService).deleteIncompletePropertiesOlderThan28Days()

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/scheduledTaskRunners/IncompletePropertiesReminderTaskApplicationRunnerTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/scheduledTaskRunners/IncompletePropertiesReminderTaskApplicationRunnerTests.kt
@@ -14,9 +14,7 @@ import org.mockito.kotlin.never
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
-import org.springframework.context.ApplicationContext
-import uk.gov.communities.prsdb.webapp.application.IncompletePropertiesReminderTaskApplicationRunner
-import uk.gov.communities.prsdb.webapp.application.IncompletePropertiesReminderTaskApplicationRunner.Companion.INCOMPLETE_PROPERTY_REMINDER_TASK_METHOD_NAME
+import uk.gov.communities.prsdb.webapp.application.IncompletePropertiesReminderTaskLogic
 import uk.gov.communities.prsdb.webapp.constants.INCOMPLETE_PROPERTY_AGE_WHEN_REMINDER_EMAIL_DUE_IN_DAYS
 import uk.gov.communities.prsdb.webapp.database.entity.LandlordIncompleteProperties
 import uk.gov.communities.prsdb.webapp.database.entity.SavedJourneyState
@@ -37,9 +35,6 @@ import java.time.LocalDate
 @ExtendWith(MockitoExtension::class)
 class IncompletePropertiesReminderTaskApplicationRunnerTests {
     @Mock
-    private lateinit var context: ApplicationContext
-
-    @Mock
     private lateinit var emailSender: EmailNotificationService<IncompletePropertyReminderEmail>
 
     @Mock
@@ -49,13 +44,10 @@ class IncompletePropertiesReminderTaskApplicationRunnerTests {
     private lateinit var incompletePropertiesService: IncompletePropertiesService
 
     @InjectMocks
-    private lateinit var runner: IncompletePropertiesReminderTaskApplicationRunner
+    private lateinit var taskLogic: IncompletePropertiesReminderTaskLogic
 
     private val mockPrsdUrl = "www.prsd-url.com/landlord/dashboard"
 
-    private val incompletePropertyReminderTaskMethod =
-        IncompletePropertiesReminderTaskApplicationRunner::class.java
-            .getDeclaredMethod(INCOMPLETE_PROPERTY_REMINDER_TASK_METHOD_NAME)
     private val emailAddress1 = "user.one@example.com"
     private val emailAddress2 = "user.two@example.com"
     private lateinit var reminderEmail1: IncompletePropertyReminderEmail
@@ -66,18 +58,16 @@ class IncompletePropertiesReminderTaskApplicationRunnerTests {
     @BeforeEach
     fun setUp() {
         whenever(absoluteUrlProvider.buildLandlordDashboardUri()).thenReturn(URI(mockPrsdUrl))
-
-        incompletePropertyReminderTaskMethod.isAccessible = true
     }
 
     @Test
-    fun `incompletePropertiesReminderTaskLogic sends an email to the landlord for each incomplete property older than 21 days`() {
+    fun `sendIncompletePropertyReminders sends an email to the landlord for each incomplete property older than 21 days`() {
         // Arrange
         setupTwoEmailsToSend()
         setupTwoEntriesOnOneDatabasePage()
 
         // Act
-        incompletePropertyReminderTaskMethod.invoke(runner)
+        taskLogic.sendIncompletePropertyReminders()
 
         // Assert
         verify(emailSender).sendEmail(emailAddress1, reminderEmail1)
@@ -85,7 +75,7 @@ class IncompletePropertiesReminderTaskApplicationRunnerTests {
     }
 
     @Test
-    fun `incompletePropertiesReminderTaskLogic still attempts other sends when one email fails, and completes task`() {
+    fun `sendIncompletePropertyReminders still attempts other sends when one email fails, and completes task`() {
         // Arrange
         setupTwoEmailsToSend()
         setupTwoEntriesOnOneDatabasePage()
@@ -103,7 +93,7 @@ class IncompletePropertiesReminderTaskApplicationRunnerTests {
         try {
             assertDoesNotThrow {
                 // Act
-                incompletePropertyReminderTaskMethod.invoke(runner)
+                taskLogic.sendIncompletePropertyReminders()
             }
 
             val output = outContent.toString()
@@ -118,13 +108,13 @@ class IncompletePropertiesReminderTaskApplicationRunnerTests {
     }
 
     @Test
-    fun `incompletePropertiesReminderTaskLogic records reminder email sent when email is sent`() {
+    fun `sendIncompletePropertyReminders records reminder email sent when email is sent`() {
         // Arrange
         setupTwoEmailsToSend()
         setupTwoEntriesOnOneDatabasePage()
 
         // Act
-        incompletePropertyReminderTaskMethod.invoke(runner)
+        taskLogic.sendIncompletePropertyReminders()
 
         // Assert
         verify(incompletePropertiesService).recordReminderEmailSent(savedJourneyState1)
@@ -132,7 +122,7 @@ class IncompletePropertiesReminderTaskApplicationRunnerTests {
     }
 
     @Test
-    fun `incompletePropertiesReminderTaskLogic prints error then continues to next send if recording email sent fails`() {
+    fun `sendIncompletePropertyReminders prints error then continues to next send if recording email sent fails`() {
         // Arrange
         setupTwoEmailsToSend()
         setupTwoEntriesOnOneDatabasePage()
@@ -148,7 +138,7 @@ class IncompletePropertiesReminderTaskApplicationRunnerTests {
         try {
             assertDoesNotThrow {
                 // Act
-                incompletePropertyReminderTaskMethod.invoke(runner)
+                taskLogic.sendIncompletePropertyReminders()
             }
 
             val output = outContent.toString()
@@ -166,7 +156,7 @@ class IncompletePropertiesReminderTaskApplicationRunnerTests {
     }
 
     @Test
-    fun `incompletePropertiesReminderTaskLogic does not try to record the email sent if email sending fails`() {
+    fun `sendIncompletePropertyReminders does not try to record the email sent if email sending fails`() {
         // Arrange
         setupTwoEmailsToSend()
         setupTwoEntriesOnOneDatabasePage()
@@ -175,7 +165,7 @@ class IncompletePropertiesReminderTaskApplicationRunnerTests {
             .doThrow(PersistentEmailSendException("Persistent email failure"))
 
         // Act
-        incompletePropertyReminderTaskMethod.invoke(runner)
+        taskLogic.sendIncompletePropertyReminders()
 
         // Assert
         verify(emailSender).sendEmail(emailAddress1, reminderEmail1)
@@ -185,13 +175,13 @@ class IncompletePropertiesReminderTaskApplicationRunnerTests {
     }
 
     @Test
-    fun `incompletePropertiesReminderTaskLogic processes multiple database pages of incomplete properties`() {
+    fun `sendIncompletePropertyReminders processes multiple database pages of incomplete properties`() {
         // Arrange
         setupTwoEmailsToSend()
         setupTwoEntriesOnTwoDatabasePages()
 
         // Act
-        incompletePropertyReminderTaskMethod.invoke(runner)
+        taskLogic.sendIncompletePropertyReminders()
 
         // Assert
         verify(incompletePropertiesService, times(2)).getIncompletePropertiesDueReminderPage(any(), any())

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/scheduledTaskRunners/JointLandlordInvitationExpiryEmailTaskApplicationRunnerTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/scheduledTaskRunners/JointLandlordInvitationExpiryEmailTaskApplicationRunnerTests.kt
@@ -6,32 +6,21 @@ import org.mockito.InjectMocks
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.verify
-import org.springframework.context.ApplicationContext
-import uk.gov.communities.prsdb.webapp.application.JointLandlordInvitationExpiryEmailTaskApplicationRunner
-import uk.gov.communities.prsdb.webapp.application.JointLandlordInvitationExpiryEmailTaskApplicationRunner.Companion.SEND_JOINT_LANDLORD_INVITATION_EXPIRY_EMAILS_TASK_METHOD_NAME
+import uk.gov.communities.prsdb.webapp.application.JointLandlordInvitationExpiryEmailTaskLogic
 import uk.gov.communities.prsdb.webapp.services.JointLandlordInvitationExpiryEmailService
 
 @ExtendWith(MockitoExtension::class)
 class JointLandlordInvitationExpiryEmailTaskApplicationRunnerTests {
     @Mock
-    private lateinit var context: ApplicationContext
-
-    @Mock
     private lateinit var jointLandlordInvitationExpiryEmailService: JointLandlordInvitationExpiryEmailService
 
     @InjectMocks
-    private lateinit var runner: JointLandlordInvitationExpiryEmailTaskApplicationRunner
+    private lateinit var taskLogic: JointLandlordInvitationExpiryEmailTaskLogic
 
     @Test
-    fun `sendJointLandlordInvitationExpiryEmailsTaskLogic calls service to send expiry emails`() {
-        // Arrange
-        val method =
-            JointLandlordInvitationExpiryEmailTaskApplicationRunner::class.java
-                .getDeclaredMethod(SEND_JOINT_LANDLORD_INVITATION_EXPIRY_EMAILS_TASK_METHOD_NAME)
-        method.isAccessible = true
-
+    fun `sendJointLandlordInvitationExpiryEmails calls service to send expiry emails`() {
         // Act
-        method.invoke(runner)
+        taskLogic.sendJointLandlordInvitationExpiryEmails()
 
         // Assert
         verify(jointLandlordInvitationExpiryEmailService).sendExpiryEmailsForExpiredInvitations()


### PR DESCRIPTION
## Ticket number

[PDJB-268](https://mhclgdigital.atlassian.net/browse/PDJB-268) [PDJB-269](https://mhclgdigital.atlassian.net/browse/PDJB-269)

## Goal of change

fix it so the transaction block does not contain exitProcess, since exiting the process reverts the transaction

refactors all tasks to follow this pattern

also updates tests as we now have a reason to split the task logic away from the runner so no more private method accessing

## Checklist

Delete any that are not applicable, and add explanation below for any that are applicable but haven't been done

- [x] Unit tests for new logic (e.g. new service methods) have been added
- [x] Test suite has been run in full locally and is passing
- [x] Branch has been rebased onto main and run locally, with everything working as expected (both for your new feature
  and any related functionality)
