### PR TITLE
PDJB-1069: Remove primaryLandlord references from local council endpoints

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/PropertyDetailsController.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/PropertyDetailsController.kt
@@ -1,6 +1,5 @@
 package uk.gov.communities.prsdb.webapp.controllers
 
-import kotlinx.datetime.toKotlinInstant
 import org.springframework.context.MessageSource
 import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.security.core.context.SecurityContextHolder
@@ -23,7 +22,6 @@ import uk.gov.communities.prsdb.webapp.constants.PROPERTY_DETAILS_SEGMENT
 import uk.gov.communities.prsdb.webapp.constants.REMOVE_EXPIRED_INVITE_PATH_SEGMENT
 import uk.gov.communities.prsdb.webapp.controllers.LandlordController.Companion.LANDLORD_DASHBOARD_URL
 import uk.gov.communities.prsdb.webapp.controllers.LocalCouncilDashboardController.Companion.LOCAL_COUNCIL_DASHBOARD_URL
-import uk.gov.communities.prsdb.webapp.helpers.DateTimeHelper
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.JointLandlordsPropertyRegistrationStrategy
 import uk.gov.communities.prsdb.webapp.models.viewModels.InvitationViewModelBuilder
 import uk.gov.communities.prsdb.webapp.models.viewModels.summaryModels.PropertyDetailsLandlordViewModelBuilder
