### PR TITLE
PDJB-1034: Fix ECS dashboard metrics namespace so utilisation metrics return data

### DIFF
--- a/docs/MetricsReadMe.md
+++ b/docs/MetricsReadMe.md
@@ -15,9 +15,9 @@ The system operator metrics page (`/system-operator/metrics`) shows a single sum
 
 | Dashboard row                 | Namespace             | Metric             | Statistic | Dimensions                              | Region      |
 |-------------------------------|-----------------------|--------------------|-----------|-----------------------------------------|-------------|
-| Peak memory utilisation       | `ECS/ContainerInsights` | `MemoryUtilization` | Maximum   | `ClusterName`, `ServiceName`            | `eu-west-2` |
-| Average memory utilisation    | `ECS/ContainerInsights` | `MemoryUtilization` | Average   | `ClusterName`, `ServiceName`            | `eu-west-2` |
-| Peak CPU utilisation          | `ECS/ContainerInsights` | `CPUUtilization`    | Maximum   | `ClusterName`, `ServiceName`            | `eu-west-2` |
+| Peak memory utilisation       | `AWS/ECS`               | `MemoryUtilization` | Maximum   | `ClusterName`, `ServiceName`            | `eu-west-2` |
+| Average memory utilisation    | `AWS/ECS`               | `MemoryUtilization` | Average   | `ClusterName`, `ServiceName`            | `eu-west-2` |
+| Peak CPU utilisation          | `AWS/ECS`               | `CPUUtilization`    | Maximum   | `ClusterName`, `ServiceName`            | `eu-west-2` |
 | ElastiCache CPU utilisation   | `AWS/ElastiCache`       | `CPUUtilization`    | Maximum   | `CacheClusterId`                        | `eu-west-2` |
 | Client error rate (HTTP 4xx)  | `AWS/CloudFront`        | `4xxErrorRate`      | Average   | `DistributionId`, `Region=Global`       | `us-east-1` |
 | Server error rate (HTTP 5xx)  | `AWS/CloudFront`        | `5xxErrorRate`      | Average   | `DistributionId`, `Region=Global`       | `us-east-1` |

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -87,7 +87,7 @@ plausible:
 
 cloudwatch-metrics:
   ecs:
-    namespace: ${CLOUDWATCH_ECS_NAMESPACE:ECS/ContainerInsights}
+    namespace: ${CLOUDWATCH_ECS_NAMESPACE:AWS/ECS}
     memory-utilisation-metric: ${CLOUDWATCH_ECS_MEMORY_METRIC:MemoryUtilization}
     cpu-utilisation-metric: ${CLOUDWATCH_ECS_CPU_METRIC:CPUUtilization}
     cluster-name: ${CLOUDWATCH_ECS_CLUSTER_NAME:}

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/CloudWatchMetricsServiceTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/CloudWatchMetricsServiceTests.kt
@@ -27,7 +27,7 @@ class CloudWatchMetricsServiceTests {
     private fun service() =
         CloudWatchMetricsService(
             client,
-            ecsNamespace = "ECS/ContainerInsights",
+            ecsNamespace = "AWS/ECS",
             ecsMemoryMetric = "MemoryUtilization",
             ecsCpuMetric = "CPUUtilization",
             ecsClusterName = "cluster",
@@ -45,7 +45,7 @@ class CloudWatchMetricsServiceTests {
     fun `getMetrics maps memory, cpu, elasticache and cloudfront error rate values`() {
         whenever(
             client.getMetricStatistic(
-                eq("ECS/ContainerInsights"),
+                eq("AWS/ECS"),
                 eq("MemoryUtilization"),
                 any(),
                 eq(Statistic.MAXIMUM),
@@ -55,7 +55,7 @@ class CloudWatchMetricsServiceTests {
         ).thenReturn(73.42)
         whenever(
             client.getMetricStatistic(
-                eq("ECS/ContainerInsights"),
+                eq("AWS/ECS"),
                 eq("MemoryUtilization"),
                 any(),
                 eq(Statistic.AVERAGE),
@@ -64,7 +64,7 @@ class CloudWatchMetricsServiceTests {
             ),
         ).thenReturn(41.21)
         whenever(
-            client.getMetricStatistic(eq("ECS/ContainerInsights"), eq("CPUUtilization"), any(), eq(Statistic.MAXIMUM), any(), anyOrNull()),
+            client.getMetricStatistic(eq("AWS/ECS"), eq("CPUUtilization"), any(), eq(Statistic.MAXIMUM), any(), anyOrNull()),
         ).thenReturn(62.5)
         whenever(
             client.getMetricStatistic(eq("AWS/ElastiCache"), eq("CPUUtilization"), any(), eq(Statistic.MAXIMUM), any(), anyOrNull()),

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -41,7 +41,7 @@ plausible:
 
 cloudwatch-metrics:
   ecs:
-    namespace: ECS/ContainerInsights
+    namespace: AWS/ECS
     memory-utilisation-metric: MemoryUtilization
     cpu-utilisation-metric: CPUUtilization
     cluster-name: test-cluster


### PR DESCRIPTION
## Ticket number

PDJB-1034

## Goal of change

Fix the System Operator metrics dashboard showing "No data" for peak memory utilisation, average memory utilisation and peak CPU utilisation on deployed environments.

## Description of main change(s)

- PR #1486 configured the ECS dashboard metrics with the namespace `ECS/ContainerInsights` but the metric names `MemoryUtilization` / `CPUUtilization`. Those percentage-utilisation metric names only exist in the `AWS/ECS` namespace; `ECS/ContainerInsights` publishes differently named metrics (`MemoryUtilized`, `CpuUtilized`, etc.). The mismatch meant CloudWatch returned no datapoints, so the three ECS rows rendered "No data".
- Changes the default ECS namespace from `ECS/ContainerInsights` to `AWS/ECS` (still overridable via `CLOUDWATCH_ECS_NAMESPACE`). The existing metric names and `ClusterName` + `ServiceName` dimensions are correct for `AWS/ECS`, which is enabled by default for every ECS service.

## Anything you'd like to highlight to the reviewer?



## Checklist

- [x] Unit tests for new logic (e.g. new service methods) have been added
- [x] Controller tests for any new endpoints, including testing the relevant permissions
- [x] Test suite has been run in full locally and is passing — ran the affected `CloudWatchMetricsServiceTests`, `AwsCloudWatchMetricsClientTests` and `MetricsControllerTests`, all passing
- [x] Branch has been rebased onto main and run locally, with everything working as expected
- [x] TODO comments referencing this JIRA ticket have been searched for and removed
