### PR TITLE
PDJB-1131: Part 2: Skeleton journey

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/RegisterLandlordController.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/RegisterLandlordController.kt
@@ -10,9 +10,11 @@ import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.server.ResponseStatusException
 import org.springframework.web.servlet.ModelAndView
 import uk.gov.communities.prsdb.webapp.annotations.webAnnotations.PrsdbController
+import uk.gov.communities.prsdb.webapp.config.managers.FeatureFlagManager
 import uk.gov.communities.prsdb.webapp.constants.CONFIRMATION_PATH_SEGMENT
 import uk.gov.communities.prsdb.webapp.constants.LANDLORD_PATH_SEGMENT
 import uk.gov.communities.prsdb.webapp.constants.LANDLORD_REGISTRATION_SURVEY_URL
+import uk.gov.communities.prsdb.webapp.constants.ORGANISATION_LANDLORD_REGISTRATION
 import uk.gov.communities.prsdb.webapp.constants.REGISTER_LANDLORD_JOURNEY_URL
 import uk.gov.communities.prsdb.webapp.constants.START_PAGE_PATH_SEGMENT
 import uk.gov.communities.prsdb.webapp.controllers.LandlordController.Companion.LANDLORD_DASHBOARD_URL
@@ -22,6 +24,8 @@ import uk.gov.communities.prsdb.webapp.journeys.JourneyStateService
 import uk.gov.communities.prsdb.webapp.journeys.NoSuchJourneyException
 import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.LandlordRegistrationJourneyFactory
 import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.PrivacyNoticeStep
+import uk.gov.communities.prsdb.webapp.journeys.organisationLandlordRegistration.OrganisationLandlordRegistrationJourneyFactory
+import uk.gov.communities.prsdb.webapp.journeys.organisationLandlordRegistration.steps.LandlordTypeStep
 import uk.gov.communities.prsdb.webapp.models.dataModels.RegistrationNumberDataModel
 import uk.gov.communities.prsdb.webapp.services.LandlordService
 import uk.gov.communities.prsdb.webapp.services.UserRolesService
