### PR TITLE
PDJB-308: Ensure emails are sent last when deregistering landlord

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/landlordDeregistration/stepConfig/DeregisterStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/landlordDeregistration/stepConfig/DeregisterStepConfig.kt
@@ -13,17 +13,17 @@ import uk.gov.communities.prsdb.webapp.models.viewModels.emailModels.PropertyDet
 import uk.gov.communities.prsdb.webapp.services.EmailNotificationService
 import uk.gov.communities.prsdb.webapp.services.LandlordDeregistrationService
 import uk.gov.communities.prsdb.webapp.services.LandlordService
-import uk.gov.communities.prsdb.webapp.services.PropertyOwnershipService
 import uk.gov.communities.prsdb.webapp.services.SecurityContextService
+import uk.gov.communities.prsdb.webapp.services.SwapToIndividualNudgeEmailService
 
 @JourneyFrameworkComponent
 class DeregisterStepConfig(
     private val landlordDeregistrationService: LandlordDeregistrationService,
     private val landlordService: LandlordService,
-    private val propertyOwnershipService: PropertyOwnershipService,
     private val securityContextService: SecurityContextService,
     private val confirmationWithPropertiesEmailSender: EmailNotificationService<LandlordWithPropertiesDeregistrationConfirmationEmail>,
     private val confirmationWithNoPropertiesEmailSender: EmailNotificationService<LandlordNoPropertiesDeregistrationConfirmationEmail>,
+    private val swapToIndividualNudgeEmailService: SwapToIndividualNudgeEmailService,
 ) : AbstractInternalStepConfig<Complete, LandlordDeregistrationJourneyState>() {
     override fun mode(state: LandlordDeregistrationJourneyState): Complete = Complete.COMPLETE
 
@@ -34,6 +34,7 @@ class DeregisterStepConfig(
 
         val soleLandlordProperties = landlord.landlordships.toList()
         val landlordHadActiveSoloProperties = soleLandlordProperties.isNotEmpty()
+        val jointlyOwnedProperties = landlord.landlordships.filterNot { it.isSolelyOwnedBy(landlord) }
 
         landlordDeregistrationService.deregisterLandlord(baseUserId)
         landlordDeregistrationService.addLandlordHadActivePropertiesToSession(landlordHadActiveSoloProperties)
@@ -50,6 +51,10 @@ class DeregisterStepConfig(
                 landlordEmailAddress,
                 LandlordNoPropertiesDeregistrationConfirmationEmail(),
             )
+        }
+
+        jointlyOwnedProperties.forEach {
+            swapToIndividualNudgeEmailService.sendNudgeEmailIfApplicable(it)
         }
 
         securityContextService.refreshContext()

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/LandlordDeregistrationService.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/LandlordDeregistrationService.kt
@@ -14,11 +14,14 @@ class LandlordDeregistrationService(
     private val landlordRepository: LandlordRepository,
     private val propertyOwnershipRepository: PropertyOwnershipRepository,
     private val propertyOwnershipService: PropertyOwnershipService,
-    private val swapToIndividualNudgeEmailService: SwapToIndividualNudgeEmailService,
     private val prsdbUserRepository: PrsdbUserRepository,
     private val userRolesService: UserRolesService,
     private val session: HttpSession,
 ) {
+    /**
+     * Consider whether you need to also call SwapToIndividualNudgeEmailService#sendNudgeEmailIfApplicable.
+     * This would be in case this action can lead a property marked as JL but without any active invitations.
+     */
     @Transactional
     fun deregisterLandlord(baseUserId: String) {
         landlordRepository.findByBaseUser_Id(baseUserId)?.let { landlord ->
@@ -28,10 +31,6 @@ class LandlordDeregistrationService(
                 propertyOwnershipService.removeLandlord(it, landlord)
             }
             propertyOwnershipRepository.deleteAll(solelyOwnedProperties)
-
-            jointlyOwnedProperties.forEach {
-                swapToIndividualNudgeEmailService.sendNudgeEmailIfApplicable(it)
-            }
         }
 
         landlordRepository.deleteByBaseUser_Id(baseUserId)

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/landlordDeregistration/stepConfig/DeregisterStepConfigTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/landlordDeregistration/stepConfig/DeregisterStepConfigTests.kt
@@ -11,6 +11,7 @@ import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.test.util.ReflectionTestUtils
 import uk.gov.communities.prsdb.webapp.journeys.Destination
 import uk.gov.communities.prsdb.webapp.journeys.landlordDeregistration.LandlordDeregistrationJourneyState
 import uk.gov.communities.prsdb.webapp.models.viewModels.emailModels.LandlordNoPropertiesDeregistrationConfirmationEmail
@@ -18,8 +19,8 @@ import uk.gov.communities.prsdb.webapp.models.viewModels.emailModels.LandlordWit
 import uk.gov.communities.prsdb.webapp.services.EmailNotificationService
 import uk.gov.communities.prsdb.webapp.services.LandlordDeregistrationService
 import uk.gov.communities.prsdb.webapp.services.LandlordService
-import uk.gov.communities.prsdb.webapp.services.PropertyOwnershipService
 import uk.gov.communities.prsdb.webapp.services.SecurityContextService
+import uk.gov.communities.prsdb.webapp.services.SwapToIndividualNudgeEmailService
 import uk.gov.communities.prsdb.webapp.testHelpers.JourneyTestHelper
 import uk.gov.communities.prsdb.webapp.testHelpers.mockObjects.MockLandlordData
 
@@ -32,9 +33,6 @@ class DeregisterStepConfigTests {
     lateinit var mockLandlordService: LandlordService
 
     @Mock
-    lateinit var mockPropertyOwnershipService: PropertyOwnershipService
-
-    @Mock
     lateinit var mockSecurityContextService: SecurityContextService
 
     @Mock
@@ -44,6 +42,9 @@ class DeregisterStepConfigTests {
     @Mock
     lateinit var mockConfirmationWithNoPropertiesEmailSender:
         EmailNotificationService<LandlordNoPropertiesDeregistrationConfirmationEmail>
+
+    @Mock
+    lateinit var mockSwapToIndividualNudgeEmailService: SwapToIndividualNudgeEmailService
 
     @Mock
     lateinit var mockState: LandlordDeregistrationJourneyState
@@ -157,6 +158,23 @@ class DeregisterStepConfigTests {
         verify(mockState).deleteJourney()
     }
 
+    @Test
+    fun `afterStepIsReached calls nudge email service for jointly owned properties`() {
+        val stepConfig = setupStepConfig()
+        JourneyTestHelper.setMockUser(baseUserId)
+        val landlord = MockLandlordData.createLandlord(email = landlordEmail)
+        ReflectionTestUtils.setField(landlord, "id", 1L)
+        val coLandlord = MockLandlordData.createLandlord()
+        ReflectionTestUtils.setField(coLandlord, "id", 2L)
+        val jointProperty =
+            MockLandlordData.createPropertyOwnership(landlords = mutableSetOf(landlord, coLandlord))
+        whenever(mockLandlordService.retrieveLandlordByBaseUserId(baseUserId)).thenReturn(landlord)
+
+        stepConfig.afterStepIsReached(mockState)
+
+        verify(mockSwapToIndividualNudgeEmailService).sendNudgeEmailIfApplicable(jointProperty)
+    }
+
     private fun setupMocksForWithProperties() {
         JourneyTestHelper.setMockUser(baseUserId)
         val property = MockLandlordData.createPropertyOwnership()
@@ -174,9 +192,9 @@ class DeregisterStepConfigTests {
         DeregisterStepConfig(
             mockLandlordDeregistrationService,
             mockLandlordService,
-            mockPropertyOwnershipService,
             mockSecurityContextService,
             mockConfirmationWithPropertiesEmailSender,
             mockConfirmationWithNoPropertiesEmailSender,
+            mockSwapToIndividualNudgeEmailService,
         )
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/LandlordDeregistrationServiceTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/LandlordDeregistrationServiceTests.kt
@@ -31,9 +31,6 @@ class LandlordDeregistrationServiceTests {
     private lateinit var mockPropertyOwnershipService: PropertyOwnershipService
 
     @Mock
-    private lateinit var mockSwapToIndividualNudgeEmailService: SwapToIndividualNudgeEmailService
-
-    @Mock
     private lateinit var mockPrsdbUserRepository: PrsdbUserRepository
 
     @Mock
@@ -97,7 +94,6 @@ class LandlordDeregistrationServiceTests {
 
         verify(mockPropertyOwnershipRepository).deleteAll(emptyList())
         verify(mockPropertyOwnershipService).removeLandlord(jointProperty, landlord)
-        verify(mockSwapToIndividualNudgeEmailService).sendNudgeEmailIfApplicable(jointProperty)
     }
 
     @Test


### PR DESCRIPTION
## Ticket number

[PDJB-308](https://mhclgdigital.atlassian.net/browse/PDJB-308)

## Goal of change

moves the nudge email logic for deleting landlords out of the service and into the calling task so the emails can be sent separate from any database transactions

## Anything you'd like to highlight to the reviewer?

this should make us confident that the emails will only send if the landlord could actually be removed

## Checklist

Delete any that are not applicable, and add explanation below for any that are applicable but haven't been done

- [x] Unit tests for new logic (e.g. new service methods) have been added
- [x] Test suite has been run in full locally and is passing
- [x] Branch has been rebased onto main and run locally, with everything working as expected (both for your new feature
  and any related functionality)
- [x] QA instructions have been added to the ticket (particularly if this is the last PR required to complete the ticket)
