### PR TITLE
PDJB-NONE: Fix CloudWatch config bean name collision with AWS autoconfig

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/config/CloudWatchConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/config/CloudWatchConfig.kt
@@ -10,7 +10,7 @@ import software.amazon.awssdk.services.cloudwatch.CloudWatchClient
 import uk.gov.communities.prsdb.webapp.annotations.webAnnotations.PrsdbWebConfiguration
 
 @Profile("!local")
-@PrsdbWebConfiguration
+@PrsdbWebConfiguration("prsdbCloudWatchConfig")
 class CloudWatchConfig {
     @Bean
     @Primary


### PR DESCRIPTION
## Ticket number

PDJB-NONE

## Goal of change

Fix the broken integration environment caused by PR #1486, where the application failed to start.

## Description of main change(s)

- PR #1486 introduced `@PrsdbWebConfiguration class CloudWatchConfig`, which Spring registered under the bean name `cloudWatchConfig` (derived from the class name).
- AWS Spring Cloud's `CloudWatchExportAutoConfiguration` already registers an unrelated bean of the same name (`cloudWatchConfig`, a Micrometer metrics-export config). With bean-definition overriding disabled, this clash threw `BeanDefinitionOverrideException` at startup.
- Only affected non-`local` profiles (the config is `@Profile("!local")`), so the full test suite — which runs under `local` — stayed green while the deployed integration env broke.
- Fix gives our configuration an explicit, non-colliding bean name: `@PrsdbWebConfiguration("prsdbCloudWatchConfig")`.

## Anything you'd like to highlight to the reviewer?

The two beans are entirely different types/purposes (ours builds `CloudWatchClient`s to read metrics via `GetMetricStatistics`; the autoconfig's exports app metrics to CloudWatch) — this is purely a name collision, not duplicate configuration. Verified locally by reproducing the exact `BeanDefinitionOverrideException` with an `ApplicationContextRunner` slice under non-local conditions, then confirming the fix lets both beans coexist.

## Checklist

- [x] Branch has been rebased onto main and run locally, with everything working as expected
