### PR TITLE
Chore/pdjb 1069 remove primaryLandlord references from emails

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/PropertyComplianceService.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/PropertyComplianceService.kt
@@ -375,6 +375,8 @@ class PropertyComplianceService(
                     "No landlord matching the logged in user $loggedInBaseUserId was found for property ${propertyOwnership.id}",
                 )
 
+        // TODO PDJB-1216 - send a different notification email to other landlords on the property
+
         complianceUpdateConfirmationSender.sendEmail(
             landlord.email,
             ComplianceUpdateConfirmationEmail(

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/PropertyComplianceService.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/PropertyComplianceService.kt
@@ -5,6 +5,7 @@ import jakarta.transaction.Transactional
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.PageImpl
 import org.springframework.data.domain.PageRequest
+import org.springframework.security.core.context.SecurityContextHolder
 import uk.gov.communities.prsdb.webapp.annotations.webAnnotations.PrsdbWebService
 import uk.gov.communities.prsdb.webapp.constants.MAX_ENTRIES_IN_COMPLIANCE_ACTIONS_PAGE
 import uk.gov.communities.prsdb.webapp.constants.PROVIDE_LATER_DEADLINE_DAYS
@@ -15,6 +16,7 @@ import uk.gov.communities.prsdb.webapp.database.entity.PropertyCompliance
 import uk.gov.communities.prsdb.webapp.database.repository.FileUploadRepository
 import uk.gov.communities.prsdb.webapp.database.repository.PropertyComplianceRepository
 import uk.gov.communities.prsdb.webapp.database.repository.PropertyOwnershipRepository
+import uk.gov.communities.prsdb.webapp.exceptions.PrsdbWebException
 import uk.gov.communities.prsdb.webapp.exceptions.UpdateConflictException
 import uk.gov.communities.prsdb.webapp.models.dataModels.ComplianceStatusDataModel
 import uk.gov.communities.prsdb.webapp.models.dataModels.RegistrationNumberDataModel
@@ -366,11 +368,17 @@ class PropertyComplianceService(
 
         val propertyOwnership = propertyCompliance.propertyOwnership
 
-        // TODO PDJB-321 - do not use primary landlord
+        val loggedInBaseUserId = SecurityContextHolder.getContext().authentication.name
+        val landlord =
+            propertyOwnership.landlords.singleOrNull { it.baseUser.id == loggedInBaseUserId }
+                ?: throw PrsdbWebException(
+                    "No landlord matching the logged in user $loggedInBaseUserId was found for property ${propertyOwnership.id}",
+                )
+
         complianceUpdateConfirmationSender.sendEmail(
-            propertyOwnership.primaryLandlord.email,
+            landlord.email,
             ComplianceUpdateConfirmationEmail(
-                landlordName = propertyOwnership.primaryLandlord.name,
+                landlordName = landlord.name,
                 multiLineAddress = propertyOwnership.address.toMultiLineAddress(),
                 registrationNumber = RegistrationNumberDataModel.fromRegistrationNumber(propertyOwnership.registrationNumber),
                 dashboardUrl = absoluteUrlProvider.buildLandlordDashboardUri(),

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/VirusNotificationEmailHandler.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/VirusNotificationEmailHandler.kt
@@ -38,8 +38,13 @@ class VirusNotificationEmailHandler(
 
         val email = buildAlertEmail(ownership, notification.certificateType)
 
-        // TODO PDJB-1069 - do not use primary landlord
-        emailNotificationService.sendEmail(emailAddress ?: ownership.primaryLandlord.email, email)
+        if (emailAddress != null) {
+            emailNotificationService.sendEmail(emailAddress, email)
+        } else {
+            ownership.landlords.forEach { landlord ->
+                emailNotificationService.sendEmail(landlord.email, email)
+            }
+        }
     }
 
     private fun sendAlertToMonitoringTeam(notification: VirusMonitoringEmailNotification) =

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/VirusNotificationEmailHandler.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/VirusNotificationEmailHandler.kt
@@ -22,7 +22,7 @@ class VirusNotificationEmailHandler(
 ) {
     fun handleCallback(callback: VirusScanCallback) =
         when (val callbackData = Json.decodeFromString<EmailNotificationData>(callback.encodedCallbackData)) {
-            is OwnerEmailNotification -> sendAlertToOwner(callbackData)
+            is OwnerEmailNotification -> sendAlertToOwners(callbackData)
 
             is VirusMonitoringEmailNotification -> sendAlertToMonitoringTeam(callbackData)
 
@@ -30,7 +30,7 @@ class VirusNotificationEmailHandler(
             is IncompletePropertyEmailNotification -> TODO("PDJB-717")
         }
 
-    private fun sendAlertToOwner(
+    private fun sendAlertToOwners(
         notification: OwnerEmailNotification,
         emailAddress: String? = null,
     ) {
@@ -50,7 +50,7 @@ class VirusNotificationEmailHandler(
     private fun sendAlertToMonitoringTeam(notification: VirusMonitoringEmailNotification) =
         when (val internalNotification = notification.internalEmailData) {
             is OwnerEmailNotification -> {
-                sendAlertToOwner(internalNotification, virusMonitoringEmail)
+                sendAlertToOwners(internalNotification, virusMonitoringEmail)
             }
 
             is IncompletePropertyEmailNotification -> {

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/PropertyComplianceServiceTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/PropertyComplianceServiceTests.kt
@@ -4,6 +4,7 @@ import jakarta.persistence.EntityNotFoundException
 import kotlinx.datetime.DateTimeUnit.Companion.DAY
 import kotlinx.datetime.minus
 import kotlinx.datetime.toJavaLocalDate
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
@@ -19,9 +20,13 @@ import org.mockito.Mockito.lenient
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.any
 import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
+import org.springframework.security.core.Authentication
+import org.springframework.security.core.context.SecurityContext
+import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.test.util.ReflectionTestUtils
 import uk.gov.communities.prsdb.webapp.constants.PROVIDE_LATER_DEADLINE_DAYS
 import uk.gov.communities.prsdb.webapp.constants.enums.CertificateType
@@ -76,7 +81,9 @@ class PropertyComplianceServiceTests {
 
     private val propertyOwnershipId = 1L
     private val initialLastModifiedDate = Instant.parse("2025-01-01T00:00:00Z")
-    private val mockPropertyOwnership = MockLandlordData.createPropertyOwnership()
+    private val loggedInBaseUserId = "logged-in-base-user-id"
+    private val mockLoggedInLandlord = MockLandlordData.createLandlord(baseUser = MockLandlordData.createPrsdbUser(loggedInBaseUserId))
+    private val mockPropertyOwnership = MockLandlordData.createPropertyOwnership(landlords = mutableSetOf(mockLoggedInLandlord))
     private val dateFormatter = DateTimeFormatter.ofPattern("d MMMM yyyy", Locale.UK)
 
     private fun createComplianceWithLastModifiedDate(lastModifiedDate: Instant = initialLastModifiedDate): PropertyCompliance {
@@ -93,6 +100,19 @@ class PropertyComplianceServiceTests {
             .`when`(
                 mockAbsoluteUrlProvider.buildComplianceInformationUri(any<Long>()),
             ).thenReturn(URI("https://test.example.com/compliance"))
+    }
+
+    @AfterEach
+    fun tearDown() {
+        SecurityContextHolder.clearContext()
+    }
+
+    private fun setMockPrincipal() {
+        val authentication = mock<Authentication>()
+        whenever(authentication.name).thenReturn(loggedInBaseUserId)
+        val context = mock<SecurityContext>()
+        whenever(context.authentication).thenReturn(authentication)
+        SecurityContextHolder.setContext(context)
     }
 
     @Test
@@ -245,17 +265,16 @@ class PropertyComplianceServiceTests {
         assertEquals(expectedNonCompliantProperties, returnedNonCompliantProperties.content)
     }
 
-    companion object {
-        private fun createOccupiedPropertyOwnership() =
-            MockLandlordData.createPropertyOwnership(
-                currentNumHouseholds = 1,
-                currentNumTenants = 1,
-                numberOfBedrooms = 2,
-                furnishedStatus = FurnishedStatus.FURNISHED,
-                rentFrequency = RentFrequency.MONTHLY,
-                rentAmount = BigDecimal("1000"),
-            )
-    }
+    private fun createOccupiedPropertyOwnership() =
+        MockLandlordData.createPropertyOwnership(
+            landlords = mutableSetOf(mockLoggedInLandlord),
+            currentNumHouseholds = 1,
+            currentNumTenants = 1,
+            numberOfBedrooms = 2,
+            furnishedStatus = FurnishedStatus.FURNISHED,
+            rentFrequency = RentFrequency.MONTHLY,
+            rentAmount = BigDecimal("1000"),
+        )
 
     @Nested
     inner class SaveRegistrationComplianceData {
@@ -495,6 +514,7 @@ class PropertyComplianceServiceTests {
     inner class UpdateGasSafety {
         @Test
         fun `updates gas safety fields on the compliance record`() {
+            setMockPrincipal()
             val gasUpload1 = FileUpload(FileUploadStatus.QUARANTINED, "gas-1", "pdf", "etag1", "v1")
             val gasUpload2 = FileUpload(FileUploadStatus.QUARANTINED, "gas-2", "pdf", "etag2", "v2")
             val issueDate = LocalDate.of(2025, 6, 15)
@@ -545,6 +565,7 @@ class PropertyComplianceServiceTests {
 
         @Test
         fun `resets gasSafetyCertProvideLater to null when gas safety is updated`() {
+            setMockPrincipal()
             val compliance = createComplianceWithLastModifiedDate()
             compliance.gasSafetyCertProvideLater = true
 
@@ -567,6 +588,7 @@ class PropertyComplianceServiceTests {
 
         @Test
         fun `sets up virus scan callbacks for gas safety uploads`() {
+            setMockPrincipal()
             val gasUpload = FileUpload(FileUploadStatus.QUARANTINED, "gas-1", "pdf", "etag1", "v1")
             val compliance = createComplianceWithLastModifiedDate()
 
@@ -591,6 +613,7 @@ class PropertyComplianceServiceTests {
 
         @Test
         fun `does not set up virus scan callbacks for electrical safety`() {
+            setMockPrincipal()
             val gasUpload = FileUpload(FileUploadStatus.QUARANTINED, "gas-1", "pdf", "etag1", "v1")
             val compliance = createComplianceWithLastModifiedDate()
 
@@ -666,6 +689,7 @@ class PropertyComplianceServiceTests {
 
         @Test
         fun `sends valid gas safety confirmation email when certificate is uploaded and not expired`() {
+            setMockPrincipal()
             val gasUpload = FileUpload(FileUploadStatus.QUARANTINED, "gas-1", "pdf", "etag1", "v1")
             val compliance = createComplianceWithLastModifiedDate()
             val issueDate = LocalDate.now()
@@ -685,10 +709,10 @@ class PropertyComplianceServiceTests {
             )
 
             verify(mockComplianceUpdateConfirmationSender).sendEmail(
-                eq(mockPropertyOwnership.primaryLandlord.email),
+                eq(mockLoggedInLandlord.email),
                 eq(
                     ComplianceUpdateConfirmationEmail(
-                        landlordName = mockPropertyOwnership.primaryLandlord.name,
+                        landlordName = mockLoggedInLandlord.name,
                         multiLineAddress = mockPropertyOwnership.address.toMultiLineAddress(),
                         registrationNumber = RegistrationNumberDataModel.fromRegistrationNumber(mockPropertyOwnership.registrationNumber),
                         dashboardUrl = URI("https://test.example.com"),
@@ -704,6 +728,7 @@ class PropertyComplianceServiceTests {
 
         @Test
         fun `sends expired unoccupied gas safety confirmation email when certificate is expired and property is unoccupied`() {
+            setMockPrincipal()
             val gasUpload = FileUpload(FileUploadStatus.QUARANTINED, "gas-1", "pdf", "etag1", "v1")
             val compliance = createComplianceWithLastModifiedDate()
 
@@ -723,10 +748,10 @@ class PropertyComplianceServiceTests {
             )
 
             verify(mockComplianceUpdateConfirmationSender).sendEmail(
-                eq(mockPropertyOwnership.primaryLandlord.email),
+                eq(mockLoggedInLandlord.email),
                 eq(
                     ComplianceUpdateConfirmationEmail(
-                        landlordName = mockPropertyOwnership.primaryLandlord.name,
+                        landlordName = mockLoggedInLandlord.name,
                         multiLineAddress = mockPropertyOwnership.address.toMultiLineAddress(),
                         registrationNumber = RegistrationNumberDataModel.fromRegistrationNumber(mockPropertyOwnership.registrationNumber),
                         dashboardUrl = URI("https://test.example.com"),
@@ -741,6 +766,7 @@ class PropertyComplianceServiceTests {
 
         @Test
         fun `sends expired occupied gas safety confirmation email when certificate is expired and property is occupied`() {
+            setMockPrincipal()
             val gasUpload = FileUpload(FileUploadStatus.QUARANTINED, "gas-1", "pdf", "etag1", "v1")
             val occupiedPropertyOwnership = createOccupiedPropertyOwnership()
             val compliance =
@@ -764,10 +790,10 @@ class PropertyComplianceServiceTests {
             )
 
             verify(mockComplianceUpdateConfirmationSender).sendEmail(
-                eq(occupiedPropertyOwnership.primaryLandlord.email),
+                eq(mockLoggedInLandlord.email),
                 eq(
                     ComplianceUpdateConfirmationEmail(
-                        landlordName = occupiedPropertyOwnership.primaryLandlord.name,
+                        landlordName = mockLoggedInLandlord.name,
                         multiLineAddress = occupiedPropertyOwnership.address.toMultiLineAddress(),
                         registrationNumber =
                             RegistrationNumberDataModel.fromRegistrationNumber(
@@ -786,6 +812,7 @@ class PropertyComplianceServiceTests {
 
         @Test
         fun `sends expired unoccupied gas safety confirmation email when certificate is expired and no uploads are provided`() {
+            setMockPrincipal()
             val compliance = createComplianceWithLastModifiedDate()
 
             whenever(mockPropertyComplianceRepository.findByPropertyOwnership_Id(propertyOwnershipId))
@@ -803,10 +830,10 @@ class PropertyComplianceServiceTests {
             )
 
             verify(mockComplianceUpdateConfirmationSender).sendEmail(
-                eq(mockPropertyOwnership.primaryLandlord.email),
+                eq(mockLoggedInLandlord.email),
                 eq(
                     ComplianceUpdateConfirmationEmail(
-                        landlordName = mockPropertyOwnership.primaryLandlord.name,
+                        landlordName = mockLoggedInLandlord.name,
                         multiLineAddress = mockPropertyOwnership.address.toMultiLineAddress(),
                         registrationNumber = RegistrationNumberDataModel.fromRegistrationNumber(mockPropertyOwnership.registrationNumber),
                         dashboardUrl = URI("https://test.example.com"),
@@ -821,6 +848,7 @@ class PropertyComplianceServiceTests {
 
         @Test
         fun `sends expired occupied gas safety confirmation email when certificate is expired and no uploads are provided`() {
+            setMockPrincipal()
             val occupiedPropertyOwnership = createOccupiedPropertyOwnership()
             val compliance =
                 MockPropertyComplianceData.createPropertyCompliance(propertyOwnership = occupiedPropertyOwnership)
@@ -842,10 +870,10 @@ class PropertyComplianceServiceTests {
             )
 
             verify(mockComplianceUpdateConfirmationSender).sendEmail(
-                eq(occupiedPropertyOwnership.primaryLandlord.email),
+                eq(mockLoggedInLandlord.email),
                 eq(
                     ComplianceUpdateConfirmationEmail(
-                        landlordName = occupiedPropertyOwnership.primaryLandlord.name,
+                        landlordName = mockLoggedInLandlord.name,
                         multiLineAddress = occupiedPropertyOwnership.address.toMultiLineAddress(),
                         registrationNumber =
                             RegistrationNumberDataModel.fromRegistrationNumber(
@@ -885,6 +913,7 @@ class PropertyComplianceServiceTests {
     inner class UpdateElectricalSafety {
         @Test
         fun `updates electrical safety fields on the compliance record`() {
+            setMockPrincipal()
             val eicrUpload1 = FileUpload(FileUploadStatus.QUARANTINED, "eicr-1", "pdf", "etag1", "v1")
             val eicrUpload2 = FileUpload(FileUploadStatus.QUARANTINED, "eicr-2", "pdf", "etag2", "v2")
             val expiryDate = LocalDate.of(2030, 3, 20)
@@ -915,6 +944,7 @@ class PropertyComplianceServiceTests {
 
         @Test
         fun `sets up virus scan callbacks for electrical safety uploads`() {
+            setMockPrincipal()
             val eicrUpload = FileUpload(FileUploadStatus.QUARANTINED, "eicr-1", "pdf", "etag1", "v1")
             val compliance = createComplianceWithLastModifiedDate()
 
@@ -939,6 +969,7 @@ class PropertyComplianceServiceTests {
 
         @Test
         fun `resets electricalSafetyCertProvideLater to null when electrical safety is updated`() {
+            setMockPrincipal()
             val compliance = createComplianceWithLastModifiedDate()
             compliance.electricalSafetyCertProvideLater = true
 
@@ -961,6 +992,7 @@ class PropertyComplianceServiceTests {
 
         @Test
         fun `does not set up virus scan callbacks for gas safety`() {
+            setMockPrincipal()
             val eicrUpload = FileUpload(FileUploadStatus.QUARANTINED, "eicr-1", "pdf", "etag1", "v1")
             val compliance = createComplianceWithLastModifiedDate()
 
@@ -1016,6 +1048,7 @@ class PropertyComplianceServiceTests {
 
         @Test
         fun `does not set up virus scan callbacks when no file uploads provided`() {
+            setMockPrincipal()
             val compliance = createComplianceWithLastModifiedDate()
 
             whenever(mockPropertyComplianceRepository.findByPropertyOwnership_Id(propertyOwnershipId))
@@ -1059,6 +1092,7 @@ class PropertyComplianceServiceTests {
 
         @Test
         fun `sends valid electrical safety confirmation email when certificate is uploaded and not expired`() {
+            setMockPrincipal()
             val eicrUpload = FileUpload(FileUploadStatus.QUARANTINED, "eicr-1", "pdf", "etag1", "v1")
             val compliance = createComplianceWithLastModifiedDate()
             val expiryDate = LocalDate.now().plusYears(1)
@@ -1078,10 +1112,10 @@ class PropertyComplianceServiceTests {
             )
 
             verify(mockComplianceUpdateConfirmationSender).sendEmail(
-                eq(mockPropertyOwnership.primaryLandlord.email),
+                eq(mockLoggedInLandlord.email),
                 eq(
                     ComplianceUpdateConfirmationEmail(
-                        landlordName = mockPropertyOwnership.primaryLandlord.name,
+                        landlordName = mockLoggedInLandlord.name,
                         multiLineAddress = mockPropertyOwnership.address.toMultiLineAddress(),
                         registrationNumber = RegistrationNumberDataModel.fromRegistrationNumber(mockPropertyOwnership.registrationNumber),
                         dashboardUrl = URI("https://test.example.com"),
@@ -1097,6 +1131,7 @@ class PropertyComplianceServiceTests {
 
         @Test
         fun `sends expired unoccupied electrical safety confirmation email when certificate is expired and property is unoccupied`() {
+            setMockPrincipal()
             val eicrUpload = FileUpload(FileUploadStatus.QUARANTINED, "eicr-1", "pdf", "etag1", "v1")
             val compliance = createComplianceWithLastModifiedDate()
             val expiryDate = LocalDate.now().minusDays(1)
@@ -1116,10 +1151,10 @@ class PropertyComplianceServiceTests {
             )
 
             verify(mockComplianceUpdateConfirmationSender).sendEmail(
-                eq(mockPropertyOwnership.primaryLandlord.email),
+                eq(mockLoggedInLandlord.email),
                 eq(
                     ComplianceUpdateConfirmationEmail(
-                        landlordName = mockPropertyOwnership.primaryLandlord.name,
+                        landlordName = mockLoggedInLandlord.name,
                         multiLineAddress = mockPropertyOwnership.address.toMultiLineAddress(),
                         registrationNumber = RegistrationNumberDataModel.fromRegistrationNumber(mockPropertyOwnership.registrationNumber),
                         dashboardUrl = URI("https://test.example.com"),
@@ -1134,6 +1169,7 @@ class PropertyComplianceServiceTests {
 
         @Test
         fun `sends expired occupied electrical safety confirmation email when certificate is expired and property is occupied`() {
+            setMockPrincipal()
             val eicrUpload = FileUpload(FileUploadStatus.QUARANTINED, "eicr-1", "pdf", "etag1", "v1")
             val occupiedPropertyOwnership = createOccupiedPropertyOwnership()
             val compliance =
@@ -1157,10 +1193,10 @@ class PropertyComplianceServiceTests {
             )
 
             verify(mockComplianceUpdateConfirmationSender).sendEmail(
-                eq(occupiedPropertyOwnership.primaryLandlord.email),
+                eq(mockLoggedInLandlord.email),
                 eq(
                     ComplianceUpdateConfirmationEmail(
-                        landlordName = occupiedPropertyOwnership.primaryLandlord.name,
+                        landlordName = mockLoggedInLandlord.name,
                         multiLineAddress = occupiedPropertyOwnership.address.toMultiLineAddress(),
                         registrationNumber =
                             RegistrationNumberDataModel.fromRegistrationNumber(
@@ -1179,6 +1215,7 @@ class PropertyComplianceServiceTests {
 
         @Test
         fun `sends expired unoccupied electrical safety confirmation email when certificate is expired and no uploads are provided`() {
+            setMockPrincipal()
             val compliance = createComplianceWithLastModifiedDate()
             val expiryDate = LocalDate.now().minusDays(1)
 
@@ -1196,10 +1233,10 @@ class PropertyComplianceServiceTests {
             )
 
             verify(mockComplianceUpdateConfirmationSender).sendEmail(
-                eq(mockPropertyOwnership.primaryLandlord.email),
+                eq(mockLoggedInLandlord.email),
                 eq(
                     ComplianceUpdateConfirmationEmail(
-                        landlordName = mockPropertyOwnership.primaryLandlord.name,
+                        landlordName = mockLoggedInLandlord.name,
                         multiLineAddress = mockPropertyOwnership.address.toMultiLineAddress(),
                         registrationNumber = RegistrationNumberDataModel.fromRegistrationNumber(mockPropertyOwnership.registrationNumber),
                         dashboardUrl = URI("https://test.example.com"),
@@ -1214,6 +1251,7 @@ class PropertyComplianceServiceTests {
 
         @Test
         fun `sends expired occupied electrical safety confirmation email when certificate is expired and no uploads are provided`() {
+            setMockPrincipal()
             val occupiedPropertyOwnership = createOccupiedPropertyOwnership()
             val compliance =
                 MockPropertyComplianceData.createPropertyCompliance(propertyOwnership = occupiedPropertyOwnership)
@@ -1235,10 +1273,10 @@ class PropertyComplianceServiceTests {
             )
 
             verify(mockComplianceUpdateConfirmationSender).sendEmail(
-                eq(occupiedPropertyOwnership.primaryLandlord.email),
+                eq(mockLoggedInLandlord.email),
                 eq(
                     ComplianceUpdateConfirmationEmail(
-                        landlordName = occupiedPropertyOwnership.primaryLandlord.name,
+                        landlordName = mockLoggedInLandlord.name,
                         multiLineAddress = occupiedPropertyOwnership.address.toMultiLineAddress(),
                         registrationNumber =
                             RegistrationNumberDataModel.fromRegistrationNumber(
@@ -1277,6 +1315,7 @@ class PropertyComplianceServiceTests {
     inner class UpdateEpc {
         @Test
         fun `updates EPC fields, mees exemption and tenancy check on the compliance record`() {
+            setMockPrincipal()
             val epcUrl = "https://example.com/epc/1234-5678-9012-3456-7890"
             val expiryDate = DateTimeHelper().getCurrentDateInUK().minus(5, DAY).toJavaLocalDate()
             val energyRating = "F"
@@ -1361,6 +1400,7 @@ class PropertyComplianceServiceTests {
 
         @Test
         fun `resets epcProvideLater to null when EPC is updated`() {
+            setMockPrincipal()
             val compliance = createComplianceWithLastModifiedDate()
             compliance.epcProvideLater = true
 
@@ -1416,6 +1456,7 @@ class PropertyComplianceServiceTests {
 
         @Test
         fun `sends valid EPC confirmation email when EPC URL is provided and not expired`() {
+            setMockPrincipal()
             val compliance = createComplianceWithLastModifiedDate()
             val expiryDate = LocalDate.now().plusYears(5)
 
@@ -1433,10 +1474,10 @@ class PropertyComplianceServiceTests {
             )
 
             verify(mockComplianceUpdateConfirmationSender).sendEmail(
-                eq(mockPropertyOwnership.primaryLandlord.email),
+                eq(mockLoggedInLandlord.email),
                 eq(
                     ComplianceUpdateConfirmationEmail(
-                        landlordName = mockPropertyOwnership.primaryLandlord.name,
+                        landlordName = mockLoggedInLandlord.name,
                         multiLineAddress = mockPropertyOwnership.address.toMultiLineAddress(),
                         registrationNumber = RegistrationNumberDataModel.fromRegistrationNumber(mockPropertyOwnership.registrationNumber),
                         dashboardUrl = URI("https://test.example.com"),
@@ -1452,6 +1493,7 @@ class PropertyComplianceServiceTests {
 
         @Test
         fun `sends expired unoccupied EPC confirmation email when EPC is expired and property is unoccupied`() {
+            setMockPrincipal()
             val compliance = createComplianceWithLastModifiedDate()
             val expiryDate = LocalDate.now().minusDays(1)
 
@@ -1469,10 +1511,10 @@ class PropertyComplianceServiceTests {
             )
 
             verify(mockComplianceUpdateConfirmationSender).sendEmail(
-                eq(mockPropertyOwnership.primaryLandlord.email),
+                eq(mockLoggedInLandlord.email),
                 eq(
                     ComplianceUpdateConfirmationEmail(
-                        landlordName = mockPropertyOwnership.primaryLandlord.name,
+                        landlordName = mockLoggedInLandlord.name,
                         multiLineAddress = mockPropertyOwnership.address.toMultiLineAddress(),
                         registrationNumber = RegistrationNumberDataModel.fromRegistrationNumber(mockPropertyOwnership.registrationNumber),
                         dashboardUrl = URI("https://test.example.com"),
@@ -1487,6 +1529,7 @@ class PropertyComplianceServiceTests {
 
         @Test
         fun `sends expired occupied EPC confirmation email when EPC is expired and property is occupied`() {
+            setMockPrincipal()
             val occupiedPropertyOwnership = createOccupiedPropertyOwnership()
             val compliance =
                 MockPropertyComplianceData.createPropertyCompliance(propertyOwnership = occupiedPropertyOwnership)
@@ -1508,10 +1551,10 @@ class PropertyComplianceServiceTests {
             )
 
             verify(mockComplianceUpdateConfirmationSender).sendEmail(
-                eq(occupiedPropertyOwnership.primaryLandlord.email),
+                eq(mockLoggedInLandlord.email),
                 eq(
                     ComplianceUpdateConfirmationEmail(
-                        landlordName = occupiedPropertyOwnership.primaryLandlord.name,
+                        landlordName = mockLoggedInLandlord.name,
                         multiLineAddress = occupiedPropertyOwnership.address.toMultiLineAddress(),
                         registrationNumber =
                             RegistrationNumberDataModel.fromRegistrationNumber(

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/VirusNotificationEmailHandlerTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/VirusNotificationEmailHandlerTests.kt
@@ -8,6 +8,7 @@ import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.MethodSource
 import org.mockito.Mockito.mock
 import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import uk.gov.communities.prsdb.webapp.constants.enums.CertificateType
@@ -66,7 +67,7 @@ class VirusNotificationEmailHandlerTests {
                 expectedSubject,
                 expectedHeading,
                 expectedBody,
-                "test@example.com",
+                listOf("test@example.com"),
             )
 
         // Act
@@ -80,25 +81,25 @@ class VirusNotificationEmailHandlerTests {
         )
 
         // Assert
-        assertEmailSentToAddress(virusMonitoringEmail, expectedEmail)
+        assertEmailSentToAddress(listOf(virusMonitoringEmail), expectedEmail)
     }
 
     @ParameterizedTest
     @MethodSource("certificateTestParameters")
-    fun `handleCallback for send owner email sends email to landlord`(
+    fun `handleCallback for send owner email sends email to every landlord on the property`(
         testType: CertificateType,
         expectedSubject: String,
         expectedHeading: String,
         expectedBody: String,
     ) {
         // Arrange
-        val landlordEmail = "landlord@example.com"
+        val landlordEmails = listOf("landlord1@example.com", "landlord2@example.com", "landlord3@example.com")
         val (ownershipId, expectedEmail) =
             arrangeOwnedPropertyUploadCallback(
                 expectedSubject,
                 expectedHeading,
                 expectedBody,
-                landlordEmail,
+                landlordEmails,
             )
 
         // Act
@@ -109,20 +110,20 @@ class VirusNotificationEmailHandlerTests {
         )
 
         // Assert
-        assertEmailSentToAddress(landlordEmail, expectedEmail)
+        assertEmailSentToAddress(landlordEmails, expectedEmail)
     }
 
     private fun arrangeOwnedPropertyUploadCallback(
         subjectCertificateType: String,
         headingCertificateType: String,
         bodyCertificateType: String,
-        emailAddress: String,
+        emailAddresses: List<String>,
     ): Pair<Long, VirusScanUnsuccessfulEmail> {
         val registrationNumber = RegistrationNumberDataModel(RegistrationNumberType.PROPERTY, 37L)
 
         val ownership =
             MockLandlordData.createPropertyOwnership(
-                landlords = mutableSetOf(MockLandlordData.createLandlord(email = emailAddress)),
+                landlords = emailAddresses.mapTo(mutableSetOf()) { MockLandlordData.createLandlord(email = it) },
                 address = MockLandlordData.createAddress(singleLineAddress = "123 Main St, Anytown"),
                 registrationNumber = RegistrationNumber(registrationNumber.type, registrationNumber.number),
             )
@@ -146,15 +147,17 @@ class VirusNotificationEmailHandlerTests {
     }
 
     private fun assertEmailSentToAddress(
-        emailAddress: String,
+        emailAddresses: List<String>,
         expectedEmail: VirusScanUnsuccessfulEmail,
     ) {
         val emailModelCaptor = argumentCaptor<VirusScanUnsuccessfulEmail>()
         val emailAddressCaptor = argumentCaptor<String>()
 
-        verify(emailNotificationService).sendEmail(emailAddressCaptor.capture(), emailModelCaptor.capture())
+        verify(emailNotificationService, times(emailAddresses.size)).sendEmail(emailAddressCaptor.capture(), emailModelCaptor.capture())
 
-        assertEquals(expectedEmail, emailModelCaptor.firstValue)
-        assertEquals(emailAddress, emailAddressCaptor.firstValue)
+        emailAddresses.forEachIndexed { ind, emailAddress ->
+            assertEquals(expectedEmail, emailModelCaptor.allValues[ind])
+            assertEquals(emailAddresses[ind], emailAddressCaptor.allValues[ind])
+        }
     }
 }


### PR DESCRIPTION
## Ticket number

PDJB-1069

## Goal of change

Remove primaryLandlord references from notification emails

## Description of main change(s)

* Update VirusNotification emails so they go to all landlords on the property
* Update the existing compliance update emails to go to the logged in landlord (i.e. the landlord making the update) 

## Anything you'd like to highlight to the reviewer?

A new email should go to other joint landlords on compliance update but that will be a separate ticket.

## Checklist

Delete any that are not applicable, and add explanation below for any that are applicable but haven't been done

- [x] Unit tests for new logic (e.g. new service methods) have been added
- [x] Test suite has been run in full locally and is passing
