### PR TITLE
PDJB-1069: Remove remaining references to primaryLandlord

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/PropertyDetailsController.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/PropertyDetailsController.kt
@@ -169,11 +169,6 @@ class PropertyDetailsController(
 
         val backUrlKey = backLinkStorageService.storeCurrentUrlReturningKey(LANDLORD_DETAILS_FRAGMENT)
 
-        val primaryLandlordDetailsUrl =
-            LandlordDetailsController
-                .getLandlordDetailsForLocalCouncilUserPath(propertyOwnership.primaryLandlord.id)
-                .overrideBackLinkForUrl(backUrlKey)
-
         val propertyCompliance = propertyComplianceService.getComplianceForPropertyOrNull(propertyOwnershipId)
 
         val propertyDetails =
@@ -197,6 +192,12 @@ class PropertyDetailsController(
             model.addAttribute("landlordSummaryCards", landlordSummaryCards)
             model.addAttribute("landlordCount", propertyOwnership.landlords.size)
         } else {
+            val primaryLandlord = propertyOwnership.landlords.first()
+            val primaryLandlordDetailsUrl =
+                LandlordDetailsController
+                    .getLandlordDetailsForLocalCouncilUserPath(primaryLandlord.id)
+                    .overrideBackLinkForUrl(backUrlKey)
+
             val landlordViewModel =
                 PropertyDetailsLandlordViewModelBuilder.fromEntity(
                     propertyOwnership.landlords.first(),

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/database/entity/PropertyOwnership.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/database/entity/PropertyOwnership.kt
@@ -46,9 +46,6 @@ class PropertyOwnership() : ModifiableAuditableEntity() {
 
     val landlords: Set<Landlord> get() = ownershipLinks.map { it.landlord }.toSet()
 
-    // TODO PDJB-1069 - remove the primary landlord value
-    val primaryLandlord: Landlord get() = ownershipLinks.minBy { it.id }.landlord
-
     @Column(nullable = false)
     lateinit var propertyBuildType: PropertyType
 

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyDeregistration/stepConfig/ReasonStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyDeregistration/stepConfig/ReasonStepConfig.kt
@@ -35,8 +35,10 @@ class ReasonStepConfig(
     override fun afterStepDataIsAdded(state: PropertyDeregistrationJourneyState) {
         val propertyOwnership = propertyOwnershipService.getPropertyOwnership(state.propertyOwnershipId)
 
-        // TODO PDJB-319 - do not use primary landlord
-        val primaryLandlordEmailAddress = propertyOwnership.primaryLandlord.email
+        // TODO PDJB-319 - update this to use the relevant landlord(s).
+        // primaryLandlord here arbitrary picks the landlord who registered their account first as a temporary measure.
+        val primaryLandlord = propertyOwnership.landlords.minBy { it.id }
+        val primaryLandlordEmailAddress = primaryLandlord.email
         val propertyRegistrationNumber = propertyOwnership.registrationNumber
         val propertyAddress = propertyOwnership.address.singleLineAddress
 

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyDeregistration/stepConfig/ReasonStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyDeregistration/stepConfig/ReasonStepConfig.kt
@@ -35,10 +35,10 @@ class ReasonStepConfig(
     override fun afterStepDataIsAdded(state: PropertyDeregistrationJourneyState) {
         val propertyOwnership = propertyOwnershipService.getPropertyOwnership(state.propertyOwnershipId)
 
-        // TODO PDJB-319 - update this to use the relevant landlord(s).
+        // TODO PDJB-319 - this should be deleted
         // primaryLandlord here arbitrary picks the landlord who registered their account first as a temporary measure.
-        val primaryLandlord = propertyOwnership.landlords.minBy { it.id }
-        val primaryLandlordEmailAddress = primaryLandlord.email
+        val soleLandlord = propertyOwnership.landlords.minBy { it.id }
+        val soleLandlordEmailAddress = soleLandlord.email
         val propertyRegistrationNumber = propertyOwnership.registrationNumber
         val propertyAddress = propertyOwnership.address.singleLineAddress
 
@@ -47,7 +47,7 @@ class ReasonStepConfig(
         propertyDeregistrationService.addDeregisteredPropertyOwnershipIdToSession(state.propertyOwnershipId)
 
         confirmationEmailSender.sendEmail(
-            primaryLandlordEmailAddress,
+            soleLandlordEmailAddress,
             PropertyDeregistrationConfirmationEmailOld(
                 RegistrationNumberDataModel.fromRegistrationNumber(propertyRegistrationNumber).toString(),
                 propertyAddress,


### PR DESCRIPTION
## Ticket number

PDJB-1069

## Goal of change

Remove remaining references to primaryLandlord

## Description of main change(s)

* Remove missed reference in PropertyDetailsController
* Replaced primaryLandlord reference in ReasonStepConfig with the definition that was on propertyOwnership. This is a temporary measure to be resolved in PDJB-319
* Removed the primaryLandlord getter from propertyOwnership

## Anything you'd like to highlight to the reviewer?

Include e.g. anything unusual about the PR, where there was some debate over how to implement it, or anywhere you were
unsure of the approach to take and would like specific feedback.

## Checklist

Delete any that are not applicable, and add explanation below for any that are applicable but haven't been done

- [x] Test suite has been run in full locally and is passing
- [x] TODO comments referencing this JIRA ticket have been searched for and removed - if a future PR will address them,
  mention that here
- [ ] QA instructions have been added to the ticket (particularly if this is the last PR required to complete the ticket)
