### PR TITLE
PDJB-1261: prevent self JL invite

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/PropertyRegistrationJourneyFactory.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/PropertyRegistrationJourneyFactory.kt
@@ -2,6 +2,7 @@ package uk.gov.communities.prsdb.webapp.journeys.propertyRegistration
 
 import kotlinx.datetime.Instant
 import org.springframework.beans.factory.ObjectFactory
+import org.springframework.security.core.context.SecurityContextHolder
 import uk.gov.communities.prsdb.webapp.annotations.webAnnotations.JourneyFrameworkComponent
 import uk.gov.communities.prsdb.webapp.annotations.webAnnotations.PrsdbWebService
 import uk.gov.communities.prsdb.webapp.constants.CONFIRMATION_PATH_SEGMENT
@@ -120,6 +121,7 @@ import uk.gov.communities.prsdb.webapp.journeys.shared.stepConfig.SelectAddressS
 import uk.gov.communities.prsdb.webapp.models.dataModels.AddressDataModel
 import uk.gov.communities.prsdb.webapp.models.dataModels.EpcDataModel
 import uk.gov.communities.prsdb.webapp.models.viewModels.SectionHeaderViewModel
+import uk.gov.communities.prsdb.webapp.services.LandlordService
 import java.security.Principal
 
 @PrsdbWebService
