### PR TITLE
PDJB-307: Return to landlord details tab from switch IL journey

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/switchToIndividual/SwitchToIndividualJourneyFactory.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/switchToIndividual/SwitchToIndividualJourneyFactory.kt
@@ -4,6 +4,7 @@ import org.springframework.beans.factory.ObjectFactory
 import uk.gov.communities.prsdb.webapp.annotations.webAnnotations.JourneyFrameworkComponent
 import uk.gov.communities.prsdb.webapp.annotations.webAnnotations.PrsdbWebService
 import uk.gov.communities.prsdb.webapp.constants.CONFIRMATION_PATH_SEGMENT
+import uk.gov.communities.prsdb.webapp.constants.LANDLORD_DETAILS_FRAGMENT
 import uk.gov.communities.prsdb.webapp.controllers.PropertyDetailsController
 import uk.gov.communities.prsdb.webapp.controllers.SwitchToIndividualController
 import uk.gov.communities.prsdb.webapp.journeys.AbstractJourneyState
@@ -29,15 +30,18 @@ class SwitchToIndividualJourneyFactory(
     fun createJourneySteps(propertyOwnershipId: Long): Map<String, StepLifecycleOrchestrator> {
         val state = getInitializedState(propertyOwnershipId)
 
+        val propertyDetailsLandlordTab =
+            "${PropertyDetailsController.getPropertyDetailsPath(propertyOwnershipId)}#$LANDLORD_DETAILS_FRAGMENT"
+
         return journey(state) {
-            unreachableStepUrl { PropertyDetailsController.getPropertyDetailsPath(propertyOwnershipId) }
+            unreachableStepUrl { propertyDetailsLandlordTab }
             configure {
                 withAdditionalContentProperty { "title" to "switchToIndividual.title" }
             }
             step(journey.hasPendingInvitationsStep) {
                 routeSegment(HasPendingInvitationsStep.ROUTE_SEGMENT)
                 initialStep()
-                backUrl { PropertyDetailsController.getPropertyDetailsPath(propertyOwnershipId) }
+                backUrl { propertyDetailsLandlordTab }
                 nextStep { mode ->
                     when (mode) {
                         HasPendingInvitationsMode.YES -> journey.checkPendingInvitationsStep


### PR DESCRIPTION
## Ticket number

[PDJB-307](https://mhclgdigital.atlassian.net/browse/PDJB-307)

## Goal of change

when returning from the switch to individual landlord journey by pressing back, go to property details landlord tab

## Checklist

Delete any that are not applicable, and add explanation below for any that are applicable but haven't been done

- [x] Test suite has been run in full locally and is passing
- [x] Branch has been rebased onto main and run locally, with everything working as expected (both for your new feature
  and any related functionality)
