### PR TITLE
PDJB-NONE: Update post-release instructions on PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -36,5 +36,6 @@ Delete any that are not applicable, and add explanation below for any that are a
   mention that here
 - [ ] Seed data has been updated as needed for your feature to be tested without having to e.g. register a new property
 - [ ] `NftDataSeeder` has been updated to reflect any changes to the database schema
-- [ ] Any special release instructions (e.g. the database will need resetting, emails to be added/removed) have been to the relevant release ticket on the Jira board
+- [ ] Any special release instructions (e.g. the database will need resetting, emails to be added/removed) have been to the relevant release
+  ticket on the Jira board, referencing your ticket number
 - [ ] QA instructions have been added to the ticket (particularly if this is the last PR required to complete the ticket)

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,6 @@
 ## Ticket number
 
-In the format of "PDJB-XXXX" or "PRSD-XXXX" so that github will auto-link to the jira ticket
+In the format of "PDJB-XXXX" so that github will auto-link to the jira ticket
 
 ## Goal of change
 


### PR DESCRIPTION
## Ticket number

PDJB-NONE

## Goal of change

Update PR template post-release checklist item

## Description of main change(s)

Adds instruction to x-ref to originating ticket for post-release instructions when adding them to a release ticket.

Also removes obsolete mention of PRSD ticket numbering from the template.