@@ -507,6 +509,7 @@ class PropertyRegistrationJourney(
     override val savePropertyRegistrationDataStep: SavePropertyRegistrationDataStep,
     journeyStateService: JourneyStateService,
     override val stateFactory: ObjectFactory<PropertyRegistrationJourneyState>,
+    private val landlordService: LandlordService,
 ) : AbstractJourneyState(journeyStateService),
     PropertyRegistrationJourneyState {
     private var delegateProvider = JourneyStateDelegateProvider(journeyStateService)
@@ -518,6 +521,12 @@ class PropertyRegistrationJourney(
     override var originalJourneyUpdated: Instant? by delegateProvider.nullableDelegate("originalJourneyUpdated")
     override var invitedJointLandlordEmailsMap: Map<Int, String>? by delegateProvider.nullableDelegate("invitedJointLandlordEmails")
     override var nextJointLandlordMemberId: Int? by delegateProvider.nullableDelegate("nextJointLandlordMemberId")
+
+    override val loggedInLandlordEmail: String?
+        get() =
+            landlordService
+                .retrieveLandlordByBaseUserId(SecurityContextHolder.getContext().authentication.name)
+                ?.email
     override var checkingAnswersFor: String? by delegateProvider.nullableDelegate("checkingAnswersFor")
 
     override var epcRetrievedByUprn: EpcDataModel? by delegateProvider.nullableDelegate("epcRetrievedByUprn")

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/shared/inviteJointLandlord/InviteJointLandlordStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/shared/inviteJointLandlord/InviteJointLandlordStepConfig.kt
@@ -63,7 +63,8 @@ class InviteJointLandlordStepConfig(
         return super.enrichSubmittedDataBeforeValidation(state, formData) +
             (InviteJointLandlordsFormModel::invitedEmailAddresses.name to allInvitedEmails) +
             (InviteJointLandlordsFormModel::existingLandlordEmails.name to state.existingLandlordEmails) +
-            (InviteJointLandlordsFormModel::emailBeingEdited.name to emailBeingEdited)
+            (InviteJointLandlordsFormModel::emailBeingEdited.name to emailBeingEdited) +
+            (InviteJointLandlordsFormModel::loggedInLandlordEmail.name to state.loggedInLandlordEmail)
     }
 
     override fun afterStepDataIsAdded(state: InviteJointLandlordState) {

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/shared/states/InviteJointLandlordState.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/shared/states/InviteJointLandlordState.kt
@@ -22,4 +22,7 @@ interface InviteJointLandlordState : JourneyState {
 
     val existingLandlordEmails: List<String>
         get() = emptyList()
+
+    val loggedInLandlordEmail: String?
+        get() = null
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/requestModels/formModels/InviteJointLandlordsFormModel.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/requestModels/formModels/InviteJointLandlordsFormModel.kt
@@ -15,6 +15,8 @@ class InviteJointLandlordsFormModel : FormModel {
 
     var emailBeingEdited: String? = null
 
+    var loggedInLandlordEmail: String? = null
+
     @ValidatedBy(
         constraints = [
             ConstraintDescriptor(
@@ -24,6 +26,11 @@ class InviteJointLandlordsFormModel : FormModel {
             ConstraintDescriptor(
                 messageKey = "jointLandlords.inviteJointLandlord.error.invalidEmail",
                 validatorType = EmailConstraintValidator::class,
+            ),
+            ConstraintDescriptor(
+                messageKey = "jointLandlords.inviteJointLandlord.error.cannotInviteSelf",
+                validatorType = DelegatedPropertyConstraintValidator::class,
+                targetMethod = "isEmailNotLoggedInLandlord",
             ),
             ConstraintDescriptor(
                 messageKey = "jointLandlords.inviteJointLandlord.error.alreadyOnProperty",
@@ -47,5 +54,11 @@ class InviteJointLandlordsFormModel : FormModel {
     fun isEmailNotAlreadyOnProperty(): Boolean {
         val submittedEmail = emailAddress ?: return true
         return !existingLandlordEmails.contains(submittedEmail)
+    }
+
+    fun isEmailNotLoggedInLandlord(): Boolean {
+        val submittedEmail = emailAddress ?: return true
+        val ownEmail = loggedInLandlordEmail ?: return true
+        return submittedEmail != ownEmail
     }
 }

--- a/src/main/resources/messages/jointLandlords.yml
+++ b/src/main/resources/messages/jointLandlords.yml
@@ -21,6 +21,7 @@ inviteJointLandlord:
     label: Enter their email address
   error:
     invalidEmail: Enter an email address in the correct format, like name@example.com
+    cannotInviteSelf: You cannot invite yourself as a joint landlord
     alreadyInvited: You have already invited this email address
     alreadyOnProperty: This email address is already being used by another joint landlord
 checkJointLandlords:

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/PropertyRegistrationJourneyTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/PropertyRegistrationJourneyTests.kt
@@ -1486,4 +1486,19 @@ class PropertyRegistrationJourneyTests : IntegrationTestWithMutableData("data-lo
         changeLink.clickAndWait()
         assertPageIs(page, HasJointLandlordsFormBasePagePropertyRegistration::class)
     }
+
+    @Test
+    fun `a landlord cannot invite themselves as a joint landlord`(page: Page) {
+        featureFlagManager.enableFeature(JOINT_LANDLORDS)
+        val inviteJointLandlordPage = navigator.skipToPropertyRegistrationInviteJointLandlordPage()
+
+        inviteJointLandlordPage.submitEmail("alex.surname@example.com")
+
+        val inviteJointLandlordPageWithError = assertPageIs(page, InviteJointLandlordFormPagePropertyRegistration::class)
+        assertThat(inviteJointLandlordPageWithError.form.getErrorMessage())
+            .containsText("You cannot invite yourself as a joint landlord")
+
+        inviteJointLandlordPageWithError.submitEmail("someone.else@example.com")
+        assertPageIs(page, CheckJointLandlordsFormPagePropertyRegistration::class)
+    }
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/shared/inviteJointLandlord/InviteJointLandlordStepConfigTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/shared/inviteJointLandlord/InviteJointLandlordStepConfigTests.kt
@@ -86,6 +86,7 @@ class InviteJointLandlordStepConfigTests {
         whenever(mockJourneyState.invitedJointLandlords).thenReturn(listOf("session@example.com"))
         whenever(mockJourneyState.existingInvitedEmails).thenReturn(listOf("existing@example.com"))
         whenever(mockJourneyState.existingLandlordEmails).thenReturn(listOf("landlord@example.com"))
+        whenever(mockJourneyState.loggedInLandlordEmail).thenReturn("me@example.com")
         whenever(urlParameterService.getParameterOrNull()).thenReturn(null)
 
         val result = stepConfig.enrichSubmittedDataBeforeValidation(mockJourneyState, emptyMap())
@@ -96,6 +97,7 @@ class InviteJointLandlordStepConfigTests {
         @Suppress("UNCHECKED_CAST")
         val landlordEmails = result["existingLandlordEmails"] as List<String>
         assertEquals(listOf("landlord@example.com"), landlordEmails)
+        assertEquals("me@example.com", result["loggedInLandlordEmail"])
     }
 
     private fun setupStepConfig(): InviteJointLandlordStepConfig {

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/models/requestModels/formModels/InviteJointLandlordsFormModelTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/models/requestModels/formModels/InviteJointLandlordsFormModelTests.kt
@@ -84,4 +84,37 @@ class InviteJointLandlordsFormModelTests {
 
         assertTrue(formModel.isEmailNotAlreadyOnProperty())
     }
+
+    @Test
+    fun `a user cannot invite their own logged-in email address`() {
+        val formModel =
+            InviteJointLandlordsFormModel().apply {
+                loggedInLandlordEmail = "me@example.com"
+                emailAddress = "me@example.com"
+            }
+
+        assertFalse(formModel.isEmailNotLoggedInLandlord())
+    }
+
+    @Test
+    fun `a user can invite an email that is not their own logged-in email address`() {
+        val formModel =
+            InviteJointLandlordsFormModel().apply {
+                loggedInLandlordEmail = "me@example.com"
+                emailAddress = "someone@example.com"
+            }
+
+        assertTrue(formModel.isEmailNotLoggedInLandlord())
+    }
+
+    @Test
+    fun `self-invite check passes when logged-in email is unknown`() {
+        val formModel =
+            InviteJointLandlordsFormModel().apply {
+                loggedInLandlordEmail = null
+                emailAddress = "someone@example.com"
+            }
+
+        assertTrue(formModel.isEmailNotLoggedInLandlord())
+    }
 }


### PR DESCRIPTION
## Ticket number

PDJB-1261

## Goal of change

Prevent self invite of the logged in user on the JL page

## Description of main change(s)

<img width="777" height="570" alt="image" src="https://github.com/user-attachments/assets/8116d279-484e-48dd-80ed-622baba213a3" />
Adds a new error to property reg JL page when inviting the logged in user.

## Anything you'd like to highlight to the reviewer?

The text is new, but it's my best guess as to a valid message. I didn't think any of the existing ones fit.

## Checklist

Delete any that are not applicable, and add explanation below for any that are applicable but haven't been done

- [x] Screenshots of any UI changes have been added
- [x] Unit tests for new logic (e.g. new service methods) have been added
- [x] Single page integration tests have been added for any unhappy-flow UI features, e.g. validation errors
- [x] Test suite has been run in full locally and is passing
- [x] Branch has been rebased onto main and run locally, with everything working as expected (both for your new feature
  and any related functionality)
- [x] QA instructions have been added to the ticket (particularly if this is the last PR required to complete the ticket)
