### PR TITLE
PDJB-1035: Add Plausible domain-id config for Stats API metrics

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -205,7 +205,7 @@
         "filename": "src\\main\\resources\\application-local.yml",
         "hashed_secret": "ce8c74ce64b55dc94183540aac1aee68fd6d27ad",
         "is_verified": false,
-        "line_number": 135,
+        "line_number": 136,
         "is_secret": false
       }
     ],
@@ -220,5 +220,5 @@
       }
     ]
   },
-  "generated_at": "2026-06-12T14:05:15Z"
+  "generated_at": "2026-06-17T14:09:59Z"
 }

--- a/docs/AnalyticsReadMe.md
+++ b/docs/AnalyticsReadMe.md
@@ -16,7 +16,15 @@ the inline init script). By default Plausible already strips most query params b
 The script URL is per-environment (Plausible v2 site-specific snippet of the form
 `https://plausible.io/js/pa-<siteId>.js`) and is configured via the `PLAUSIBLE_SITE_ID`
 environment variable (mapped to `plausible.site-id` in `application.yml`). Get the site ID from
-the Plausible dashboard under Site Settings → Site Installation → Review Installation.
+the Plausible dashboard under Site Settings → Site Installation → Review Installation — it is the
+`pa-<id>` value in the snippet, **not** the site domain.
+
+Separately, the Stats API (used to fetch journey completion rates) is configured via the
+`PLAUSIBLE_DOMAIN_ID` environment variable (mapped to `plausible.domain-id`). The Stats API
+`site_id` must be the site's **domain** as registered in Plausible, e.g.
+`register-home-to-rent.communities.gov.uk` for non-production environments and
+`prod.register-home-to-rent.communities.gov.uk` for production. These two values are different and
+must both be set.
 
 Optional measurements (e.g. outbound links, file downloads, hashed page paths) are now configured
 in the Plausible dashboard rather than via the script filename. Enable or disable them there.

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/PlausibleMetricsService.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/PlausibleMetricsService.kt
@@ -21,7 +21,7 @@ import java.time.format.DateTimeFormatter
 @PrsdbWebService
 class PlausibleMetricsService(
     private val plausibleClient: PlausibleClient,
-    @Value("\${plausible.site-id}") private val siteId: String,
+    @Value("\${plausible.domain-id}") private val domainId: String,
 ) {
     fun getCompletionRates(period: ReportingPeriod): JourneyCompletionRatesDataModel =
         try {
@@ -53,7 +53,7 @@ class PlausibleMetricsService(
     //  pages, but pagination will need to be addressed if a query ever returns more than 10,000 entries from Plausible.
     private fun buildQuery(period: ReportingPeriod): PlausibleQuery =
         PlausibleQuery(
-            siteId = siteId,
+            siteId = domainId,
             dateRange = listOf(period.start.toUkDate(), period.end.toUkDate()),
             metrics = METRICS,
             dimensions = listOf("event:page"),

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -88,6 +88,7 @@ management:
 
 plausible:
   site-id: local-no-analytics
+  domain-id: local-no-analytics
   base-url: http://localhost:${server.port}/local/plausible
   api-key: local-no-analytics
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -81,6 +81,7 @@ base-url:
 
 plausible:
   site-id: ${PLAUSIBLE_SITE_ID}
+  domain-id: ${PLAUSIBLE_DOMAIN_ID}
   base-url: https://plausible.io
   api-key: ${PLAUSIBLE_API_KEY}
 

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/PlausibleMetricsServiceTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/PlausibleMetricsServiceTests.kt
@@ -23,14 +23,14 @@ class PlausibleMetricsServiceTests {
     @Mock
     private lateinit var plausibleClient: PlausibleClient
 
-    private val siteId = "test-site-id"
+    private val domainId = "test-domain-id"
     private val period =
         ReportingPeriod(
             Instant.parse("2025-01-10T00:00:00Z"),
             Instant.parse("2025-01-20T23:59:59Z"),
         )
 
-    private fun service() = PlausibleMetricsService(plausibleClient, siteId)
+    private fun service() = PlausibleMetricsService(plausibleClient, domainId)
 
     private fun row(
         page: String,
@@ -127,7 +127,7 @@ class PlausibleMetricsServiceTests {
         val captor = argumentCaptor<PlausibleQuery>()
         verify(plausibleClient).query(captor.capture())
         val query = captor.firstValue
-        assertEquals(siteId, query.siteId)
+        assertEquals(domainId, query.siteId)
         assertEquals(listOf("2025-01-10", "2025-01-20"), query.dateRange)
         assertEquals(listOf("visitors", "pageviews"), query.metrics)
         assertEquals(listOf("event:page"), query.dimensions)

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -35,6 +35,7 @@ aws:
 
 plausible:
   site-id: test-site-id
+  domain-id: test-domain-id
   base-url: https://plausible.test
   api-key: test-api-key
 


### PR DESCRIPTION
## Ticket number

PDJB-1035

## Goal of change

Fix the journey completion-rate metrics returning no data on deployed environments by separating the two Plausible identifiers that were incorrectly sharing a single config value.

## Description of main change(s)

- Adds a second Plausible config value so the browser tracking snippet and the Stats API use the correct identifier each:
  - `plausible.site-id` (`PLAUSIBLE_SITE_ID`) — unchanged; the `pa-<id>` installation id used to build the browser tracking snippet URL.
  - `plausible.domain-id` (`PLAUSIBLE_DOMAIN_ID`) — new; the site **domain**, used by the Stats API to fetch completion-rate metrics.
- Updates `PlausibleMetricsService` to query the Stats API with `domain-id`; `GlobalModelAttributes` continues to build the snippet from `site-id`.
- Updates `AnalyticsReadMe.md` to document the two distinct values and their per-environment meaning.

## Anything you'd like to highlight to the reviewer?

A matching infra change is required: every deployed environment keeps its existing `PLAUSIBLE_SITE_ID` (the `pa-` id) and must additionally set a new `PLAUSIBLE_DOMAIN_ID` (the domain, e.g. `register-home-to-rent.communities.gov.uk` for non-prod). Without `PLAUSIBLE_DOMAIN_ID` the app will fail to start, so infra must be updated before this deploys.

## Checklist

- [x] Branch is based on the latest `main`

Note: this is a config split with an existing unit test updated to match; the full suite has not yet been run locally.