@@ -169,10 +167,6 @@ class PropertyDetailsController(
         val propertyOwnership =
             propertyOwnershipService.getPropertyOwnershipIfAuthorizedUser(propertyOwnershipId, principal.name)
 
-        val lastModifiedDate = DateTimeHelper.getDateInUK(propertyOwnership.getMostRecentlyUpdated().toKotlinInstant())
-        // TODO PDJB-1069 - properly track who last modified the property
-        val lastModifiedBy = propertyOwnership.primaryLandlord.name
-
         val backUrlKey = backLinkStorageService.storeCurrentUrlReturningKey(LANDLORD_DETAILS_FRAGMENT)
 
         val primaryLandlordDetailsUrl =
@@ -221,8 +215,6 @@ class PropertyDetailsController(
             }
 
         model.addAttribute("propertyDetails", propertyDetails)
-        model.addAttribute("lastModifiedDate", lastModifiedDate)
-        model.addAttribute("lastModifiedBy", lastModifiedBy)
         model.addAttribute("complianceDetails", propertyComplianceDetails)
         model.addAttribute("complianceInfoTabId", COMPLIANCE_INFO_FRAGMENT)
         model.addAttribute("isLandlordView", false)

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/searchResultModels/PropertySearchResultViewModel.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/searchResultModels/PropertySearchResultViewModel.kt
@@ -1,7 +1,6 @@
 package uk.gov.communities.prsdb.webapp.models.viewModels.searchResultModels
 
 import uk.gov.communities.prsdb.webapp.config.interceptors.BackLinkInterceptor.Companion.overrideBackLinkForUrl
-import uk.gov.communities.prsdb.webapp.controllers.LandlordDetailsController
 import uk.gov.communities.prsdb.webapp.controllers.PropertyDetailsController
 import uk.gov.communities.prsdb.webapp.database.entity.PropertyOwnership
 import uk.gov.communities.prsdb.webapp.models.dataModels.RegistrationNumberDataModel
@@ -11,7 +10,6 @@ data class PropertySearchResultViewModel(
     val address: String,
     val registrationNumber: String,
     val localCouncil: String?,
-    val landlord: PropertySearchResultLandlordViewModel,
     val recordLink: String,
 ) {
     companion object {
@@ -28,16 +26,6 @@ data class PropertySearchResultViewModel(
             localCouncil =
                 propertyOwnership.address.localCouncil
                     ?.name,
-            // TODO PDJB-1069 - do not use primary landlord
-            landlord =
-                PropertySearchResultLandlordViewModel(
-                    id = propertyOwnership.primaryLandlord.id,
-                    name = propertyOwnership.primaryLandlord.name,
-                    recordLink =
-                        LandlordDetailsController
-                            .getLandlordDetailsForLocalCouncilUserPath(propertyOwnership.primaryLandlord.id)
-                            .overrideBackLinkForUrl(currentUrlKey),
-                ),
             recordLink =
                 PropertyDetailsController
                     .getPropertyDetailsPath(propertyOwnership.id, isLocalCouncilView = true)
@@ -45,9 +33,3 @@ data class PropertySearchResultViewModel(
         )
     }
 }
-
-data class PropertySearchResultLandlordViewModel(
-    val id: Long,
-    val name: String,
-    val recordLink: String,
-)

--- a/src/main/resources/messages/propertySearch.yml
+++ b/src/main/resources/messages/propertySearch.yml
@@ -22,7 +22,6 @@ table:
   'heading.address': Property address
   'heading.prn': Registration number
   'heading.localCouncil': Local council
-  'heading.landlord': Registered landlord
 noResults:
   heading: No property record found
   hint:

--- a/src/main/resources/templates/propertyDetailsView.html
+++ b/src/main/resources/templates/propertyDetailsView.html
@@ -62,8 +62,6 @@
             <p class="govuk-body">
                 <div th:replace="~{fragments/tag :: tag(messageKey = ${propertyDetails.isOccupiedKey()}, tagColour = ${propertyDetails.isOccupied() ? 'turquoise' : 'grey'})}"></div>
             </p>
-            <div th:replace="~{fragments/lastModifiedInsetText :: lastModifiedInsetText(${lastModifiedBy}, ${lastModifiedDate})}"></div>
-
             <div id="tabs" th:replace="~{fragments/tabs/tabs :: tabs(~{::#tabs/content()})}">
                 <ul id="tab-headings" th:replace="~{fragments/tabs/tabsHeadingList :: tabsHeadingList(~{::#tab-headings/content()})}">
                     <li th:replace="~{fragments/tabs/tabsListItem :: tabsListItem('property-details', #{propertyDetails.propertyDetails.heading})}"></li>

--- a/src/main/resources/templates/searchProperty.html
+++ b/src/main/resources/templates/searchProperty.html
@@ -25,28 +25,22 @@
                      th:replace="~{fragments/layouts/scrollablePane :: scrollablePane(~{::#scrollable-content/content()})}">
 
                     <table th:replace="~{fragments/tables/table :: table(
-                            ${ {'propertySearch.table.heading.address','propertySearch.table.heading.prn','propertySearch.table.heading.localCouncil', 'propertySearch.table.heading.landlord'} },
+                            ${ {'propertySearch.table.heading.address','propertySearch.table.heading.prn','propertySearch.table.heading.localCouncil'} },
                             ~{::tbody},
                             #{propertySearch.table.heading}
                         )}">
                         <tbody class="govuk-table__body">
                         <tr class="govuk_table__row" th:each="property: ${searchResults}">
-                            <td class="govuk-table__cell govuk-!-width-one-quarter">
+                            <td class="govuk-table__cell govuk-!-width-one-third">
                                 <a class="govuk-link" th:href="@{${property.recordLink}}"
                                    th:text="${property.address}">
                                 </a>
                             </td>
-                            <td class="govuk-table__cell govuk-!-width-one-quarter"
+                            <td class="govuk-table__cell govuk-!-width-one-third"
                                 th:text="${property.registrationNumber}">
                             </td>
-                            <td class="govuk-table__cell govuk-!-width-one-quarter"
+                            <td class="govuk-table__cell govuk-!-width-one-third"
                                 th:text="${property.localCouncil}">
-                            </td>
-                            <td class="govuk-table__cell govuk-!-width-one-quarter">
-                                <a class="govuk-link"
-                                   th:href="@{${property.landlord.recordLink}}"
-                                   th:text="${property.landlord.name}">
-                                </a>
                             </td>
                         </tr>
                         </tbody>

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/PropertyDetailsTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/PropertyDetailsTests.kt
@@ -300,14 +300,6 @@ class PropertyDetailsTests : IntegrationTestWithImmutableData("data-local.sql") 
             assertThat(detailsPage.propertyDetailsSummaryList.propertyTypeRow).containsText("End terrace")
         }
 
