### PR TITLE
PDJB-1034: Count transactions from the Plausible Transaction event after a cutover date

### DIFF
--- a/docs/MetricsReadMe.md
+++ b/docs/MetricsReadMe.md
@@ -6,7 +6,67 @@ The system operator metrics page (`/system-operator/metrics`) shows a single sum
   percentiles, from the database (`MetricsService`).
 - **Journey completion rates** — from the Plausible Stats API (`PlausibleMetricsService`, see
   [AnalyticsReadMe](AnalyticsReadMe.md)).
+- **Transaction counts** — completed transactions from the Plausible `Transaction` custom event
+  (`PlausibleMetricsService`), described below.
 - **Infrastructure metrics** — from Amazon CloudWatch (`CloudWatchMetricsService`), described below.
+
+The page (`MetricsController`) shows no rows until the operator submits a **reporting period** (From/To
+dates); on submit, the four services are queried for that period and their results are rendered as one
+combined summary list (`getMetricRows`). Counts are formatted as integers, durations via
+`MetricsDurationHelper`, and rates/utilisations as `0.00%`. Any value that is missing — or whose upstream
+call failed — renders as **"No data"** rather than erroring the page. Row labels come from
+`messages/metrics.yml` (`metrics.rows.*`).
+
+## Dashboard rows
+
+The summary list contains the following rows, in display order:
+
+| # | Dashboard label | Source | Derivation |
+|---|-----------------|--------|------------|
+| 1 | Number of registrations (landlords) | Database (`MetricsService`) | Landlords created in the period. |
+| 2 | Landlords verified by One Login | Database (`MetricsService`) | Landlords created in the period with `isVerified = true`. |
+| 3 | Number of properties | Database (`MetricsService`) | Property ownerships created in the period. |
+| 4 | Number of landlords with at least 1 property | Database (`MetricsService`) | Distinct landlords owning a property created in the period. |
+| 5 | Median time between registration and first property | Database (`MetricsService`) | Median (p50) of registration→first-property durations; ignores joint landlords. |
+| 6 | 90th percentile time between registration and first property | Database (`MetricsService`) | p90 of the same durations. |
+| 7 | 95th percentile time between registration and first property | Database (`MetricsService`) | p95 of the same durations. |
+| 8 | Landlord registration completion rate | Plausible Stats API (`PlausibleMetricsService.getCompletionRates`) | Unique **visitors** at the confirmation page ÷ start page. |
+| 9 | Property registration completion rate | Plausible Stats API (`PlausibleMetricsService.getCompletionRates`) | **Page views** at confirmation ÷ start (a landlord may register several properties). |
+| 10 | Local council user registration completion rate | Plausible Stats API (`PlausibleMetricsService.getCompletionRates`) | Unique **visitors** at confirmation ÷ privacy-notice page. |
+| 11 | Peak memory utilisation | CloudWatch (`CloudWatchMetricsService`) | See [CloudWatch infrastructure metrics](#cloudwatch-infrastructure-metrics). |
+| 12 | Average memory utilisation | CloudWatch (`CloudWatchMetricsService`) | See below. |
+| 13 | Peak CPU utilisation | CloudWatch (`CloudWatchMetricsService`) | See below. |
+| 14 | ElastiCache CPU utilisation | CloudWatch (`CloudWatchMetricsService`) | See below. |
+| 15 | Client error rate (HTTP 4xx) | CloudWatch (`CloudWatchMetricsService`) | See below. |
+| 16 | Server error rate (HTTP 5xx) | CloudWatch (`CloudWatchMetricsService`) | See below. |
+| 17 | Total number of transactions | Plausible (`PlausibleMetricsService.getTransactionCounts`) | See [Transaction counts](#transaction-counts). |
+
+> **Completion rates** use visitors for landlord and local council user registration but page views for
+> property registration, because a single landlord may register multiple properties. This is surfaced on
+> the page via `metrics.completionRateExplanation`.
+
+## Transaction counts
+
+Completed transactions — registrations, deregistrations, updates, switch-to-individual, and accepting a
+joint landlord invitation — are counted from a dedicated Plausible `Transaction` custom event. The event
+is fired by a button press on each journey's final commit step: the commit button is rendered from a
+fragment tagged `data-plausible-event="Transaction"` (`transactionSubmitButton` / `transactionWarningButton`).
+For reporting periods before the configured cutover date (`plausible.transaction-event-start-date`) the
+legacy Flow event is used instead. See [AnalyticsReadMe](AnalyticsReadMe.md) and `PlausibleMetricsService`
+for details.
+
+### Known coverage gap: landlord deregistration with no registered properties
+
+A landlord who has **no registered properties** deregisters via the `are-you-sure` page, which goes
+straight to the internal deregistration step and skips the `reason` page that carries the `Transaction`
+tag. There is no clean place to fire the event for this path: the `are-you-sure` page is a yes/no
+question (so its button would fire the event even when the user chooses *not* to proceed), and the
+deregistration step itself has no button to tag.
+
+**Decision:** these deregistrations are intentionally **not counted**. The volume is expected to be
+minimal (a landlord with no properties leaving the service) and there is no clean solution that avoids
+over-counting. Landlord deregistrations where the landlord *does* have properties, and all property
+deregistrations, are counted as normal.
 
 ## CloudWatch infrastructure metrics
 

--- a/src/main/js/index.js
+++ b/src/main/js/index.js
@@ -4,6 +4,7 @@ import {addFileUploadListener} from "./fileUploadScript";
 import $ from 'jquery'
 import {initAll as initMoJDS} from '@ministryofjustice/frontend'
 import {initFilterToggleButton} from "./filterToggleButton"
+import {initPlausibleEventButtons} from "./plausibleTransactionEvent"
 import '../resources/css/custom.scss'
 import {setJsEnabled} from "#main-javascript/setJsEnabled.js";
 
@@ -18,3 +19,4 @@ addFileUploadListener()
 window.$ = $
 initMoJDS()
 initFilterToggleButton()
+initPlausibleEventButtons()

--- a/src/main/js/plausibleTransactionEvent.js
+++ b/src/main/js/plausibleTransactionEvent.js
@@ -1,0 +1,18 @@
+export function initPlausibleEventButtons() {
+    document.querySelectorAll('[data-plausible-event]').forEach((element) => {
+        const eventName = element.dataset.plausibleEvent;
+        const form = element.closest('form');
+
+        if (form) {
+            form.addEventListener('submit', () => fireEvent(eventName));
+        } else {
+            element.addEventListener('click', () => fireEvent(eventName));
+        }
+    });
+}
+
+function fireEvent(eventName) {
+    if (typeof window.plausible === 'function') {
+        window.plausible(eventName);
+    }
+}

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/landlordDeregistration/LandlordDeregistrationJourneyFactory.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/landlordDeregistration/LandlordDeregistrationJourneyFactory.kt
@@ -58,7 +58,7 @@ class LandlordDeregistrationJourneyFactory(
                 routeSegment(ReasonStep.ROUTE_SEGMENT)
                 parents { journey.areYouSureStep.hasOutcome(AreYouSureMode.WANTS_TO_PROCEED) }
                 nextDestination { Destination(journey.deregisterStep) }
-                withAdditionalContentProperties { mapOf("isTransactionSubmit" to true) }
+                withAdditionalContentProperties { mapOf("submitButton" to "transactionSubmitButton") }
             }
             step(journey.deregisterStep) {
                 parents {

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/landlordDeregistration/LandlordDeregistrationJourneyFactory.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/landlordDeregistration/LandlordDeregistrationJourneyFactory.kt
@@ -58,6 +58,7 @@ class LandlordDeregistrationJourneyFactory(
                 routeSegment(ReasonStep.ROUTE_SEGMENT)
                 parents { journey.areYouSureStep.hasOutcome(AreYouSureMode.WANTS_TO_PROCEED) }
                 nextDestination { Destination(journey.deregisterStep) }
+                withAdditionalContentProperties { mapOf("isTransactionSubmit" to true) }
             }
             step(journey.deregisterStep) {
                 parents {

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/landlordRegistration/update/dateOfBirth/UpdateDateOfBirthJourneyFactory.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/landlordRegistration/update/dateOfBirth/UpdateDateOfBirthJourneyFactory.kt
@@ -39,7 +39,7 @@ class UpdateDateOfBirthJourneyFactory(
                         "title" to "landlordDetails.update.title",
                         "fieldSetHeading" to "forms.update.dateOfBirth.fieldSetHeading",
                         "submitButtonText" to "forms.buttons.confirmAndSubmitUpdate",
-                        "isTransactionSubmit" to true,
+                        "submitButton" to "transactionSubmitButton",
                     )
                 }
             }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/landlordRegistration/update/dateOfBirth/UpdateDateOfBirthJourneyFactory.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/landlordRegistration/update/dateOfBirth/UpdateDateOfBirthJourneyFactory.kt
@@ -39,6 +39,7 @@ class UpdateDateOfBirthJourneyFactory(
                         "title" to "landlordDetails.update.title",
                         "fieldSetHeading" to "forms.update.dateOfBirth.fieldSetHeading",
                         "submitButtonText" to "forms.buttons.confirmAndSubmitUpdate",
+                        "isTransactionSubmit" to true,
                     )
                 }
             }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/landlordRegistration/update/email/UpdateEmailJourneyFactory.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/landlordRegistration/update/email/UpdateEmailJourneyFactory.kt
@@ -32,6 +32,7 @@ class UpdateEmailJourneyFactory(
                         "title" to "landlordDetails.update.title",
                         "fieldSetHeading" to "forms.update.email.fieldSetHeading",
                         "submitButtonText" to "forms.buttons.confirmAndSubmitUpdate",
+                        "isTransactionSubmit" to true,
                         "showWarning" to true,
                     )
                 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/landlordRegistration/update/email/UpdateEmailJourneyFactory.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/landlordRegistration/update/email/UpdateEmailJourneyFactory.kt
@@ -32,7 +32,7 @@ class UpdateEmailJourneyFactory(
                         "title" to "landlordDetails.update.title",
                         "fieldSetHeading" to "forms.update.email.fieldSetHeading",
                         "submitButtonText" to "forms.buttons.confirmAndSubmitUpdate",
-                        "isTransactionSubmit" to true,
+                        "submitButton" to "transactionSubmitButton",
                         "showWarning" to true,
                     )
                 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/landlordRegistration/update/name/UpdateNameJourneyFactory.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/landlordRegistration/update/name/UpdateNameJourneyFactory.kt
@@ -39,6 +39,7 @@ class UpdateNameJourneyFactory(
                         "title" to "landlordDetails.update.title",
                         "fieldSetHeading" to "forms.update.name.fieldSetHeading",
                         "submitButtonText" to "forms.buttons.confirmAndSubmitUpdate",
+                        "isTransactionSubmit" to true,
                         "showWarning" to true,
                     )
                 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/landlordRegistration/update/name/UpdateNameJourneyFactory.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/landlordRegistration/update/name/UpdateNameJourneyFactory.kt
@@ -39,7 +39,7 @@ class UpdateNameJourneyFactory(
                         "title" to "landlordDetails.update.title",
                         "fieldSetHeading" to "forms.update.name.fieldSetHeading",
                         "submitButtonText" to "forms.buttons.confirmAndSubmitUpdate",
-                        "isTransactionSubmit" to true,
+                        "submitButton" to "transactionSubmitButton",
                         "showWarning" to true,
                     )
                 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/landlordRegistration/update/phoneNumber/UpdatePhoneNumberJourneyFactory.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/landlordRegistration/update/phoneNumber/UpdatePhoneNumberJourneyFactory.kt
@@ -32,6 +32,7 @@ class UpdatePhoneNumberJourneyFactory(
                         "title" to "landlordDetails.update.title",
                         "fieldSetHeading" to "forms.update.phoneNumber.fieldSetHeading",
                         "submitButtonText" to "forms.buttons.confirmAndSubmitUpdate",
+                        "isTransactionSubmit" to true,
                         "showWarning" to true,
                     )
                 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/landlordRegistration/update/phoneNumber/UpdatePhoneNumberJourneyFactory.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/landlordRegistration/update/phoneNumber/UpdatePhoneNumberJourneyFactory.kt
@@ -32,7 +32,7 @@ class UpdatePhoneNumberJourneyFactory(
                         "title" to "landlordDetails.update.title",
                         "fieldSetHeading" to "forms.update.phoneNumber.fieldSetHeading",
                         "submitButtonText" to "forms.buttons.confirmAndSubmitUpdate",
-                        "isTransactionSubmit" to true,
+                        "submitButton" to "transactionSubmitButton",
                         "showWarning" to true,
                     )
                 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/update/bedrooms/UpdateBedroomsJourneyFactory.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/update/bedrooms/UpdateBedroomsJourneyFactory.kt
@@ -50,7 +50,7 @@ class UpdateBedroomsJourneyFactory(
                         "title" to "propertyDetails.update.title",
                         "heading" to "forms.update.numberOfBedrooms.heading",
                         "submitButtonText" to "forms.buttons.confirmAndSubmitUpdate",
-                        "isTransactionSubmit" to true,
+                        "submitButton" to "transactionSubmitButton",
                         "showWarning" to true,
                     )
                 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/update/bedrooms/UpdateBedroomsJourneyFactory.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/update/bedrooms/UpdateBedroomsJourneyFactory.kt
@@ -50,6 +50,7 @@ class UpdateBedroomsJourneyFactory(
                         "title" to "propertyDetails.update.title",
                         "heading" to "forms.update.numberOfBedrooms.heading",
                         "submitButtonText" to "forms.buttons.confirmAndSubmitUpdate",
+                        "isTransactionSubmit" to true,
                         "showWarning" to true,
                     )
                 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/update/electricalSafety/UpdateCheckElectricalSafetyAnswersStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/update/electricalSafety/UpdateCheckElectricalSafetyAnswersStepConfig.kt
@@ -24,6 +24,7 @@ class UpdateCheckElectricalSafetyAnswersStepConfig(
             "rows" to factory.createRows(),
             "insetTextKey" to factory.getInsetTextKey(),
             "submitButtonText" to "forms.buttons.saveAndContinue",
+            "isTransactionSubmit" to true,
         )
     }
 

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/update/electricalSafety/UpdateCheckElectricalSafetyAnswersStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/update/electricalSafety/UpdateCheckElectricalSafetyAnswersStepConfig.kt
@@ -24,7 +24,7 @@ class UpdateCheckElectricalSafetyAnswersStepConfig(
             "rows" to factory.createRows(),
             "insetTextKey" to factory.getInsetTextKey(),
             "submitButtonText" to "forms.buttons.saveAndContinue",
-            "isTransactionSubmit" to true,
+            "submitButton" to "transactionSubmitButton",
         )
     }
 

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/update/epc/UpdateCheckEpcAnswersStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/update/epc/UpdateCheckEpcAnswersStepConfig.kt
@@ -30,6 +30,7 @@ class UpdateCheckEpcAnswersStepConfig(
             "exemptionReasonRows" to factory.createExemptionReasonRows(),
             "nonEpcRows" to factory.createNonEpcRows(),
             "insetTextKey" to factory.getInsetTextKey(),
+            "isTransactionSubmit" to true,
         )
     }
 

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/update/epc/UpdateCheckEpcAnswersStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/update/epc/UpdateCheckEpcAnswersStepConfig.kt
@@ -30,7 +30,7 @@ class UpdateCheckEpcAnswersStepConfig(
             "exemptionReasonRows" to factory.createExemptionReasonRows(),
             "nonEpcRows" to factory.createNonEpcRows(),
             "insetTextKey" to factory.getInsetTextKey(),
-            "isTransactionSubmit" to true,
+            "submitButton" to "transactionSubmitButton",
         )
     }
 

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/update/furnishedStatus/UpdateFurnishedStatusJourneyFactory.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/update/furnishedStatus/UpdateFurnishedStatusJourneyFactory.kt
@@ -50,6 +50,7 @@ class UpdateFurnishedStatusJourneyFactory(
                         "title" to "propertyDetails.update.title",
                         "fieldSetHeading" to "forms.update.furnishedStatus.fieldSetHeading",
                         "submitButtonText" to "forms.buttons.confirmAndSubmitUpdate",
+                        "isTransactionSubmit" to true,
                         "showWarning" to true,
                     )
                 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/update/furnishedStatus/UpdateFurnishedStatusJourneyFactory.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/update/furnishedStatus/UpdateFurnishedStatusJourneyFactory.kt
