### PR TITLE
PDJB-NONE: Bump Spring Boot to 3.5.16 and resolve remaining Dependabot alerts

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
     kotlin("jvm") version "1.9.25"
     kotlin("plugin.spring") version "1.9.25"
     kotlin("plugin.serialization") version "2.0.20"
-    id("org.springframework.boot") version "3.5.14"
+    id("org.springframework.boot") version "3.5.16"
     id("io.spring.dependency-management") version "1.1.7"
     kotlin("plugin.jpa") version "1.9.25"
     id("org.jlleitschuh.gradle.ktlint") version "12.1.1"
@@ -31,12 +31,8 @@ repositories {
     mavenCentral()
 }
 
-// Override Spring Boot 3.5.14 managed versions to pick up security fixes ahead of the next Spring Boot release.
-extra["tomcat.version"] = "10.1.55"
-extra["netty.version"] = "4.1.135.Final"
-extra["postgresql.version"] = "42.7.11"
+// Override Spring Boot 3.5.16 managed versions to pick up security fixes ahead of the next Spring Boot release.
 extra["commons-lang3.version"] = "3.18.0"
-extra["jackson-bom.version"] = "2.22.0"
 
 dependencies {
     // Spring Boot Web
@@ -252,5 +248,12 @@ buildscript {
     dependencies {
         classpath("org.postgresql:postgresql:42.7.11")
         classpath("org.flywaydb:flyway-database-postgresql:10.18.0")
+    }
+    configurations.classpath {
+        resolutionStrategy {
+            // spring-boot-buildpack-platform pulls a vulnerable commons-lang3 transitively onto the
+            // build classpath; GitHub's dependency submission reports it even though it is build-time only.
+            force("org.apache.commons:commons-lang3:3.18.0")
+        }
     }
 }


### PR DESCRIPTION
## Ticket number

PDJB-NONE

## Goal of change

Close the Dependabot alerts that PR #1519 did not resolve, and pull in the latest Spring Boot 3.5.x patch.

## Description of main change(s)

- Bump Spring Boot `3.5.14` → `3.5.16`. This manages netty (`4.1.135.Final`), tomcat (`10.1.55`), postgresql (`42.7.11`) and spring-security (`6.5.11`) at patched versions, so the corresponding manual overrides are no longer needed.
- Remove the now-obsolete `tomcat`, `netty`, `postgresql` and `jackson-bom` version overrides.
- Keep `commons-lang3` pinned to `3.18.0` (Spring Boot still manages only `3.17.0`), and additionally force it on the build (plugin) classpath.
- Resolves the spring-security-web alert (`6.5.11`), the commons-lang3 alert (`3.18.0`), and six jackson-databind alerts (`2.21.4`).

## Anything you'd like to highlight to the reviewer?

- **Why #1519 didn't close most alerts:** the repo's Dependabot graph comes from GitHub's *Automatic Dependency Submission*, which resolves the whole Gradle build including the **plugin/buildscript classpath**. The `extra["…version"]` overrides only govern the application's runtime configurations, so build-time copies of jackson and commons-lang3 (dragged in by the Gradle plugins, e.g. `spring-boot-buildpack-platform` → `commons-compress` → `commons-lang3`) stayed in the submitted graph. This PR fixes both scopes — hence the buildscript-classpath `force`. Verified locally that every jackson-databind / commons-lang3 / netty-handler resolves to a patched version across all configurations.
- **Two alerts intentionally left open:** jackson-databind CVE-2026-54515 (GHSA-5jmj-h7xm-6q6v). Every published jackson ≥ 2.19 is affected (including 2.22.0); the fixes (2.21.5 / 2.22.1) are not released yet. Since jackson is now Spring-Boot-managed, these will auto-resolve when a future Spring Boot patch picks up the fix.
- A longer-term alternative to the buildscript `force` would be to scope the dependency submission to runtime configurations only, so build-time-only tooling is not reported. Left out of scope here.

## Checklist

- [x] Test suite has been run in full locally and is passing
- [x] Branch has been rebased onto main and run locally, with everything working as expected (both for your new feature and any related functionality)
- [x] TODO comments referencing this JIRA ticket have been searched for and removed - if a future PR will address them, mention that here
