### PR TITLE
PDJB-1031: fix edge case with has problems screen incorrectly appearing for expired EPC

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/HasMissingComplianceStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/HasMissingComplianceStepConfig.kt
@@ -38,11 +38,16 @@ class HasMissingComplianceStepConfig : AbstractInternalStepConfig<ConfirmMissing
             val acceptedEpc =
                 state.acceptedEpcIfStillAccepted
                     ?: return state.epcExemptionStep.formModelIfReachableOrNull?.exemptionReason == null
-            return acceptedEpc.isPastExpiryDate() ||
+            return (
                 (
-                    !acceptedEpc.isEnergyRatingEOrBetter() &&
-                        state.meesExemptionStep.formModelIfReachableOrNull?.exemptionReason == null
-                )
+                    acceptedEpc.isPastExpiryDate() &&
+                        (state.epcInDateAtStartOfTenancyCheckStep.outcome != EpcInDateAtStartOfTenancyCheckMode.IN_DATE)
+                ) ||
+                    (
+                        !acceptedEpc.isEnergyRatingEOrBetter() &&
+                            (state.meesExemptionStep.formModelIfReachableOrNull?.exemptionReason == null)
+                    )
+            )
         }
     }
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/HasMissingComplianceStepConfigTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/HasMissingComplianceStepConfigTests.kt
@@ -336,6 +336,23 @@ class HasMissingComplianceStepConfigTests {
         }
 
         @Test
+        fun `returns true when accepted epc is expired with tenancy started before expiry but has low rating and no mees exemption`() {
+            whenever(mockState.hasEpcStep).thenReturn(mock<HasEpcStep>())
+            val mockEpc = mock<EpcDataModel>()
+            whenever(mockEpc.isPastExpiryDate()).thenReturn(true)
+            whenever(mockEpc.isEnergyRatingEOrBetter()).thenReturn(false)
+            whenever(mockState.acceptedEpcIfStillAccepted).thenReturn(mockEpc)
+            val mockTenancyStep = mock<EpcInDateAtStartOfTenancyCheckStep>()
+            whenever(mockTenancyStep.outcome).thenReturn(EpcInDateAtStartOfTenancyCheckMode.IN_DATE)
+            whenever(mockState.epcInDateAtStartOfTenancyCheckStep).thenReturn(mockTenancyStep)
+            val mockMeesExemptionStep = mock<MeesExemptionStep>()
+            whenever(mockMeesExemptionStep.formModelIfReachableOrNull).thenReturn(null)
+            whenever(mockState.meesExemptionStep).thenReturn(mockMeesExemptionStep)
+
+            assertTrue(HasMissingComplianceStepConfig.isEpcInvalid(mockState))
+        }
+
+        @Test
         fun `returns true when accepted epc has low rating and no mees exemption`() {
             whenever(mockState.hasEpcStep).thenReturn(mock<HasEpcStep>())
             val mockEpc = mock<EpcDataModel>()

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/HasMissingComplianceStepConfigTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/HasMissingComplianceStepConfigTests.kt
@@ -309,13 +309,30 @@ class HasMissingComplianceStepConfigTests {
         }
 
         @Test
-        fun `returns true when accepted epc present but expired`() {
+        fun `returns true when accepted epc present but expired and tenancy did not start before expiry`() {
             whenever(mockState.hasEpcStep).thenReturn(mock<HasEpcStep>())
             val mockEpc = mock<EpcDataModel>()
             whenever(mockEpc.isPastExpiryDate()).thenReturn(true)
             whenever(mockState.acceptedEpcIfStillAccepted).thenReturn(mockEpc)
+            val mockTenancyStep = mock<EpcInDateAtStartOfTenancyCheckStep>()
+            whenever(mockTenancyStep.outcome).thenReturn(EpcInDateAtStartOfTenancyCheckMode.NOT_IN_DATE)
+            whenever(mockState.epcInDateAtStartOfTenancyCheckStep).thenReturn(mockTenancyStep)
 
             assertTrue(HasMissingComplianceStepConfig.isEpcInvalid(mockState))
+        }
+
+        @Test
+        fun `returns false when accepted epc present but expired and tenancy started before expiry`() {
+            whenever(mockState.hasEpcStep).thenReturn(mock<HasEpcStep>())
+            val mockEpc = mock<EpcDataModel>()
+            whenever(mockEpc.isPastExpiryDate()).thenReturn(true)
+            whenever(mockEpc.isEnergyRatingEOrBetter()).thenReturn(true)
+            whenever(mockState.acceptedEpcIfStillAccepted).thenReturn(mockEpc)
+            val mockTenancyStep = mock<EpcInDateAtStartOfTenancyCheckStep>()
+            whenever(mockTenancyStep.outcome).thenReturn(EpcInDateAtStartOfTenancyCheckMode.IN_DATE)
+            whenever(mockState.epcInDateAtStartOfTenancyCheckStep).thenReturn(mockTenancyStep)
+
+            assertFalse(HasMissingComplianceStepConfig.isEpcInvalid(mockState))
         }
 
         @Test


### PR DESCRIPTION
## Ticket number

PDJB-1031

## Goal of change

Previously the "has problems" screen in property registration appeared when the certificate was expired, but still in date when the tenancy began. This fixes that

## Description of main change(s)

Adds a check for the epc in date when tenacy began to the check.

## Anything you'd like to highlight to the reviewer?

On the compliance tab, we still show the expired banner in this case, which I think is correct but just wanted to flag. May be worth changing in this ticket if we disagree with how the behaviour is currently.

## Checklist

Delete any that are not applicable, and add explanation below for any that are applicable but haven't been done

- [x] Unit tests for new logic (e.g. new service methods) have been added
- [x] Test suite has been run in full locally and is passing
- [x] Branch has been rebased onto main and run locally, with everything working as expected (both for your new feature
  and any related functionality)
- [x] QA instructions have been added to the ticket (particularly if this is the last PR required to complete the ticket)