-        @Test
-        fun `loading the landlord details page shows the last time the landlords record was updated`(page: Page) {
-            val detailsPage = navigator.goToPropertyDetailsLocalCouncilView(1)
-            detailsPage.tabs.goToLandlordDetails()
-
-            assertThat(detailsPage.lastModifiedInsetText).containsText("updated these details on")
-        }
-
         @Nested
         inner class LandlordDetails {
             @Test

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/SearchRegisterTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/SearchRegisterTests.kt
@@ -21,7 +21,6 @@ import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.SearchLandl
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.SearchPropertyRegisterPage
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.SearchPropertyRegisterPage.Companion.LOCAL_COUNCIL_COL_INDEX
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.SearchPropertyRegisterPage.Companion.PROPERTY_COL_INDEX
-import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.SearchPropertyRegisterPage.Companion.PROPERTY_LANDLORD_COL_INDEX
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.SearchPropertyRegisterPage.Companion.REG_NUM_COL_INDEX
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages.BasePage.Companion.assertPageIs
 import uk.gov.communities.prsdb.webapp.services.LandlordService
@@ -264,9 +263,6 @@ class SearchRegisterTests : IntegrationTestWithImmutableData("data-search.sql") 
             assertThat(resultTable.headerRow.getCell(LOCAL_COUNCIL_COL_INDEX)).containsText("Local council")
             assertThat(resultTable.getCell(0, LOCAL_COUNCIL_COL_INDEX)).containsText("BATH AND NORTH EAST SOMERSET COUNCIL")
 
-            assertThat(resultTable.headerRow.getCell(PROPERTY_LANDLORD_COL_INDEX)).containsText("Registered landlord")
-            assertThat(resultTable.getCell(0, PROPERTY_LANDLORD_COL_INDEX)).containsText("Alexander Smith")
-
             assertTrue(searchPropertyRegisterPage.noResultErrorMessage.isHidden)
         }
 
@@ -295,15 +291,6 @@ class SearchRegisterTests : IntegrationTestWithImmutableData("data-search.sql") 
             searchPropertyRegisterPage.searchBar.search("P-C5YY-J34H")
             searchPropertyRegisterPage.getPropertyLink(rowIndex = 0).clickAndWait()
             assertPageIs(page, PropertyDetailsPageLocalCouncilView::class, mapOf("propertyOwnershipId" to "1"))
-        }
-
-        @Test
-        fun `landlord link goes to landlord details page`(page: Page) {
-            val searchPropertyRegisterPage = navigator.goToPropertySearchPage()
-            searchPropertyRegisterPage.searchBar.search("P-C5YY-J34H")
-            searchPropertyRegisterPage.getLandlordLink(rowIndex = 0).clickAndWait()
-
-            assertPageIs(page, LocalCouncilViewLandlordDetailsPage::class, mapOf("id" to "1"))
         }
 
         @Test
@@ -440,21 +427,6 @@ class SearchRegisterTests : IntegrationTestWithImmutableData("data-search.sql") 
             val searchPropertyRegisterPage = navigator.goToLandlordSearchPage()
             searchPropertyRegisterPage.backLink.clickAndWait()
             assertPageIs(page, LocalCouncilDashboardPage::class)
