### PR TITLE
PDJB-1127: individual or org page

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/organisationLandlordRegistration/OrganisationLandlordRegistrationJourneyFactory.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/organisationLandlordRegistration/OrganisationLandlordRegistrationJourneyFactory.kt
@@ -27,6 +27,7 @@ import uk.gov.communities.prsdb.webapp.journeys.organisationLandlordRegistration
 import uk.gov.communities.prsdb.webapp.journeys.organisationLandlordRegistration.steps.OrgTrusteesStep
 import uk.gov.communities.prsdb.webapp.journeys.organisationLandlordRegistration.steps.OrgTypeStep
 import uk.gov.communities.prsdb.webapp.journeys.organisationLandlordRegistration.steps.YourDetailsStep
+import uk.gov.communities.prsdb.webapp.models.viewModels.SectionHeaderViewModel
 import java.security.Principal
 
 @JourneyFrameworkComponent("organisationLandlordRegistrationJourneyFactory")
@@ -44,6 +45,15 @@ class OrganisationLandlordRegistrationJourneyFactory(
             unreachableStepUrl { LANDLORD_REGISTRATION_START_PAGE_ROUTE }
             configure {
                 withAdditionalContentProperty { "title" to "registerAsALandlord.title" }
+                withAdditionalContentProperty {
+                    "sectionHeaderInfo" to
+                        SectionHeaderViewModel(
+                            sectionNameKey = "registerAsALandlord.landlordType.caption",
+                            sectionNumber = 0,
+                            totalSections = 0,
+                            useNumbering = false,
+                        )
+                }
             }
             step(journey.landlordTypeStep) {
                 routeSegment(LandlordTypeStep.ROUTE_SEGMENT)

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/organisationLandlordRegistration/OrganisationLandlordRegistrationJourneyFactory.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/organisationLandlordRegistration/OrganisationLandlordRegistrationJourneyFactory.kt
@@ -27,7 +27,6 @@ import uk.gov.communities.prsdb.webapp.journeys.organisationLandlordRegistration
 import uk.gov.communities.prsdb.webapp.journeys.organisationLandlordRegistration.steps.OrgTrusteesStep
 import uk.gov.communities.prsdb.webapp.journeys.organisationLandlordRegistration.steps.OrgTypeStep
 import uk.gov.communities.prsdb.webapp.journeys.organisationLandlordRegistration.steps.YourDetailsStep
-import uk.gov.communities.prsdb.webapp.models.viewModels.SectionHeaderViewModel
 import java.security.Principal
 
 @JourneyFrameworkComponent("organisationLandlordRegistrationJourneyFactory")
@@ -45,90 +44,84 @@ class OrganisationLandlordRegistrationJourneyFactory(
             unreachableStepUrl { LANDLORD_REGISTRATION_START_PAGE_ROUTE }
             configure {
                 withAdditionalContentProperty { "title" to "registerAsALandlord.title" }
-                withAdditionalContentProperty {
-                    "sectionHeaderInfo" to
-                        SectionHeaderViewModel(
-                            sectionNameKey = "registerAsALandlord.landlordType.caption",
-                            sectionNumber = 0,
-                            totalSections = 0,
-                            useNumbering = false,
-                        )
-                }
             }
-            step(journey.landlordTypeStep) {
-                routeSegment(LandlordTypeStep.ROUTE_SEGMENT)
-                initialStep()
-                nextDestination { mode ->
-                    when (mode) {
-                        LandlordTypeMode.INDIVIDUAL -> Destination(journey.individualLandlordPlaceholderStep)
-                        LandlordTypeMode.ORGANISATION -> Destination(journey.yourDetailsStep)
+            section {
+                withHeadingMessageKey("registerAsALandlord.landlordType.caption", shouldUseNumbering = false)
+                step(journey.landlordTypeStep) {
+                    routeSegment(LandlordTypeStep.ROUTE_SEGMENT)
+                    initialStep()
+                    nextDestination { mode ->
+                        when (mode) {
+                            LandlordTypeMode.INDIVIDUAL -> Destination(journey.individualLandlordPlaceholderStep)
+                            LandlordTypeMode.ORGANISATION -> Destination(journey.yourDetailsStep)
+                        }
                     }
                 }
-            }
-            step(journey.individualLandlordPlaceholderStep) {
-                routeSegment(IndividualLandlordPlaceholderStep.ROUTE_SEGMENT)
-                parents { journey.landlordTypeStep.hasOutcome(LandlordTypeMode.INDIVIDUAL) }
-                nextUrl { LANDLORD_REGISTRATION_START_PAGE_ROUTE }
-            }
-            step(journey.yourDetailsStep) {
-                routeSegment(YourDetailsStep.ROUTE_SEGMENT)
-                parents { journey.landlordTypeStep.hasOutcome(LandlordTypeMode.ORGANISATION) }
-                nextStep { journey.orgNameStep }
-            }
-            step(journey.orgNameStep) {
-                routeSegment(OrgNameStep.ROUTE_SEGMENT)
-                parents { journey.yourDetailsStep.isComplete() }
-                nextStep { journey.orgAddressStep }
-            }
-            step(journey.orgAddressStep) {
-                routeSegment(OrgAddressStep.ROUTE_SEGMENT)
-                parents { journey.orgNameStep.isComplete() }
-                nextStep { journey.orgEmailStep }
-            }
-            step(journey.orgEmailStep) {
-                routeSegment(OrgEmailStep.ROUTE_SEGMENT)
-                parents { journey.orgAddressStep.isComplete() }
-                nextStep { journey.orgPhoneNumberStep }
-            }
-            step(journey.orgPhoneNumberStep) {
-                routeSegment(OrgPhoneNumberStep.ROUTE_SEGMENT)
-                parents { journey.orgEmailStep.isComplete() }
-                nextStep { journey.orgTypeStep }
-            }
-            step(journey.orgTypeStep) {
-                routeSegment(OrgTypeStep.ROUTE_SEGMENT)
-                parents { journey.orgPhoneNumberStep.isComplete() }
-                nextStep { journey.orgCompaniesHouseStep }
-            }
-            step(journey.orgCompaniesHouseStep) {
-                routeSegment(OrgCompaniesHouseStep.ROUTE_SEGMENT)
-                parents { journey.orgTypeStep.isComplete() }
-                nextStep { journey.orgCharityStep }
-            }
-            step(journey.orgCharityStep) {
-                routeSegment(OrgCharityStep.ROUTE_SEGMENT)
-                parents { journey.orgCompaniesHouseStep.isComplete() }
-                nextStep { journey.orgDirectorsStep }
-            }
-            step(journey.orgDirectorsStep) {
-                routeSegment(OrgDirectorsStep.ROUTE_SEGMENT)
-                parents { journey.orgCharityStep.isComplete() }
-                nextStep { journey.orgTrusteesStep }
-            }
-            step(journey.orgTrusteesStep) {
-                routeSegment(OrgTrusteesStep.ROUTE_SEGMENT)
-                parents { journey.orgDirectorsStep.isComplete() }
-                nextStep { journey.orgMainContactStep }
-            }
-            step(journey.orgMainContactStep) {
-                routeSegment(OrgMainContactStep.ROUTE_SEGMENT)
-                parents { journey.orgTrusteesStep.isComplete() }
-                nextStep { journey.orgLandlordCyaStep }
-            }
-            step(journey.orgLandlordCyaStep) {
-                routeSegment(OrgLandlordCyaStep.ROUTE_SEGMENT)
-                parents { journey.orgMainContactStep.isComplete() }
-                nextUrl { LANDLORD_REGISTRATION_CONFIRMATION_ROUTE }
+                step(journey.individualLandlordPlaceholderStep) {
+                    routeSegment(IndividualLandlordPlaceholderStep.ROUTE_SEGMENT)
+                    parents { journey.landlordTypeStep.hasOutcome(LandlordTypeMode.INDIVIDUAL) }
+                    nextUrl { LANDLORD_REGISTRATION_START_PAGE_ROUTE }
+                }
+                step(journey.yourDetailsStep) {
+                    routeSegment(YourDetailsStep.ROUTE_SEGMENT)
+                    parents { journey.landlordTypeStep.hasOutcome(LandlordTypeMode.ORGANISATION) }
+                    nextStep { journey.orgNameStep }
+                }
+                step(journey.orgNameStep) {
+                    routeSegment(OrgNameStep.ROUTE_SEGMENT)
+                    parents { journey.yourDetailsStep.isComplete() }
+                    nextStep { journey.orgAddressStep }
+                }
+                step(journey.orgAddressStep) {
+                    routeSegment(OrgAddressStep.ROUTE_SEGMENT)
+                    parents { journey.orgNameStep.isComplete() }
+                    nextStep { journey.orgEmailStep }
+                }
+                step(journey.orgEmailStep) {
+                    routeSegment(OrgEmailStep.ROUTE_SEGMENT)
+                    parents { journey.orgAddressStep.isComplete() }
+                    nextStep { journey.orgPhoneNumberStep }
+                }
+                step(journey.orgPhoneNumberStep) {
+                    routeSegment(OrgPhoneNumberStep.ROUTE_SEGMENT)
+                    parents { journey.orgEmailStep.isComplete() }
+                    nextStep { journey.orgTypeStep }
+                }
+                step(journey.orgTypeStep) {
+                    routeSegment(OrgTypeStep.ROUTE_SEGMENT)
+                    parents { journey.orgPhoneNumberStep.isComplete() }
+                    nextStep { journey.orgCompaniesHouseStep }
+                }
+                step(journey.orgCompaniesHouseStep) {
+                    routeSegment(OrgCompaniesHouseStep.ROUTE_SEGMENT)
+                    parents { journey.orgTypeStep.isComplete() }
+                    nextStep { journey.orgCharityStep }
+                }
+                step(journey.orgCharityStep) {
+                    routeSegment(OrgCharityStep.ROUTE_SEGMENT)
+                    parents { journey.orgCompaniesHouseStep.isComplete() }
+                    nextStep { journey.orgDirectorsStep }
+                }
+                step(journey.orgDirectorsStep) {
+                    routeSegment(OrgDirectorsStep.ROUTE_SEGMENT)
+                    parents { journey.orgCharityStep.isComplete() }
+                    nextStep { journey.orgTrusteesStep }
+                }
+                step(journey.orgTrusteesStep) {
+                    routeSegment(OrgTrusteesStep.ROUTE_SEGMENT)
+                    parents { journey.orgDirectorsStep.isComplete() }
+                    nextStep { journey.orgMainContactStep }
+                }
+                step(journey.orgMainContactStep) {
+                    routeSegment(OrgMainContactStep.ROUTE_SEGMENT)
+                    parents { journey.orgTrusteesStep.isComplete() }
+                    nextStep { journey.orgLandlordCyaStep }
+                }
+                step(journey.orgLandlordCyaStep) {
+                    routeSegment(OrgLandlordCyaStep.ROUTE_SEGMENT)
+                    parents { journey.orgMainContactStep.isComplete() }
+                    nextUrl { LANDLORD_REGISTRATION_CONFIRMATION_ROUTE }
+                }
             }
         }
 

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/organisationLandlordRegistration/steps/LandlordTypeStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/organisationLandlordRegistration/steps/LandlordTypeStepConfig.kt
@@ -15,7 +15,6 @@ class LandlordTypeStepConfig : AbstractRequestableStepConfig<LandlordTypeMode, L
     override fun getStepSpecificContent(state: JourneyState) =
         mapOf(
             "fieldSetHeading" to "registerAsALandlord.landlordType.fieldSetHeading",
-            "legend" to "registerAsALandlord.landlordType.legend",
             "partnershipSummary" to "registerAsALandlord.landlordType.partnership.summary",
             "partnershipParagraphOne" to "registerAsALandlord.landlordType.partnership.paragraph.one",
             "partnershipParagraphTwo" to "registerAsALandlord.landlordType.partnership.paragraph.two",

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/organisationLandlordRegistration/steps/LandlordTypeStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/organisationLandlordRegistration/steps/LandlordTypeStepConfig.kt
@@ -8,7 +8,6 @@ import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.LandlordT
 import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.LandlordTypeFormModel
 import uk.gov.communities.prsdb.webapp.models.viewModels.formModels.RadiosButtonViewModel
 
-// TODO: PDJB-1127 update copy
 @JourneyFrameworkComponent("landlordTypeStepConfig")
 class LandlordTypeStepConfig : AbstractRequestableStepConfig<LandlordTypeMode, LandlordTypeFormModel, JourneyState>() {
     override val formModelClass = LandlordTypeFormModel::class
@@ -16,15 +15,21 @@ class LandlordTypeStepConfig : AbstractRequestableStepConfig<LandlordTypeMode, L
     override fun getStepSpecificContent(state: JourneyState) =
         mapOf(
             "fieldSetHeading" to "registerAsALandlord.landlordType.fieldSetHeading",
+            "legend" to "registerAsALandlord.landlordType.legend",
+            "partnershipSummary" to "registerAsALandlord.landlordType.partnership.summary",
+            "partnershipParagraphOne" to "registerAsALandlord.landlordType.partnership.paragraph.one",
+            "partnershipParagraphTwo" to "registerAsALandlord.landlordType.partnership.paragraph.two",
             "radioOptions" to
                 listOf(
                     RadiosButtonViewModel(
                         value = LandlordType.INDIVIDUAL,
                         labelMsgKey = "registerAsALandlord.landlordType.radios.individual.label",
+                        hintMsgKey = "registerAsALandlord.landlordType.radios.individual.hint",
                     ),
                     RadiosButtonViewModel(
                         value = LandlordType.ORGANISATION,
                         labelMsgKey = "registerAsALandlord.landlordType.radios.organisation.label",
+                        hintMsgKey = "registerAsALandlord.landlordType.radios.organisation.hint",
                     ),
                 ),
         )

--- a/src/main/resources/messages/registerAsALandlord.yml
+++ b/src/main/resources/messages/registerAsALandlord.yml
@@ -77,7 +77,6 @@ landlordType:
     paragraph:
       one: All members of English business partnerships must register as individuals and follow the guidance for joint landlords.
       two: Limited Liability Partnerships (LLPs) and Scottish partnerships must register as organisations.
-  legend: Select if you are registering as an individual or an organisation
   radios:
     individual:
       label: An individual

--- a/src/main/resources/messages/registerAsALandlord.yml
+++ b/src/main/resources/messages/registerAsALandlord.yml
@@ -70,11 +70,20 @@ privacyNotice:
     label: I confirm I have read the privacy notice for this private beta
   oneLoginInset: "When you continue, you\u2019ll be asked to prove your identity using your GOV.UK One Login."
 landlordType:
+  caption: Register as a landlord
   fieldSetHeading: Are you registering as an individual or an organisation?
+  partnership:
+    summary: Registering a partnership
+    paragraph:
+      one: All members of English business partnerships must register as individuals and follow the guidance for joint landlords.
+      two: Limited Liability Partnerships (LLPs) and Scottish partnerships must register as organisations.
+  legend: Select if you are registering as an individual or an organisation
   radios:
     individual:
-      label: Individual
+      label: An individual
+      hint: You rent out a property as an individual, sole trader or joint landlord
     organisation:
-      label: Organisation
+      label: An organisation
+      hint: You rent out a property as a company, charity or trust
     error:
-      missing: Select whether you are registering as an individual or an organisation
+      missing: Select if you are registering as an individual or an organisation

--- a/src/main/resources/templates/forms/landlordTypeForm.html
+++ b/src/main/resources/templates/forms/landlordTypeForm.html
@@ -1,7 +1,6 @@
 <!--/*@thymesVar id="title" type="java.lang.String"*/-->
 <!--/*@thymesVar id="formModel" type="java.lang.Object"*/-->
 <!--/*@thymesVar id="fieldSetHeading" type="java.lang.String"*/-->
-<!--/*@thymesVar id="legend" type="java.lang.String"*/-->
 <!--/*@thymesVar id="partnershipSummary" type="java.lang.String"*/-->
 <!--/*@thymesVar id="partnershipParagraphOne" type="java.lang.String"*/-->
 <!--/*@thymesVar id="partnershipParagraphTwo" type="java.lang.String"*/-->
@@ -20,7 +19,7 @@
 </th:block>
 <th:block id="form-content">
     <th:block id="fieldset-content"
-              th:replace="~{fragments/forms/minorFieldSet :: minorFieldSet(~{::#fieldset-content/content()}, 'landlordType', #{${legend}}, null)}">
+              th:replace="~{fragments/forms/minorFieldSet :: minorFieldSet(~{::#fieldset-content/content()}, 'landlordType', null, null)}">
         <th:block th:replace="~{fragments/forms/radios :: radios(null,'landlordType',null, ${radioOptions})}"></th:block>
     </th:block>
     <div class="govuk-button-group">

--- a/src/main/resources/templates/forms/landlordTypeForm.html
+++ b/src/main/resources/templates/forms/landlordTypeForm.html
@@ -1,13 +1,26 @@
 <!--/*@thymesVar id="title" type="java.lang.String"*/-->
 <!--/*@thymesVar id="formModel" type="java.lang.Object"*/-->
 <!--/*@thymesVar id="fieldSetHeading" type="java.lang.String"*/-->
+<!--/*@thymesVar id="legend" type="java.lang.String"*/-->
+<!--/*@thymesVar id="partnershipSummary" type="java.lang.String"*/-->
+<!--/*@thymesVar id="partnershipParagraphOne" type="java.lang.String"*/-->
+<!--/*@thymesVar id="partnershipParagraphTwo" type="java.lang.String"*/-->
 <!--/*@thymesVar id="backUrl" type="java.lang.String"*/-->
 <!--/*@thymesVar id="radioOptions" type="java.lang.Object"*/-->
 <!DOCTYPE html>
-<html th:replace="~{fragments/forms/questionPage :: questionPage(#{${title}}, ${formModel}, ~{::#form-content}, ${backUrl}, null)}">
+<html th:replace="~{fragments/forms/complexQuestionPage :: complexQuestionPage(#{${title}}, ${formModel}, ~{::#form-content}, ~{::#question-content}, ${backUrl}, ${sectionHeaderInfo})}">
+<th:block id="question-content">
+    <h1 class="govuk-heading-l" th:text="#{${fieldSetHeading}}"></h1>
+    <details id="details" th:replace="~{fragments/details :: details(#{${partnershipSummary}}, ~{::#details/content()})}">
+        <div class="govuk-details__text">
+            <p class="govuk-body" th:text="#{${partnershipParagraphOne}}"></p>
+            <p class="govuk-body" th:text="#{${partnershipParagraphTwo}}"></p>
+        </div>
+    </details>
+</th:block>
 <th:block id="form-content">
     <th:block id="fieldset-content"
-              th:replace="~{fragments/forms/fieldSet :: fieldSet(~{::#fieldset-content/content()}, 'landlordType', #{${fieldSetHeading}}, null)}">
+              th:replace="~{fragments/forms/minorFieldSet :: minorFieldSet(~{::#fieldset-content/content()}, 'landlordType', #{${legend}}, null)}">
         <th:block th:replace="~{fragments/forms/radios :: radios(null,'landlordType',null, ${radioOptions})}"></th:block>
     </th:block>
     <div class="govuk-button-group">

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/OrganisationLandlordRegistrationSinglePageTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/OrganisationLandlordRegistrationSinglePageTests.kt
@@ -1,0 +1,53 @@
+package uk.gov.communities.prsdb.webapp.integration
+
+import com.microsoft.playwright.Page
+import com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import uk.gov.communities.prsdb.webapp.constants.ORGANISATION_LANDLORD_REGISTRATION
+
+class OrganisationLandlordRegistrationSinglePageTests : IntegrationTestWithImmutableData("data-mockuser-not-landlord.sql") {
+    @BeforeEach
+    fun enableOrgLandlordFlag() {
+        featureFlagManager.enable(ORGANISATION_LANDLORD_REGISTRATION)
+    }
+
+    @Nested
+    inner class LandlordTypeStep {
+        @Test
+        fun `the landlord type page renders the caption, heading, partnership details and radio options`(page: Page) {
+            val landlordTypePage = navigator.goToOrganisationLandlordRegistrationLandlordTypePage()
+
+            assertThat(landlordTypePage.page.locator("#section-header")).containsText("Register as a landlord")
+            assertThat(landlordTypePage.page.locator("h1"))
+                .containsText("Are you registering as an individual or an organisation?")
+            assertThat(landlordTypePage.page.locator(".govuk-details__summary-text"))
+                .containsText("Registering a partnership")
+            assertThat(landlordTypePage.page.locator("label[for='landlordType-INDIVIDUAL']")).containsText("An individual")
+            assertThat(landlordTypePage.page.locator("#landlordType-INDIVIDUAL-hint"))
+                .containsText("You rent out a property as an individual, sole trader or joint landlord")
+            assertThat(landlordTypePage.page.locator("label[for='landlordType-ORGANISATION']")).containsText("An organisation")
+            assertThat(landlordTypePage.page.locator("#landlordType-ORGANISATION-hint"))
+                .containsText("You rent out a property as a company, charity or trust")
+        }
+
+        @Test
+        fun `the legend text is not shown as a header when there is no error`(page: Page) {
+            val landlordTypePage = navigator.goToOrganisationLandlordRegistrationLandlordTypePage()
+
+            assertThat(landlordTypePage.page.locator(".govuk-fieldset__legend")).hasCount(0)
+            assertThat(landlordTypePage.page.locator(".govuk-error-message")).hasCount(0)
+        }
+
+        @Test
+        fun `submitting with no landlord type selected returns an error`(page: Page) {
+            val landlordTypePage = navigator.goToOrganisationLandlordRegistrationLandlordTypePage()
+
+            landlordTypePage.form.submit()
+
+            assertThat(landlordTypePage.form.getErrorMessage())
+                .containsText("Select if you are registering as an individual or an organisation")
+        }
+    }
+}

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/OrganisationLandlordRegistrationSinglePageTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/OrganisationLandlordRegistrationSinglePageTests.kt
@@ -17,7 +17,7 @@ class OrganisationLandlordRegistrationSinglePageTests : IntegrationTestWithImmut
     inner class LandlordTypeStep {
         @Test
         fun `the landlord type page renders the caption, heading, partnership details and radio options`(page: Page) {
-            val landlordTypePage = navigator.goToOrganisationLandlordRegistrationLandlordTypePage()
+            val landlordTypePage = navigator.goToLandlordRegistrationLandlordTypePage()
 
             assertThat(landlordTypePage.page.locator("#section-header")).containsText("Register as a landlord")
             assertThat(landlordTypePage.page.locator("h1"))
@@ -34,7 +34,7 @@ class OrganisationLandlordRegistrationSinglePageTests : IntegrationTestWithImmut
 
         @Test
         fun `the legend text is not shown as a header when there is no error`(page: Page) {
-            val landlordTypePage = navigator.goToOrganisationLandlordRegistrationLandlordTypePage()
+            val landlordTypePage = navigator.goToLandlordRegistrationLandlordTypePage()
 
             assertThat(landlordTypePage.page.locator(".govuk-fieldset__legend")).hasCount(0)
             assertThat(landlordTypePage.page.locator(".govuk-error-message")).hasCount(0)
@@ -42,7 +42,7 @@ class OrganisationLandlordRegistrationSinglePageTests : IntegrationTestWithImmut
 
         @Test
         fun `submitting with no landlord type selected returns an error`(page: Page) {
-            val landlordTypePage = navigator.goToOrganisationLandlordRegistrationLandlordTypePage()
+            val landlordTypePage = navigator.goToLandlordRegistrationLandlordTypePage()
 
             landlordTypePage.form.submit()
 

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/Navigator.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/Navigator.kt
@@ -102,7 +102,7 @@ import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.localCounci
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.localCouncilUserRegistrationJourneyPages.EmailFormPageLocalCouncilUserRegistration
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.localCouncilUserRegistrationJourneyPages.NameFormPageLocalCouncilUserRegistration
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.localCouncilUserRegistrationJourneyPages.PrivacyNoticePageLocalCouncilUserRegistration
-import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.organisationLandlordRegistrationJourneyPages.LandlordTypeFormPageOrganisationLandlordRegistration
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.organisationLandlordRegistrationJourneyPages.LandlordTypePageLandlordRegistration
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyDeregistrationJourneyPages.AreYouSurePagePropertyDeregistration
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyDeregistrationJourneyPages.CannotDeregisterPropertyJointLandlordsPage
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyDeregistrationJourneyPages.CheckInvitationsPage
@@ -269,9 +269,9 @@ class Navigator(
         return createValidPage(page, ServiceInformationStartPageLandlordRegistration::class)
     }
 
-    fun goToOrganisationLandlordRegistrationLandlordTypePage(): LandlordTypeFormPageOrganisationLandlordRegistration {
+    fun goToLandlordRegistrationLandlordTypePage(): LandlordTypePageLandlordRegistration {
         navigate("$LANDLORD_REGISTRATION_ROUTE/${LandlordTypeStep.ROUTE_SEGMENT}")
-        return createValidPage(page, LandlordTypeFormPageOrganisationLandlordRegistration::class)
+        return createValidPage(page, LandlordTypePageLandlordRegistration::class)
     }
 
     fun goToLandlordRegistrationPrivacyNoticePage(): PrivacyNoticePageLandlordRegistration {

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/Navigator.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/Navigator.kt
@@ -102,6 +102,7 @@ import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.localCounci
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.localCouncilUserRegistrationJourneyPages.EmailFormPageLocalCouncilUserRegistration
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.localCouncilUserRegistrationJourneyPages.NameFormPageLocalCouncilUserRegistration
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.localCouncilUserRegistrationJourneyPages.PrivacyNoticePageLocalCouncilUserRegistration
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.organisationLandlordRegistrationJourneyPages.LandlordTypeFormPageOrganisationLandlordRegistration
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyDeregistrationJourneyPages.AreYouSurePagePropertyDeregistration
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyDeregistrationJourneyPages.CannotDeregisterPropertyJointLandlordsPage
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyDeregistrationJourneyPages.CheckInvitationsPage
@@ -164,6 +165,7 @@ import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.
 import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.EmailStep
 import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.PhoneNumberStep
 import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.PrivacyNoticeStep
+import uk.gov.communities.prsdb.webapp.journeys.organisationLandlordRegistration.steps.LandlordTypeStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.BedroomsStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.BillsIncludedStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.CheckElectricalSafetyAnswersStep
@@ -265,6 +267,11 @@ class Navigator(
     fun goToLandlordRegistrationServiceInformationStartPage(): ServiceInformationStartPageLandlordRegistration {
         navigate(LANDLORD_REGISTRATION_START_PAGE_ROUTE)
         return createValidPage(page, ServiceInformationStartPageLandlordRegistration::class)
+    }
+
+    fun goToOrganisationLandlordRegistrationLandlordTypePage(): LandlordTypeFormPageOrganisationLandlordRegistration {
+        navigate("$LANDLORD_REGISTRATION_ROUTE/${LandlordTypeStep.ROUTE_SEGMENT}")
+        return createValidPage(page, LandlordTypeFormPageOrganisationLandlordRegistration::class)
     }
 
     fun goToLandlordRegistrationPrivacyNoticePage(): PrivacyNoticePageLandlordRegistration {

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/organisationLandlordRegistrationJourneyPages/LandlordTypeFormPageOrganisationLandlordRegistration.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/organisationLandlordRegistrationJourneyPages/LandlordTypeFormPageOrganisationLandlordRegistration.kt
@@ -1,0 +1,26 @@
+package uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.organisationLandlordRegistrationJourneyPages
+
+import com.microsoft.playwright.Page
+import uk.gov.communities.prsdb.webapp.controllers.RegisterLandlordController.Companion.LANDLORD_REGISTRATION_ROUTE
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.FormWithSectionHeader
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.Radios
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages.BasePage
+import uk.gov.communities.prsdb.webapp.journeys.organisationLandlordRegistration.steps.LandlordTypeStep
+import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.LandlordType
+
+class LandlordTypeFormPageOrganisationLandlordRegistration(
+    page: Page,
+) : BasePage(page, "$LANDLORD_REGISTRATION_ROUTE/${LandlordTypeStep.ROUTE_SEGMENT}") {
+    val form = LandlordTypeForm(page)
+
+    fun submitLandlordType(landlordType: LandlordType) {
+        form.landlordTypeRadios.selectValue(landlordType)
+        form.submit()
+    }
+
+    class LandlordTypeForm(
+        page: Page,
+    ) : FormWithSectionHeader(page) {
+        val landlordTypeRadios = Radios(locator)
+    }
+}

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/organisationLandlordRegistrationJourneyPages/LandlordTypePageLandlordRegistration.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/organisationLandlordRegistrationJourneyPages/LandlordTypePageLandlordRegistration.kt
@@ -8,7 +8,7 @@ import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages.B
 import uk.gov.communities.prsdb.webapp.journeys.organisationLandlordRegistration.steps.LandlordTypeStep
 import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.LandlordType
 
-class LandlordTypeFormPageOrganisationLandlordRegistration(
+class LandlordTypePageLandlordRegistration(
     page: Page,
 ) : BasePage(page, "$LANDLORD_REGISTRATION_ROUTE/${LandlordTypeStep.ROUTE_SEGMENT}") {
     val form = LandlordTypeForm(page)


### PR DESCRIPTION
## Ticket number

PDJB-1127

## Goal of change

Adds the individual or org landlord page

## Description of main change(s)

<img width="978" height="927" alt="image" src="https://github.com/user-attachments/assets/2b19acfe-6922-4140-ba4f-b850c38c552f" />
Adds a page in landlord registration so users can choose between individual or org.

## Checklist

Delete any that are not applicable, and add explanation below for any that are applicable but haven't been done

- [x] Screenshots of any UI changes have been added
- [x] Unit tests for new logic (e.g. new service methods) have been added
- [x] Single page integration tests have been added for any unhappy-flow UI features, e.g. validation errors
- [x] New journey steps have been added to the appropriate journey integration test(s)
- [x] Test suite has been run in full locally and is passing
- [x] Branch has been rebased onto main and run locally, with everything working as expected (both for your new feature
  and any related functionality)
- [x] TODO comments referencing this JIRA ticket have been searched for and removed - if a future PR will address them,
  mention that here
- [ ] QA instructions have been added to the ticket (particularly if this is the last PR required to complete the ticket)