@@ -50,7 +50,7 @@ class UpdateFurnishedStatusJourneyFactory(
                         "title" to "propertyDetails.update.title",
                         "fieldSetHeading" to "forms.update.furnishedStatus.fieldSetHeading",
                         "submitButtonText" to "forms.buttons.confirmAndSubmitUpdate",
-                        "isTransactionSubmit" to true,
+                        "submitButton" to "transactionSubmitButton",
                         "showWarning" to true,
                     )
                 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/update/gasSafety/UpdateCheckGasSafetyAnswersStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/update/gasSafety/UpdateCheckGasSafetyAnswersStepConfig.kt
@@ -25,6 +25,7 @@ class UpdateCheckGasSafetyAnswersStepConfig(
             "certRows" to factory.createCertRows(),
             "insetTextKey" to factory.getInsetTextKey(),
             "submitButtonText" to "forms.buttons.saveAndContinue",
+            "isTransactionSubmit" to true,
         )
     }
 

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/update/gasSafety/UpdateCheckGasSafetyAnswersStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/update/gasSafety/UpdateCheckGasSafetyAnswersStepConfig.kt
@@ -25,7 +25,7 @@ class UpdateCheckGasSafetyAnswersStepConfig(
             "certRows" to factory.createCertRows(),
             "insetTextKey" to factory.getInsetTextKey(),
             "submitButtonText" to "forms.buttons.saveAndContinue",
-            "isTransactionSubmit" to true,
+            "submitButton" to "transactionSubmitButton",
         )
     }
 

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/update/ownershipType/UpdateOwnershipTypeJourneyFactory.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/update/ownershipType/UpdateOwnershipTypeJourneyFactory.kt
@@ -48,7 +48,7 @@ class UpdateOwnershipTypeJourneyFactory(
                         "title" to "propertyDetails.update.title",
                         "fieldSetHeading" to "forms.update.ownershipType.fieldSetHeading",
                         "submitButtonText" to "forms.buttons.confirmAndSubmitUpdate",
-                        "isTransactionSubmit" to true,
+                        "submitButton" to "transactionSubmitButton",
                         "showWarning" to true,
                     )
                 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/update/ownershipType/UpdateOwnershipTypeJourneyFactory.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/update/ownershipType/UpdateOwnershipTypeJourneyFactory.kt
@@ -48,6 +48,7 @@ class UpdateOwnershipTypeJourneyFactory(
                         "title" to "propertyDetails.update.title",
                         "fieldSetHeading" to "forms.update.ownershipType.fieldSetHeading",
                         "submitButtonText" to "forms.buttons.confirmAndSubmitUpdate",
+                        "isTransactionSubmit" to true,
                         "showWarning" to true,
                     )
                 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/local/api/controllers/MockPlausibleController.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/local/api/controllers/MockPlausibleController.kt