-        }
-
-        @Test
-        fun `Back link on a landlord returns to the search`(page: Page) {
-            val searchPropertyRegisterPage = navigator.goToPropertySearchPage()
-            searchPropertyRegisterPage.searchBar.search("P-CCCT-GRKQ")
-            val resultTable = searchPropertyRegisterPage.resultTable
-
-            resultTable.getClickableCell(0, PROPERTY_LANDLORD_COL_INDEX).link.clickAndWait()
-
-            val landlordPage = assertPageIs(page, LocalCouncilViewLandlordDetailsPage::class, mapOf("id" to "1"))
-            landlordPage.backLink.clickAndWait()
-
-            assertPageIs(page, SearchPropertyRegisterPage::class)
-            assertThat(resultTable.getCell(0, PROPERTY_COL_INDEX)).containsText("11 PRSDB Square, EG1 2AK")
         }
 
         @Test

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/PropertyDetailsPageLocalCouncilView.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/PropertyDetailsPageLocalCouncilView.kt
@@ -18,8 +18,6 @@ class PropertyDetailsPageLocalCouncilView(
             isLocalCouncilView = true,
         ),
     ) {
-    val lastModifiedInsetText = page.locator(".govuk-inset-text:not(.govuk-tabs__panel .govuk-inset-text)")
-
     val notificationBanner = NotificationBanner(page)
 
     val landlordSummaryCards: List<LandlordSummaryCard>

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/SearchPropertyRegisterPage.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/SearchPropertyRegisterPage.kt
@@ -10,14 +10,11 @@ class SearchPropertyRegisterPage(
 ) : SearchRegisterBasePage(page, SearchRegisterController.SEARCH_PROPERTY_URL) {
     fun getPropertyLink(rowIndex: Int) = resultTable.getClickableCell(rowIndex, PROPERTY_COL_INDEX).link
 
-    fun getLandlordLink(rowIndex: Int) = resultTable.getClickableCell(rowIndex, PROPERTY_LANDLORD_COL_INDEX).link
-
     fun getLandlordSearchLink() = Link(noResultErrorMessage.locator("a"))
 
     companion object {
         const val PROPERTY_COL_INDEX: Int = 0
         const val REG_NUM_COL_INDEX: Int = 1
         const val LOCAL_COUNCIL_COL_INDEX: Int = 2
-        const val PROPERTY_LANDLORD_COL_INDEX: Int = 3
     }
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/searchResultModels/PropertySearchResultViewModelTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/searchResultModels/PropertySearchResultViewModelTests.kt
@@ -1,7 +1,6 @@
 package uk.gov.communities.prsdb.webapp.models.viewModels.searchResultModels
 
 import org.junit.jupiter.api.Test
-import uk.gov.communities.prsdb.webapp.controllers.LandlordDetailsController
 import uk.gov.communities.prsdb.webapp.controllers.PropertyDetailsController
 import uk.gov.communities.prsdb.webapp.models.dataModels.RegistrationNumberDataModel
 import uk.gov.communities.prsdb.webapp.testHelpers.mockObjects.MockLandlordData
@@ -22,15 +21,6 @@ class PropertySearchResultViewModelTests {
                         .toString(),
                 localCouncil =
                     propertyOwnership.address.localCouncil?.name,
-                landlord =
-                    PropertySearchResultLandlordViewModel(
-                        id = propertyOwnership.primaryLandlord.id,
-                        name = propertyOwnership.primaryLandlord.name,
-                        recordLink =
-                            LandlordDetailsController.getLandlordDetailsForLocalCouncilUserPath(
-                                propertyOwnership.primaryLandlord.id,
-                            ),
-                    ),
                 recordLink = PropertyDetailsController.getPropertyDetailsPath(propertyOwnership.id, isLocalCouncilView = true),
             )
 


### PR DESCRIPTION

## Ticket number

PDJB-1069

## Goal of change

Remove primaryLandlord references from local council endpoints 

## Description of main change(s)

* Remove the "Last updated by" inset text on the local council view as we don't know this anymore so that multiple landlords can edit the property (screenshot has before on the left and after on the right)

<img width="2126" height="601" alt="image" src="https://github.com/user-attachments/assets/71c7312f-24b9-41ce-b744-0ed910514f50" />


* Remove "Registered landlord" from the property search results as there is more than one
<img width="2175" height="648" alt="image" src="https://github.com/user-attachments/assets/9cd66436-803d-4a43-92a3-d713afc98950" />


## Anything you'd like to highlight to the reviewer?

Include e.g. anything unusual about the PR, where there was some debate over how to implement it, or anywhere you were
unsure of the approach to take and would like specific feedback.

## Checklist

Delete any that are not applicable, and add explanation below for any that are applicable but haven't been done

- [x] Screenshots of any UI changes have been added
- [x] Test suite has been run in full locally and is passing
