### PR TITLE
Chore/pdjb 1069 remove misc references to primaryLandlord

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/PropertyDetailsController.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/PropertyDetailsController.kt
@@ -98,7 +98,7 @@ class PropertyDetailsController(
         } else {
             val landlordViewModel =
                 PropertyDetailsLandlordViewModelBuilder.fromEntity(
-                    propertyOwnership.primaryLandlord,
+                    propertyOwnership.landlords.first(),
                     landlordDetailsUrl,
                 )
             modelAndView.addObject("landlordDetails", landlordViewModel)

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/switchToIndividual/stepConfig/CompleteSwitchToIndividualStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/switchToIndividual/stepConfig/CompleteSwitchToIndividualStepConfig.kt
@@ -38,11 +38,10 @@ class CompleteSwitchToIndividualStepConfig(
         val pendingInvitations = jointLandlordInvitationService.getPendingInvitations(propertyOwnership)
         val propertyAddress = propertyOwnership.address.toMultiLineAddress()
 
-        val landlord = propertyOwnership.primaryLandlord
-
         propertyOwnershipService.markAsNotJointLandlord(propertyOwnership)
         jointLandlordInvitationService.removeInvitations(pendingInvitations)
 
+        val landlord = propertyOwnership.landlords.single()
         switchToIndividualConfirmationEmailSender.sendEmail(
             landlord.email,
             SwitchToIndividualConfirmationEmail(landlordName = landlord.name, propertyAddress = propertyAddress),

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/switchToIndividual/stepConfig/CompleteSwitchToIndividualStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/switchToIndividual/stepConfig/CompleteSwitchToIndividualStepConfig.kt
@@ -41,7 +41,7 @@ class CompleteSwitchToIndividualStepConfig(
         propertyOwnershipService.markAsNotJointLandlord(propertyOwnership)
         jointLandlordInvitationService.removeInvitations(pendingInvitations)
 
-        val landlord = propertyOwnership.landlords.single()
+        val landlord = propertyOwnership.landlords.first()
         switchToIndividualConfirmationEmailSender.sendEmail(
             landlord.email,
             SwitchToIndividualConfirmationEmail(landlordName = landlord.name, propertyAddress = propertyAddress),

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/switchToIndividual/stepConfig/CompleteSwitchToIndividualStepConfigTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/switchToIndividual/stepConfig/CompleteSwitchToIndividualStepConfigTests.kt
@@ -164,7 +164,7 @@ class CompleteSwitchToIndividualStepConfigTests {
         stepConfig.afterStepIsReached(mockState)
 
         verify(mockSwitchToIndividualConfirmationEmailSender).sendEmail(
-            eq(propertyOwnership.primaryLandlord.email),
+            eq(propertyOwnership.landlords.first().email),
             any<SwitchToIndividualConfirmationEmail>(),
         )
     }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/urlProviders/LandlordDashboardUrlTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/urlProviders/LandlordDashboardUrlTests.kt
@@ -171,7 +171,8 @@ class LandlordDashboardUrlTests(
     @WithMockUser(roles = ["LANDLORD"])
     fun `The sign in url generated when a property is registered is routed to the landlord dashboard`() {
         // Arrange
-        val propertyOwnership = createPropertyOwnership()
+        val landlord = createLandlord()
+        val propertyOwnership = createPropertyOwnership(landlords = mutableSetOf(landlord))
         val mockLandlordRepository = mock<LandlordRepository>()
         val propertyRegistrationService =
             PropertyRegistrationService(
@@ -187,7 +188,7 @@ class LandlordDashboardUrlTests(
                 propertyComplianceService = mock(),
             )
 
-        whenever(mockLandlordRepository.findByBaseUser_Id(any())).thenReturn(propertyOwnership.primaryLandlord)
+        whenever(mockLandlordRepository.findByBaseUser_Id(any())).thenReturn(landlord)
         whenever(
             mockPropertyOwnershipService.createPropertyOwnership(
                 anyOrNull(),
@@ -226,7 +227,7 @@ class LandlordDashboardUrlTests(
             ownershipType = propertyOwnership.ownershipType,
             numberOfHouseholds = propertyOwnership.currentNumHouseholds,
             numberOfPeople = propertyOwnership.currentNumTenants,
-            baseUserId = propertyOwnership.primaryLandlord.baseUser.id,
+            baseUserId = landlord.baseUser.id,
             numBedrooms = propertyOwnership.numBedrooms,
             billsIncludedList = propertyOwnership.billsIncludedList,
             customBillsIncluded = propertyOwnership.customBillsIncluded,


### PR DESCRIPTION
## Ticket number

PDJB-1069

## Goal of change

Remove more references to primaryLandlord

## Description of main change(s)

primaryLandlord removed from
* CompleteSwitchToIndividualStepConfig
* Property details, landlords tab, joint landlords off

## Anything you'd like to highlight to the reviewer?

More to come in other PRs

## Checklist

Delete any that are not applicable, and add explanation below for any that are applicable but haven't been done

- [x] Test suite has been run in full locally and is passing
