### PR TITLE
PDJB-1034: Count completed transactions using the Plausible Flow event

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/MetricsController.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/MetricsController.kt
@@ -55,6 +55,7 @@ class MetricsController(
                         metricsService.getMetrics(period),
                         plausibleMetricsService.getCompletionRates(period),
                         cloudWatchMetricsService.getMetrics(period),
+                        plausibleMetricsService.getTransactionCounts(period),
                     )
                 }
                 ?: emptyList()
@@ -76,6 +77,7 @@ class MetricsController(
         metrics: MetricsDataModel,
         completionRates: JourneyCompletionRatesDataModel,
         cloudWatch: CloudWatchMetricsDataModel,
+        totalTransactions: Long,
     ): List<SummaryListRowViewModel> =
         listOf(
             countRow("metrics.rows.landlordRegistrations", metrics.numberOfLandlordRegistrations),
@@ -97,6 +99,7 @@ class MetricsController(
             percentRow("metrics.rows.elastiCacheCpuUtilisation", cloudWatch.elastiCacheCpuUtilisation),
             percentRow("metrics.rows.cloudFrontClientErrorRate", cloudWatch.cloudFrontClientErrorRate),
             percentRow("metrics.rows.cloudFrontServerErrorRate", cloudWatch.cloudFrontServerErrorRate),
+            countRow("metrics.rows.totalTransactions", totalTransactions),
         )
 
     private fun percentRow(

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/local/api/controllers/MockPlausibleController.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/local/api/controllers/MockPlausibleController.kt
@@ -23,21 +23,32 @@ class MockPlausibleController {
     fun query(
         @RequestBody query: PlausibleQuery,
     ): PlausibleQueryResponse =
-        PlausibleQueryResponse(
-            results =
-                listOf(
-                    row(LANDLORD_REGISTRATION_START_PAGE_ROUTE, visitors = 1000.0, pageViews = 1200.0),
-                    row(LANDLORD_REGISTRATION_CONFIRMATION_ROUTE, visitors = 732.0, pageViews = 800.0),
-                    row(PROPERTY_REGISTRATION_ROUTE, visitors = 60.0, pageViews = 80.0),
-                    row(PROPERTY_REGISTRATION_CONFIRMATION_ROUTE, visitors = 18.0, pageViews = 20.0),
-                    row(LOCAL_COUNCIL_USER_REGISTRATION_PRIVACY_NOTICE_ROUTE, visitors = 3.0, pageViews = 4.0),
-                    row(LOCAL_COUNCIL_USER_REGISTRATION_CONFIRMATION_ROUTE, visitors = 1.0, pageViews = 2.0),
-                ),
-        )
+        if (query.dimensions.isEmpty()) {
+            // The transaction-counts query has no dimensions and aggregates a single events total.
+            PlausibleQueryResponse(
+                results = listOf(PlausibleResultRow(metrics = listOf(MOCK_TRANSACTION_COUNT), dimensions = emptyList())),
+            )
+        } else {
+            PlausibleQueryResponse(
+                results =
+                    listOf(
+                        row(LANDLORD_REGISTRATION_START_PAGE_ROUTE, visitors = 1000.0, pageViews = 1200.0),
+                        row(LANDLORD_REGISTRATION_CONFIRMATION_ROUTE, visitors = 732.0, pageViews = 800.0),
+                        row(PROPERTY_REGISTRATION_ROUTE, visitors = 60.0, pageViews = 80.0),
+                        row(PROPERTY_REGISTRATION_CONFIRMATION_ROUTE, visitors = 18.0, pageViews = 20.0),
+                        row(LOCAL_COUNCIL_USER_REGISTRATION_PRIVACY_NOTICE_ROUTE, visitors = 3.0, pageViews = 4.0),
+                        row(LOCAL_COUNCIL_USER_REGISTRATION_CONFIRMATION_ROUTE, visitors = 1.0, pageViews = 2.0),
+                    ),
+            )
+        }
 
     private fun row(
         page: String,
         visitors: Double,
         pageViews: Double,
     ) = PlausibleResultRow(metrics = listOf(visitors, pageViews), dimensions = listOf(page))
+
+    companion object {
+        private const val MOCK_TRANSACTION_COUNT = 753.0
+    }
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/PlausibleMetricsService.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/PlausibleMetricsService.kt
@@ -5,6 +5,8 @@ import uk.gov.communities.prsdb.webapp.annotations.webAnnotations.PrsdbWebServic
 import uk.gov.communities.prsdb.webapp.clients.PlausibleClient
 import uk.gov.communities.prsdb.webapp.constants.CONFIRMATION_PATH_SEGMENT
 import uk.gov.communities.prsdb.webapp.constants.PRIVACY_NOTICE_PATH_SEGMENT
+import uk.gov.communities.prsdb.webapp.controllers.InviteJointLandlordController.Companion.INVITE_JOINT_LANDLORD_ROUTE
+import uk.gov.communities.prsdb.webapp.controllers.PropertyDetailsController.Companion.LANDLORD_PROPERTY_DETAILS_ROUTE
 import uk.gov.communities.prsdb.webapp.controllers.RegisterLandlordController.Companion.LANDLORD_REGISTRATION_CONFIRMATION_ROUTE
 import uk.gov.communities.prsdb.webapp.controllers.RegisterLandlordController.Companion.LANDLORD_REGISTRATION_START_PAGE_ROUTE
 import uk.gov.communities.prsdb.webapp.controllers.RegisterLocalCouncilUserController.Companion.LOCAL_COUNCIL_USER_REGISTRATION_ROUTE
@@ -17,6 +19,14 @@ import uk.gov.communities.prsdb.webapp.controllers.UpdateLicensingController
 import uk.gov.communities.prsdb.webapp.controllers.UpdateOccupancyController
 import uk.gov.communities.prsdb.webapp.controllers.UpdateRentFrequencyAndAmountController
 import uk.gov.communities.prsdb.webapp.controllers.UpdateRentIncludesBillsController
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.update.electricalSafety.UpdateCheckElectricalSafetyAnswersStep
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.update.epc.UpdateCheckEpcAnswersStep
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.update.gasSafety.UpdateCheckGasSafetyAnswersStep
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.update.householdsAndTenants.UpdateHouseholdsAndTenantsCyaStep
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.update.occupancy.UpdateOccupancyCyaStep
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.update.rentFrequencyAndAmount.UpdateRentFrequencyAndAmountCyaStep
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.update.rentIncludesBills.UpdateRentIncludesBillsCyaStep
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.update.updateLicensing.UpdateLicensingCyaStep
 import uk.gov.communities.prsdb.webapp.models.dataModels.JourneyCompletionRatesDataModel
 import uk.gov.communities.prsdb.webapp.models.dataModels.ReportingPeriod
 import uk.gov.communities.prsdb.webapp.models.dataModels.plausible.PlausibleQuery
@@ -159,38 +169,42 @@ class PlausibleMetricsService(
             )
 
         // A landlord lands back on the property record (which contains a numeric property id) after completing an update.
-        private const val PROPERTY_RECORD_REGEX = "^/landlord/property-details/\\d+$"
+        private val PROPERTY_RECORD_REGEX = routeRegex(LANDLORD_PROPERTY_DETAILS_ROUTE)
 
         // The invite-joint-landlord journey finishes on its own confirmation URL nested under the property record.
-        private const val INVITE_JOINT_LANDLORD_CONFIRMATION_REGEX =
-            "^/landlord/property-details/\\d+/invite-joint-landlord/confirmation$"
+        private val INVITE_JOINT_LANDLORD_CONFIRMATION_REGEX =
+            routeRegex("$INVITE_JOINT_LANDLORD_ROUTE/$CONFIRMATION_PATH_SEGMENT")
 
         // The eight check-answers property updates are detected by their final check-answers step as the Flow referrer.
-        // Segment literals are kept inline to avoid coupling to each update controller's check-answers step package.
         private val PROPERTY_UPDATE_REFERRER_REGEXES =
             listOf(
-                updateReferrerRegex(UpdateGasSafetyController.UPDATE_GAS_SAFETY_ROUTE, "check-gas-safety-answers"),
-                updateReferrerRegex(UpdateElectricalSafetyController.UPDATE_ELECTRICAL_SAFETY_ROUTE, "check-electrical-safety-answers"),
-                updateReferrerRegex(UpdateEpcController.UPDATE_EPC_ROUTE, "check-epc-answers"),
-                updateReferrerRegex(UpdateOccupancyController.UPDATE_OCCUPANCY_ROUTE, "occupancy-check-your-answers"),
-                updateReferrerRegex(UpdateLicensingController.UPDATE_LICENSING_ROUTE, "check-licensing-answers"),
+                updateReferrerRegex(UpdateGasSafetyController.UPDATE_GAS_SAFETY_ROUTE, UpdateCheckGasSafetyAnswersStep.ROUTE_SEGMENT),
+                updateReferrerRegex(
+                    UpdateElectricalSafetyController.UPDATE_ELECTRICAL_SAFETY_ROUTE,
+                    UpdateCheckElectricalSafetyAnswersStep.ROUTE_SEGMENT,
+                ),
+                updateReferrerRegex(UpdateEpcController.UPDATE_EPC_ROUTE, UpdateCheckEpcAnswersStep.ROUTE_SEGMENT),
+                updateReferrerRegex(UpdateOccupancyController.UPDATE_OCCUPANCY_ROUTE, UpdateOccupancyCyaStep.ROUTE_SEGMENT),
+                updateReferrerRegex(UpdateLicensingController.UPDATE_LICENSING_ROUTE, UpdateLicensingCyaStep.ROUTE_SEGMENT),
                 updateReferrerRegex(
                     UpdateRentFrequencyAndAmountController.UPDATE_RENT_FREQUENCY_AND_AMOUNT_ROUTE,
-                    "rent-frequency-and-amount-check-your-answers",
+                    UpdateRentFrequencyAndAmountCyaStep.ROUTE_SEGMENT,
                 ),
                 updateReferrerRegex(
                     UpdateRentIncludesBillsController.UPDATE_RENT_INCLUDES_BILLS_ROUTE,
-                    "rent-includes-bills-check-your-answers",
+                    UpdateRentIncludesBillsCyaStep.ROUTE_SEGMENT,
                 ),
                 updateReferrerRegex(
                     UpdateHouseholdsAndTenantsController.UPDATE_HOUSEHOLDS_AND_TENANTS_ROUTE,
-                    "households-tenants-check-your-answers",
+                    UpdateHouseholdsAndTenantsCyaStep.ROUTE_SEGMENT,
                 ),
             )
 
         private fun updateReferrerRegex(
             routeTemplate: String,
             cyaSegment: String,
-        ): String = "^" + routeTemplate.replace("{propertyOwnershipId}", "\\d+") + "/" + cyaSegment + "$"
+        ): String = routeRegex("$routeTemplate/$cyaSegment")
+
+        private fun routeRegex(routeTemplate: String): String = "^" + routeTemplate.replace("{propertyOwnershipId}", "\\d+") + "$"
     }
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/PlausibleMetricsService.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/PlausibleMetricsService.kt
@@ -9,6 +9,14 @@ import uk.gov.communities.prsdb.webapp.controllers.RegisterLandlordController.Co
 import uk.gov.communities.prsdb.webapp.controllers.RegisterLandlordController.Companion.LANDLORD_REGISTRATION_START_PAGE_ROUTE
 import uk.gov.communities.prsdb.webapp.controllers.RegisterLocalCouncilUserController.Companion.LOCAL_COUNCIL_USER_REGISTRATION_ROUTE
 import uk.gov.communities.prsdb.webapp.controllers.RegisterPropertyController.Companion.PROPERTY_REGISTRATION_ROUTE
+import uk.gov.communities.prsdb.webapp.controllers.UpdateElectricalSafetyController
+import uk.gov.communities.prsdb.webapp.controllers.UpdateEpcController
+import uk.gov.communities.prsdb.webapp.controllers.UpdateGasSafetyController
+import uk.gov.communities.prsdb.webapp.controllers.UpdateHouseholdsAndTenantsController
+import uk.gov.communities.prsdb.webapp.controllers.UpdateLicensingController
+import uk.gov.communities.prsdb.webapp.controllers.UpdateOccupancyController
+import uk.gov.communities.prsdb.webapp.controllers.UpdateRentFrequencyAndAmountController
+import uk.gov.communities.prsdb.webapp.controllers.UpdateRentIncludesBillsController
 import uk.gov.communities.prsdb.webapp.models.dataModels.JourneyCompletionRatesDataModel
 import uk.gov.communities.prsdb.webapp.models.dataModels.ReportingPeriod
 import uk.gov.communities.prsdb.webapp.models.dataModels.plausible.PlausibleQuery
@@ -60,6 +68,47 @@ class PlausibleMetricsService(
             filters = listOf(listOf("is", "event:page", ALL_PAGES)),
         )
 
+    fun getTransactionCounts(period: ReportingPeriod): Long =
+        try {
+            val response = plausibleClient.query(buildTransactionQuery(period))
+            (response.results.firstOrNull()?.metrics?.firstOrNull() ?: 0.0).toLong()
+        } catch (e: Exception) {
+            println("Failed to fetch transaction counts from Plausible: ${e.message}")
+            0L
+        }
+
+    private fun buildTransactionQuery(period: ReportingPeriod): PlausibleQuery =
+        PlausibleQuery(
+            siteId = domainId,
+            dateRange = listOf(period.start.toUkDate(), period.end.toUkDate()),
+            metrics = listOf("events"),
+            dimensions = emptyList(),
+            filters = listOf(transactionFilter()),
+        )
+
+    // A transaction is a completed journey, counted from the Plausible "Flow" custom event (which carries the
+    // server-side referrer and currentUrl paths as props). Each completion has a distinct (referrer, currentUrl)
+    // signature. The seven single-step update journeys are deliberately excluded: their completion and a "Back"
+    // click produce identical Flow props, so they cannot be counted without double-counting.
+    private fun transactionFilter(): List<Any> =
+        listOf(
+            "or",
+            listOf(
+                // Registrations land on a unique confirmation URL.
+                listOf("is", "event:props:currentUrl", REGISTRATION_CONFIRMATION_PAGES),
+                // Invite joint landlord lands on its own confirmation URL (contains a property id).
+                listOf("matches", "event:props:currentUrl", listOf(INVITE_JOINT_LANDLORD_CONFIRMATION_REGEX)),
+                // Check-answers property updates: final check-answers step (referrer) -> property record (currentUrl).
+                listOf(
+                    "and",
+                    listOf(
+                        listOf("matches", "event:props:referrer", PROPERTY_UPDATE_REFERRER_REGEXES),
+                        listOf("matches", "event:props:currentUrl", listOf(PROPERTY_RECORD_REGEX)),
+                    ),
+                ),
+            ),
+        )
+
     private fun completionRate(
         countsByPage: Map<String, Double>,
         startPage: String,
@@ -100,5 +149,48 @@ class PlausibleMetricsService(
                 LOCAL_COUNCIL_USER_REGISTRATION_PRIVACY_NOTICE_ROUTE,
                 LOCAL_COUNCIL_USER_REGISTRATION_CONFIRMATION_ROUTE,
             )
+
+        // The three registration journeys each finish on a fixed confirmation URL with no path variables.
+        private val REGISTRATION_CONFIRMATION_PAGES =
+            listOf(
+                LANDLORD_REGISTRATION_CONFIRMATION_ROUTE,
+                PROPERTY_REGISTRATION_CONFIRMATION_ROUTE,
+                LOCAL_COUNCIL_USER_REGISTRATION_CONFIRMATION_ROUTE,
+            )
+
+        // A landlord lands back on the property record (which contains a numeric property id) after completing an update.
+        private const val PROPERTY_RECORD_REGEX = "^/landlord/property-details/\\d+$"
+
+        // The invite-joint-landlord journey finishes on its own confirmation URL nested under the property record.
+        private const val INVITE_JOINT_LANDLORD_CONFIRMATION_REGEX =
+            "^/landlord/property-details/\\d+/invite-joint-landlord/confirmation$"
+
+        // The eight check-answers property updates are detected by their final check-answers step as the Flow referrer.
+        // Segment literals are kept inline to avoid coupling to each update controller's check-answers step package.
+        private val PROPERTY_UPDATE_REFERRER_REGEXES =
+            listOf(
+                updateReferrerRegex(UpdateGasSafetyController.UPDATE_GAS_SAFETY_ROUTE, "check-gas-safety-answers"),
+                updateReferrerRegex(UpdateElectricalSafetyController.UPDATE_ELECTRICAL_SAFETY_ROUTE, "check-electrical-safety-answers"),
+                updateReferrerRegex(UpdateEpcController.UPDATE_EPC_ROUTE, "check-epc-answers"),
+                updateReferrerRegex(UpdateOccupancyController.UPDATE_OCCUPANCY_ROUTE, "occupancy-check-your-answers"),
+                updateReferrerRegex(UpdateLicensingController.UPDATE_LICENSING_ROUTE, "check-licensing-answers"),
+                updateReferrerRegex(
+                    UpdateRentFrequencyAndAmountController.UPDATE_RENT_FREQUENCY_AND_AMOUNT_ROUTE,
+                    "rent-frequency-and-amount-check-your-answers",
+                ),
+                updateReferrerRegex(
+                    UpdateRentIncludesBillsController.UPDATE_RENT_INCLUDES_BILLS_ROUTE,
+                    "rent-includes-bills-check-your-answers",
+                ),
+                updateReferrerRegex(
+                    UpdateHouseholdsAndTenantsController.UPDATE_HOUSEHOLDS_AND_TENANTS_ROUTE,
+                    "households-tenants-check-your-answers",
+                ),
+            )
+
+        private fun updateReferrerRegex(
+            routeTemplate: String,
+            cyaSegment: String,
+        ): String = "^" + routeTemplate.replace("{propertyOwnershipId}", "\\d+") + "/" + cyaSegment + "$"
     }
 }

