### PR TITLE
PDJB-1179: Add skeleton organisation charity questions

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/acceptOrRejectJointLandlordInvitation/AcceptOrRejectJointLandlordInvitationJourneyFactory.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/acceptOrRejectJointLandlordInvitation/AcceptOrRejectJointLandlordInvitationJourneyFactory.kt
@@ -38,6 +38,8 @@ import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.
 import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.LandlordTypeStep
 import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.NonEnglandOrWalesAddressStep
 import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.OrgAddressStep
+import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.OrgCharityNumberStep
+import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.OrgCharityRegisteredWithStep
 import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.OrgCharityStep
 import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.OrgCompaniesHouseStep
 import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.OrgDirectorsStep
@@ -222,6 +224,8 @@ class AcceptOrRejectJointLandlordInvitationJourney(
     override val orgTypeStep: OrgTypeStep,
     override val orgCompaniesHouseStep: OrgCompaniesHouseStep,
     override val orgCharityStep: OrgCharityStep,
+    override val orgCharityRegisteredWithStep: OrgCharityRegisteredWithStep,
+    override val orgCharityNumberStep: OrgCharityNumberStep,
     override val orgDirectorsStep: OrgDirectorsStep,
     override val orgTrusteesStep: OrgTrusteesStep,
     override val orgMainContactStep: OrgMainContactStep,

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/landlordRegistration/LandlordRegistrationJourneyFactory.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/landlordRegistration/LandlordRegistrationJourneyFactory.kt
@@ -24,6 +24,8 @@ import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.
 import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.LandlordTypeStep
 import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.NonEnglandOrWalesAddressStep
 import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.OrgAddressStep
+import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.OrgCharityNumberStep
+import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.OrgCharityRegisteredWithStep
 import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.OrgCharityStep
 import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.OrgCompaniesHouseStep
 import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.OrgDirectorsStep
@@ -130,6 +132,8 @@ class LandlordRegistrationJourney(
     override val orgTypeStep: OrgTypeStep,
     override val orgCompaniesHouseStep: OrgCompaniesHouseStep,
     override val orgCharityStep: OrgCharityStep,
+    override val orgCharityRegisteredWithStep: OrgCharityRegisteredWithStep,
+    override val orgCharityNumberStep: OrgCharityNumberStep,
     override val orgDirectorsStep: OrgDirectorsStep,
     override val orgTrusteesStep: OrgTrusteesStep,
     override val orgMainContactStep: OrgMainContactStep,

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/landlordRegistration/states/LandlordRegistrationOrgLandlordState.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/landlordRegistration/states/LandlordRegistrationOrgLandlordState.kt
@@ -2,6 +2,8 @@ package uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.states
 
 import uk.gov.communities.prsdb.webapp.journeys.JourneyState
 import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.OrgAddressStep
+import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.OrgCharityNumberStep
+import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.OrgCharityRegisteredWithStep
 import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.OrgCharityStep
 import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.OrgCompaniesHouseStep
 import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.OrgDirectorsStep
@@ -25,6 +27,8 @@ interface LandlordRegistrationOrgLandlordState : JourneyState {
     val orgTypeStep: OrgTypeStep
     val orgCompaniesHouseStep: OrgCompaniesHouseStep
     val orgCharityStep: OrgCharityStep
+    val orgCharityRegisteredWithStep: OrgCharityRegisteredWithStep
+    val orgCharityNumberStep: OrgCharityNumberStep
     val orgDirectorsStep: OrgDirectorsStep
     val orgTrusteesStep: OrgTrusteesStep
     val orgMainContactStep: OrgMainContactStep

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/landlordRegistration/stepConfig/OrgCharityNumberStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/landlordRegistration/stepConfig/OrgCharityNumberStepConfig.kt
@@ -1,0 +1,29 @@
+package uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig
+
+import uk.gov.communities.prsdb.webapp.annotations.webAnnotations.JourneyFrameworkComponent
+import uk.gov.communities.prsdb.webapp.journeys.AbstractRequestableStepConfig
+import uk.gov.communities.prsdb.webapp.journeys.JourneyState
+import uk.gov.communities.prsdb.webapp.journeys.JourneyStep.RequestableStep
+import uk.gov.communities.prsdb.webapp.journeys.shared.Complete
+import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.NoInputFormModel
+
+@JourneyFrameworkComponent
+class OrgCharityNumberStepConfig : AbstractRequestableStepConfig<Complete, NoInputFormModel, JourneyState>() {
+    override val formModelClass = NoInputFormModel::class
+
+    override fun getStepSpecificContent(state: JourneyState) =
+        mapOf("todoComment" to "TODO: PDJB-1142 - What is your organisation's charity number")
+
+    override fun chooseTemplate(state: JourneyState) = "forms/todo"
+
+    override fun mode(state: JourneyState) = getFormModelFromStateOrNull(state)?.let { Complete.COMPLETE }
+}
+
+@JourneyFrameworkComponent
+final class OrgCharityNumberStep(
+    stepConfig: OrgCharityNumberStepConfig,
+) : RequestableStep<Complete, NoInputFormModel, JourneyState>(stepConfig) {
+    companion object {
+        const val ROUTE_SEGMENT = "organisation-charity-number"
+    }
+}

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/landlordRegistration/stepConfig/OrgCharityRegisteredWithStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/landlordRegistration/stepConfig/OrgCharityRegisteredWithStepConfig.kt
@@ -1,0 +1,29 @@
+package uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig
+
+import uk.gov.communities.prsdb.webapp.annotations.webAnnotations.JourneyFrameworkComponent
+import uk.gov.communities.prsdb.webapp.journeys.AbstractRequestableStepConfig
+import uk.gov.communities.prsdb.webapp.journeys.JourneyState
+import uk.gov.communities.prsdb.webapp.journeys.JourneyStep.RequestableStep
+import uk.gov.communities.prsdb.webapp.journeys.shared.Complete
+import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.NoInputFormModel
+
+@JourneyFrameworkComponent
+class OrgCharityRegisteredWithStepConfig : AbstractRequestableStepConfig<Complete, NoInputFormModel, JourneyState>() {
+    override val formModelClass = NoInputFormModel::class
+
+    override fun getStepSpecificContent(state: JourneyState) =
+        mapOf("todoComment" to "TODO: PDJB-1141 - Who is your charity registered with")
+
+    override fun chooseTemplate(state: JourneyState) = "forms/todo"
+
+    override fun mode(state: JourneyState) = getFormModelFromStateOrNull(state)?.let { Complete.COMPLETE }
+}
+
+@JourneyFrameworkComponent
+final class OrgCharityRegisteredWithStep(
+    stepConfig: OrgCharityRegisteredWithStepConfig,
+) : RequestableStep<Complete, NoInputFormModel, JourneyState>(stepConfig) {
+    companion object {
+        const val ROUTE_SEGMENT = "organisation-charity-registered-with"
+    }
+}

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/landlordRegistration/stepConfig/OrgCharityStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/landlordRegistration/stepConfig/OrgCharityStepConfig.kt
@@ -4,24 +4,34 @@ import uk.gov.communities.prsdb.webapp.annotations.webAnnotations.JourneyFramewo
 import uk.gov.communities.prsdb.webapp.journeys.AbstractRequestableStepConfig
 import uk.gov.communities.prsdb.webapp.journeys.JourneyState
 import uk.gov.communities.prsdb.webapp.journeys.JourneyStep.RequestableStep
-import uk.gov.communities.prsdb.webapp.journeys.shared.Complete
-import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.NoInputFormModel
+import uk.gov.communities.prsdb.webapp.journeys.shared.YesOrNo
+import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.OrgCharityFormModel
+import uk.gov.communities.prsdb.webapp.models.viewModels.formModels.RadiosViewModel
 
 @JourneyFrameworkComponent
-class OrgCharityStepConfig : AbstractRequestableStepConfig<Complete, NoInputFormModel, JourneyState>() {
-    override val formModelClass = NoInputFormModel::class
+class OrgCharityStepConfig : AbstractRequestableStepConfig<YesOrNo, OrgCharityFormModel, JourneyState>() {
+    override val formModelClass = OrgCharityFormModel::class
 
-    override fun getStepSpecificContent(state: JourneyState) = mapOf("todoComment" to "TODO: PDJB-1179 Organisation charity questions")
+    override fun getStepSpecificContent(state: JourneyState) =
+        mapOf(
+            "fieldSetHeading" to "forms.orgCharity.fieldSetHeading",
+            "fieldName" to "charity",
+            "radioOptions" to RadiosViewModel.yesOrNoRadios(),
+            "todoComment" to "TODO: PDJB-1140 - Is your organisation a registered charity",
+        )
 
-    override fun chooseTemplate(state: JourneyState) = "forms/todo"
+    override fun chooseTemplate(state: JourneyState) = "forms/todoWithRadios"
 
-    override fun mode(state: JourneyState) = getFormModelFromStateOrNull(state)?.let { Complete.COMPLETE }
+    override fun mode(state: JourneyState) =
+        getFormModelFromStateOrNull(state)?.charity?.let {
+            if (it) YesOrNo.YES else YesOrNo.NO
+        }
 }
 
 @JourneyFrameworkComponent
 final class OrgCharityStep(
     stepConfig: OrgCharityStepConfig,
-) : RequestableStep<Complete, NoInputFormModel, JourneyState>(stepConfig) {
+) : RequestableStep<YesOrNo, OrgCharityFormModel, JourneyState>(stepConfig) {
     companion object {
         const val ROUTE_SEGMENT = "organisation-charity"
     }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/landlordRegistration/tasks/OrgLandlordRegistrationTask.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/landlordRegistration/tasks/OrgLandlordRegistrationTask.kt
@@ -1,10 +1,15 @@
 package uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.tasks
 
 import uk.gov.communities.prsdb.webapp.annotations.webAnnotations.JourneyFrameworkComponent
+import uk.gov.communities.prsdb.webapp.journeys.Destination
+import uk.gov.communities.prsdb.webapp.journeys.OrParents
 import uk.gov.communities.prsdb.webapp.journeys.Task
+import uk.gov.communities.prsdb.webapp.journeys.hasOutcome
 import uk.gov.communities.prsdb.webapp.journeys.isComplete
 import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.states.LandlordRegistrationOrgLandlordState
 import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.OrgAddressStep
+import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.OrgCharityNumberStep
+import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.OrgCharityRegisteredWithStep
 import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.OrgCharityStep
 import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.OrgCompaniesHouseStep
 import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.OrgDirectorsStep
@@ -16,6 +21,7 @@ import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.
 import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.OrgTrusteesStep
 import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.OrgTypeStep
 import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.YourDetailsStep
+import uk.gov.communities.prsdb.webapp.journeys.shared.YesOrNo
 
 @JourneyFrameworkComponent
 class OrgLandlordRegistrationTask : Task<LandlordRegistrationOrgLandlordState>() {
@@ -58,11 +64,31 @@ class OrgLandlordRegistrationTask : Task<LandlordRegistrationOrgLandlordState>()
             step(journey.orgCharityStep) {
                 routeSegment(OrgCharityStep.ROUTE_SEGMENT)
                 parents { journey.orgCompaniesHouseStep.isComplete() }
+                nextDestination { mode ->
+                    when (mode) {
+                        YesOrNo.YES -> Destination(journey.orgCharityRegisteredWithStep)
+                        YesOrNo.NO -> Destination(journey.orgDirectorsStep)
+                    }
+                }
+            }
+            step(journey.orgCharityRegisteredWithStep) {
+                routeSegment(OrgCharityRegisteredWithStep.ROUTE_SEGMENT)
+                parents { journey.orgCharityStep.hasOutcome(YesOrNo.YES) }
+                nextStep { journey.orgCharityNumberStep }
+            }
+            step(journey.orgCharityNumberStep) {
+                routeSegment(OrgCharityNumberStep.ROUTE_SEGMENT)
+                parents { journey.orgCharityRegisteredWithStep.isComplete() }
                 nextStep { journey.orgDirectorsStep }
             }
             step(journey.orgDirectorsStep) {
                 routeSegment(OrgDirectorsStep.ROUTE_SEGMENT)
-                parents { journey.orgCharityStep.isComplete() }
+                parents {
+                    OrParents(
+                        journey.orgCharityStep.hasOutcome(YesOrNo.NO),
+                        journey.orgCharityNumberStep.isComplete(),
+                    )
+                }
                 nextStep { journey.orgTrusteesStep }
             }
             step(journey.orgTrusteesStep) {

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/requestModels/formModels/OrgCharityFormModel.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/requestModels/formModels/OrgCharityFormModel.kt
@@ -1,0 +1,5 @@
+package uk.gov.communities.prsdb.webapp.models.requestModels.formModels
+
+class OrgCharityFormModel : FormModel {
+    var charity: Boolean? = null
+}

--- a/src/main/resources/messages/forms.yml
+++ b/src/main/resources/messages/forms.yml
@@ -54,6 +54,8 @@ phoneNumber:
   error:
     missing: Enter a phone number
     invalidFormat: Enter a phone number including the country code for international numbers
+orgCharity:
+  fieldSetHeading: 'TODO PDJB-1140: Is your organisation a registered charity?'
 email:
   fieldSetHeading: What is your email address?
   fieldSetHint: We’ll use this to send you information and updates.


### PR DESCRIPTION
## Ticket number

[PDJB-1179](https://mhclgdigital.atlassian.net/browse/PDJB-1179)

## Goal of change

adds skeleton org landlord charity questions

<details><summary>screenshots</summary>
<img alt="is charity" src="https://github.com/user-attachments/assets/0d3028e3-c326-434f-8337-673bd58bbe76" />

<img alt="where charity" src="https://github.com/user-attachments/assets/4e533a73-38a7-4c9b-afd0-366b8900586a" />

<img alt="charity number" src="https://github.com/user-attachments/assets/609f10db-31cb-4dbd-84ca-2e427dfa72cb" />
</details>

## Description of main change(s)

reworks existing charity todo question to have a choice

if yes, sends to the two following skeleton questions

## Anything you'd like to highlight to the reviewer?

by the letter of the figma design neither of the two follow up questions are predicated on the 'is org a charity' question being yes, but this seems wrong. I've tagged design on the ticket to confirm, but for now I've implemented the dependency as I suspect this is correct

## Checklist

Delete any that are not applicable, and add explanation below for any that are applicable but haven't been done

- [x] Screenshots of any UI changes have been added
- [x] Test suite has been run in full locally and is passing
- [x] Branch has been rebased onto main and run locally, with everything working as expected (both for your new feature
  and any related functionality) (not based on main)
- [x] TODO comments referencing this JIRA ticket have been searched for and removed - if a future PR will address them,
  mention that here
- [x] QA instructions have been added to the ticket (particularly if this is the last PR required to complete the ticket)
