### PR TITLE
PDJB-426: Show multiple landlords in local council property details view

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/PropertyDetailsController.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/PropertyDetailsController.kt
@@ -188,12 +188,27 @@ class PropertyDetailsController(
                 messageSource = messageSource,
             )
 
-        // TODO PDJB-426 - do not use primary landlord when it is not needed
-        val landlordViewModel =
-            PropertyDetailsLandlordViewModelBuilder.fromEntity(
-                propertyOwnership.primaryLandlord,
-                primaryLandlordDetailsUrl,
-            )
+        if (jointLandlordsIsEnabled) {
+            val backUrlKey = backLinkStorageService.storeCurrentUrlReturningKey(LANDLORD_DETAILS_FRAGMENT)
+            val landlordSummaryCards =
+                PropertyDetailsLandlordViewModelBuilder.buildLocalCouncilSummaryCards(
+                    propertyOwnership.landlords,
+                    landlordDetailsUrlProvider = { landlord ->
+                        LandlordDetailsController
+                            .getLandlordDetailsForLocalCouncilUserPath(landlord.id)
+                            .overrideBackLinkForUrl(backUrlKey)
+                    },
+                )
+            model.addAttribute("landlordSummaryCards", landlordSummaryCards)
+            model.addAttribute("landlordCount", propertyOwnership.landlords.size)
+        } else {
+            val landlordViewModel =
+                PropertyDetailsLandlordViewModelBuilder.fromEntity(
+                    propertyOwnership.primaryLandlord,
+                    primaryLandlordDetailsUrl,
+                )
+            model.addAttribute("landlordDetails", landlordViewModel)
+        }
 
         val propertyComplianceDetails =
             propertyCompliance?.let {
@@ -207,7 +222,6 @@ class PropertyDetailsController(
         model.addAttribute("propertyDetails", propertyDetails)
         model.addAttribute("lastModifiedDate", lastModifiedDate)
         model.addAttribute("lastModifiedBy", lastModifiedBy)
-        model.addAttribute("landlordDetails", landlordViewModel)
         model.addAttribute("complianceDetails", propertyComplianceDetails)
         model.addAttribute("complianceInfoTabId", COMPLIANCE_INFO_FRAGMENT)
         model.addAttribute("isLandlordView", false)

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/PropertyDetailsController.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/PropertyDetailsController.kt
@@ -204,7 +204,7 @@ class PropertyDetailsController(
         } else {
             val landlordViewModel =
                 PropertyDetailsLandlordViewModelBuilder.fromEntity(
-                    propertyOwnership.primaryLandlord,
+                    propertyOwnership.landlords.first(),
                     primaryLandlordDetailsUrl,
                 )
             model.addAttribute("landlordDetails", landlordViewModel)

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/PropertyDetailsController.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/PropertyDetailsController.kt
@@ -170,13 +170,15 @@ class PropertyDetailsController(
             propertyOwnershipService.getPropertyOwnershipIfAuthorizedUser(propertyOwnershipId, principal.name)
 
         val lastModifiedDate = DateTimeHelper.getDateInUK(propertyOwnership.getMostRecentlyUpdated().toKotlinInstant())
-
         // TODO PDJB-1069 - properly track who last modified the property
         val lastModifiedBy = propertyOwnership.primaryLandlord.name
+
+        val backUrlKey = backLinkStorageService.storeCurrentUrlReturningKey(LANDLORD_DETAILS_FRAGMENT)
+
         val primaryLandlordDetailsUrl =
             LandlordDetailsController
                 .getLandlordDetailsForLocalCouncilUserPath(propertyOwnership.primaryLandlord.id)
-                .overrideBackLinkForUrl(backLinkStorageService.storeCurrentUrlReturningKey(LANDLORD_DETAILS_FRAGMENT))
+                .overrideBackLinkForUrl(backUrlKey)
 
         val propertyCompliance = propertyComplianceService.getComplianceForPropertyOrNull(propertyOwnershipId)
 
@@ -189,7 +191,6 @@ class PropertyDetailsController(
             )
 
         if (jointLandlordsIsEnabled) {
-            val backUrlKey = backLinkStorageService.storeCurrentUrlReturningKey(LANDLORD_DETAILS_FRAGMENT)
             val landlordSummaryCards =
                 PropertyDetailsLandlordViewModelBuilder.buildLocalCouncilSummaryCards(
                     propertyOwnership.landlords,

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/summaryModels/PropertyDetailsLandlordViewModelBuilder.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/summaryModels/PropertyDetailsLandlordViewModelBuilder.kt
@@ -85,5 +85,46 @@ class PropertyDetailsLandlordViewModelBuilder {
                     fieldValue = landlord.email,
                 ),
             )
+
+        fun buildLocalCouncilSummaryCards(
+            landlords: Set<Landlord>,
+            landlordDetailsUrlProvider: (Landlord) -> String,
+        ): List<SummaryCardViewModel> =
+            landlords
+                .sortedBy { it.name }
+                .map { landlord ->
+                    SummaryCardViewModel(
+                        title = landlord.name,
+                        summaryList = buildLocalCouncilCardRows(landlord),
+                        actions =
+                            listOf(
+                                SummaryCardActionViewModel(
+                                    text = "propertyDetails.landlordDetails.registeredLandlords.viewLandlordRecord",
+                                    url = landlordDetailsUrlProvider(landlord),
+                                    opensInNewTab = true,
+                                ),
+                            ),
+                    )
+                }
+
+        private fun buildLocalCouncilCardRows(landlord: Landlord): List<SummaryListRowViewModel> =
+            listOf(
+                SummaryListRowViewModel(
+                    fieldHeading = "landlordDetails.personalDetails.lrn",
+                    fieldValue = RegistrationNumberDataModel.fromRegistrationNumber(landlord.registrationNumber),
+                ),
+                SummaryListRowViewModel(
+                    fieldHeading = "landlordDetails.personalDetails.emailAddress",
+                    fieldValue = landlord.email,
+                ),
+                SummaryListRowViewModel(
+                    fieldHeading = "propertyDetails.landlordDetails.contactNumber",
+                    fieldValue = landlord.phoneNumber,
+                ),
+                SummaryListRowViewModel(
+                    fieldHeading = "landlordDetails.personalDetails.contactAddress",
+                    fieldValue = landlord.address.toMultiLineAddress().split("\n"),
+                ),
+            )
     }
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/summaryModels/PropertyDetailsViewModel.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/summaryModels/PropertyDetailsViewModel.kt
@@ -34,6 +34,7 @@ class PropertyDetailsViewModel(
     private val messageSource: MessageSource,
 ) {
     val address: String = propertyOwnership.address.singleLineAddress
+    val addressParts: List<String> = propertyOwnership.address.toMultiLineAddress().split("\n")
 
     private val changeLinkMessageKey = "forms.links.change"
 

--- a/src/main/resources/messages/propertyDetails.yml
+++ b/src/main/resources/messages/propertyDetails.yml
@@ -10,6 +10,7 @@ landlordDetails:
   registeredLandlords:
     heading: 'Registered landlords ({0})'
     currentUserCardTitle: '{0} (you)'
+    viewLandlordRecord: View landlord record (opens in new tab)
   registeredLandlord:
     heading: Registered landlord
   inviteJointLandlord:

--- a/src/main/resources/templates/propertyDetailsView.html
+++ b/src/main/resources/templates/propertyDetailsView.html
@@ -86,14 +86,14 @@
                 <div  id="landlord-details-panel" th:replace="~{fragments/tabs/tabsPanel :: tabsPanel('landlord-details', ~{::#landlord-details-panel/content()})}">
                     <h2 class="govuk-heading-m" th:text="#{propertyDetails.landlordDetails.heading}">propertyDetails.landlordDetails.heading</h2>
                     <!-- Multi-landlord summary cards (joint landlords flag on) -->
-                    <th:block th:if="${isLandlordView && jointLandlordsIsEnabled}">
+                    <th:block th:if="${jointLandlordsIsEnabled}">
                         <h3 class="govuk-heading-s" th:text="#{propertyDetails.landlordDetails.registeredLandlords.heading(${landlordCount})}">propertyDetails.landlordDetails.registeredLandlords.heading(landlordCount)</h3>
                         <th:block th:each="card : ${landlordSummaryCards}">
                             <div th:replace="~{fragments/summaryCard :: summaryCard(${card.title}, ${card.cardNumber}, ${card.actions}, ${card.summaryList})}"></div>
                         </th:block>
                     </th:block>
-                    <!-- Single landlord summary list (flag off / local council view) -->
-                    <th:block th:if="${!jointLandlordsIsEnabled || !isLandlordView}">
+                    <!-- Single landlord summary list (flag off) -->
+                    <th:block th:if="${!jointLandlordsIsEnabled}">
                         <h3 class="govuk-heading-s" th:text="#{propertyDetails.landlordDetails.registeredLandlord.heading}">propertyDetails.landlordDetails.registeredLandlord.heading</h3>
                         <dl th:replace="~{fragments/summaryList :: summaryList(${landlordDetails})}"></dl>
                     </th:block>

--- a/src/main/resources/templates/propertyDetailsView.html
+++ b/src/main/resources/templates/propertyDetailsView.html
@@ -56,7 +56,9 @@
                 </div>
             </th:block>
             <span class="govuk-caption-l" th:text="#{propertyDetails.heading}">propertyDetails.heading</span>
-            <h1 class="govuk-heading-l" th:text="${propertyDetails.address}">propertyDetails.address</h1>
+            <h1 class="govuk-heading-l">
+                <th:block th:replace="~{fragments/multiLineText :: multiLineText(${propertyDetails.addressParts})}"></th:block>
+            </h1>
             <p class="govuk-body">
                 <div th:replace="~{fragments/tag :: tag(messageKey = ${propertyDetails.isOccupiedKey()}, tagColour = ${propertyDetails.isOccupied() ? 'turquoise' : 'grey'})}"></div>
             </p>

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/PropertyDetailsTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/PropertyDetailsTests.kt
@@ -22,6 +22,7 @@ import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages.B
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyDeregistrationJourneyPages.DeregisterPropertyInfoPage
 import uk.gov.communities.prsdb.webapp.testHelpers.FeatureFlagConfigUpdater
 import java.net.URI
+import java.util.regex.Pattern
 import kotlin.test.assertEquals
 
 class PropertyDetailsTests : IntegrationTestWithImmutableData("data-local.sql") {
@@ -286,27 +287,6 @@ class PropertyDetailsTests : IntegrationTestWithImmutableData("data-local.sql") 
         }
 
         @Test
-        fun `in the landlord details section the landlord name link goes the local council view of landlord details`(page: Page) {
-            val detailsPage = navigator.goToPropertyDetailsLocalCouncilView(1)
-            detailsPage.tabs.goToLandlordDetails()
-
-            detailsPage.landlordSummaryList.nameRow
-                .valueLinkByText("Alexander Smith")
-                .clickAndWait()
-
-            val landlordDetailsPage = assertPageIs(page, LocalCouncilViewLandlordDetailsPage::class, mapOf("id" to "1"))
-
-            landlordDetailsPage.backLink.clickAndWait()
-            val detailsPageAfterBack =
-                assertPageIs(
-                    page,
-                    PropertyDetailsPageLocalCouncilView::class,
-                    mapOf("propertyOwnershipId" to "1"),
-                )
-            assertEquals(LANDLORD_DETAILS_FRAGMENT, detailsPageAfterBack.tabs.activeTabPanelId)
-        }
-
-        @Test
         fun `the back link returns to the dashboard`(page: Page) {
             val detailsPage = navigator.goToPropertyDetailsLocalCouncilView(1)
             detailsPage.backLink.clickAndWait()
@@ -326,6 +306,78 @@ class PropertyDetailsTests : IntegrationTestWithImmutableData("data-local.sql") 
             detailsPage.tabs.goToLandlordDetails()
 
             assertThat(detailsPage.lastModifiedInsetText).containsText("updated these details on")
+        }
+
+        @Nested
+        inner class LandlordDetails {
+            @Test
+            fun `when joint landlords flag is enabled the landlord tab shows summary cards sorted alphabetically`(page: Page) {
+                FeatureFlagConfigUpdater(featureFlagManager).enableUnreleasedFeature(JOINT_LANDLORDS)
+
+                val detailsPage = navigator.goToPropertyDetailsLocalCouncilView(8)
+                detailsPage.tabs.goToLandlordDetails()
+
+                assertEquals(3, detailsPage.landlordSummaryCards.size)
+                assertEquals("Alexander Smith", detailsPage.landlordSummaryCards[0].title.getText())
+                assertEquals("Alexandra Davies", detailsPage.landlordSummaryCards[1].title.getText())
+                assertEquals("Tobias Evans", detailsPage.landlordSummaryCards[2].title.getText())
+            }
+
+            @Test
+            fun `when joint landlords flag is enabled the landlord cards contain LRN, email, phone, and address`(page: Page) {
+                FeatureFlagConfigUpdater(featureFlagManager).enableUnreleasedFeature(JOINT_LANDLORDS)
+
+                val detailsPage = navigator.goToPropertyDetailsLocalCouncilView(8)
+                detailsPage.tabs.goToLandlordDetails()
+
+                val firstCard = detailsPage.landlordSummaryCards[0]
+                assertThat(firstCard.summaryList.registrationNumberRow.value).not().isEmpty()
+                assertThat(firstCard.summaryList.emailAddressRow.value).containsText("alex.surname@example.com")
+                assertThat(firstCard.summaryList.contactNumberRow.value).containsText("7111111111")
+                assertThat(firstCard.summaryList.contactAddressRow.value).containsText("FA1 1AA")
+            }
+
+            @Test
+            fun `when joint landlords flag is enabled the landlord cards have a view landlord record action`(page: Page) {
+                FeatureFlagConfigUpdater(featureFlagManager).enableUnreleasedFeature(JOINT_LANDLORDS)
+
+                val detailsPage = navigator.goToPropertyDetailsLocalCouncilView(8)
+                detailsPage.tabs.goToLandlordDetails()
+
+                val firstCard = detailsPage.landlordSummaryCards[0]
+                val actionLink = firstCard.getAction("View landlord record").link
+                assertThat(actionLink).hasAttribute(
+                    "href",
+                    Pattern.compile("/local-council/landlord-details/1.*"),
+                )
+                assertThat(actionLink).hasAttribute("target", "_blank")
+                assertThat(actionLink).hasAttribute("rel", "noreferrer noopener")
+            }
+        }
+
+        @Nested
+        inner class LandlordDetailsJointLandlordsDisabled {
+            @Test
+            fun `in the landlord details section the landlord name link goes the local council view of landlord details`(page: Page) {
+                featureFlagManager.disableFeature(JOINT_LANDLORDS)
+                val detailsPage = navigator.goToPropertyDetailsLocalCouncilView(1)
+                detailsPage.tabs.goToLandlordDetails()
+
+                detailsPage.landlordSummaryList.nameRow
+                    .valueLinkByText("Alexander Smith")
+                    .clickAndWait()
+
+                val landlordDetailsPage = assertPageIs(page, LocalCouncilViewLandlordDetailsPage::class, mapOf("id" to "1"))
+
+                landlordDetailsPage.backLink.clickAndWait()
+                val detailsPageAfterBack =
+                    assertPageIs(
+                        page,
+                        PropertyDetailsPageLocalCouncilView::class,
+                        mapOf("propertyOwnershipId" to "1"),
+                    )
+                assertEquals(LANDLORD_DETAILS_FRAGMENT, detailsPageAfterBack.tabs.activeTabPanelId)
+            }
         }
 
         // Test properties used for notification banner tests:

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/PropertyDetailsPageLandlordView.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/PropertyDetailsPageLandlordView.kt
@@ -54,13 +54,6 @@ class PropertyDetailsPageLandlordView(
     class LandlordSummaryCard(
         locator: Locator,
     ) : SummaryCard(locator) {
-        constructor(page: Page, title: String) : this(
-            page.locator(
-                ".govuk-summary-card",
-                Page.LocatorOptions().setHasText(title),
-            ),
-        )
-
         override val summaryList = LandlordCardSummaryList(locator)
     }
 

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/PropertyDetailsPageLocalCouncilView.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/PropertyDetailsPageLocalCouncilView.kt
@@ -1,8 +1,11 @@
 package uk.gov.communities.prsdb.webapp.integration.pageObjects.pages
 
+import com.microsoft.playwright.Locator
 import com.microsoft.playwright.Page
 import uk.gov.communities.prsdb.webapp.controllers.PropertyDetailsController
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.NotificationBanner
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.SummaryCard
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.SummaryList
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages.PropertyDetailsBasePage
 
 class PropertyDetailsPageLocalCouncilView(
@@ -18,4 +21,25 @@ class PropertyDetailsPageLocalCouncilView(
     val lastModifiedInsetText = page.locator(".govuk-inset-text:not(.govuk-tabs__panel .govuk-inset-text)")
 
     val notificationBanner = NotificationBanner(page)
+
+    val landlordSummaryCards: List<LandlordSummaryCard>
+        get() {
+            val count = page.locator("#landlord-details .govuk-summary-card").count()
+            return (0 until count).map { LandlordSummaryCard(page.locator("#landlord-details .govuk-summary-card").nth(it)) }
+        }
+
+    class LandlordSummaryCard(
+        locator: Locator,
+    ) : SummaryCard(locator) {
+        override val summaryList = LandlordCardSummaryList(locator)
+    }
+
+    class LandlordCardSummaryList(
+        locator: Locator,
+    ) : SummaryList(locator) {
+        val registrationNumberRow = getRow("Landlord Registration Number")
+        val emailAddressRow = getRow("Email address")
+        val contactNumberRow = getRow("Contact number")
+        val contactAddressRow = getRow("Contact address")
+    }
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/summaryModels/PropertyDetailsLandlordViewModelBuilderTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/summaryModels/PropertyDetailsLandlordViewModelBuilderTests.kt
@@ -278,4 +278,70 @@ class PropertyDetailsLandlordViewModelBuilderTests {
             assertEquals("Zack Anderson", cards[2].title)
         }
     }
+
+    @Nested
+    inner class BuildLocalCouncilSummaryCardsTests {
+        @Test
+        fun `returns cards sorted alphabetically by landlord name`() {
+            val landlords =
+                setOf(
+                    MockLandlordData.createLandlord(name = "Zoe Adams"),
+                    MockLandlordData.createLandlord(name = "Alice Brown"),
+                    MockLandlordData.createLandlord(name = "Mike Clark"),
+                )
+
+            val cards =
+                PropertyDetailsLandlordViewModelBuilder.buildLocalCouncilSummaryCards(
+                    landlords,
+                    landlordDetailsUrlProvider = { "/local-council/landlord-details/${it.id}" },
+                )
+
+            assertEquals(3, cards.size)
+            assertEquals("Alice Brown", cards[0].title)
+            assertEquals("Mike Clark", cards[1].title)
+            assertEquals("Zoe Adams", cards[2].title)
+        }
+
+        @Test
+        fun `each card contains LRN, email, phone, and contact address rows`() {
+            val landlord =
+                MockLandlordData.createLandlord(
+                    name = "John Smith",
+                    email = "john@example.com",
+                    phoneNumber = "07712345678",
+                )
+
+            val cards =
+                PropertyDetailsLandlordViewModelBuilder.buildLocalCouncilSummaryCards(
+                    setOf(landlord),
+                    landlordDetailsUrlProvider = { "/local-council/landlord-details/${it.id}" },
+                )
+
+            val card = cards.single()
+            assertEquals(4, card.summaryList.size)
+            assertEquals("landlordDetails.personalDetails.lrn", card.summaryList[0].fieldHeading)
+            assertEquals("landlordDetails.personalDetails.emailAddress", card.summaryList[1].fieldHeading)
+            assertEquals("john@example.com", card.summaryList[1].fieldValue)
+            assertEquals("propertyDetails.landlordDetails.contactNumber", card.summaryList[2].fieldHeading)
+            assertEquals("07712345678", card.summaryList[2].fieldValue)
+            assertEquals("landlordDetails.personalDetails.contactAddress", card.summaryList[3].fieldHeading)
+        }
+
+        @Test
+        fun `each card has a view landlord record action that opens in new tab`() {
+            val landlord = MockLandlordData.createLandlord(name = "John Smith")
+
+            val cards =
+                PropertyDetailsLandlordViewModelBuilder.buildLocalCouncilSummaryCards(
+                    setOf(landlord),
+                    landlordDetailsUrlProvider = { "/local-council/landlord-details/${it.id}" },
+                )
+
+            val card = cards.single()
+            assertEquals(1, card.actions!!.size)
+            assertEquals("propertyDetails.landlordDetails.registeredLandlords.viewLandlordRecord", card.actions!![0].text)
+            assertEquals("/local-council/landlord-details/${landlord.id}", card.actions!![0].url)
+            assertEquals(true, card.actions!![0].opensInNewTab)
+        }
+    }
 }


### PR DESCRIPTION
## Ticket number

PDJB-426

## Goal of change

Show multiple landlord summary cards in the local council property details view when the joint-landlords feature flag is enabled.

## Description of main change(s)

- Update the local council view of the property record to show multiple landlords using a summary card (when joint landlords is switched on)
- Make the property address at the top of the record multiline

<img width="705" height="1108" alt="image" src="https://github.com/user-attachments/assets/7927af7d-c2c2-4f43-8c9f-e4f2e585ecb9" />

## Checklist

- [x] Screenshots of any UI changes have been added
- [x] Unit tests for new logic (e.g. new service methods) have been added
- [x] Single page integration tests have been added for any unhappy-flow UI features, e.g. validation errors
- [x] Test suite has been run in full locally and is passing
- [x] Branch has been rebased onto main and run locally, with everything working as expected (both for your new feature and any related functionality)
- [x] TODO comments referencing this JIRA ticket have been searched for and removed - if a future PR will address them, mention that here
- [ ] QA instructions have been added to the ticket (particularly if this is the last PR required to complete the ticket)