--- a/src/main/resources/messages/metrics.yml
+++ b/src/main/resources/messages/metrics.yml
@@ -29,6 +29,7 @@ rows:
   elastiCacheCpuUtilisation: ElastiCache CPU utilisation
   cloudFrontClientErrorRate: Client error rate (HTTP 4xx)
   cloudFrontServerErrorRate: Server error rate (HTTP 5xx)
+  totalTransactions: Total number of transactions
 completionRateExplanation: Completion rates for landlord and local council user registration are based on unique visitors. Property registration completion rate is based on page views, as a single landlord may register multiple properties.
 saveAndReturn:
   day: '{0} day'

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/controllers/MetricsControllerTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/controllers/MetricsControllerTests.kt
@@ -172,7 +172,7 @@ class MetricsControllerTests(
 
     @Test
     @WithMockUser(roles = ["SYSTEM_OPERATOR"])
-    fun `submitMetrics populates sixteen metric rows for a valid date range`() {
+    fun `submitMetrics populates seventeen metric rows for a valid date range`() {
         whenever(metricsService.getMetrics(any())).thenReturn(
             MetricsDataModel(
                 numberOfLandlordRegistrations = 5L,
@@ -187,6 +187,7 @@ class MetricsControllerTests(
         whenever(plausibleMetricsService.getCompletionRates(any())).thenReturn(
             JourneyCompletionRatesDataModel(73.24, 25.0, null),
         )
+        whenever(plausibleMetricsService.getTransactionCounts(any())).thenReturn(725L)
         whenever(cloudWatchMetricsService.getMetrics(any())).thenReturn(
             CloudWatchMetricsDataModel(73.4, 41.2, 62.5, 18.9, 0.82, 0.05),
         )
@@ -205,7 +206,7 @@ class MetricsControllerTests(
                 status { isOk() }
                 view { name("metrics") }
                 model {
-                    attribute("metricRows", hasSize<Any>(16))
+                    attribute("metricRows", hasSize<Any>(17))
                 }
                 content {
                     string(
@@ -222,6 +223,8 @@ class MetricsControllerTests(
                             "0.82%",
                             "Server error rate (HTTP 5xx)",
                             "0.05%",
+                            "Total number of transactions",
+                            "725",
                         ),
                     )
                 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/MetricsSinglePageTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/MetricsSinglePageTests.kt
@@ -2,12 +2,56 @@ package uk.gov.communities.prsdb.webapp.integration
 
 import com.microsoft.playwright.Page
 import com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.whenever
+import org.springframework.test.context.bean.override.mockito.MockitoBean
+import uk.gov.communities.prsdb.webapp.clients.PlausibleClient
+import uk.gov.communities.prsdb.webapp.controllers.RegisterLandlordController.Companion.LANDLORD_REGISTRATION_CONFIRMATION_ROUTE
+import uk.gov.communities.prsdb.webapp.controllers.RegisterLandlordController.Companion.LANDLORD_REGISTRATION_START_PAGE_ROUTE
+import uk.gov.communities.prsdb.webapp.controllers.RegisterPropertyController.Companion.PROPERTY_REGISTRATION_ROUTE
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.BaseComponent
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.MetricsPage
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages.BasePage.Companion.assertPageIs
+import uk.gov.communities.prsdb.webapp.models.dataModels.plausible.PlausibleQuery
+import uk.gov.communities.prsdb.webapp.models.dataModels.plausible.PlausibleQueryResponse
+import uk.gov.communities.prsdb.webapp.models.dataModels.plausible.PlausibleResultRow
+import uk.gov.communities.prsdb.webapp.services.PlausibleMetricsService.Companion.LOCAL_COUNCIL_USER_REGISTRATION_CONFIRMATION_ROUTE
+import uk.gov.communities.prsdb.webapp.services.PlausibleMetricsService.Companion.LOCAL_COUNCIL_USER_REGISTRATION_PRIVACY_NOTICE_ROUTE
+import uk.gov.communities.prsdb.webapp.services.PlausibleMetricsService.Companion.PROPERTY_REGISTRATION_CONFIRMATION_ROUTE
 
 class MetricsSinglePageTests : IntegrationTestWithImmutableData("data-metrics-local.sql") {
+    @MockitoBean
+    private lateinit var plausibleClient: PlausibleClient
+
+    @BeforeEach
+    fun setUp() {
+        whenever(plausibleClient.query(any())).thenAnswer { invocation ->
+            val query = invocation.arguments[0] as PlausibleQuery
+            if (query.dimensions.isEmpty()) {
+                PlausibleQueryResponse(listOf(PlausibleResultRow(metrics = listOf(753.0), dimensions = emptyList())))
+            } else {
+                PlausibleQueryResponse(
+                    listOf(
+                        completionRow(LANDLORD_REGISTRATION_START_PAGE_ROUTE, 1000.0, 1200.0),
+                        completionRow(LANDLORD_REGISTRATION_CONFIRMATION_ROUTE, 732.0, 800.0),
+                        completionRow(PROPERTY_REGISTRATION_ROUTE, 60.0, 80.0),
+                        completionRow(PROPERTY_REGISTRATION_CONFIRMATION_ROUTE, 18.0, 20.0),
+                        completionRow(LOCAL_COUNCIL_USER_REGISTRATION_PRIVACY_NOTICE_ROUTE, 3.0, 4.0),
+                        completionRow(LOCAL_COUNCIL_USER_REGISTRATION_CONFIRMATION_ROUTE, 1.0, 2.0),
+                    ),
+                )
+            }
+        }
+    }
+
+    private fun completionRow(
+        page: String,
+        visitors: Double,
+        pageViews: Double,
+    ) = PlausibleResultRow(metrics = listOf(visitors, pageViews), dimensions = listOf(page))
+
     @Test
     fun `the metrics page loads with both reporting-period date inputs and a refresh button`(page: Page) {
         val metricsPage = navigator.goToMetricsPage()
@@ -98,5 +142,18 @@ class MetricsSinglePageTests : IntegrationTestWithImmutableData("data-metrics-lo
         assertThat(reloadedPage.metricsList.rowValue(13)).containsText("18.90%")
         assertThat(reloadedPage.metricsList.rowValue(14)).containsText("0.82%")
         assertThat(reloadedPage.metricsList.rowValue(15)).containsText("0.05%")
+    }
+
+    @Test
+    fun `submitting a valid date range renders the completion-rate and transaction-count rows from the Plausible stub`(page: Page) {
+        val metricsPage = navigator.goToMetricsPage()
+
+        metricsPage.submitDateRange("1", "9", "2024", "30", "6", "2025")
+
+        val reloadedPage = assertPageIs(page, MetricsPage::class)
+        assertThat(reloadedPage.metricsList.rowValue(7)).containsText("73.20%")
+        assertThat(reloadedPage.metricsList.rowValue(8)).containsText("25.00%")
+        assertThat(reloadedPage.metricsList.rowValue(9)).containsText("33.33%")
+        assertThat(reloadedPage.metricsList.rowValue(16)).containsText("753")
     }
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/PlausibleMetricsServiceTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/PlausibleMetricsServiceTests.kt
@@ -38,6 +38,8 @@ class PlausibleMetricsServiceTests {
         pageViews: Double = visitors,
     ) = PlausibleResultRow(metrics = listOf(visitors, pageViews), dimensions = listOf(page))
 
+    private fun aggregateRow(count: Double) = PlausibleResultRow(metrics = listOf(count), dimensions = emptyList())
+
     @Test
     fun `getCompletionRates uses visitors for landlord and council and pageViews for property`() {
         whenever(plausibleClient.query(any())).thenReturn(
@@ -138,5 +140,49 @@ class PlausibleMetricsServiceTests {
         val pages = filter[2] as List<String>
         assertEquals(6, pages.size)
         assertTrue(pages.contains("/landlord/register-as-a-landlord/confirmation"))
+    }
+
+    @Test
+    fun `getTransactionCounts returns the aggregate events total as a Long`() {
+        whenever(plausibleClient.query(any())).thenReturn(PlausibleQueryResponse(listOf(aggregateRow(842.0))))
+
+        assertEquals(842L, service().getTransactionCounts(period))
+    }
+
+    @Test
+    fun `getTransactionCounts returns zero when there are no results`() {
+        whenever(plausibleClient.query(any())).thenReturn(PlausibleQueryResponse(emptyList()))
+
+        assertEquals(0L, service().getTransactionCounts(period))
+    }
+
+    @Test
+    fun `getTransactionCounts returns zero when the client throws`() {
+        whenever(plausibleClient.query(any())).thenThrow(RuntimeException("boom"))
+
+        assertEquals(0L, service().getTransactionCounts(period))
+    }
+
+    @Test
+    fun `getTransactionCounts queries Plausible with the events metric, no dimensions and a Flow props filter`() {
+        whenever(plausibleClient.query(any())).thenReturn(PlausibleQueryResponse(emptyList()))
+
+        service().getTransactionCounts(period)
+
+        val captor = argumentCaptor<PlausibleQuery>()
+        verify(plausibleClient).query(captor.capture())
+        val query = captor.firstValue
+        assertEquals(domainId, query.siteId)
+        assertEquals(listOf("2025-01-10", "2025-01-20"), query.dateRange)
+        assertEquals(listOf("events"), query.metrics)
+        assertTrue(query.dimensions.isEmpty())
+        val filter = query.filters.single()
+        assertEquals("or", filter[0])
+        val serialised = query.filters.toString()
+        assertTrue(serialised.contains("event:props:currentUrl"))
+        assertTrue(serialised.contains("event:props:referrer"))
+        assertTrue(serialised.contains("/landlord/register-as-a-landlord/confirmation"))
+        assertTrue(serialised.contains("check-gas-safety-answers"))
+        assertTrue(!serialised.contains("update-bedrooms"))
     }
 }


### PR DESCRIPTION
## Ticket number

PDJB-1034

## Goal of change

Add a "Total number of transactions" metric to the system-operator dashboard that counts completed journeys, including update journeys that have no dedicated confirmation page.

## Description of main change(s)

- Counts completed transactions from the Plausible `Flow` custom event (which carries the server-side `currentUrl` and `referrer` paths as props), via a single filtered query returning a scalar total.
- Counts 12 completion signatures: the 3 registration journeys, invite-joint-landlord, and the 8 check-answers property-update journeys.
- Deliberately excludes the 7 single-step update journeys, whose completion is indistinguishable from a "Back" click in the Flow props (would double-count).
- Renders the total as a new row on the metrics page; the local Plausible mock returns an aggregate count so the row is populated in local dev.

## Anything you'd like to highlight to the reviewer?

The 8 check-answers updates are matched by `and(referrer matches <check-answers-step>, currentUrl matches /landlord/property-details/<id>)`. All URL path segments are now derived from the relevant controller and step `ROUTE_SEGMENT` constants rather than literals, so counting won't silently break if a route changes. The metrics page is integration-tested by stubbing `PlausibleClient` (the same `@MockitoBean` approach used for the EPC API), asserting the completion-rate and transaction rows render.

## Checklist

- [x] Unit tests for new logic (e.g. new service methods) have been added
- [x] Controller tests for any new endpoints, including testing the relevant permissions
- [x] Branch has been rebased onto main and run locally, with everything working as expected (both for your new feature and any related functionality)
- [x] TODO comments referencing this JIRA ticket have been searched for and removed
- [ ] QA instructions have been added to the ticket (particularly if this is the last PR required to complete the ticket)

