### PR TITLE
PDJB-1085: Fix CYA links for Joint landlords on property reg

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/PropertyRegistrationJourneyFactory.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/PropertyRegistrationJourneyFactory.kt
@@ -202,7 +202,9 @@ class PropertyRegistrationJourneyFactory(
                     checkAnswerTask(journey.rentFrequencyAndAmountTask)
                 }
 
-                CheckJointLandlordsStep.ROUTE_SEGMENT -> {
+                HasJointLandlordsStep.ROUTE_SEGMENT,
+                CheckJointLandlordsStep.ROUTE_SEGMENT,
+                -> {
                     checkAnswerTask(journey.jointLandlordsTask)
                 }
 

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/PropertyRegistrationCyaStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/PropertyRegistrationCyaStepConfig.kt
@@ -61,13 +61,13 @@ class PropertyRegistrationCyaStepConfig(
             SummaryListRowViewModel.forCheckYourAnswersPage(
                 "forms.checkPropertyAnswers.jointLandlordsDetails.invitations",
                 state.invitedJointLandlords,
-                Destination(state.hasJointLandlordsStep),
+                Destination.VisitableStep(state.checkJointLandlordsStep, state.getCyaJourneyId(state.checkJointLandlordsStep)),
             )
         } else {
             SummaryListRowViewModel.forCheckYourAnswersPage(
                 "forms.checkPropertyAnswers.jointLandlordsDetails.areThereJointLandlords",
                 "forms.checkPropertyAnswers.jointLandlordsDetails.noJointLandlords",
-                Destination(state.hasJointLandlordsStep),
+                Destination.VisitableStep(state.hasJointLandlordsStep, state.getCyaJourneyId(state.hasJointLandlordsStep)),
             )
         }
     }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/PropertyRegistrationJourneyTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/PropertyRegistrationJourneyTests.kt
@@ -1453,4 +1453,29 @@ class PropertyRegistrationJourneyTests : IntegrationTestWithMutableData("data-lo
         assertThat(checkAnswersPage.summaryList.numberOfTenantsRow.value).containsText("4")
         assertThat(checkAnswersPage.summaryList.numberOfBedroomsRow.value).containsText("3")
     }
+
+    @Test
+    fun `CYA joint landlords row shows a change link to the check joint landlords page when landlords are invited`(page: Page) {
+        featureFlagManager.enableFeature(JOINT_LANDLORDS)
+        val checkAnswersPage = navigator.skipToPropertyRegistrationCheckAnswersPageWithJointLandlords()
+
+        val changeLink = checkAnswersPage.summaryList.jointLandlordsInvitationsRow.actions.getActionLink("Change")
+        assertThat(changeLink).isVisible()
+
+        changeLink.clickAndWait()
+        val checkJointLandlordsPage = assertPageIs(page, CheckJointLandlordsFormPagePropertyRegistration::class)
+        assertThat(checkJointLandlordsPage.summaryList.firstRow.value).containsText("email@address.com")
+    }
+
+    @Test
+    fun `CYA joint landlords row shows a change link to the has joint landlords page when there are no joint landlords`(page: Page) {
+        featureFlagManager.enableFeature(JOINT_LANDLORDS)
+        val checkAnswersPage = navigator.skipToPropertyRegistrationCheckAnswersPage()
+
+        val changeLink = checkAnswersPage.summaryList.jointLandlordsAreThereRow.actions.getActionLink("Change")
+        assertThat(changeLink).isVisible()
+
+        changeLink.clickAndWait()
+        assertPageIs(page, HasJointLandlordsFormBasePagePropertyRegistration::class)
+    }
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/Navigator.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/Navigator.kt
@@ -759,6 +759,12 @@ class Navigator(
         return createValidPage(page, CheckAnswersPagePropertyRegistration::class)
     }
 