@@ -31,15 +35,23 @@ import java.security.Principal
 @RequestMapping(LANDLORD_REGISTRATION_ROUTE)
 class RegisterLandlordController(
     private val landlordRegistrationJourneyFactory: LandlordRegistrationJourneyFactory,
+    private val organisationLandlordRegistrationJourneyFactory: OrganisationLandlordRegistrationJourneyFactory,
     private val landlordService: LandlordService,
     private val userRolesService: UserRolesService,
+    private val featureFlagManager: FeatureFlagManager,
 ) {
     @GetMapping
     fun redirectToStart(): String = "redirect:$LANDLORD_REGISTRATION_START_PAGE_ROUTE"
 
     @GetMapping("/$START_PAGE_PATH_SEGMENT")
     fun getStart(model: Model): CharSequence {
-        model.addAttribute("registerAsALandlordFirstStepRoute", "$LANDLORD_REGISTRATION_ROUTE/${PrivacyNoticeStep.ROUTE_SEGMENT}")
+        val firstStepRoute =
+            if (featureFlagManager.checkFeature(ORGANISATION_LANDLORD_REGISTRATION)) {
+                "$LANDLORD_REGISTRATION_ROUTE/${LandlordTypeStep.ROUTE_SEGMENT}"
+            } else {
+                "$LANDLORD_REGISTRATION_ROUTE/${PrivacyNoticeStep.ROUTE_SEGMENT}"
+            }
+        model.addAttribute("registerAsALandlordFirstStepRoute", firstStepRoute)
         return "registerAsALandlord"
     }
 
@@ -54,11 +66,11 @@ class RegisterLandlordController(
             ModelAndView("redirect:$LANDLORD_DASHBOARD_URL")
         } else {
             try {
-                val journeyMap = landlordRegistrationJourneyFactory.createJourneySteps()
+                val journeyMap = getJourneySteps()
                 journeyMap[stepRouteSegment]?.getStepModelAndView()
                     ?: throw ResponseStatusException(HttpStatus.NOT_FOUND, "Step not found")
             } catch (_: NoSuchJourneyException) {
-                val journeyId = landlordRegistrationJourneyFactory.initializeJourneyState(principal)
+                val journeyId = initializeJourneyState(principal)
                 val redirectUrl = JourneyStateService.urlWithJourneyState(stepRouteSegment, journeyId)
                 ModelAndView("redirect:$redirectUrl")
             }
@@ -71,11 +83,11 @@ class RegisterLandlordController(
         principal: Principal,
     ): ModelAndView =
         try {
-            val journeyMap = landlordRegistrationJourneyFactory.createJourneySteps()
+            val journeyMap = getJourneySteps()
             journeyMap[stepRouteSegment]?.postStepModelAndView(formData)
                 ?: throw ResponseStatusException(HttpStatus.NOT_FOUND, "Step not found")
         } catch (_: NoSuchJourneyException) {
-            val journeyId = landlordRegistrationJourneyFactory.initializeJourneyState(principal)
+            val journeyId = initializeJourneyState(principal)
             val redirectUrl = JourneyStateService.urlWithJourneyState(stepRouteSegment, journeyId)
             ModelAndView("redirect:$redirectUrl")
         }
@@ -98,6 +110,20 @@ class RegisterLandlordController(
 
         return "registerAsALandlordConfirmation"
     }
+
+    private fun getJourneySteps() =
+        if (featureFlagManager.checkFeature(ORGANISATION_LANDLORD_REGISTRATION)) {
+            organisationLandlordRegistrationJourneyFactory.createJourneySteps()
+        } else {
+            landlordRegistrationJourneyFactory.createJourneySteps()
+        }
+
+    private fun initializeJourneyState(principal: Principal) =
+        if (featureFlagManager.checkFeature(ORGANISATION_LANDLORD_REGISTRATION)) {
+            organisationLandlordRegistrationJourneyFactory.initializeJourneyState(principal)
+        } else {
+            landlordRegistrationJourneyFactory.initializeJourneyState(principal)
+        }
 
     companion object {
         const val LANDLORD_REGISTRATION_ROUTE = "/$LANDLORD_PATH_SEGMENT/$REGISTER_LANDLORD_JOURNEY_URL"

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/organisationLandlordRegistration/OrganisationLandlordRegistrationJourneyFactory.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/organisationLandlordRegistration/OrganisationLandlordRegistrationJourneyFactory.kt
@@ -15,10 +15,15 @@ import uk.gov.communities.prsdb.webapp.journeys.isComplete
 import uk.gov.communities.prsdb.webapp.journeys.organisationLandlordRegistration.steps.IndividualLandlordPlaceholderStep
 import uk.gov.communities.prsdb.webapp.journeys.organisationLandlordRegistration.steps.LandlordTypeMode
 import uk.gov.communities.prsdb.webapp.journeys.organisationLandlordRegistration.steps.LandlordTypeStep
-import uk.gov.communities.prsdb.webapp.journeys.organisationLandlordRegistration.steps.OrgContactInfoStep
+import uk.gov.communities.prsdb.webapp.journeys.organisationLandlordRegistration.steps.OrgAddressStep
+import uk.gov.communities.prsdb.webapp.journeys.organisationLandlordRegistration.steps.OrgCharityStep
+import uk.gov.communities.prsdb.webapp.journeys.organisationLandlordRegistration.steps.OrgCompaniesHouseStep
 import uk.gov.communities.prsdb.webapp.journeys.organisationLandlordRegistration.steps.OrgDirectorsStep
+import uk.gov.communities.prsdb.webapp.journeys.organisationLandlordRegistration.steps.OrgEmailStep
 import uk.gov.communities.prsdb.webapp.journeys.organisationLandlordRegistration.steps.OrgLandlordCyaStep
 import uk.gov.communities.prsdb.webapp.journeys.organisationLandlordRegistration.steps.OrgMainContactStep
+import uk.gov.communities.prsdb.webapp.journeys.organisationLandlordRegistration.steps.OrgNameStep
+import uk.gov.communities.prsdb.webapp.journeys.organisationLandlordRegistration.steps.OrgPhoneNumberStep
 import uk.gov.communities.prsdb.webapp.journeys.organisationLandlordRegistration.steps.OrgTrusteesStep
 import uk.gov.communities.prsdb.webapp.journeys.organisationLandlordRegistration.steps.OrgTypeStep
 import uk.gov.communities.prsdb.webapp.journeys.organisationLandlordRegistration.steps.YourDetailsStep
@@ -58,21 +63,46 @@ class OrganisationLandlordRegistrationJourneyFactory(
             step(journey.yourDetailsStep) {
                 routeSegment(YourDetailsStep.ROUTE_SEGMENT)
                 parents { journey.landlordTypeStep.hasOutcome(LandlordTypeMode.ORGANISATION) }
-                nextStep { journey.orgContactInfoStep }
+                nextStep { journey.orgNameStep }
             }
-            step(journey.orgContactInfoStep) {
-                routeSegment(OrgContactInfoStep.ROUTE_SEGMENT)
+            step(journey.orgNameStep) {
+                routeSegment(OrgNameStep.ROUTE_SEGMENT)
                 parents { journey.yourDetailsStep.isComplete() }
+                nextStep { journey.orgAddressStep }
+            }
+            step(journey.orgAddressStep) {
+                routeSegment(OrgAddressStep.ROUTE_SEGMENT)
+                parents { journey.orgNameStep.isComplete() }
+                nextStep { journey.orgEmailStep }
+            }
+            step(journey.orgEmailStep) {
+                routeSegment(OrgEmailStep.ROUTE_SEGMENT)
+                parents { journey.orgAddressStep.isComplete() }
+                nextStep { journey.orgPhoneNumberStep }
+            }
+            step(journey.orgPhoneNumberStep) {
+                routeSegment(OrgPhoneNumberStep.ROUTE_SEGMENT)
+                parents { journey.orgEmailStep.isComplete() }
                 nextStep { journey.orgTypeStep }
             }
             step(journey.orgTypeStep) {
                 routeSegment(OrgTypeStep.ROUTE_SEGMENT)
-                parents { journey.orgContactInfoStep.isComplete() }
+                parents { journey.orgPhoneNumberStep.isComplete() }
+                nextStep { journey.orgCompaniesHouseStep }
+            }
+            step(journey.orgCompaniesHouseStep) {
+                routeSegment(OrgCompaniesHouseStep.ROUTE_SEGMENT)
+                parents { journey.orgTypeStep.isComplete() }
+                nextStep { journey.orgCharityStep }
+            }
+            step(journey.orgCharityStep) {
+                routeSegment(OrgCharityStep.ROUTE_SEGMENT)
+                parents { journey.orgCompaniesHouseStep.isComplete() }
                 nextStep { journey.orgDirectorsStep }
             }
             step(journey.orgDirectorsStep) {
                 routeSegment(OrgDirectorsStep.ROUTE_SEGMENT)
-                parents { journey.orgTypeStep.isComplete() }
+                parents { journey.orgCharityStep.isComplete() }
                 nextStep { journey.orgTrusteesStep }
             }
             step(journey.orgTrusteesStep) {
@@ -103,8 +133,13 @@ class OrganisationLandlordRegistrationJourney(
     override val landlordTypeStep: LandlordTypeStep,
     override val individualLandlordPlaceholderStep: IndividualLandlordPlaceholderStep,
     override val yourDetailsStep: YourDetailsStep,
-    override val orgContactInfoStep: OrgContactInfoStep,
+    override val orgNameStep: OrgNameStep,
+    override val orgAddressStep: OrgAddressStep,
+    override val orgEmailStep: OrgEmailStep,
+    override val orgPhoneNumberStep: OrgPhoneNumberStep,
     override val orgTypeStep: OrgTypeStep,
+    override val orgCompaniesHouseStep: OrgCompaniesHouseStep,
+    override val orgCharityStep: OrgCharityStep,
     override val orgDirectorsStep: OrgDirectorsStep,
     override val orgTrusteesStep: OrgTrusteesStep,
     override val orgMainContactStep: OrgMainContactStep,
@@ -124,4 +159,3 @@ class OrganisationLandlordRegistrationJourney(
             "Organisation landlord registration journey for ${user.name} at time ${System.currentTimeMillis()}"
     }
 }
-

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/organisationLandlordRegistration/OrganisationLandlordRegistrationJourneyFactory.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/organisationLandlordRegistration/OrganisationLandlordRegistrationJourneyFactory.kt
@@ -1,0 +1,127 @@
+package uk.gov.communities.prsdb.webapp.journeys.organisationLandlordRegistration
+
+import org.springframework.beans.factory.ObjectFactory
+import uk.gov.communities.prsdb.webapp.annotations.webAnnotations.JourneyFrameworkComponent
+import uk.gov.communities.prsdb.webapp.controllers.RegisterLandlordController.Companion.LANDLORD_REGISTRATION_CONFIRMATION_ROUTE
+import uk.gov.communities.prsdb.webapp.controllers.RegisterLandlordController.Companion.LANDLORD_REGISTRATION_START_PAGE_ROUTE
+import uk.gov.communities.prsdb.webapp.journeys.AbstractJourneyState
+import uk.gov.communities.prsdb.webapp.journeys.Destination
+import uk.gov.communities.prsdb.webapp.journeys.JourneyStateDelegateProvider
+import uk.gov.communities.prsdb.webapp.journeys.JourneyStateService
+import uk.gov.communities.prsdb.webapp.journeys.StepLifecycleOrchestrator
+import uk.gov.communities.prsdb.webapp.journeys.builders.JourneyBuilder.Companion.journey
+import uk.gov.communities.prsdb.webapp.journeys.hasOutcome
+import uk.gov.communities.prsdb.webapp.journeys.isComplete
+import uk.gov.communities.prsdb.webapp.journeys.organisationLandlordRegistration.steps.IndividualLandlordPlaceholderStep
+import uk.gov.communities.prsdb.webapp.journeys.organisationLandlordRegistration.steps.LandlordTypeMode
+import uk.gov.communities.prsdb.webapp.journeys.organisationLandlordRegistration.steps.LandlordTypeStep
+import uk.gov.communities.prsdb.webapp.journeys.organisationLandlordRegistration.steps.OrgContactInfoStep
+import uk.gov.communities.prsdb.webapp.journeys.organisationLandlordRegistration.steps.OrgDirectorsStep
+import uk.gov.communities.prsdb.webapp.journeys.organisationLandlordRegistration.steps.OrgLandlordCyaStep
+import uk.gov.communities.prsdb.webapp.journeys.organisationLandlordRegistration.steps.OrgMainContactStep
+import uk.gov.communities.prsdb.webapp.journeys.organisationLandlordRegistration.steps.OrgTrusteesStep
+import uk.gov.communities.prsdb.webapp.journeys.organisationLandlordRegistration.steps.OrgTypeStep
+import uk.gov.communities.prsdb.webapp.journeys.organisationLandlordRegistration.steps.YourDetailsStep
+import java.security.Principal
+
+@JourneyFrameworkComponent("organisationLandlordRegistrationJourneyFactory")
+class OrganisationLandlordRegistrationJourneyFactory(
+    private val stateFactory: ObjectFactory<OrganisationLandlordRegistrationJourney>,
+) {
+    fun createJourneySteps(): Map<String, StepLifecycleOrchestrator> {
+        val state = stateFactory.getObject()
+        return mainJourneyMap(state)
+    }
+
+    private fun mainJourneyMap(state: OrganisationLandlordRegistrationJourney): Map<String, StepLifecycleOrchestrator> =
+        journey(state) {
+            configureFirst { backDestination { Destination.ExternalUrl(LANDLORD_REGISTRATION_START_PAGE_ROUTE) } }
+            unreachableStepUrl { LANDLORD_REGISTRATION_START_PAGE_ROUTE }
+            configure {
+                withAdditionalContentProperty { "title" to "registerAsALandlord.title" }
+            }
+            step(journey.landlordTypeStep) {
+                routeSegment(LandlordTypeStep.ROUTE_SEGMENT)
+                initialStep()
+                nextDestination { mode ->
+                    when (mode) {
+                        LandlordTypeMode.INDIVIDUAL -> Destination(journey.individualLandlordPlaceholderStep)
+                        LandlordTypeMode.ORGANISATION -> Destination(journey.yourDetailsStep)
+                    }
+                }
+            }
+            step(journey.individualLandlordPlaceholderStep) {
+                routeSegment(IndividualLandlordPlaceholderStep.ROUTE_SEGMENT)
+                parents { journey.landlordTypeStep.hasOutcome(LandlordTypeMode.INDIVIDUAL) }
+                nextUrl { LANDLORD_REGISTRATION_START_PAGE_ROUTE }
+            }
+            step(journey.yourDetailsStep) {
+                routeSegment(YourDetailsStep.ROUTE_SEGMENT)
+                parents { journey.landlordTypeStep.hasOutcome(LandlordTypeMode.ORGANISATION) }
+                nextStep { journey.orgContactInfoStep }
+            }
+            step(journey.orgContactInfoStep) {
+                routeSegment(OrgContactInfoStep.ROUTE_SEGMENT)
+                parents { journey.yourDetailsStep.isComplete() }
+                nextStep { journey.orgTypeStep }
+            }
+            step(journey.orgTypeStep) {
+                routeSegment(OrgTypeStep.ROUTE_SEGMENT)
+                parents { journey.orgContactInfoStep.isComplete() }
+                nextStep { journey.orgDirectorsStep }
+            }
+            step(journey.orgDirectorsStep) {
+                routeSegment(OrgDirectorsStep.ROUTE_SEGMENT)
+                parents { journey.orgTypeStep.isComplete() }
+                nextStep { journey.orgTrusteesStep }
+            }
+            step(journey.orgTrusteesStep) {
+                routeSegment(OrgTrusteesStep.ROUTE_SEGMENT)
+                parents { journey.orgDirectorsStep.isComplete() }
+                nextStep { journey.orgMainContactStep }
+            }
+            step(journey.orgMainContactStep) {
+                routeSegment(OrgMainContactStep.ROUTE_SEGMENT)
+                parents { journey.orgTrusteesStep.isComplete() }
+                nextStep { journey.orgLandlordCyaStep }
+            }
+            step(journey.orgLandlordCyaStep) {
+                routeSegment(OrgLandlordCyaStep.ROUTE_SEGMENT)
+                parents { journey.orgMainContactStep.isComplete() }
+                nextUrl { LANDLORD_REGISTRATION_CONFIRMATION_ROUTE }
+            }
+        }
+
+    fun initializeJourneyState(user: Principal): String {
+        val state = stateFactory.getObject()
+        return state.initializeState(user)
+    }
+}
+
+@JourneyFrameworkComponent("organisationLandlordRegistrationJourney")
+class OrganisationLandlordRegistrationJourney(
+    override val landlordTypeStep: LandlordTypeStep,
+    override val individualLandlordPlaceholderStep: IndividualLandlordPlaceholderStep,
+    override val yourDetailsStep: YourDetailsStep,
+    override val orgContactInfoStep: OrgContactInfoStep,
+    override val orgTypeStep: OrgTypeStep,
+    override val orgDirectorsStep: OrgDirectorsStep,
+    override val orgTrusteesStep: OrgTrusteesStep,
+    override val orgMainContactStep: OrgMainContactStep,
+    override val orgLandlordCyaStep: OrgLandlordCyaStep,
+    journeyStateService: JourneyStateService,
+) : AbstractJourneyState(journeyStateService),
+    OrganisationLandlordRegistrationState {
+    private val delegateProvider = JourneyStateDelegateProvider(journeyStateService)
+
+    override fun generateJourneyId(seed: Any?): String {
+        val user = seed as? Principal
+        return super<AbstractJourneyState>.generateJourneyId(user?.let { generateSeedForUser(user) })
+    }
+
+    companion object {
+        private fun generateSeedForUser(user: Principal): String =
+            "Organisation landlord registration journey for ${user.name} at time ${System.currentTimeMillis()}"
+    }
+}
+

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/organisationLandlordRegistration/OrganisationLandlordRegistrationState.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/organisationLandlordRegistration/OrganisationLandlordRegistrationState.kt
@@ -3,10 +3,15 @@ package uk.gov.communities.prsdb.webapp.journeys.organisationLandlordRegistratio
 import uk.gov.communities.prsdb.webapp.journeys.JourneyState
 import uk.gov.communities.prsdb.webapp.journeys.organisationLandlordRegistration.steps.IndividualLandlordPlaceholderStep
 import uk.gov.communities.prsdb.webapp.journeys.organisationLandlordRegistration.steps.LandlordTypeStep
-import uk.gov.communities.prsdb.webapp.journeys.organisationLandlordRegistration.steps.OrgContactInfoStep
+import uk.gov.communities.prsdb.webapp.journeys.organisationLandlordRegistration.steps.OrgAddressStep
+import uk.gov.communities.prsdb.webapp.journeys.organisationLandlordRegistration.steps.OrgCharityStep
+import uk.gov.communities.prsdb.webapp.journeys.organisationLandlordRegistration.steps.OrgCompaniesHouseStep
 import uk.gov.communities.prsdb.webapp.journeys.organisationLandlordRegistration.steps.OrgDirectorsStep
+import uk.gov.communities.prsdb.webapp.journeys.organisationLandlordRegistration.steps.OrgEmailStep
 import uk.gov.communities.prsdb.webapp.journeys.organisationLandlordRegistration.steps.OrgLandlordCyaStep
 import uk.gov.communities.prsdb.webapp.journeys.organisationLandlordRegistration.steps.OrgMainContactStep
+import uk.gov.communities.prsdb.webapp.journeys.organisationLandlordRegistration.steps.OrgNameStep
+import uk.gov.communities.prsdb.webapp.journeys.organisationLandlordRegistration.steps.OrgPhoneNumberStep
 import uk.gov.communities.prsdb.webapp.journeys.organisationLandlordRegistration.steps.OrgTrusteesStep
 import uk.gov.communities.prsdb.webapp.journeys.organisationLandlordRegistration.steps.OrgTypeStep
 import uk.gov.communities.prsdb.webapp.journeys.organisationLandlordRegistration.steps.YourDetailsStep
@@ -15,11 +20,15 @@ interface OrganisationLandlordRegistrationState : JourneyState {
     val landlordTypeStep: LandlordTypeStep
     val individualLandlordPlaceholderStep: IndividualLandlordPlaceholderStep
     val yourDetailsStep: YourDetailsStep
-    val orgContactInfoStep: OrgContactInfoStep
+    val orgNameStep: OrgNameStep
+    val orgAddressStep: OrgAddressStep
+    val orgEmailStep: OrgEmailStep
+    val orgPhoneNumberStep: OrgPhoneNumberStep
     val orgTypeStep: OrgTypeStep
+    val orgCompaniesHouseStep: OrgCompaniesHouseStep
+    val orgCharityStep: OrgCharityStep
     val orgDirectorsStep: OrgDirectorsStep
     val orgTrusteesStep: OrgTrusteesStep
     val orgMainContactStep: OrgMainContactStep
     val orgLandlordCyaStep: OrgLandlordCyaStep
 }
-

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/organisationLandlordRegistration/OrganisationLandlordRegistrationState.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/organisationLandlordRegistration/OrganisationLandlordRegistrationState.kt
@@ -1,0 +1,25 @@
+package uk.gov.communities.prsdb.webapp.journeys.organisationLandlordRegistration
+
+import uk.gov.communities.prsdb.webapp.journeys.JourneyState
+import uk.gov.communities.prsdb.webapp.journeys.organisationLandlordRegistration.steps.IndividualLandlordPlaceholderStep
+import uk.gov.communities.prsdb.webapp.journeys.organisationLandlordRegistration.steps.LandlordTypeStep
+import uk.gov.communities.prsdb.webapp.journeys.organisationLandlordRegistration.steps.OrgContactInfoStep
+import uk.gov.communities.prsdb.webapp.journeys.organisationLandlordRegistration.steps.OrgDirectorsStep
+import uk.gov.communities.prsdb.webapp.journeys.organisationLandlordRegistration.steps.OrgLandlordCyaStep
+import uk.gov.communities.prsdb.webapp.journeys.organisationLandlordRegistration.steps.OrgMainContactStep
+import uk.gov.communities.prsdb.webapp.journeys.organisationLandlordRegistration.steps.OrgTrusteesStep
+import uk.gov.communities.prsdb.webapp.journeys.organisationLandlordRegistration.steps.OrgTypeStep
+import uk.gov.communities.prsdb.webapp.journeys.organisationLandlordRegistration.steps.YourDetailsStep
+
+interface OrganisationLandlordRegistrationState : JourneyState {
+    val landlordTypeStep: LandlordTypeStep
+    val individualLandlordPlaceholderStep: IndividualLandlordPlaceholderStep
+    val yourDetailsStep: YourDetailsStep
+    val orgContactInfoStep: OrgContactInfoStep
+    val orgTypeStep: OrgTypeStep
+    val orgDirectorsStep: OrgDirectorsStep
+    val orgTrusteesStep: OrgTrusteesStep
+    val orgMainContactStep: OrgMainContactStep
+    val orgLandlordCyaStep: OrgLandlordCyaStep
+}
+

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/organisationLandlordRegistration/steps/IndividualLandlordPlaceholderStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/organisationLandlordRegistration/steps/IndividualLandlordPlaceholderStepConfig.kt
@@ -11,7 +11,8 @@ import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.NoInputFo
 class IndividualLandlordPlaceholderStepConfig : AbstractRequestableStepConfig<Complete, NoInputFormModel, JourneyState>() {
     override val formModelClass = NoInputFormModel::class
 
-    override fun getStepSpecificContent(state: JourneyState) = mapOf("todoComment" to "TODO: Send to individual landlord registration flow")
+    override fun getStepSpecificContent(state: JourneyState) =
+        mapOf("todoComment" to "TODO PDJB-1131: Send to individual landlord registration flow")
 
     override fun chooseTemplate(state: JourneyState) = "forms/todo"
 

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/organisationLandlordRegistration/steps/IndividualLandlordPlaceholderStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/organisationLandlordRegistration/steps/IndividualLandlordPlaceholderStepConfig.kt
@@ -1,0 +1,28 @@
+package uk.gov.communities.prsdb.webapp.journeys.organisationLandlordRegistration.steps
+
+import uk.gov.communities.prsdb.webapp.annotations.webAnnotations.JourneyFrameworkComponent
+import uk.gov.communities.prsdb.webapp.journeys.AbstractRequestableStepConfig
+import uk.gov.communities.prsdb.webapp.journeys.JourneyState
+import uk.gov.communities.prsdb.webapp.journeys.JourneyStep.RequestableStep
+import uk.gov.communities.prsdb.webapp.journeys.shared.Complete
+import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.NoInputFormModel
+
+@JourneyFrameworkComponent
+class IndividualLandlordPlaceholderStepConfig : AbstractRequestableStepConfig<Complete, NoInputFormModel, JourneyState>() {
+    override val formModelClass = NoInputFormModel::class
+
+    override fun getStepSpecificContent(state: JourneyState) = mapOf("todoComment" to "TODO: Send to individual landlord registration flow")
+
+    override fun chooseTemplate(state: JourneyState) = "forms/todo"
+
+    override fun mode(state: JourneyState) = getFormModelFromStateOrNull(state)?.let { Complete.COMPLETE }
+}
+
+@JourneyFrameworkComponent
+final class IndividualLandlordPlaceholderStep(
+    stepConfig: IndividualLandlordPlaceholderStepConfig,
+) : RequestableStep<Complete, NoInputFormModel, JourneyState>(stepConfig) {
+    companion object {
+        const val ROUTE_SEGMENT = "individual-landlord"
+    }
+}

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/organisationLandlordRegistration/steps/LandlordTypeStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/organisationLandlordRegistration/steps/LandlordTypeStepConfig.kt
@@ -1,0 +1,54 @@
+package uk.gov.communities.prsdb.webapp.journeys.organisationLandlordRegistration.steps
+
+import uk.gov.communities.prsdb.webapp.annotations.webAnnotations.JourneyFrameworkComponent
+import uk.gov.communities.prsdb.webapp.journeys.AbstractRequestableStepConfig
+import uk.gov.communities.prsdb.webapp.journeys.JourneyState
+import uk.gov.communities.prsdb.webapp.journeys.JourneyStep.RequestableStep
+import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.LandlordType
+import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.LandlordTypeFormModel
+import uk.gov.communities.prsdb.webapp.models.viewModels.formModels.RadiosButtonViewModel
+
+@JourneyFrameworkComponent("landlordTypeStepConfig")
+class LandlordTypeStepConfig : AbstractRequestableStepConfig<LandlordTypeMode, LandlordTypeFormModel, JourneyState>() {
+    override val formModelClass = LandlordTypeFormModel::class
+
+    override fun getStepSpecificContent(state: JourneyState) =
+        mapOf(
+            "fieldSetHeading" to "registerAsALandlord.landlordType.fieldSetHeading",
+            "radioOptions" to
+                listOf(
+                    RadiosButtonViewModel(
+                        value = LandlordType.INDIVIDUAL,
+                        labelMsgKey = "registerAsALandlord.landlordType.radios.individual.label",
+                    ),
+                    RadiosButtonViewModel(
+                        value = LandlordType.ORGANISATION,
+                        labelMsgKey = "registerAsALandlord.landlordType.radios.organisation.label",
+                    ),
+                ),
+        )
+
+    override fun chooseTemplate(state: JourneyState) = "forms/landlordTypeForm"
+
+    override fun mode(state: JourneyState) =
+        getFormModelFromStateOrNull(state)?.landlordType?.let {
+            when (it) {
+                LandlordType.INDIVIDUAL -> LandlordTypeMode.INDIVIDUAL
+                LandlordType.ORGANISATION -> LandlordTypeMode.ORGANISATION
+            }
+        }
+}
+
+@JourneyFrameworkComponent("landlordTypeStep")
+final class LandlordTypeStep(
+    stepConfig: LandlordTypeStepConfig,
+) : RequestableStep<LandlordTypeMode, LandlordTypeFormModel, JourneyState>(stepConfig) {
+    companion object {
+        const val ROUTE_SEGMENT = "landlord-type"
+    }
+}
+
+enum class LandlordTypeMode {
+    INDIVIDUAL,
+    ORGANISATION,
+}

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/organisationLandlordRegistration/steps/LandlordTypeStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/organisationLandlordRegistration/steps/LandlordTypeStepConfig.kt
@@ -8,6 +8,7 @@ import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.LandlordT
 import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.LandlordTypeFormModel
 import uk.gov.communities.prsdb.webapp.models.viewModels.formModels.RadiosButtonViewModel
 
+// TODO: PDJB-1127 update copy
 @JourneyFrameworkComponent("landlordTypeStepConfig")
 class LandlordTypeStepConfig : AbstractRequestableStepConfig<LandlordTypeMode, LandlordTypeFormModel, JourneyState>() {
     override val formModelClass = LandlordTypeFormModel::class

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/organisationLandlordRegistration/steps/OrgAddressStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/organisationLandlordRegistration/steps/OrgAddressStepConfig.kt
@@ -8,10 +8,10 @@ import uk.gov.communities.prsdb.webapp.journeys.shared.Complete
 import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.NoInputFormModel
 
 @JourneyFrameworkComponent
-class OrgLandlordCyaStepConfig : AbstractRequestableStepConfig<Complete, NoInputFormModel, JourneyState>() {
+class OrgAddressStepConfig : AbstractRequestableStepConfig<Complete, NoInputFormModel, JourneyState>() {
     override val formModelClass = NoInputFormModel::class
 
-    override fun getStepSpecificContent(state: JourneyState) = mapOf("todoComment" to "TODO: PDJB-1168 - Check your answers")
+    override fun getStepSpecificContent(state: JourneyState) = mapOf("todoComment" to "TODO: PDJB-1133/PDJB-1134 - Organisation address")
 
     override fun chooseTemplate(state: JourneyState) = "forms/todo"
 
@@ -19,10 +19,10 @@ class OrgLandlordCyaStepConfig : AbstractRequestableStepConfig<Complete, NoInput
 }
 
 @JourneyFrameworkComponent
-final class OrgLandlordCyaStep(
-    stepConfig: OrgLandlordCyaStepConfig,
+final class OrgAddressStep(
+    stepConfig: OrgAddressStepConfig,
 ) : RequestableStep<Complete, NoInputFormModel, JourneyState>(stepConfig) {
     companion object {
-        const val ROUTE_SEGMENT = "check-answers"
+        const val ROUTE_SEGMENT = "organisation-address"
     }
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/organisationLandlordRegistration/steps/OrgCharityStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/organisationLandlordRegistration/steps/OrgCharityStepConfig.kt
@@ -8,10 +8,10 @@ import uk.gov.communities.prsdb.webapp.journeys.shared.Complete
 import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.NoInputFormModel
 
 @JourneyFrameworkComponent
-class OrgLandlordCyaStepConfig : AbstractRequestableStepConfig<Complete, NoInputFormModel, JourneyState>() {
+class OrgCharityStepConfig : AbstractRequestableStepConfig<Complete, NoInputFormModel, JourneyState>() {
     override val formModelClass = NoInputFormModel::class
 
-    override fun getStepSpecificContent(state: JourneyState) = mapOf("todoComment" to "TODO: PDJB-1168 - Check your answers")
+    override fun getStepSpecificContent(state: JourneyState) = mapOf("todoComment" to "TODO: PDJB-1139 - Is the organisation a charity")
 
     override fun chooseTemplate(state: JourneyState) = "forms/todo"
 
@@ -19,10 +19,10 @@ class OrgLandlordCyaStepConfig : AbstractRequestableStepConfig<Complete, NoInput
 }
 
 @JourneyFrameworkComponent
-final class OrgLandlordCyaStep(
-    stepConfig: OrgLandlordCyaStepConfig,
+final class OrgCharityStep(
+    stepConfig: OrgCharityStepConfig,
 ) : RequestableStep<Complete, NoInputFormModel, JourneyState>(stepConfig) {
     companion object {
-        const val ROUTE_SEGMENT = "check-answers"
+        const val ROUTE_SEGMENT = "organisation-charity"
     }
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/organisationLandlordRegistration/steps/OrgCompaniesHouseStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/organisationLandlordRegistration/steps/OrgCompaniesHouseStepConfig.kt
@@ -8,11 +8,11 @@ import uk.gov.communities.prsdb.webapp.journeys.shared.Complete
 import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.NoInputFormModel
 
 @JourneyFrameworkComponent
-class OrgContactInfoStepConfig : AbstractRequestableStepConfig<Complete, NoInputFormModel, JourneyState>() {
+class OrgCompaniesHouseStepConfig : AbstractRequestableStepConfig<Complete, NoInputFormModel, JourneyState>() {
     override val formModelClass = NoInputFormModel::class
 
     override fun getStepSpecificContent(state: JourneyState) =
-        mapOf("todoComment" to "TODO: PDJB-1131 - Organisation contact information")
+        mapOf("todoComment" to "TODO: PDJB-1138 - Is the organisation on Companies House")
 
     override fun chooseTemplate(state: JourneyState) = "forms/todo"
 
@@ -20,10 +20,10 @@ class OrgContactInfoStepConfig : AbstractRequestableStepConfig<Complete, NoInput
 }
 
 @JourneyFrameworkComponent
-final class OrgContactInfoStep(
-    stepConfig: OrgContactInfoStepConfig,
+final class OrgCompaniesHouseStep(
+    stepConfig: OrgCompaniesHouseStepConfig,
 ) : RequestableStep<Complete, NoInputFormModel, JourneyState>(stepConfig) {
     companion object {
-        const val ROUTE_SEGMENT = "organisation-contact-info"
+        const val ROUTE_SEGMENT = "organisation-companies-house"
     }
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/organisationLandlordRegistration/steps/OrgContactInfoStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/organisationLandlordRegistration/steps/OrgContactInfoStepConfig.kt
@@ -1,0 +1,29 @@
+package uk.gov.communities.prsdb.webapp.journeys.organisationLandlordRegistration.steps
+
+import uk.gov.communities.prsdb.webapp.annotations.webAnnotations.JourneyFrameworkComponent
+import uk.gov.communities.prsdb.webapp.journeys.AbstractRequestableStepConfig
+import uk.gov.communities.prsdb.webapp.journeys.JourneyState
+import uk.gov.communities.prsdb.webapp.journeys.JourneyStep.RequestableStep
+import uk.gov.communities.prsdb.webapp.journeys.shared.Complete
+import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.NoInputFormModel
+
+@JourneyFrameworkComponent
+class OrgContactInfoStepConfig : AbstractRequestableStepConfig<Complete, NoInputFormModel, JourneyState>() {
+    override val formModelClass = NoInputFormModel::class
+
+    override fun getStepSpecificContent(state: JourneyState) =
+        mapOf("todoComment" to "TODO: PDJB-1131 - Organisation contact information")
+
+    override fun chooseTemplate(state: JourneyState) = "forms/todo"
+
+    override fun mode(state: JourneyState) = getFormModelFromStateOrNull(state)?.let { Complete.COMPLETE }
+}
+
+@JourneyFrameworkComponent
+final class OrgContactInfoStep(
+    stepConfig: OrgContactInfoStepConfig,
+) : RequestableStep<Complete, NoInputFormModel, JourneyState>(stepConfig) {
+    companion object {
+        const val ROUTE_SEGMENT = "organisation-contact-info"
+    }
+}

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/organisationLandlordRegistration/steps/OrgDirectorsStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/organisationLandlordRegistration/steps/OrgDirectorsStepConfig.kt
@@ -11,8 +11,7 @@ import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.NoInputFo
 class OrgDirectorsStepConfig : AbstractRequestableStepConfig<Complete, NoInputFormModel, JourneyState>() {
     override val formModelClass = NoInputFormModel::class
 
-    override fun getStepSpecificContent(state: JourneyState) =
-        mapOf("todoComment" to "TODO: PDJB-1131 - Organisation directors")
+    override fun getStepSpecificContent(state: JourneyState) = mapOf("todoComment" to "TODO: PDJB-1173 - Organisation directors")
 
     override fun chooseTemplate(state: JourneyState) = "forms/todo"
 

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/organisationLandlordRegistration/steps/OrgDirectorsStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/organisationLandlordRegistration/steps/OrgDirectorsStepConfig.kt
@@ -1,0 +1,29 @@
+package uk.gov.communities.prsdb.webapp.journeys.organisationLandlordRegistration.steps
+
+import uk.gov.communities.prsdb.webapp.annotations.webAnnotations.JourneyFrameworkComponent
+import uk.gov.communities.prsdb.webapp.journeys.AbstractRequestableStepConfig
+import uk.gov.communities.prsdb.webapp.journeys.JourneyState
+import uk.gov.communities.prsdb.webapp.journeys.JourneyStep.RequestableStep
+import uk.gov.communities.prsdb.webapp.journeys.shared.Complete
+import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.NoInputFormModel
+
+@JourneyFrameworkComponent
+class OrgDirectorsStepConfig : AbstractRequestableStepConfig<Complete, NoInputFormModel, JourneyState>() {
+    override val formModelClass = NoInputFormModel::class
+
+    override fun getStepSpecificContent(state: JourneyState) =
+        mapOf("todoComment" to "TODO: PDJB-1131 - Organisation directors")
+
+    override fun chooseTemplate(state: JourneyState) = "forms/todo"
+
+    override fun mode(state: JourneyState) = getFormModelFromStateOrNull(state)?.let { Complete.COMPLETE }
+}
+
+@JourneyFrameworkComponent
+final class OrgDirectorsStep(
+    stepConfig: OrgDirectorsStepConfig,
+) : RequestableStep<Complete, NoInputFormModel, JourneyState>(stepConfig) {
+    companion object {
+        const val ROUTE_SEGMENT = "organisation-directors"
+    }
+}

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/organisationLandlordRegistration/steps/OrgEmailStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/organisationLandlordRegistration/steps/OrgEmailStepConfig.kt
@@ -8,10 +8,11 @@ import uk.gov.communities.prsdb.webapp.journeys.shared.Complete
 import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.NoInputFormModel
 
 @JourneyFrameworkComponent
-class OrgLandlordCyaStepConfig : AbstractRequestableStepConfig<Complete, NoInputFormModel, JourneyState>() {
+class OrgEmailStepConfig : AbstractRequestableStepConfig<Complete, NoInputFormModel, JourneyState>() {
     override val formModelClass = NoInputFormModel::class
 
-    override fun getStepSpecificContent(state: JourneyState) = mapOf("todoComment" to "TODO: PDJB-1168 - Check your answers")
+    override fun getStepSpecificContent(state: JourneyState) =
+        mapOf("todoComment" to "TODO: PDJB-1135 - What is the email of the organisation")
 
     override fun chooseTemplate(state: JourneyState) = "forms/todo"
 
@@ -19,10 +20,10 @@ class OrgLandlordCyaStepConfig : AbstractRequestableStepConfig<Complete, NoInput
 }
 
 @JourneyFrameworkComponent
-final class OrgLandlordCyaStep(
-    stepConfig: OrgLandlordCyaStepConfig,
+final class OrgEmailStep(
+    stepConfig: OrgEmailStepConfig,
 ) : RequestableStep<Complete, NoInputFormModel, JourneyState>(stepConfig) {
     companion object {
-        const val ROUTE_SEGMENT = "check-answers"
+        const val ROUTE_SEGMENT = "organisation-email"
     }
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/organisationLandlordRegistration/steps/OrgLandlordCyaStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/organisationLandlordRegistration/steps/OrgLandlordCyaStepConfig.kt
@@ -1,0 +1,29 @@
+package uk.gov.communities.prsdb.webapp.journeys.organisationLandlordRegistration.steps
+
+import uk.gov.communities.prsdb.webapp.annotations.webAnnotations.JourneyFrameworkComponent
+import uk.gov.communities.prsdb.webapp.journeys.AbstractRequestableStepConfig
+import uk.gov.communities.prsdb.webapp.journeys.JourneyState
+import uk.gov.communities.prsdb.webapp.journeys.JourneyStep.RequestableStep
+import uk.gov.communities.prsdb.webapp.journeys.shared.Complete
+import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.NoInputFormModel
+
+@JourneyFrameworkComponent
+class OrgLandlordCyaStepConfig : AbstractRequestableStepConfig<Complete, NoInputFormModel, JourneyState>() {
+    override val formModelClass = NoInputFormModel::class
+
+    override fun getStepSpecificContent(state: JourneyState) =
+        mapOf("todoComment" to "TODO: PDJB-1131 - Check your answers")
+
+    override fun chooseTemplate(state: JourneyState) = "forms/todo"
+
+    override fun mode(state: JourneyState) = getFormModelFromStateOrNull(state)?.let { Complete.COMPLETE }
+}
+
+@JourneyFrameworkComponent
+final class OrgLandlordCyaStep(
+    stepConfig: OrgLandlordCyaStepConfig,
+) : RequestableStep<Complete, NoInputFormModel, JourneyState>(stepConfig) {
+    companion object {
+        const val ROUTE_SEGMENT = "check-answers"
+    }
+}

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/organisationLandlordRegistration/steps/OrgMainContactStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/organisationLandlordRegistration/steps/OrgMainContactStepConfig.kt
@@ -1,0 +1,29 @@
+package uk.gov.communities.prsdb.webapp.journeys.organisationLandlordRegistration.steps
+
+import uk.gov.communities.prsdb.webapp.annotations.webAnnotations.JourneyFrameworkComponent
+import uk.gov.communities.prsdb.webapp.journeys.AbstractRequestableStepConfig
+import uk.gov.communities.prsdb.webapp.journeys.JourneyState
+import uk.gov.communities.prsdb.webapp.journeys.JourneyStep.RequestableStep
+import uk.gov.communities.prsdb.webapp.journeys.shared.Complete
+import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.NoInputFormModel
+
+@JourneyFrameworkComponent
+class OrgMainContactStepConfig : AbstractRequestableStepConfig<Complete, NoInputFormModel, JourneyState>() {
+    override val formModelClass = NoInputFormModel::class
+
+    override fun getStepSpecificContent(state: JourneyState) =
+        mapOf("todoComment" to "TODO: PDJB-1131 - Organisation main contact")
+
+    override fun chooseTemplate(state: JourneyState) = "forms/todo"
+
+    override fun mode(state: JourneyState) = getFormModelFromStateOrNull(state)?.let { Complete.COMPLETE }
+}
+
+@JourneyFrameworkComponent
+final class OrgMainContactStep(
+    stepConfig: OrgMainContactStepConfig,
+) : RequestableStep<Complete, NoInputFormModel, JourneyState>(stepConfig) {
+    companion object {
+        const val ROUTE_SEGMENT = "organisation-main-contact"
+    }
+}

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/organisationLandlordRegistration/steps/OrgMainContactStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/organisationLandlordRegistration/steps/OrgMainContactStepConfig.kt
@@ -11,8 +11,7 @@ import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.NoInputFo
 class OrgMainContactStepConfig : AbstractRequestableStepConfig<Complete, NoInputFormModel, JourneyState>() {
     override val formModelClass = NoInputFormModel::class
 
-    override fun getStepSpecificContent(state: JourneyState) =
-        mapOf("todoComment" to "TODO: PDJB-1131 - Organisation main contact")
+    override fun getStepSpecificContent(state: JourneyState) = mapOf("todoComment" to "TODO: PDJB-1167 - Organisation main contact")
 
     override fun chooseTemplate(state: JourneyState) = "forms/todo"
 

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/organisationLandlordRegistration/steps/OrgNameStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/organisationLandlordRegistration/steps/OrgNameStepConfig.kt
@@ -8,10 +8,11 @@ import uk.gov.communities.prsdb.webapp.journeys.shared.Complete
 import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.NoInputFormModel
 
 @JourneyFrameworkComponent
-class OrgLandlordCyaStepConfig : AbstractRequestableStepConfig<Complete, NoInputFormModel, JourneyState>() {
+class OrgNameStepConfig : AbstractRequestableStepConfig<Complete, NoInputFormModel, JourneyState>() {
     override val formModelClass = NoInputFormModel::class
 
-    override fun getStepSpecificContent(state: JourneyState) = mapOf("todoComment" to "TODO: PDJB-1168 - Check your answers")
+    override fun getStepSpecificContent(state: JourneyState) =
+        mapOf("todoComment" to "TODO: PDJB-1132 - What is the name of the organisation")
 
     override fun chooseTemplate(state: JourneyState) = "forms/todo"
 
@@ -19,10 +20,10 @@ class OrgLandlordCyaStepConfig : AbstractRequestableStepConfig<Complete, NoInput
 }
 
 @JourneyFrameworkComponent
-final class OrgLandlordCyaStep(
-    stepConfig: OrgLandlordCyaStepConfig,
+final class OrgNameStep(
+    stepConfig: OrgNameStepConfig,
 ) : RequestableStep<Complete, NoInputFormModel, JourneyState>(stepConfig) {
     companion object {
-        const val ROUTE_SEGMENT = "check-answers"
+        const val ROUTE_SEGMENT = "organisation-name"
     }
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/organisationLandlordRegistration/steps/OrgPhoneNumberStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/organisationLandlordRegistration/steps/OrgPhoneNumberStepConfig.kt
@@ -8,10 +8,11 @@ import uk.gov.communities.prsdb.webapp.journeys.shared.Complete
 import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.NoInputFormModel
 
 @JourneyFrameworkComponent
-class OrgLandlordCyaStepConfig : AbstractRequestableStepConfig<Complete, NoInputFormModel, JourneyState>() {
+class OrgPhoneNumberStepConfig : AbstractRequestableStepConfig<Complete, NoInputFormModel, JourneyState>() {
     override val formModelClass = NoInputFormModel::class
 
-    override fun getStepSpecificContent(state: JourneyState) = mapOf("todoComment" to "TODO: PDJB-1168 - Check your answers")
+    override fun getStepSpecificContent(state: JourneyState) =
+        mapOf("todoComment" to "TODO: PDJB-1136 - What is the phone number of the organisation")
 
     override fun chooseTemplate(state: JourneyState) = "forms/todo"
 
@@ -19,10 +20,10 @@ class OrgLandlordCyaStepConfig : AbstractRequestableStepConfig<Complete, NoInput
 }
 
 @JourneyFrameworkComponent
-final class OrgLandlordCyaStep(
-    stepConfig: OrgLandlordCyaStepConfig,
+final class OrgPhoneNumberStep(
+    stepConfig: OrgPhoneNumberStepConfig,
 ) : RequestableStep<Complete, NoInputFormModel, JourneyState>(stepConfig) {
     companion object {
-        const val ROUTE_SEGMENT = "check-answers"
+        const val ROUTE_SEGMENT = "organisation-phone-number"
     }
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/organisationLandlordRegistration/steps/OrgTrusteesStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/organisationLandlordRegistration/steps/OrgTrusteesStepConfig.kt
@@ -1,0 +1,29 @@
+package uk.gov.communities.prsdb.webapp.journeys.organisationLandlordRegistration.steps
+
+import uk.gov.communities.prsdb.webapp.annotations.webAnnotations.JourneyFrameworkComponent
+import uk.gov.communities.prsdb.webapp.journeys.AbstractRequestableStepConfig
+import uk.gov.communities.prsdb.webapp.journeys.JourneyState
+import uk.gov.communities.prsdb.webapp.journeys.JourneyStep.RequestableStep
+import uk.gov.communities.prsdb.webapp.journeys.shared.Complete
+import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.NoInputFormModel
+
+@JourneyFrameworkComponent
+class OrgTrusteesStepConfig : AbstractRequestableStepConfig<Complete, NoInputFormModel, JourneyState>() {
+    override val formModelClass = NoInputFormModel::class
+
+    override fun getStepSpecificContent(state: JourneyState) =
+        mapOf("todoComment" to "TODO: PDJB-1131 - Organisation trustees")
+
+    override fun chooseTemplate(state: JourneyState) = "forms/todo"
+
+    override fun mode(state: JourneyState) = getFormModelFromStateOrNull(state)?.let { Complete.COMPLETE }
+}
+
+@JourneyFrameworkComponent
+final class OrgTrusteesStep(
+    stepConfig: OrgTrusteesStepConfig,
+) : RequestableStep<Complete, NoInputFormModel, JourneyState>(stepConfig) {
+    companion object {
+        const val ROUTE_SEGMENT = "organisation-trustees"
+    }
+}

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/organisationLandlordRegistration/steps/OrgTrusteesStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/organisationLandlordRegistration/steps/OrgTrusteesStepConfig.kt
@@ -11,8 +11,7 @@ import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.NoInputFo
 class OrgTrusteesStepConfig : AbstractRequestableStepConfig<Complete, NoInputFormModel, JourneyState>() {
     override val formModelClass = NoInputFormModel::class
 
-    override fun getStepSpecificContent(state: JourneyState) =
-        mapOf("todoComment" to "TODO: PDJB-1131 - Organisation trustees")
+    override fun getStepSpecificContent(state: JourneyState) = mapOf("todoComment" to "TODO: PDJB-1174 - Organisation trustees")
 
     override fun chooseTemplate(state: JourneyState) = "forms/todo"
 

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/organisationLandlordRegistration/steps/OrgTypeStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/organisationLandlordRegistration/steps/OrgTypeStepConfig.kt
@@ -11,7 +11,8 @@ import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.NoInputFo
 class OrgTypeStepConfig : AbstractRequestableStepConfig<Complete, NoInputFormModel, JourneyState>() {
     override val formModelClass = NoInputFormModel::class
 
-    override fun getStepSpecificContent(state: JourneyState) = mapOf("todoComment" to "TODO: PDJB-1131 - Organisation type")
+    override fun getStepSpecificContent(state: JourneyState) =
+        mapOf("todoComment" to "TODO: PDJB-1137 - What is the type of the organisation")
 
     override fun chooseTemplate(state: JourneyState) = "forms/todo"
 

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/organisationLandlordRegistration/steps/OrgTypeStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/organisationLandlordRegistration/steps/OrgTypeStepConfig.kt
@@ -1,0 +1,28 @@
+package uk.gov.communities.prsdb.webapp.journeys.organisationLandlordRegistration.steps
+
+import uk.gov.communities.prsdb.webapp.annotations.webAnnotations.JourneyFrameworkComponent
+import uk.gov.communities.prsdb.webapp.journeys.AbstractRequestableStepConfig
+import uk.gov.communities.prsdb.webapp.journeys.JourneyState
+import uk.gov.communities.prsdb.webapp.journeys.JourneyStep.RequestableStep
+import uk.gov.communities.prsdb.webapp.journeys.shared.Complete
+import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.NoInputFormModel
+
+@JourneyFrameworkComponent
+class OrgTypeStepConfig : AbstractRequestableStepConfig<Complete, NoInputFormModel, JourneyState>() {
+    override val formModelClass = NoInputFormModel::class
+
+    override fun getStepSpecificContent(state: JourneyState) = mapOf("todoComment" to "TODO: PDJB-1131 - Organisation type")
+
+    override fun chooseTemplate(state: JourneyState) = "forms/todo"
+
+    override fun mode(state: JourneyState) = getFormModelFromStateOrNull(state)?.let { Complete.COMPLETE }
+}
+
+@JourneyFrameworkComponent
+final class OrgTypeStep(
+    stepConfig: OrgTypeStepConfig,
+) : RequestableStep<Complete, NoInputFormModel, JourneyState>(stepConfig) {
+    companion object {
+        const val ROUTE_SEGMENT = "organisation-type"
+    }
+}

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/organisationLandlordRegistration/steps/YourDetailsStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/organisationLandlordRegistration/steps/YourDetailsStepConfig.kt
@@ -11,7 +11,7 @@ import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.NoInputFo
 class YourDetailsStepConfig : AbstractRequestableStepConfig<Complete, NoInputFormModel, JourneyState>() {
     override val formModelClass = NoInputFormModel::class
 
-    override fun getStepSpecificContent(state: JourneyState) = mapOf("todoComment" to "TODO: PDJB-1131 - Your details")
+    override fun getStepSpecificContent(state: JourneyState) = mapOf("todoComment" to "TODO: PDJB-1172 - Your details")
 
     override fun chooseTemplate(state: JourneyState) = "forms/todo"
 

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/organisationLandlordRegistration/steps/YourDetailsStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/organisationLandlordRegistration/steps/YourDetailsStepConfig.kt
@@ -1,0 +1,28 @@
+package uk.gov.communities.prsdb.webapp.journeys.organisationLandlordRegistration.steps
+
+import uk.gov.communities.prsdb.webapp.annotations.webAnnotations.JourneyFrameworkComponent
+import uk.gov.communities.prsdb.webapp.journeys.AbstractRequestableStepConfig
+import uk.gov.communities.prsdb.webapp.journeys.JourneyState
+import uk.gov.communities.prsdb.webapp.journeys.JourneyStep.RequestableStep
+import uk.gov.communities.prsdb.webapp.journeys.shared.Complete
+import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.NoInputFormModel
+
+@JourneyFrameworkComponent
+class YourDetailsStepConfig : AbstractRequestableStepConfig<Complete, NoInputFormModel, JourneyState>() {
+    override val formModelClass = NoInputFormModel::class
+
+    override fun getStepSpecificContent(state: JourneyState) = mapOf("todoComment" to "TODO: PDJB-1131 - Your details")
+
+    override fun chooseTemplate(state: JourneyState) = "forms/todo"
+
+    override fun mode(state: JourneyState) = getFormModelFromStateOrNull(state)?.let { Complete.COMPLETE }
+}
+
+@JourneyFrameworkComponent
+final class YourDetailsStep(
+    stepConfig: YourDetailsStepConfig,
+) : RequestableStep<Complete, NoInputFormModel, JourneyState>(stepConfig) {
+    companion object {
+        const val ROUTE_SEGMENT = "your-details"
+    }
+}

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/requestModels/formModels/LandlordTypeFormModel.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/requestModels/formModels/LandlordTypeFormModel.kt
@@ -1,0 +1,24 @@
+package uk.gov.communities.prsdb.webapp.models.requestModels.formModels
+
+import uk.gov.communities.prsdb.webapp.validation.ConstraintDescriptor
+import uk.gov.communities.prsdb.webapp.validation.IsValidPrioritised
+import uk.gov.communities.prsdb.webapp.validation.NotNullConstraintValidator
+import uk.gov.communities.prsdb.webapp.validation.ValidatedBy
+
+@IsValidPrioritised
+class LandlordTypeFormModel(
+    @ValidatedBy(
+        constraints = [
+            ConstraintDescriptor(
+                messageKey = "registerAsALandlord.landlordType.radios.error.missing",
+                validatorType = NotNullConstraintValidator::class,
+            ),
+        ],
+    )
+    var landlordType: LandlordType? = null,
+) : FormModel
+
+enum class LandlordType {
+    INDIVIDUAL,
+    ORGANISATION,
+}

--- a/src/main/resources/messages/registerAsALandlord.yml
+++ b/src/main/resources/messages/registerAsALandlord.yml
@@ -69,3 +69,12 @@ privacyNotice:
     heading: Confirm you have read the privacy notice
     label: I confirm I have read the privacy notice for this private beta
   oneLoginInset: "When you continue, you\u2019ll be asked to prove your identity using your GOV.UK One Login."
+landlordType:
+  fieldSetHeading: Are you registering as an individual or an organisation?
+  radios:
+    individual:
+      label: Individual
+    organisation:
+      label: Organisation
+    error:
+      missing: Select whether you are registering as an individual or an organisation

--- a/src/main/resources/templates/forms/landlordTypeForm.html
+++ b/src/main/resources/templates/forms/landlordTypeForm.html
@@ -1,0 +1,17 @@
+<!--/*@thymesVar id="title" type="java.lang.String"*/-->
+<!--/*@thymesVar id="formModel" type="java.lang.Object"*/-->
+<!--/*@thymesVar id="fieldSetHeading" type="java.lang.String"*/-->
+<!--/*@thymesVar id="backUrl" type="java.lang.String"*/-->
+<!--/*@thymesVar id="radioOptions" type="java.lang.Object"*/-->
+<!DOCTYPE html>
+<html th:replace="~{fragments/forms/questionPage :: questionPage(#{${title}}, ${formModel}, ~{::#form-content}, ${backUrl}, null)}">
+<th:block id="form-content">
+    <th:block id="fieldset-content"
+              th:replace="~{fragments/forms/fieldSet :: fieldSet(~{::#fieldset-content/content()}, 'landlordType', #{${fieldSetHeading}}, null)}">
+        <th:block th:replace="~{fragments/forms/radios :: radios(null,'landlordType',null, ${radioOptions})}"></th:block>
+    </th:block>
+    <div class="govuk-button-group">
+        <button th:replace="~{fragments/buttons/primaryButton :: primaryButton(#{forms.buttons.continue})}"></button>
+    </div>
+</th:block>
+</html>

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/controllers/RegisterLandlordControllerTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/controllers/RegisterLandlordControllerTests.kt
@@ -9,6 +9,7 @@ import org.springframework.security.test.context.support.WithMockUser
 import org.springframework.test.context.bean.override.mockito.MockitoBean
 import org.springframework.test.web.servlet.get
 import org.springframework.web.context.WebApplicationContext
+import uk.gov.communities.prsdb.webapp.config.managers.FeatureFlagManager
 import uk.gov.communities.prsdb.webapp.constants.LANDLORD_REGISTRATION_SURVEY_URL
 import uk.gov.communities.prsdb.webapp.controllers.LandlordController.Companion.LANDLORD_DASHBOARD_URL
 import uk.gov.communities.prsdb.webapp.controllers.RegisterLandlordController.Companion.LANDLORD_REGISTRATION_CONFIRMATION_ROUTE
@@ -18,6 +19,7 @@ import uk.gov.communities.prsdb.webapp.journeys.JourneyStateService
 import uk.gov.communities.prsdb.webapp.journeys.NoSuchJourneyException
 import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.LandlordRegistrationJourneyFactory
 import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.PrivacyNoticeStep
+import uk.gov.communities.prsdb.webapp.journeys.organisationLandlordRegistration.OrganisationLandlordRegistrationJourneyFactory
 import uk.gov.communities.prsdb.webapp.services.LandlordService
 import uk.gov.communities.prsdb.webapp.testHelpers.mockObjects.MockLandlordData
 
@@ -27,6 +29,12 @@ class RegisterLandlordControllerTests(
 ) : ControllerTest(webContext) {
     @MockitoBean
     private lateinit var landlordRegistrationJourneyFactory: LandlordRegistrationJourneyFactory
+
+    @MockitoBean
+    private lateinit var organisationLandlordRegistrationJourneyFactory: OrganisationLandlordRegistrationJourneyFactory
+
+    @MockitoBean
+    private lateinit var featureFlagManager: FeatureFlagManager
 
     @MockitoBean
     private lateinit var landlordService: LandlordService

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/LandlordRegistrationJourneyTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/LandlordRegistrationJourneyTests.kt
@@ -11,6 +11,7 @@ import org.mockito.kotlin.whenever
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.test.context.bean.override.mockito.MockitoBean
 import uk.gov.communities.prsdb.webapp.constants.MANUAL_ADDRESS_CHOSEN
+import uk.gov.communities.prsdb.webapp.constants.ORGANISATION_LANDLORD_REGISTRATION
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.BaseComponent.Companion.assertThat
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.LandlordDashboardPage
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages.BasePage.Companion.assertPageIs
@@ -50,6 +51,7 @@ class LandlordRegistrationJourneyTests : IntegrationTestWithMutableData("data-mo
     @BeforeEach
     fun setup() {
         whenever(absoluteUrlProvider.buildLandlordDashboardUri()).thenReturn(URI(absoluteLandlordUrl))
+        featureFlagManager.disable(ORGANISATION_LANDLORD_REGISTRATION)
     }
 
     @Test

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/LandlordRegistrationSinglePageTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/LandlordRegistrationSinglePageTests.kt
@@ -6,11 +6,13 @@ import com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat
 import kotlinx.datetime.DatePeriod
 import kotlinx.datetime.minus
 import kotlinx.datetime.plus
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.CsvSource
 import org.junit.jupiter.params.provider.ValueSource
+import uk.gov.communities.prsdb.webapp.constants.ORGANISATION_LANDLORD_REGISTRATION
 import uk.gov.communities.prsdb.webapp.helpers.DateTimeHelper
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.BaseComponent
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.ErrorPage
@@ -27,6 +29,11 @@ import uk.gov.communities.prsdb.webapp.testHelpers.extensions.getFormattedIntern
 
 class LandlordRegistrationSinglePageTests : IntegrationTestWithImmutableData("data-mockuser-not-landlord.sql") {
     private val phoneNumberUtil = PhoneNumberUtil.getInstance()
+
+    @BeforeEach
+    fun disableOrgLandlordFlag() {
+        featureFlagManager.disable(ORGANISATION_LANDLORD_REGISTRATION)
+    }
 
     @Nested
     inner class LandlordRegistrationServiceInformationStartPage {

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/urlProviders/LandlordDashboardUrlTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/urlProviders/LandlordDashboardUrlTests.kt
@@ -26,6 +26,7 @@ import uk.gov.communities.prsdb.webapp.database.entity.PrsdbUser
 import uk.gov.communities.prsdb.webapp.database.repository.LandlordRepository
 import uk.gov.communities.prsdb.webapp.helpers.CertificateUploadHelper
 import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.LandlordRegistrationJourneyFactory
+import uk.gov.communities.prsdb.webapp.journeys.organisationLandlordRegistration.OrganisationLandlordRegistrationJourneyFactory
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.JointLandlordsPropertyRegistrationStrategy
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.PropertyRegistrationJourneyFactory
 import uk.gov.communities.prsdb.webapp.models.dataModels.AddressDataModel
@@ -64,6 +65,9 @@ class LandlordDashboardUrlTests(
 ) : ControllerTest(context) {
     @MockitoBean
     private lateinit var mockLandlordRegistrationJourneyFactory: LandlordRegistrationJourneyFactory
+
+    @MockitoBean
+    private lateinit var mockOrgLandlordRegistrationJourneyFactory: OrganisationLandlordRegistrationJourneyFactory
 
     @MockitoBean
     private lateinit var mockPropertyRegistrationJourneyFactory: PropertyRegistrationJourneyFactory


### PR DESCRIPTION
## Ticket number

[PDJB-1131](https://mhclgdigital.atlassian.net/browse/PDJB-1131)

## Goal of change

adds a skeleton journey for org landlords to unblock other tickets

## Description of main change(s)

adds a journey factory for the new flow after we turn the feature flag on

adds many new todo steps

## Anything you'd like to highlight to the reviewer?

I think the way we plug into the original LL registration flow could use some more work, I don't think it's quite explicit on what we want to do here. I raise this PR as an MVP that at least adds the skeleton journey and should unblock the other tickets surrounding it

I'll raise a part 3 that integrates this in a way I believe we can keep permanently (or something close to that)

## Checklist

Delete any that are not applicable, and add explanation below for any that are applicable but haven't been done

- [ ] Screenshots of any UI changes have been added
- [ ] Unit tests for new logic (e.g. new service methods) have been added (I've skipped testing for now as these are WIP skeleton pages)
- [ ] Controller tests for any new endpoints, including testing the relevant permissions
- [ ] Single page integration tests have been added for any unhappy-flow UI features, e.g. validation errors
- [ ] New journey steps have been added to the appropriate journey integration test(s)
- [ ] A new journey integration test has been added for any new journeys
- [ ] Test suite has been run in full locally and is passing
- [ ] Branch has been rebased onto main and run locally, with everything working as expected (both for your new feature
  and any related functionality) (not based on main)
- [x] TODO comments referencing this JIRA ticket have been searched for and removed - if a future PR will address them,
  mention that here
