### PR TITLE
PDJB-NONE: update readme with mac gradle workaround

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -82,6 +82,19 @@ If you run into issues such as the one shown below, you can try the following:
 
 ![detect-secrets-error.png](readMeAssets/detect-secrets-error.png)
 
+### Troubleshooting gradle issues on apple silicon macs
+
+If you run into an issue with an apple silicon mac where gradle fails to build the app as it can't find npm (typically when using nvm),
+you have to start a gradle daemon on the command line first using
+
+```bash
+./gradlew --stop
+./gradlew assemble
+```
+
+This then gives you a window of time you can run the app via the intelliJ gradle runner. If it breaks again, you may need to repeat this.
+This is due to the gradle runner in intelliJ not finding variables on the PATH specifically on apple silicon macs.
+
 ### Testing
 
 The project uses a combination of unit tests and integration tests. The integration tests use a testcontainer to run a


### PR DESCRIPTION
## Ticket number

PDJB-NONE

## Goal of change

Improve readme for mac users

## Description of main change(s)

Adds readme instructions to help with running the app if your gradle won't pick up npm on the path, if using nvm and a mac with an apple silicon chip.

## Anything you'd like to highlight to the reviewer?

See related issues:
https://github.com/gradle/gradle/issues/10483#issuecomment-2141505147
https://youtrack.jetbrains.com/issue/IDEA-334183

I did also have a fix for this but I think it was very ugly, it involved scanning the path in the build step which shouldn't really be necessary, so I think this workaround is a bit better for the time being.