+    fun skipToPropertyRegistrationCheckAnswersPageWithJointLandlords(): CheckAnswersPagePropertyRegistration {
+        setJourneyStateInSession(PropertyStateSessionBuilder.beforePropertyRegistrationCheckAnswersWithJointLandlords().build())
+        navigateToPropertyRegistrationJourneyStep(PropertyRegistrationCyaStep.ROUTE_SEGMENT)
+        return createValidPage(page, CheckAnswersPagePropertyRegistration::class)
+    }
+
     fun skipToPropertyRegistrationCheckAnswersPageWithSelectiveLicence(): CheckAnswersPagePropertyRegistration {
         setJourneyStateInSession(PropertyStateSessionBuilder.beforePropertyRegistrationCheckAnswersWithSelectiveLicence().build())
         navigateToPropertyRegistrationJourneyStep(PropertyRegistrationCyaStep.ROUTE_SEGMENT)

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/propertyRegistrationJourneyPages/CheckAnswersPagePropertyRegistration.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/propertyRegistrationJourneyPages/CheckAnswersPagePropertyRegistration.kt
@@ -49,6 +49,8 @@ class CheckAnswersPagePropertyRegistration(
         val numberOfTenantsRow = getRow("Number of tenants")
         val numberOfBedroomsRow = getRow("Number of bedrooms")
         val rentAmountRow = getRow("Rent amount")
+        val jointLandlordsInvitationsRow = getRow("Invitations")
+        val jointLandlordsAreThereRow = getRow("Are there any other landlords for this property?")
     }
 
     class ComplianceSummaryList(

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/testHelpers/builders/JointLandlordsStateBuilder.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/testHelpers/builders/JointLandlordsStateBuilder.kt
@@ -3,10 +3,12 @@ package uk.gov.communities.prsdb.webapp.testHelpers.builders
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.serializer
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.HasJointLandlordsStep
+import uk.gov.communities.prsdb.webapp.journeys.shared.inviteJointLandlord.CheckJointLandlordsStep
 import uk.gov.communities.prsdb.webapp.journeys.shared.inviteJointLandlord.InviteJointLandlordStep
 import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.FormModel
 import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.HasJointLandlordsFormModel
 import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.InviteJointLandlordsFormModel
+import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.NoInputFormModel
 
 interface JointLandlordsStateBuilder<SelfType : JointLandlordsStateBuilder<SelfType>> {
     val submittedValueMap: MutableMap<String, FormModel>
@@ -57,6 +59,12 @@ interface JointLandlordsStateBuilder<SelfType : JointLandlordsStateBuilder<SelfT
         withHasJointLandlords(true)
         withInvitedJointLandlords(emailAddresses)
         @Suppress("UNCHECKED_CAST")
+        return self()
+    }
+
+    fun withCheckedJointLandlords(emailAddresses: MutableList<String> = mutableListOf<String>("email@address.com")): SelfType {
+        withJointLandlords(emailAddresses)
+        withSubmittedValue(CheckJointLandlordsStep.ROUTE_SEGMENT, NoInputFormModel())
         return self()
     }
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/testHelpers/builders/PropertyStateSessionBuilder.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/testHelpers/builders/PropertyStateSessionBuilder.kt
@@ -353,6 +353,15 @@ class PropertyStateSessionBuilder(
                 .withElectricalSafetyCertificateMissing()
                 .withCompliantEpc()
 
+        fun beforePropertyRegistrationCheckAnswersWithJointLandlords(
+            invitedEmails: MutableList<String> = mutableListOf("email@address.com"),
+        ) = beforePropertyRegistrationOccupancy()
+            .withOccupancyStatus(false)
+            .withCheckedJointLandlords(invitedEmails)
+            .withGasSafetyTaskCompletedWithNoGasSupply()
+            .withElectricalSafetyCertificateMissing()
+            .withCompliantEpc()
+
         fun beforePropertyRegistrationCheckAnswersWithSelectiveLicence() =
             beforePropertyRegistrationLicensingType()
                 .withLicensing(LicensingType.SELECTIVE_LICENCE, "SL-12345")


### PR DESCRIPTION
## Ticket number

PDJB-1085

## Goal of change

Adds the CYA link back for joint landlords

## Description of main change(s)

Fixes the branching logic to point at a step that is reachable in the case where we have a landlord.

## Checklist

Delete any that are not applicable, and add explanation below for any that are applicable but haven't been done

- [x] Unit tests for new logic (e.g. new service methods) have been added
- [x] Test suite has been run in full locally and is passing
- [x] Branch has been rebased onto main and run locally, with everything working as expected (both for your new feature
  and any related functionality)
- [x] TODO comments referencing this JIRA ticket have been searched for and removed - if a future PR will address them,
  mention that here
- [x] QA instructions have been added to the ticket (particularly if this is the last PR required to complete the ticket)
