### PR TITLE
PDJB-307: Fix initial step in journey

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/SwitchToIndividualController.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/SwitchToIndividualController.kt
@@ -17,6 +17,7 @@ import uk.gov.communities.prsdb.webapp.annotations.webAnnotations.PrsdbControlle
 import uk.gov.communities.prsdb.webapp.constants.CONFIRMATION_PATH_SEGMENT
 import uk.gov.communities.prsdb.webapp.constants.JOINT_LANDLORDS
 import uk.gov.communities.prsdb.webapp.constants.LANDLORD_PATH_SEGMENT
+import uk.gov.communities.prsdb.webapp.constants.PROPERTY_DETAILS_SEGMENT
 import uk.gov.communities.prsdb.webapp.constants.SWITCHED_TO_INDIVIDUAL_PROPERTY_ID
 import uk.gov.communities.prsdb.webapp.constants.SWITCH_TO_INDIVIDUAL_JOURNEY_URL
 import uk.gov.communities.prsdb.webapp.controllers.SwitchToIndividualController.Companion.SWITCH_TO_INDIVIDUAL_ROUTE
@@ -118,7 +119,8 @@ class SwitchToIndividualController(
     }
 
     companion object {
-        const val SWITCH_TO_INDIVIDUAL_ROUTE = "/$LANDLORD_PATH_SEGMENT/$SWITCH_TO_INDIVIDUAL_JOURNEY_URL/{propertyOwnershipId}"
+        const val SWITCH_TO_INDIVIDUAL_ROUTE =
+            "/$LANDLORD_PATH_SEGMENT/$PROPERTY_DETAILS_SEGMENT/{propertyOwnershipId}/$SWITCH_TO_INDIVIDUAL_JOURNEY_URL"
 
         fun getSwitchToIndividualBasePath(propertyOwnershipId: Long): String =
             UriTemplate(SWITCH_TO_INDIVIDUAL_ROUTE)

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/SwitchToIndividualController.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/SwitchToIndividualController.kt
@@ -24,7 +24,7 @@ import uk.gov.communities.prsdb.webapp.exceptions.PropertyOwnershipMismatchExcep
 import uk.gov.communities.prsdb.webapp.journeys.FormData
 import uk.gov.communities.prsdb.webapp.journeys.JourneyStateService
 import uk.gov.communities.prsdb.webapp.journeys.NoSuchJourneyException
-import uk.gov.communities.prsdb.webapp.journeys.shared.stepConfig.CheckPendingInvitationsStep
+import uk.gov.communities.prsdb.webapp.journeys.shared.stepConfig.HasPendingInvitationsStep
 import uk.gov.communities.prsdb.webapp.journeys.switchToIndividual.SwitchToIndividualJourneyFactory
 import uk.gov.communities.prsdb.webapp.services.PropertyOwnershipService
 import java.security.Principal
@@ -126,6 +126,6 @@ class SwitchToIndividualController(
                 .toASCIIString()
 
         fun getSwitchToIndividualFirstStepPath(propertyOwnershipId: Long): String =
-            "${getSwitchToIndividualBasePath(propertyOwnershipId)}/${CheckPendingInvitationsStep.ROUTE_SEGMENT}"
+            "${getSwitchToIndividualBasePath(propertyOwnershipId)}/${HasPendingInvitationsStep.ROUTE_SEGMENT}"
     }
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyDeregistration/PropertyDeregistrationJourneyFactory.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyDeregistration/PropertyDeregistrationJourneyFactory.kt
@@ -45,6 +45,7 @@ class PropertyDeregistrationJourneyFactory(
                 nextDestination { Destination(journey.hasPendingInvitationsStep) }
             }
             step(journey.hasPendingInvitationsStep) {
+                routeSegment(HasPendingInvitationsStep.ROUTE_SEGMENT)
                 parents { journey.deregisterInfoStep.isComplete() }
                 nextStep { mode ->
                     when (mode) {

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/shared/stepConfig/HasPendingInvitationsStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/shared/stepConfig/HasPendingInvitationsStepConfig.kt
@@ -1,9 +1,11 @@
 package uk.gov.communities.prsdb.webapp.journeys.shared.stepConfig
 
 import uk.gov.communities.prsdb.webapp.annotations.webAnnotations.JourneyFrameworkComponent
-import uk.gov.communities.prsdb.webapp.journeys.AbstractInternalStepConfig
+import uk.gov.communities.prsdb.webapp.journeys.AbstractRequestableStepConfig
 import uk.gov.communities.prsdb.webapp.journeys.JourneyStep
+import uk.gov.communities.prsdb.webapp.journeys.StepLifecycleOrchestrator.RedirectingStepLifecycleOrchestrator
 import uk.gov.communities.prsdb.webapp.journeys.shared.states.PropertyOwnershipJourneyState
+import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.NoInputFormModel
 import uk.gov.communities.prsdb.webapp.services.JointLandlordInvitationService
 import uk.gov.communities.prsdb.webapp.services.PropertyOwnershipService
 
@@ -11,7 +13,15 @@ import uk.gov.communities.prsdb.webapp.services.PropertyOwnershipService
 class HasPendingInvitationsStepConfig(
     private val propertyOwnershipService: PropertyOwnershipService,
     private val jointLandlordInvitationService: JointLandlordInvitationService,
-) : AbstractInternalStepConfig<HasPendingInvitationsMode, PropertyOwnershipJourneyState>() {
+) : AbstractRequestableStepConfig<HasPendingInvitationsMode, NoInputFormModel, PropertyOwnershipJourneyState>() {
+    override val formModelClass = NoInputFormModel::class
+
+    override fun getStepLifecycleOrchestrator(journeyStep: JourneyStep<*, *, *>) = RedirectingStepLifecycleOrchestrator(journeyStep)
+
+    override fun getStepSpecificContent(state: PropertyOwnershipJourneyState): Map<String, Any?> = mapOf<String, String>()
+
+    override fun chooseTemplate(state: PropertyOwnershipJourneyState): String = ""
+
     override fun mode(state: PropertyOwnershipJourneyState): HasPendingInvitationsMode {
         val propertyOwnership = propertyOwnershipService.getPropertyOwnership(state.propertyOwnershipId)
         val pendingInvitations = jointLandlordInvitationService.getPendingInvitations(propertyOwnership)
@@ -26,7 +36,11 @@ class HasPendingInvitationsStepConfig(
 @JourneyFrameworkComponent
 final class HasPendingInvitationsStep(
     stepConfig: HasPendingInvitationsStepConfig,
-) : JourneyStep.InternalStep<HasPendingInvitationsMode, PropertyOwnershipJourneyState>(stepConfig)
+) : JourneyStep.RequestableStep<HasPendingInvitationsMode, NoInputFormModel, PropertyOwnershipJourneyState>(stepConfig) {
+    companion object {
+        const val ROUTE_SEGMENT = "start"
+    }
+}
 
 enum class HasPendingInvitationsMode {
     YES,

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/switchToIndividual/SwitchToIndividualJourneyFactory.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/switchToIndividual/SwitchToIndividualJourneyFactory.kt
@@ -30,11 +30,12 @@ class SwitchToIndividualJourneyFactory(
         val state = getInitializedState(propertyOwnershipId)
 
         return journey(state) {
-            unreachableStepStep { journey.hasPendingInvitationsStep }
+            unreachableStepUrl { PropertyDetailsController.getPropertyDetailsPath(propertyOwnershipId) }
             configure {
                 withAdditionalContentProperty { "title" to "switchToIndividual.title" }
             }
             step(journey.hasPendingInvitationsStep) {
+                routeSegment(HasPendingInvitationsStep.ROUTE_SEGMENT)
                 initialStep()
                 backUrl { PropertyDetailsController.getPropertyDetailsPath(propertyOwnershipId) }
                 nextStep { mode ->

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/controllers/SwitchToIndividualControllerTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/controllers/SwitchToIndividualControllerTests.kt
@@ -20,7 +20,7 @@ import uk.gov.communities.prsdb.webapp.controllers.SwitchToIndividualController.
 import uk.gov.communities.prsdb.webapp.exceptions.PropertyOwnershipMismatchException
 import uk.gov.communities.prsdb.webapp.journeys.NoSuchJourneyException
 import uk.gov.communities.prsdb.webapp.journeys.StepLifecycleOrchestrator
-import uk.gov.communities.prsdb.webapp.journeys.shared.stepConfig.CheckPendingInvitationsStep
+import uk.gov.communities.prsdb.webapp.journeys.shared.stepConfig.HasPendingInvitationsStep
 import uk.gov.communities.prsdb.webapp.journeys.switchToIndividual.SwitchToIndividualJourneyFactory
 import uk.gov.communities.prsdb.webapp.services.PropertyOwnershipService
 import uk.gov.communities.prsdb.webapp.testHelpers.mockObjects.MockLandlordData
@@ -78,7 +78,7 @@ class SwitchToIndividualControllerTests(
             val propertyOwnershipId = 1L
             whenever(propertyOwnershipService.getIsPrimaryLandlord(eq(propertyOwnershipId), anyString())).thenReturn(true)
             whenever(switchToIndividualJourneyFactory.createJourneySteps(propertyOwnershipId))
-                .thenReturn(mapOf(CheckPendingInvitationsStep.ROUTE_SEGMENT to mockStepLifecycleOrchestrator))
+                .thenReturn(mapOf(HasPendingInvitationsStep.ROUTE_SEGMENT to mockStepLifecycleOrchestrator))
             whenever(mockStepLifecycleOrchestrator.getStepModelAndView())
                 .thenReturn(ModelAndView("placeholder", mapOf("title" to "placeholder")))
 


### PR DESCRIPTION
## Ticket number

[PDJB-307](https://mhclgdigital.atlassian.net/browse/PDJB-307)

## Goal of change

fix two issues on the journey

- give it a proper start step as we immediately need to redirect. based on `StartInviteJointLandlordStepConfig`
- fix the route to be consistent with the other prop details journeys `/landlord/property-details/<id>/switch-to-individual/<step>`

## Checklist

Delete any that are not applicable, and add explanation below for any that are applicable but haven't been done

- [x] Unit tests for new logic (e.g. new service methods) have been added
- [x] Test suite has been run in full locally and is passing
- [x] Branch has been rebased onto main and run locally, with everything working as expected (both for your new feature
  and any related functionality)
- [x] QA instructions have been added to the ticket (particularly if this is the last PR required to complete the ticket)