@@ -23,23 +23,29 @@ class MockPlausibleController {
     fun query(
         @RequestBody query: PlausibleQuery,
     ): PlausibleQueryResponse =
-        if (query.dimensions.isEmpty()) {
-            // The transaction-counts query has no dimensions and aggregates a single events total.
-            PlausibleQueryResponse(
-                results = listOf(PlausibleResultRow(metrics = listOf(MOCK_TRANSACTION_COUNT), dimensions = emptyList())),
-            )
-        } else {
-            PlausibleQueryResponse(
-                results =
-                    listOf(
-                        row(LANDLORD_REGISTRATION_START_PAGE_ROUTE, visitors = 1000.0, pageViews = 1200.0),
-                        row(LANDLORD_REGISTRATION_CONFIRMATION_ROUTE, visitors = 732.0, pageViews = 800.0),
-                        row(PROPERTY_REGISTRATION_ROUTE, visitors = 60.0, pageViews = 80.0),
-                        row(PROPERTY_REGISTRATION_CONFIRMATION_ROUTE, visitors = 18.0, pageViews = 20.0),
-                        row(LOCAL_COUNCIL_USER_REGISTRATION_PRIVACY_NOTICE_ROUTE, visitors = 3.0, pageViews = 4.0),
-                        row(LOCAL_COUNCIL_USER_REGISTRATION_CONFIRMATION_ROUTE, visitors = 1.0, pageViews = 2.0),
-                    ),
-            )
+        when {
+            query.dimensions.isNotEmpty() ->
+                PlausibleQueryResponse(
+                    results =
+                        listOf(
+                            row(LANDLORD_REGISTRATION_START_PAGE_ROUTE, visitors = 1000.0, pageViews = 1200.0),
+                            row(LANDLORD_REGISTRATION_CONFIRMATION_ROUTE, visitors = 732.0, pageViews = 800.0),
+                            row(PROPERTY_REGISTRATION_ROUTE, visitors = 60.0, pageViews = 80.0),
+                            row(PROPERTY_REGISTRATION_CONFIRMATION_ROUTE, visitors = 18.0, pageViews = 20.0),
+                            row(LOCAL_COUNCIL_USER_REGISTRATION_PRIVACY_NOTICE_ROUTE, visitors = 3.0, pageViews = 4.0),
+                            row(LOCAL_COUNCIL_USER_REGISTRATION_CONFIRMATION_ROUTE, visitors = 1.0, pageViews = 2.0),
+                        ),
+                )
+            // The Transaction-event count query filters on the custom event name.
+            query.filters.toString().contains("event:name") ->
+                PlausibleQueryResponse(
+                    results = listOf(PlausibleResultRow(metrics = listOf(MOCK_TRANSACTION_EVENT_COUNT), dimensions = emptyList())),
+                )
+            // Otherwise this is the legacy Flow-event transaction-counts query (dimensionless, props filter).
+            else ->
+                PlausibleQueryResponse(
+                    results = listOf(PlausibleResultRow(metrics = listOf(MOCK_FLOW_TRANSACTION_COUNT), dimensions = emptyList())),
+                )
         }
 
     private fun row(
@@ -49,6 +55,7 @@ class MockPlausibleController {
     ) = PlausibleResultRow(metrics = listOf(visitors, pageViews), dimensions = listOf(page))
 
     companion object {
-        private const val MOCK_TRANSACTION_COUNT = 753.0
+        private const val MOCK_FLOW_TRANSACTION_COUNT = 753.0
+        private const val MOCK_TRANSACTION_EVENT_COUNT = 318.0
     }
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/PlausibleMetricsService.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/PlausibleMetricsService.kt
@@ -103,14 +103,14 @@ class PlausibleMetricsService(
     private fun flowEventCount(
         start: LocalDate,
         end: LocalDate,
-    ): Long = aggregateEvents(buildFlowTransactionQuery(start, end))
+    ): Long = queryEventCount(buildFlowTransactionQuery(start, end))
 
     private fun transactionEventCount(
         start: LocalDate,
         end: LocalDate,
-    ): Long = aggregateEvents(buildTransactionEventQuery(start, end))
+    ): Long = queryEventCount(buildTransactionEventQuery(start, end))
 
-    private fun aggregateEvents(query: PlausibleQuery): Long =
+    private fun queryEventCount(query: PlausibleQuery): Long =
         (plausibleClient.query(query).results.firstOrNull()?.metrics?.firstOrNull() ?: 0.0).toLong()
 
     private fun buildFlowTransactionQuery(

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/PlausibleMetricsService.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/PlausibleMetricsService.kt
@@ -33,6 +33,7 @@ import uk.gov.communities.prsdb.webapp.models.dataModels.plausible.PlausibleQuer
 import java.math.BigDecimal
 import java.math.RoundingMode
 import java.time.Instant
+import java.time.LocalDate
 import java.time.ZoneId
 import java.time.format.DateTimeFormatter
 
@@ -40,7 +41,10 @@ import java.time.format.DateTimeFormatter
 class PlausibleMetricsService(
     private val plausibleClient: PlausibleClient,
     @Value("\${plausible.domain-id}") private val domainId: String,
+    @Value("\${plausible.transaction-event-start-date}") transactionEventStartDate: String,
 ) {
+    private val transactionEventStartDate: LocalDate = LocalDate.parse(transactionEventStartDate)
+
     fun getCompletionRates(period: ReportingPeriod): JourneyCompletionRatesDataModel =
         try {
             val response = plausibleClient.query(buildQuery(period))
@@ -80,20 +84,57 @@ class PlausibleMetricsService(
 
     fun getTransactionCounts(period: ReportingPeriod): Long =
         try {
-            val response = plausibleClient.query(buildTransactionQuery(period))
-            (response.results.firstOrNull()?.metrics?.firstOrNull() ?: 0.0).toLong()
+            val startDate = period.start.toUkLocalDate()
+            val endDate = period.end.toUkLocalDate()
+            when {
+                endDate.isBefore(transactionEventStartDate) ->
+                    flowEventCount(startDate, endDate)
+                !startDate.isBefore(transactionEventStartDate) ->
+                    transactionEventCount(startDate, endDate)
+                else ->
+                    flowEventCount(startDate, transactionEventStartDate.minusDays(1)) +
+                        transactionEventCount(transactionEventStartDate, endDate)
+            }
         } catch (e: Exception) {
             println("Failed to fetch transaction counts from Plausible: ${e.message}")
             0L
         }
 
-    private fun buildTransactionQuery(period: ReportingPeriod): PlausibleQuery =
+    private fun flowEventCount(
+        start: LocalDate,
+        end: LocalDate,
+    ): Long = aggregateEvents(buildFlowTransactionQuery(start, end))
+
+    private fun transactionEventCount(
+        start: LocalDate,
+        end: LocalDate,
+    ): Long = aggregateEvents(buildTransactionEventQuery(start, end))
+
+    private fun aggregateEvents(query: PlausibleQuery): Long =
+        (plausibleClient.query(query).results.firstOrNull()?.metrics?.firstOrNull() ?: 0.0).toLong()
+
+    private fun buildFlowTransactionQuery(
+        start: LocalDate,
+        end: LocalDate,
+    ): PlausibleQuery =
         PlausibleQuery(
             siteId = domainId,
-            dateRange = listOf(period.start.toUkDate(), period.end.toUkDate()),
+            dateRange = listOf(start.toString(), end.toString()),
             metrics = listOf("events"),
             dimensions = emptyList(),
             filters = listOf(transactionFilter()),
+        )
+
+    private fun buildTransactionEventQuery(
+        start: LocalDate,
+        end: LocalDate,
+    ): PlausibleQuery =
+        PlausibleQuery(
+            siteId = domainId,
+            dateRange = listOf(start.toString(), end.toString()),
+            metrics = listOf("events"),
+            dimensions = emptyList(),
+            filters = listOf(listOf("is", "event:name", listOf(TRANSACTION_EVENT_NAME))),
         )
 
     // A transaction is a completed journey, counted from the Plausible "Flow" custom event (which carries the
@@ -135,8 +176,13 @@ class PlausibleMetricsService(
 
     private fun Instant.toUkDate(): String = DateTimeFormatter.ISO_LOCAL_DATE.format(this.atZone(UK_ZONE).toLocalDate())
 
+    private fun Instant.toUkLocalDate(): LocalDate = this.atZone(UK_ZONE).toLocalDate()
+
     companion object {
         private val UK_ZONE = ZoneId.of("Europe/London")
+
+        // The name of the Plausible custom event fired on journey completion (see templates/fragments/layout.html).
+        const val TRANSACTION_EVENT_NAME = "Transaction"
 
         // Visitors are used for one-off-per-user journeys (landlord and local council registration); page views are
         // used for property registration, where a single landlord may register multiple properties.

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -84,6 +84,9 @@ plausible:
   domain-id: ${PLAUSIBLE_DOMAIN_ID}
   base-url: https://plausible.io
   api-key: ${PLAUSIBLE_API_KEY}
+  # Date the Transaction custom event went live in production. Until set to the real go-live date, the
+  # far-future default keeps the total-transactions metric on the legacy Flow-event counting method.
+  transaction-event-start-date: ${PLAUSIBLE_TRANSACTION_EVENT_START_DATE:2099-01-01}
 
 cloudwatch-metrics:
   ecs:

--- a/src/main/resources/templates/forms/checkAnswersForm.html
+++ b/src/main/resources/templates/forms/checkAnswersForm.html
@@ -23,6 +23,6 @@
 </th:block>
     <th:block id="form-content">
         <input type="hidden" name="submittedFilteredJourneyData" th:value="${submittedFilteredJourneyData}"/>
-        <button th:replace="~{fragments/buttons/primaryButton :: primaryButton(#{${submitButtonText}})}"></button>
+        <button th:replace="~{fragments/buttons/transactionSubmitButton :: transactionSubmitButton(#{${submitButtonText}})}"></button>
     </th:block>
 </html>

--- a/src/main/resources/templates/forms/checkElectricalSafetyAnswersForm.html
+++ b/src/main/resources/templates/forms/checkElectricalSafetyAnswersForm.html
@@ -14,11 +14,6 @@
     </th:block>
 </th:block>
 <th:block id="form-content">
-    <th:block th:if="${isTransactionSubmit}">
-        <button th:replace="~{fragments/buttons/transactionSubmitButton :: transactionSubmitButton(#{${submitButtonText}})}"></button>
-    </th:block>
-    <th:block th:unless="${isTransactionSubmit}">
-        <button th:replace="~{fragments/buttons/primaryButton :: primaryButton(#{${submitButtonText}})}"></button>
-    </th:block>
+    <button th:replace="~{fragments/buttons/__${submitButton ?: 'primaryButton'}__ :: __${submitButton ?: 'primaryButton'}__(#{${submitButtonText}})}"></button>
 </th:block>
 </html>

--- a/src/main/resources/templates/forms/checkElectricalSafetyAnswersForm.html
+++ b/src/main/resources/templates/forms/checkElectricalSafetyAnswersForm.html
@@ -14,6 +14,11 @@
     </th:block>
 </th:block>
 <th:block id="form-content">
-    <button th:replace="~{fragments/buttons/primaryButton :: primaryButton(#{${submitButtonText}})}"></button>
+    <th:block th:if="${isTransactionSubmit}">
+        <button th:replace="~{fragments/buttons/transactionSubmitButton :: transactionSubmitButton(#{${submitButtonText}})}"></button>
+    </th:block>
+    <th:block th:unless="${isTransactionSubmit}">
+        <button th:replace="~{fragments/buttons/primaryButton :: primaryButton(#{${submitButtonText}})}"></button>
+    </th:block>
 </th:block>
 </html>

--- a/src/main/resources/templates/forms/checkEpcAnswersForm.html
+++ b/src/main/resources/templates/forms/checkEpcAnswersForm.html
@@ -41,6 +41,11 @@
         </div>
     </th:block>
     <th:block id="form-content">
-        <button th:replace="~{fragments/buttons/primaryButton :: primaryButton(#{forms.buttons.saveAndContinue})}"></button>
+        <th:block th:if="${isTransactionSubmit}">
+            <button th:replace="~{fragments/buttons/transactionSubmitButton :: transactionSubmitButton(#{forms.buttons.saveAndContinue})}"></button>
+        </th:block>
+        <th:block th:unless="${isTransactionSubmit}">
+            <button th:replace="~{fragments/buttons/primaryButton :: primaryButton(#{forms.buttons.saveAndContinue})}"></button>
+        </th:block>
     </th:block>
 </html>

--- a/src/main/resources/templates/forms/checkEpcAnswersForm.html
+++ b/src/main/resources/templates/forms/checkEpcAnswersForm.html
@@ -41,11 +41,6 @@
         </div>
     </th:block>
     <th:block id="form-content">
-        <th:block th:if="${isTransactionSubmit}">
-            <button th:replace="~{fragments/buttons/transactionSubmitButton :: transactionSubmitButton(#{forms.buttons.saveAndContinue})}"></button>
-        </th:block>
-        <th:block th:unless="${isTransactionSubmit}">
-            <button th:replace="~{fragments/buttons/primaryButton :: primaryButton(#{forms.buttons.saveAndContinue})}"></button>
-        </th:block>
+        <button th:replace="~{fragments/buttons/__${submitButton ?: 'primaryButton'}__ :: __${submitButton ?: 'primaryButton'}__(#{forms.buttons.saveAndContinue})}"></button>
     </th:block>
 </html>

--- a/src/main/resources/templates/forms/checkGasSafetyAnswersForm.html
+++ b/src/main/resources/templates/forms/checkGasSafetyAnswersForm.html
@@ -19,11 +19,6 @@
     </th:block>
 </th:block>
 <th:block id="form-content">
-    <th:block th:if="${isTransactionSubmit}">
-        <button th:replace="~{fragments/buttons/transactionSubmitButton :: transactionSubmitButton(#{${submitButtonText}})}"></button>
-    </th:block>
-    <th:block th:unless="${isTransactionSubmit}">
-        <button th:replace="~{fragments/buttons/primaryButton :: primaryButton(#{${submitButtonText}})}"></button>
-    </th:block>
+    <button th:replace="~{fragments/buttons/__${submitButton ?: 'primaryButton'}__ :: __${submitButton ?: 'primaryButton'}__(#{${submitButtonText}})}"></button>
 </th:block>
 </html>

--- a/src/main/resources/templates/forms/checkGasSafetyAnswersForm.html
+++ b/src/main/resources/templates/forms/checkGasSafetyAnswersForm.html
@@ -19,6 +19,11 @@
     </th:block>
 </th:block>
 <th:block id="form-content">
-    <button th:replace="~{fragments/buttons/primaryButton :: primaryButton(#{${submitButtonText}})}"></button>
+    <th:block th:if="${isTransactionSubmit}">
+        <button th:replace="~{fragments/buttons/transactionSubmitButton :: transactionSubmitButton(#{${submitButtonText}})}"></button>
+    </th:block>
+    <th:block th:unless="${isTransactionSubmit}">
+        <button th:replace="~{fragments/buttons/primaryButton :: primaryButton(#{${submitButtonText}})}"></button>
+    </th:block>
 </th:block>
 </html>

--- a/src/main/resources/templates/forms/confirmOnlyLandlordForm.html
+++ b/src/main/resources/templates/forms/confirmOnlyLandlordForm.html
@@ -23,7 +23,7 @@
             </p>
             <form th:action="@{''}" method="post" novalidate>
                 <div class="govuk-button-group">
-                    <button th:replace="~{fragments/buttons/primaryButton :: primaryButton(#{switchToIndividual.confirm.confirmButton})}"></button>
+                    <button th:replace="~{fragments/buttons/transactionSubmitButton :: transactionSubmitButton(#{switchToIndividual.confirm.confirmButton})}"></button>
                     <a th:href="@{${cancelLinkUrl}}" class="govuk-link" th:text="#{switchToIndividual.confirm.cancelLink}">
                         switchToIndividual.confirm.cancelLink
                     </a>

--- a/src/main/resources/templates/forms/confirmPropertyDeregistrationForm.html
+++ b/src/main/resources/templates/forms/confirmPropertyDeregistrationForm.html
@@ -18,7 +18,7 @@
             <div th:replace="~{fragments/warningText :: warningText(#{deregisterProperty.confirm.warning})}"></div>
             <form th:action="@{''}" method="post" novalidate>
                 <div class="govuk-button-group">
-                    <button th:replace="~{fragments/buttons/warningButton :: warningButton(#{deregisterProperty.confirm.confirmButton})}"></button>
+                    <button th:replace="~{fragments/buttons/transactionWarningButton :: transactionWarningButton(#{deregisterProperty.confirm.confirmButton})}"></button>
                     <a th:href="@{${cancelLinkUrl}}" class="govuk-link" th:text="#{deregisterProperty.confirm.cancelLink}">
                         deregisterProperty.confirm.cancelLink
                     </a>

--- a/src/main/resources/templates/forms/confirmYouAreALandlordForThisPropertyForm.html
+++ b/src/main/resources/templates/forms/confirmYouAreALandlordForThisPropertyForm.html
@@ -29,6 +29,6 @@
     </ul>
 </th:block>
 <th:block id="form-content">
-    <button th:replace="~{fragments/buttons/primaryButton :: primaryButton(#{forms.buttons.confirm})}"></button>
+    <button th:replace="~{fragments/buttons/transactionSubmitButton :: transactionSubmitButton(#{forms.buttons.confirm})}"></button>
 </th:block>
 </html>

--- a/src/main/resources/templates/forms/dateForm.html
+++ b/src/main/resources/templates/forms/dateForm.html
@@ -12,10 +12,5 @@
     <th:block th:if="${showWarning}">
         <div th:replace="~{fragments/warningText :: warningText(#{forms.warning})}">forms.update.warning</div>
     </th:block>
-    <th:block th:if="${isTransactionSubmit}">
-        <button th:replace="~{fragments/buttons/transactionSubmitButton :: transactionSubmitButton(#{${submitButtonText}})}"></button>
-    </th:block>
-    <th:block th:unless="${isTransactionSubmit}">
-        <button th:replace="~{fragments/buttons/primaryButton :: primaryButton(#{${submitButtonText}})}"></button>
-    </th:block>
+    <button th:replace="~{fragments/buttons/__${submitButton ?: 'primaryButton'}__ :: __${submitButton ?: 'primaryButton'}__(#{${submitButtonText}})}"></button>
 </html>

--- a/src/main/resources/templates/forms/dateForm.html
+++ b/src/main/resources/templates/forms/dateForm.html
@@ -12,5 +12,10 @@
     <th:block th:if="${showWarning}">
         <div th:replace="~{fragments/warningText :: warningText(#{forms.warning})}">forms.update.warning</div>
     </th:block>
-    <button th:replace="~{fragments/buttons/primaryButton :: primaryButton(#{${submitButtonText}})}"></button>
+    <th:block th:if="${isTransactionSubmit}">
+        <button th:replace="~{fragments/buttons/transactionSubmitButton :: transactionSubmitButton(#{${submitButtonText}})}"></button>
+    </th:block>
+    <th:block th:unless="${isTransactionSubmit}">
+        <button th:replace="~{fragments/buttons/primaryButton :: primaryButton(#{${submitButtonText}})}"></button>
+    </th:block>
 </html>

--- a/src/main/resources/templates/forms/deregistrationReasonForm.html
+++ b/src/main/resources/templates/forms/deregistrationReasonForm.html
@@ -13,11 +13,6 @@
         <div th:replace="~{fragments/forms/textArea :: textArea(null, 'reason', null)}">
         </div>
     </th:block>
-    <th:block th:if="${isTransactionSubmit}">
-        <button th:replace="~{fragments/buttons/transactionSubmitButton :: transactionSubmitButton(#{${submitButtonText}})}"></button>
-    </th:block>
-    <th:block th:unless="${isTransactionSubmit}">
-        <button th:replace="~{fragments/buttons/primaryButton :: primaryButton(#{${submitButtonText}})}"></button>
-    </th:block>
+    <button th:replace="~{fragments/buttons/__${submitButton ?: 'primaryButton'}__ :: __${submitButton ?: 'primaryButton'}__(#{${submitButtonText}})}"></button>
 </th:block>
 </html>

--- a/src/main/resources/templates/forms/deregistrationReasonForm.html
+++ b/src/main/resources/templates/forms/deregistrationReasonForm.html
@@ -13,6 +13,11 @@
         <div th:replace="~{fragments/forms/textArea :: textArea(null, 'reason', null)}">
         </div>
     </th:block>
-    <button th:replace="~{fragments/buttons/primaryButton :: primaryButton(#{${submitButtonText}})}"></button>
+    <th:block th:if="${isTransactionSubmit}">
+        <button th:replace="~{fragments/buttons/transactionSubmitButton :: transactionSubmitButton(#{${submitButtonText}})}"></button>
+    </th:block>
+    <th:block th:unless="${isTransactionSubmit}">
+        <button th:replace="~{fragments/buttons/primaryButton :: primaryButton(#{${submitButtonText}})}"></button>
+    </th:block>
 </th:block>
 </html>

--- a/src/main/resources/templates/forms/emailForm.html
+++ b/src/main/resources/templates/forms/emailForm.html
@@ -15,10 +15,5 @@
     <th:block th:if="${showWarning}">
         <div th:replace="~{fragments/warningText :: warningText(#{forms.update.warning})}">forms.update.warning</div>
     </th:block>
-    <th:block th:if="${isTransactionSubmit}">
-        <button th:replace="~{fragments/buttons/transactionSubmitButton :: transactionSubmitButton(#{${submitButtonText}})}"></button>
-    </th:block>
-    <th:block th:unless="${isTransactionSubmit}">
-        <button th:replace="~{fragments/buttons/primaryButton :: primaryButton(#{${submitButtonText}})}"></button>
-    </th:block>
+    <button th:replace="~{fragments/buttons/__${submitButton ?: 'primaryButton'}__ :: __${submitButton ?: 'primaryButton'}__(#{${submitButtonText}})}"></button>
 </html>

--- a/src/main/resources/templates/forms/emailForm.html
+++ b/src/main/resources/templates/forms/emailForm.html
@@ -15,5 +15,10 @@
     <th:block th:if="${showWarning}">
         <div th:replace="~{fragments/warningText :: warningText(#{forms.update.warning})}">forms.update.warning</div>
     </th:block>
-    <button th:replace="~{fragments/buttons/primaryButton :: primaryButton(#{${submitButtonText}})}"></button>
+    <th:block th:if="${isTransactionSubmit}">
+        <button th:replace="~{fragments/buttons/transactionSubmitButton :: transactionSubmitButton(#{${submitButtonText}})}"></button>
+    </th:block>
+    <th:block th:unless="${isTransactionSubmit}">
+        <button th:replace="~{fragments/buttons/primaryButton :: primaryButton(#{${submitButtonText}})}"></button>
+    </th:block>
 </html>

--- a/src/main/resources/templates/forms/furnishedStatusForm.html
+++ b/src/main/resources/templates/forms/furnishedStatusForm.html
@@ -14,11 +14,6 @@
     <th:block th:if="${showWarning}">
         <div th:replace="~{fragments/warningText :: warningText(#{forms.warning})}">forms.update.warning</div>
     </th:block>
-    <th:block th:if="${isTransactionSubmit}">
-        <button th:replace="~{fragments/buttons/transactionSubmitButton :: transactionSubmitButton(#{${submitButtonText}})}"></button>
-    </th:block>
-    <th:block th:unless="${isTransactionSubmit}">
-        <button th:replace="~{fragments/buttons/primaryButton :: primaryButton(#{${submitButtonText}})}"></button>
-    </th:block>
+    <button th:replace="~{fragments/buttons/__${submitButton ?: 'primaryButton'}__ :: __${submitButton ?: 'primaryButton'}__(#{${submitButtonText}})}"></button>
 </th:block>
 </html>

--- a/src/main/resources/templates/forms/furnishedStatusForm.html
+++ b/src/main/resources/templates/forms/furnishedStatusForm.html
@@ -14,6 +14,11 @@
     <th:block th:if="${showWarning}">
         <div th:replace="~{fragments/warningText :: warningText(#{forms.warning})}">forms.update.warning</div>
     </th:block>
-    <button th:replace="~{fragments/buttons/primaryButton :: primaryButton(#{${submitButtonText}})}"></button>
+    <th:block th:if="${isTransactionSubmit}">
+        <button th:replace="~{fragments/buttons/transactionSubmitButton :: transactionSubmitButton(#{${submitButtonText}})}"></button>
+    </th:block>
+    <th:block th:unless="${isTransactionSubmit}">
+        <button th:replace="~{fragments/buttons/primaryButton :: primaryButton(#{${submitButtonText}})}"></button>
+    </th:block>
 </th:block>
 </html>

--- a/src/main/resources/templates/forms/nameForm.html
+++ b/src/main/resources/templates/forms/nameForm.html
@@ -17,10 +17,5 @@
     <th:block th:if="${showWarning}">
         <div th:replace="~{fragments/warningText :: warningText(#{forms.warning})}">forms.update.warning</div>
     </th:block>
-    <th:block th:if="${isTransactionSubmit}">
-        <button th:replace="~{fragments/buttons/transactionSubmitButton :: transactionSubmitButton(#{${submitButtonText}})}"></button>
-    </th:block>
-    <th:block th:unless="${isTransactionSubmit}">
-        <button th:replace="~{fragments/buttons/primaryButton :: primaryButton(#{${submitButtonText}})}"></button>
-    </th:block>
+    <button th:replace="~{fragments/buttons/__${submitButton ?: 'primaryButton'}__ :: __${submitButton ?: 'primaryButton'}__(#{${submitButtonText}})}"></button>
 </html>

--- a/src/main/resources/templates/forms/nameForm.html
+++ b/src/main/resources/templates/forms/nameForm.html
@@ -17,5 +17,10 @@
     <th:block th:if="${showWarning}">
         <div th:replace="~{fragments/warningText :: warningText(#{forms.warning})}">forms.update.warning</div>
     </th:block>
-    <button th:replace="~{fragments/buttons/primaryButton :: primaryButton(#{${submitButtonText}})}"></button>
+    <th:block th:if="${isTransactionSubmit}">
+        <button th:replace="~{fragments/buttons/transactionSubmitButton :: transactionSubmitButton(#{${submitButtonText}})}"></button>
+    </th:block>
+    <th:block th:unless="${isTransactionSubmit}">
+        <button th:replace="~{fragments/buttons/primaryButton :: primaryButton(#{${submitButtonText}})}"></button>
+    </th:block>
 </html>

--- a/src/main/resources/templates/forms/numberOfBedroomsForm.html
+++ b/src/main/resources/templates/forms/numberOfBedroomsForm.html
@@ -34,11 +34,6 @@
     <th:block th:if="${showWarning}">
         <div th:replace="~{fragments/warningText :: warningText(#{forms.warning})}">forms.update.warning</div>
     </th:block>
-    <th:block th:if="${isTransactionSubmit}">
-        <button th:replace="~{fragments/buttons/transactionSubmitButton :: transactionSubmitButton(#{${submitButtonText}})}"></button>
-    </th:block>
-    <th:block th:unless="${isTransactionSubmit}">
-        <button th:replace="~{fragments/buttons/primaryButton :: primaryButton(#{${submitButtonText}})}"></button>
-    </th:block>
+    <button th:replace="~{fragments/buttons/__${submitButton ?: 'primaryButton'}__ :: __${submitButton ?: 'primaryButton'}__(#{${submitButtonText}})}"></button>
 </th:block>
 </html>

--- a/src/main/resources/templates/forms/numberOfBedroomsForm.html
+++ b/src/main/resources/templates/forms/numberOfBedroomsForm.html
@@ -34,6 +34,11 @@
     <th:block th:if="${showWarning}">
         <div th:replace="~{fragments/warningText :: warningText(#{forms.warning})}">forms.update.warning</div>
     </th:block>
-    <button th:replace="~{fragments/buttons/primaryButton :: primaryButton(#{${submitButtonText}})}"></button>
+    <th:block th:if="${isTransactionSubmit}">
+        <button th:replace="~{fragments/buttons/transactionSubmitButton :: transactionSubmitButton(#{${submitButtonText}})}"></button>
+    </th:block>
+    <th:block th:unless="${isTransactionSubmit}">
+        <button th:replace="~{fragments/buttons/primaryButton :: primaryButton(#{${submitButtonText}})}"></button>
+    </th:block>
 </th:block>
 </html>

--- a/src/main/resources/templates/forms/ownershipTypeForm.html
+++ b/src/main/resources/templates/forms/ownershipTypeForm.html
@@ -17,10 +17,5 @@
     <th:block th:if="${showWarning}">
         <div th:replace="~{fragments/warningText :: warningText(#{forms.warning})}">forms.update.warning</div>
     </th:block>
-    <th:block th:if="${isTransactionSubmit}">
-        <button th:replace="~{fragments/buttons/transactionSubmitButton :: transactionSubmitButton(#{${submitButtonText}})}"></button>
-    </th:block>
-    <th:block th:unless="${isTransactionSubmit}">
-        <button th:replace="~{fragments/buttons/primaryButton :: primaryButton(#{${submitButtonText}})}"></button>
-    </th:block>
+    <button th:replace="~{fragments/buttons/__${submitButton ?: 'primaryButton'}__ :: __${submitButton ?: 'primaryButton'}__(#{${submitButtonText}})}"></button>
 </html>

--- a/src/main/resources/templates/forms/ownershipTypeForm.html
+++ b/src/main/resources/templates/forms/ownershipTypeForm.html
@@ -17,5 +17,10 @@
     <th:block th:if="${showWarning}">
         <div th:replace="~{fragments/warningText :: warningText(#{forms.warning})}">forms.update.warning</div>
     </th:block>
-    <button th:replace="~{fragments/buttons/primaryButton :: primaryButton(#{${submitButtonText}})}"></button>
+    <th:block th:if="${isTransactionSubmit}">
+        <button th:replace="~{fragments/buttons/transactionSubmitButton :: transactionSubmitButton(#{${submitButtonText}})}"></button>
+    </th:block>
+    <th:block th:unless="${isTransactionSubmit}">
+        <button th:replace="~{fragments/buttons/primaryButton :: primaryButton(#{${submitButtonText}})}"></button>
+    </th:block>
 </html>

--- a/src/main/resources/templates/forms/phoneNumberForm.html
+++ b/src/main/resources/templates/forms/phoneNumberForm.html
@@ -16,5 +16,10 @@
     <th:block th:if="${showWarning}">
         <div th:replace="~{fragments/warningText :: warningText(#{forms.update.warning})}">forms.update.warning</div>
     </th:block>
-    <button th:replace="~{fragments/buttons/primaryButton :: primaryButton(#{${submitButtonText}})}"></button>
+    <th:block th:if="${isTransactionSubmit}">
+        <button th:replace="~{fragments/buttons/transactionSubmitButton :: transactionSubmitButton(#{${submitButtonText}})}"></button>
+    </th:block>
+    <th:block th:unless="${isTransactionSubmit}">
+        <button th:replace="~{fragments/buttons/primaryButton :: primaryButton(#{${submitButtonText}})}"></button>
+    </th:block>
 </html>

--- a/src/main/resources/templates/forms/phoneNumberForm.html
+++ b/src/main/resources/templates/forms/phoneNumberForm.html
@@ -16,10 +16,5 @@
     <th:block th:if="${showWarning}">
         <div th:replace="~{fragments/warningText :: warningText(#{forms.update.warning})}">forms.update.warning</div>
     </th:block>
-    <th:block th:if="${isTransactionSubmit}">
-        <button th:replace="~{fragments/buttons/transactionSubmitButton :: transactionSubmitButton(#{${submitButtonText}})}"></button>
-    </th:block>
-    <th:block th:unless="${isTransactionSubmit}">
-        <button th:replace="~{fragments/buttons/primaryButton :: primaryButton(#{${submitButtonText}})}"></button>
-    </th:block>
+    <button th:replace="~{fragments/buttons/__${submitButton ?: 'primaryButton'}__ :: __${submitButton ?: 'primaryButton'}__(#{${submitButtonText}})}"></button>
 </html>

--- a/src/main/resources/templates/forms/propertyRegistrationCheckAnswersForm.html
+++ b/src/main/resources/templates/forms/propertyRegistrationCheckAnswersForm.html
@@ -82,6 +82,6 @@
     </th:block>
     <th:block id="form-content">
         <input type="hidden" name="submittedFilteredJourneyData" th:value="${submittedFilteredJourneyData}"/>
-        <button th:replace="~{fragments/buttons/primaryButton :: primaryButton(#{${submitButtonText}})}"></button>
+        <button th:replace="~{fragments/buttons/transactionSubmitButton :: transactionSubmitButton(#{${submitButtonText}})}"></button>
     </th:block>
 </html>

--- a/src/main/resources/templates/fragments/buttons/transactionSubmitButton.html
+++ b/src/main/resources/templates/fragments/buttons/transactionSubmitButton.html
@@ -1,0 +1,9 @@
+<button th:fragment="transactionSubmitButton(buttonText)" th:with="id=${id}"
+        type="submit"
+        class="govuk-button"
+        data-module="govuk-button"
+        data-plausible-event="Transaction"
+        th:text="${buttonText}"
+        th:id="${id}">
+    buttonText
+</button>

--- a/src/main/resources/templates/fragments/buttons/transactionWarningButton.html
+++ b/src/main/resources/templates/fragments/buttons/transactionWarningButton.html
@@ -1,0 +1,10 @@
+<div th:remove="tag" th:fragment="transactionWarningButton(buttonText)">
+    <a th:if="${href != null}" th:href="${href}" th:text="${buttonText}" role="button" draggable="false"
+       class="govuk-button govuk-button--warning" data-module="govuk-button" data-plausible-event="Transaction">
+        Warning
+    </a>
+    <button th:if="${href == null}" th:text="${buttonText}" type="submit" class="govuk-button govuk-button--warning"
+            data-module="govuk-button" data-plausible-event="Transaction">
+        Warning
+    </button>
+</div>

--- a/src/test/js/plausibleTransactionEvent.test.js
+++ b/src/test/js/plausibleTransactionEvent.test.js
@@ -1,0 +1,68 @@
+import assert from 'node:assert/strict';
+import { afterEach, beforeEach, describe, test } from 'node:test';
+import jsdom from 'global-jsdom';
+import { initPlausibleEventButtons } from '#main-javascript/plausibleTransactionEvent.js';
+
+describe('Plausible event buttons', () => {
+    let cleanup;
+    let plausibleCalls;
+    let submittedForms;
+
+    beforeEach(() => {
+        cleanup = jsdom('<!DOCTYPE html><html><body></body></html>');
+
+        plausibleCalls = [];
+        window.plausible = (name, options) => plausibleCalls.push({ name, options });
+
+        submittedForms = [];
+        HTMLFormElement.prototype.submit = function () {
+            submittedForms.push(this);
+        };
+    });
+
+    afterEach(() => {
+        cleanup();
+    });
+
+    test('clicking a tagged element that is not in a form fires the named event', () => {
+        document.body.innerHTML = `<a id="link" href="/next" data-plausible-event="Transaction">Go</a>`;
+
+        initPlausibleEventButtons();
+        document.getElementById('link').dispatchEvent(new window.Event('click', { bubbles: true }));
+
+        assert.strictEqual(plausibleCalls.length, 1);
+        assert.strictEqual(plausibleCalls[0].name, 'Transaction');
+    });
+
+    test('submitting a form via a tagged button fires the event without blocking submission', () => {
+        document.body.innerHTML = `
+            <form id="form">
+                <button type="submit" data-plausible-event="Transaction">Confirm and submit</button>
+            </form>`;
+        const form = document.getElementById('form');
+
+        initPlausibleEventButtons();
+        const submitEvent = new window.Event('submit', { bubbles: true, cancelable: true });
+        form.dispatchEvent(submitEvent);
+
+        assert.strictEqual(submitEvent.defaultPrevented, false, 'submission must proceed normally');
+        assert.strictEqual(plausibleCalls.length, 1);
+        assert.strictEqual(plausibleCalls[0].name, 'Transaction');
+    });
+
+    test('the form still submits normally if window.plausible is unavailable', () => {
+        delete window.plausible;
+        document.body.innerHTML = `
+            <form id="form">
+                <button type="submit" data-plausible-event="Transaction">Confirm</button>
+            </form>`;
+        const form = document.getElementById('form');
+
+        initPlausibleEventButtons();
+        const submitEvent = new window.Event('submit', { bubbles: true, cancelable: true });
+        form.dispatchEvent(submitEvent);
+
+        assert.strictEqual(submitEvent.defaultPrevented, false, 'submission must proceed normally');
+        assert.strictEqual(plausibleCalls.length, 0);
+    });
+});

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/TransactionEventTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/TransactionEventTests.kt
@@ -1,0 +1,127 @@
+package uk.gov.communities.prsdb.webapp.integration
+
+import com.microsoft.playwright.Page
+import com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.whenever
+import org.springframework.test.context.bean.override.mockito.MockitoBean
+import uk.gov.communities.prsdb.webapp.constants.ORGANISATION_LANDLORD_REGISTRATION
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.PropertyDetailsPageLandlordView
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages.BasePage.Companion.assertPageIs
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.landlordRegistrationJourneyPages.CheckAnswersPageLandlordRegistration
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.landlordRegistrationJourneyPages.ConfirmIdentityFormPageLandlordRegistration
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.landlordRegistrationJourneyPages.CountryOfResidenceFormPageLandlordRegistration
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.landlordRegistrationJourneyPages.EmailFormPageLandlordRegistration
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.landlordRegistrationJourneyPages.LookupAddressFormPageLandlordRegistration
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.landlordRegistrationJourneyPages.PhoneNumberFormPageLandlordRegistration
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.landlordRegistrationJourneyPages.PrivacyNoticePageLandlordRegistration
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.landlordRegistrationJourneyPages.SelectAddressFormPageLandlordRegistration
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyDetailsUpdateJourneyPages.NumberOfBedroomsFormPagePropertyDetailsUpdate
+import uk.gov.communities.prsdb.webapp.models.dataModels.VerifiedIdentityDataModel
+import uk.gov.communities.prsdb.webapp.models.viewModels.emailModels.LandlordRegistrationConfirmationEmail
+import uk.gov.communities.prsdb.webapp.services.AbsoluteUrlProvider
+import uk.gov.communities.prsdb.webapp.services.EmailNotificationService
+import java.net.URI
+import java.time.LocalDate
+
+private const val TAGGED_BUTTON_SELECTOR = "button[data-plausible-event='Transaction']"
+
+class LandlordRegistrationTransactionEventTests : IntegrationTestWithMutableData("data-mockuser-not-landlord.sql") {
+    private val absoluteLandlordUrl = "www.prsd.gov.uk/landlord"
+
+    @MockitoBean
+    private lateinit var confirmationEmailSender: EmailNotificationService<LandlordRegistrationConfirmationEmail>
+
+    @MockitoBean
+    private lateinit var absoluteUrlProvider: AbsoluteUrlProvider
+
+    @BeforeEach
+    fun setup() {
+        whenever(absoluteUrlProvider.buildLandlordDashboardUri()).thenReturn(URI(absoluteLandlordUrl))
+        featureFlagManager.disable(ORGANISATION_LANDLORD_REGISTRATION)
+    }
+
+    @Test
+    fun `the landlord registration check answers commit button is tagged for the Plausible Transaction event`(page: Page) {
+        whenever(identityService.getVerifiedIdentityData(any())).thenReturn(VerifiedIdentityDataModel("name", LocalDate.now()))
+
+        val landlordRegistrationStartPage = navigator.goToLandlordRegistrationServiceInformationStartPage()
+        landlordRegistrationStartPage.startButton.clickAndWait()
+
+        val privacyNoticePage = assertPageIs(page, PrivacyNoticePageLandlordRegistration::class)
+        privacyNoticePage.agreeAndSubmit()
+
+        val confirmIdentityPage = assertPageIs(page, ConfirmIdentityFormPageLandlordRegistration::class)
+        confirmIdentityPage.confirm()
+
+        val emailPage = assertPageIs(page, EmailFormPageLandlordRegistration::class)
+        emailPage.submitEmail("test@example.com")
+
+        val phoneNumPage = assertPageIs(page, PhoneNumberFormPageLandlordRegistration::class)
+        phoneNumPage.submitPhoneNumber("07123456789")
+
+        val countryOfResidencePage = assertPageIs(page, CountryOfResidenceFormPageLandlordRegistration::class)
+        countryOfResidencePage.submitUk()
+
+        val lookupAddressPage = assertPageIs(page, LookupAddressFormPageLandlordRegistration::class)
+        lookupAddressPage.submitPostcodeAndBuildingNameOrNumber("EG1 2AA", "1")
+
+        val selectAddressPage = assertPageIs(page, SelectAddressFormPageLandlordRegistration::class)
+        selectAddressPage.selectAddressAndSubmit("1 PRSDB Square, EG1 2AA")
+
+        assertPageIs(page, CheckAnswersPageLandlordRegistration::class)
+        assertThat(page.locator(TAGGED_BUTTON_SELECTOR)).isVisible()
+    }
+
+    @Test
+    fun `a mid-journey landlord registration page is not tagged for the Plausible Transaction event`(page: Page) {
+        whenever(identityService.getVerifiedIdentityData(any())).thenReturn(VerifiedIdentityDataModel("name", LocalDate.now()))
+
+        val landlordRegistrationStartPage = navigator.goToLandlordRegistrationServiceInformationStartPage()
+        landlordRegistrationStartPage.startButton.clickAndWait()
+
+        val privacyNoticePage = assertPageIs(page, PrivacyNoticePageLandlordRegistration::class)
+        privacyNoticePage.agreeAndSubmit()
+
+        val confirmIdentityPage = assertPageIs(page, ConfirmIdentityFormPageLandlordRegistration::class)
+        confirmIdentityPage.confirm()
+
+        assertPageIs(page, EmailFormPageLandlordRegistration::class)
+        assertThat(page.locator(TAGGED_BUTTON_SELECTOR)).hasCount(0)
+    }
+}
+
+class PropertyBedroomsUpdateTransactionEventTests : IntegrationTestWithMutableData("data-local.sql") {
+    private val occupiedPropertyOwnershipId = 1L
+    private val occupiedPropertyUrlArguments = mapOf("propertyOwnershipId" to occupiedPropertyOwnershipId.toString())
+
+    @MockitoBean
+    private lateinit var absoluteUrlProvider: AbsoluteUrlProvider
+
+    @BeforeEach
+    fun setUp() {
+        whenever(absoluteUrlProvider.buildLandlordDashboardUri())
+            .thenReturn(URI("example.com"))
+        whenever(absoluteUrlProvider.buildComplianceInformationUri(any()))
+            .thenReturn(URI("example.com"))
+    }
+
+    @Test
+    fun `the property bedrooms update commit button is tagged for the Plausible Transaction event`(page: Page) {
+        val propertyDetailsPage = navigator.goToPropertyDetailsLandlordView(occupiedPropertyOwnershipId)
+        propertyDetailsPage.propertyDetailsSummaryList.numberOfBedroomsRow.clickFirstActionLinkAndWait()
+
+        assertPageIs(page, NumberOfBedroomsFormPagePropertyDetailsUpdate::class, occupiedPropertyUrlArguments)
+        assertThat(page.locator(TAGGED_BUTTON_SELECTOR)).isVisible()
+    }
+
+    @Test
+    fun `the property details page is not tagged for the Plausible Transaction event`(page: Page) {
+        val propertyDetailsPage = navigator.goToPropertyDetailsLandlordView(occupiedPropertyOwnershipId)
+
+        assertPageIs(page, PropertyDetailsPageLandlordView::class, occupiedPropertyUrlArguments)
+        assertThat(propertyDetailsPage.page.locator(TAGGED_BUTTON_SELECTOR)).hasCount(0)
+    }
+}

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/TransactionEventTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/TransactionEventTests.kt
@@ -28,7 +28,7 @@ import java.time.LocalDate
 
 private const val TAGGED_BUTTON_SELECTOR = "button[data-plausible-event='Transaction']"
 
-class LandlordRegistrationTransactionEventTests : IntegrationTestWithMutableData("data-mockuser-not-landlord.sql") {
+class LandlordRegistrationTransactionEventTests : IntegrationTestWithImmutableData("data-mockuser-not-landlord.sql") {
     private val absoluteLandlordUrl = "www.prsd.gov.uk/landlord"
 
     @MockitoBean
@@ -44,56 +44,47 @@ class LandlordRegistrationTransactionEventTests : IntegrationTestWithMutableData
     }
 
     @Test
-    fun `the landlord registration check answers commit button is tagged for the Plausible Transaction event`(page: Page) {
+    fun `only the landlord registration check answers commit button is tagged for the Plausible Transaction event`(page: Page) {
         whenever(identityService.getVerifiedIdentityData(any())).thenReturn(VerifiedIdentityDataModel("name", LocalDate.now()))
 
         val landlordRegistrationStartPage = navigator.goToLandlordRegistrationServiceInformationStartPage()
+        assertThat(page.locator(TAGGED_BUTTON_SELECTOR)).hasCount(0)
         landlordRegistrationStartPage.startButton.clickAndWait()
 
         val privacyNoticePage = assertPageIs(page, PrivacyNoticePageLandlordRegistration::class)
+        assertThat(page.locator(TAGGED_BUTTON_SELECTOR)).hasCount(0)
         privacyNoticePage.agreeAndSubmit()
 
         val confirmIdentityPage = assertPageIs(page, ConfirmIdentityFormPageLandlordRegistration::class)
+        assertThat(page.locator(TAGGED_BUTTON_SELECTOR)).hasCount(0)
         confirmIdentityPage.confirm()
 
         val emailPage = assertPageIs(page, EmailFormPageLandlordRegistration::class)
+        assertThat(page.locator(TAGGED_BUTTON_SELECTOR)).hasCount(0)
         emailPage.submitEmail("test@example.com")
 
         val phoneNumPage = assertPageIs(page, PhoneNumberFormPageLandlordRegistration::class)
+        assertThat(page.locator(TAGGED_BUTTON_SELECTOR)).hasCount(0)
         phoneNumPage.submitPhoneNumber("07123456789")
 
         val countryOfResidencePage = assertPageIs(page, CountryOfResidenceFormPageLandlordRegistration::class)
+        assertThat(page.locator(TAGGED_BUTTON_SELECTOR)).hasCount(0)
         countryOfResidencePage.submitUk()
 
         val lookupAddressPage = assertPageIs(page, LookupAddressFormPageLandlordRegistration::class)
+        assertThat(page.locator(TAGGED_BUTTON_SELECTOR)).hasCount(0)
         lookupAddressPage.submitPostcodeAndBuildingNameOrNumber("EG1 2AA", "1")
 
         val selectAddressPage = assertPageIs(page, SelectAddressFormPageLandlordRegistration::class)
+        assertThat(page.locator(TAGGED_BUTTON_SELECTOR)).hasCount(0)
         selectAddressPage.selectAddressAndSubmit("1 PRSDB Square, EG1 2AA")
 
         assertPageIs(page, CheckAnswersPageLandlordRegistration::class)
         assertThat(page.locator(TAGGED_BUTTON_SELECTOR)).isVisible()
     }
-
-    @Test
-    fun `a mid-journey landlord registration page is not tagged for the Plausible Transaction event`(page: Page) {
-        whenever(identityService.getVerifiedIdentityData(any())).thenReturn(VerifiedIdentityDataModel("name", LocalDate.now()))
-
-        val landlordRegistrationStartPage = navigator.goToLandlordRegistrationServiceInformationStartPage()
-        landlordRegistrationStartPage.startButton.clickAndWait()
-
-        val privacyNoticePage = assertPageIs(page, PrivacyNoticePageLandlordRegistration::class)
-        privacyNoticePage.agreeAndSubmit()
-
-        val confirmIdentityPage = assertPageIs(page, ConfirmIdentityFormPageLandlordRegistration::class)
-        confirmIdentityPage.confirm()
-
-        assertPageIs(page, EmailFormPageLandlordRegistration::class)
-        assertThat(page.locator(TAGGED_BUTTON_SELECTOR)).hasCount(0)
-    }
 }
 
-class PropertyBedroomsUpdateTransactionEventTests : IntegrationTestWithMutableData("data-local.sql") {
+class PropertyBedroomsUpdateTransactionEventTests : IntegrationTestWithImmutableData("data-local.sql") {
     private val occupiedPropertyOwnershipId = 1L
     private val occupiedPropertyUrlArguments = mapOf("propertyOwnershipId" to occupiedPropertyOwnershipId.toString())
 

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/TransactionEventTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/TransactionEventTests.kt
@@ -7,8 +7,10 @@ import org.junit.jupiter.api.Test
 import org.mockito.kotlin.any
 import org.mockito.kotlin.whenever
 import org.springframework.test.context.bean.override.mockito.MockitoBean
+import uk.gov.communities.prsdb.webapp.constants.JOINT_LANDLORDS
 import uk.gov.communities.prsdb.webapp.constants.ORGANISATION_LANDLORD_REGISTRATION
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.PropertyDetailsPageLandlordView
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.acceptOrRejectJointLandlordInvitationJourneyPages.ConfirmYouAreALandlordForThisPropertyPage
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages.BasePage.Companion.assertPageIs
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.landlordRegistrationJourneyPages.CheckAnswersPageLandlordRegistration
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.landlordRegistrationJourneyPages.ConfirmIdentityFormPageLandlordRegistration
@@ -114,5 +116,26 @@ class PropertyBedroomsUpdateTransactionEventTests : IntegrationTestWithImmutable
 
         assertPageIs(page, PropertyDetailsPageLandlordView::class, occupiedPropertyUrlArguments)
         assertThat(propertyDetailsPage.page.locator(TAGGED_BUTTON_SELECTOR)).hasCount(0)
+    }
+}
+
+class AcceptJointLandlordInvitationTransactionEventTests :
+    IntegrationTestWithImmutableData("data-joint-landlord-invitation.sql") {
+    private val validToken = "aaaabbbb-cccc-dddd-eeee-ffff00001111"
+
+    @BeforeEach
+    fun setup() {
+        featureFlagManager.enableFeature(JOINT_LANDLORDS)
+        featureFlagManager.disable(ORGANISATION_LANDLORD_REGISTRATION)
+    }
+
+    @Test
+    fun `only the confirm-you-are-a-landlord commit button is tagged for the Plausible Transaction event`(page: Page) {
+        val acceptOrRejectPage = navigator.goToAcceptOrRejectValidJointLandlordInvitationJourney(validToken)
+        assertThat(page.locator(TAGGED_BUTTON_SELECTOR)).hasCount(0)
+        acceptOrRejectPage.acceptInvitation()
+
+        assertPageIs(page, ConfirmYouAreALandlordForThisPropertyPage::class)
+        assertThat(page.locator(TAGGED_BUTTON_SELECTOR)).isVisible()
     }
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/PlausibleMetricsServiceTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/PlausibleMetricsServiceTests.kt
@@ -6,6 +6,7 @@ import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import uk.gov.communities.prsdb.webapp.clients.PlausibleClient
@@ -30,7 +31,20 @@ class PlausibleMetricsServiceTests {
             Instant.parse("2025-01-20T23:59:59Z"),
         )
 
-    private fun service() = PlausibleMetricsService(plausibleClient, domainId)
+    private fun service(transactionEventStartDate: String = "2099-01-01") =
+        PlausibleMetricsService(plausibleClient, domainId, transactionEventStartDate)
+
+    private fun stubByEventName(
+        flowCount: Double,
+        transactionCount: Double,
+    ) {
+        whenever(plausibleClient.query(any())).thenAnswer { invocation ->
+            val query = invocation.getArgument<PlausibleQuery>(0)
+            val isTransactionEventQuery = query.filters.toString().contains("event:name")
+            val count = if (isTransactionEventQuery) transactionCount else flowCount
+            PlausibleQueryResponse(listOf(aggregateRow(count)))
+        }
+    }
 
     private fun row(
         page: String,
@@ -184,5 +198,69 @@ class PlausibleMetricsServiceTests {
         assertTrue(serialised.contains("/landlord/register-as-a-landlord/confirmation"))
         assertTrue(serialised.contains("check-gas-safety-answers"))
         assertTrue(!serialised.contains("update-bedrooms"))
+    }
+
+    @Test
+    fun `getTransactionCounts uses only the Flow query when the period ends before the cutover`() {
+        stubByEventName(flowCount = 100.0, transactionCount = 999.0)
+
+        val count =
+            PlausibleMetricsService(plausibleClient, domainId, "2025-02-01")
+                .getTransactionCounts(period)
+
+        assertEquals(100L, count)
+        val captor = argumentCaptor<PlausibleQuery>()
+        verify(plausibleClient).query(captor.capture())
+        assertTrue(captor.firstValue.filters.toString().contains("event:props:currentUrl"))
+        assertEquals(listOf("2025-01-10", "2025-01-20"), captor.firstValue.dateRange)
+    }
+
+    @Test
+    fun `getTransactionCounts uses only the Transaction event query when the period starts on or after the cutover`() {
+        stubByEventName(flowCount = 999.0, transactionCount = 250.0)
+
+        val count =
+            PlausibleMetricsService(plausibleClient, domainId, "2025-01-01")
+                .getTransactionCounts(period)
+
+        assertEquals(250L, count)
+        val captor = argumentCaptor<PlausibleQuery>()
+        verify(plausibleClient).query(captor.capture())
+        val query = captor.firstValue
+        assertEquals(listOf("events"), query.metrics)
+        assertTrue(query.dimensions.isEmpty())
+        assertEquals(listOf("2025-01-10", "2025-01-20"), query.dateRange)
+        val serialised = query.filters.toString()
+        assertTrue(serialised.contains("event:name"))
+        assertTrue(serialised.contains("Transaction"))
+    }
+
+    @Test
+    fun `getTransactionCounts sums Flow before the cutover and Transaction events on or after it`() {
+        stubByEventName(flowCount = 30.0, transactionCount = 12.0)
+
+        val count =
+            PlausibleMetricsService(plausibleClient, domainId, "2025-01-15")
+                .getTransactionCounts(period)
+
+        assertEquals(42L, count)
+
+        val captor = argumentCaptor<PlausibleQuery>()
+        verify(plausibleClient, times(2)).query(captor.capture())
+        val flowQuery = captor.allValues.single { !it.filters.toString().contains("event:name") }
+        val txnQuery = captor.allValues.single { it.filters.toString().contains("event:name") }
+        assertEquals(listOf("2025-01-10", "2025-01-14"), flowQuery.dateRange)
+        assertEquals(listOf("2025-01-15", "2025-01-20"), txnQuery.dateRange)
+    }
+
+    @Test
+    fun `getTransactionCounts returns zero when a split query throws`() {
+        whenever(plausibleClient.query(any())).thenThrow(RuntimeException("boom"))
+
+        val count =
+            PlausibleMetricsService(plausibleClient, domainId, "2025-01-15")
+                .getTransactionCounts(period)
+
+        assertEquals(0L, count)
     }
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/PlausibleMetricsServiceTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/PlausibleMetricsServiceTests.kt
@@ -204,9 +204,7 @@ class PlausibleMetricsServiceTests {
     fun `getTransactionCounts uses only the Flow query when the period ends before the cutover`() {
         stubByEventName(flowCount = 100.0, transactionCount = 999.0)
 
-        val count =
-            PlausibleMetricsService(plausibleClient, domainId, "2025-02-01")
-                .getTransactionCounts(period)
+        val count = service("2025-02-01").getTransactionCounts(period)
 
         assertEquals(100L, count)
         val captor = argumentCaptor<PlausibleQuery>()
@@ -219,9 +217,7 @@ class PlausibleMetricsServiceTests {
     fun `getTransactionCounts uses only the Transaction event query when the period starts on or after the cutover`() {
         stubByEventName(flowCount = 999.0, transactionCount = 250.0)
 
-        val count =
-            PlausibleMetricsService(plausibleClient, domainId, "2025-01-01")
-                .getTransactionCounts(period)
+        val count = service("2025-01-01").getTransactionCounts(period)
 
         assertEquals(250L, count)
         val captor = argumentCaptor<PlausibleQuery>()
@@ -239,9 +235,7 @@ class PlausibleMetricsServiceTests {
     fun `getTransactionCounts sums Flow before the cutover and Transaction events on or after it`() {
         stubByEventName(flowCount = 30.0, transactionCount = 12.0)
 
-        val count =
-            PlausibleMetricsService(plausibleClient, domainId, "2025-01-15")
-                .getTransactionCounts(period)
+        val count = service("2025-01-15").getTransactionCounts(period)
 
         assertEquals(42L, count)
 
@@ -257,9 +251,7 @@ class PlausibleMetricsServiceTests {
     fun `getTransactionCounts returns zero when a split query throws`() {
         whenever(plausibleClient.query(any())).thenThrow(RuntimeException("boom"))
 
-        val count =
-            PlausibleMetricsService(plausibleClient, domainId, "2025-01-15")
-                .getTransactionCounts(period)
+        val count = service("2025-01-15").getTransactionCounts(period)
 
         assertEquals(0L, count)
     }

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -38,6 +38,7 @@ plausible:
   domain-id: test-domain-id
   base-url: https://plausible.test
   api-key: test-api-key
+  transaction-event-start-date: 2099-01-01
 
 cloudwatch-metrics:
   ecs:


### PR DESCRIPTION
## Ticket number

PDJB-1034

## Goal of change

Count completed transactions on the System Operator metrics dashboard from a dedicated Plausible "Transaction" custom event, while still using the legacy Flow-event method for reporting periods that predate the new event.

## Description of main change(s)

The branch has two logical commits:

1. **Emit the `Transaction` event via a declarative button-press pattern** — a generic `plausibleTransactionEvent.js` handler fires `window.plausible('Transaction')` when the user presses a control tagged `data-plausible-event="Transaction"`. It fires on submit without calling `preventDefault`, so the native form submission is never blocked and the event is delivered via the Plausible beacon (and is a no-op if Plausible is unavailable). A `transactionSubmitButton` fragment (and warning-style `transactionWarningButton`) carries the tag. Dedicated completion templates adopt the fragment wholesale; shared templates (reused by non-completion steps) choose the fragment via a `submitButton` content property that names the button fragment and defaults to `primaryButton`, resolved with the existing Thymeleaf `__${...}__` fragment-preprocessing idiom. To add tracking to a future journey a developer just renders their commit button via the fragment.

2. **Split `getTransactionCounts` at a configurable cutover date** (`plausible.transaction-event-start-date`, env var `PLAUSIBLE_TRANSACTION_EVENT_START_DATE`): the part of a reporting period on or after the cutover is counted from the new `Transaction` event, the part before it from the legacy Flow event. A period straddling the cutover sums two day-granular sub-range queries (disjoint, no double-counting). The config default is a far-future date, so the metric stays on the proven Flow-event method until ops set the real go-live date. The local Plausible mock (`MockPlausibleController`) distinguishes the Flow vs Transaction queries by `event:name`.

## Anything you'd like to highlight to the reviewer?

- **Coverage:** all registration, deregistration, switch-to-individual and property/landlord update journeys are tagged, as is accepting a joint-landlord invitation (the confirm-you-are-a-landlord commit button). **Not tagged:** cancelling and rejecting joint-landlord invitations, which complete via buttonless redirects after an "are you sure?" radio page, so a plain Continue button would over-count. These are counted by the metric only once they gain a genuine commit button.
- **Deployment action required:** `PLAUSIBLE_TRANSACTION_EVENT_START_DATE` must be set to the real Transaction-event go-live date. Until then the dashboard continues to use the Flow-event count (the far-future default).

## Checklist

- [x] Unit tests for new logic (e.g. new service methods) have been added
- [x] Test suite has been run in full locally and is passing 
- [x] Branch has been rebased onto main and run locally, with everything working as expected (both for your new feature and any related functionality)
- [x] Special release instructions: `PLAUSIBLE_TRANSACTION_EVENT_START_DATE` must be set to the real go-live date on the release ticket
- [x] QA instructions have been added to the ticket


