### PR TITLE
PDJB-NONE: email case validation normalisation

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/helpers/extensions/StringExtensions.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/helpers/extensions/StringExtensions.kt
@@ -9,5 +9,11 @@ class StringExtensions {
         }
 
         fun String.toNormalizedIntegerString(): String = toIntOrNull()?.toString() ?: this
+
+        fun String.toNormalizedEmail(): String = trim().lowercase()
+
+        fun String.isSameEmailAs(other: String?): Boolean = other != null && toNormalizedEmail() == other.toNormalizedEmail()
+
+        fun Iterable<String>.containsEmail(email: String): Boolean = any { it.isSameEmailAs(email) }
     }
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/requestModels/ConfirmedEmailRequestModel.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/requestModels/ConfirmedEmailRequestModel.kt
@@ -37,5 +37,5 @@ open class ConfirmedEmailRequestModel(
     )
     var confirmEmail: String = "",
 ) {
-    fun isConfirmEmailSameAsEmail(): Boolean = email.trim() == confirmEmail.trim()
+    fun isConfirmEmailSameAsEmail(): Boolean = email.trim().equals(confirmEmail.trim(), ignoreCase = true)
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/requestModels/ConfirmedEmailRequestModel.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/requestModels/ConfirmedEmailRequestModel.kt
@@ -1,5 +1,6 @@
 package uk.gov.communities.prsdb.webapp.models.requestModels
 
+import uk.gov.communities.prsdb.webapp.helpers.extensions.StringExtensions.Companion.isSameEmailAs
 import uk.gov.communities.prsdb.webapp.validation.ConstraintDescriptor
 import uk.gov.communities.prsdb.webapp.validation.DelegatedPropertyConstraintValidator
 import uk.gov.communities.prsdb.webapp.validation.EmailConstraintValidator
@@ -37,5 +38,5 @@ open class ConfirmedEmailRequestModel(
     )
     var confirmEmail: String = "",
 ) {
-    fun isConfirmEmailSameAsEmail(): Boolean = email.trim().equals(confirmEmail.trim(), ignoreCase = true)
+    fun isConfirmEmailSameAsEmail(): Boolean = email.isSameEmailAs(confirmEmail)
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/requestModels/formModels/InviteJointLandlordsFormModel.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/requestModels/formModels/InviteJointLandlordsFormModel.kt
@@ -48,17 +48,18 @@ class InviteJointLandlordsFormModel : FormModel {
 
     fun isEmailNotAlreadyInvited(): Boolean {
         val submittedEmail = emailAddress ?: return true
-        return submittedEmail == emailBeingEdited || !invitedEmailAddresses.contains(submittedEmail)
+        return submittedEmail.equals(emailBeingEdited, ignoreCase = true) ||
+            invitedEmailAddresses.none { it.equals(submittedEmail, ignoreCase = true) }
     }
 
     fun isEmailNotAlreadyOnProperty(): Boolean {
         val submittedEmail = emailAddress ?: return true
-        return !existingLandlordEmails.contains(submittedEmail)
+        return existingLandlordEmails.none { it.equals(submittedEmail, ignoreCase = true) }
     }
 
     fun isEmailNotLoggedInLandlord(): Boolean {
         val submittedEmail = emailAddress ?: return true
         val ownEmail = loggedInLandlordEmail ?: return true
-        return submittedEmail != ownEmail
+        return !submittedEmail.equals(ownEmail, ignoreCase = true)
     }
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/requestModels/formModels/InviteJointLandlordsFormModel.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/requestModels/formModels/InviteJointLandlordsFormModel.kt
@@ -1,5 +1,7 @@
 package uk.gov.communities.prsdb.webapp.models.requestModels.formModels
 
+import uk.gov.communities.prsdb.webapp.helpers.extensions.StringExtensions.Companion.containsEmail
+import uk.gov.communities.prsdb.webapp.helpers.extensions.StringExtensions.Companion.isSameEmailAs
 import uk.gov.communities.prsdb.webapp.validation.ConstraintDescriptor
 import uk.gov.communities.prsdb.webapp.validation.DelegatedPropertyConstraintValidator
 import uk.gov.communities.prsdb.webapp.validation.EmailConstraintValidator
@@ -48,18 +50,17 @@ class InviteJointLandlordsFormModel : FormModel {
 
     fun isEmailNotAlreadyInvited(): Boolean {
         val submittedEmail = emailAddress ?: return true
-        return submittedEmail.equals(emailBeingEdited, ignoreCase = true) ||
-            invitedEmailAddresses.none { it.equals(submittedEmail, ignoreCase = true) }
+        return submittedEmail.isSameEmailAs(emailBeingEdited) ||
+            !invitedEmailAddresses.containsEmail(submittedEmail)
     }
 
     fun isEmailNotAlreadyOnProperty(): Boolean {
         val submittedEmail = emailAddress ?: return true
-        return existingLandlordEmails.none { it.equals(submittedEmail, ignoreCase = true) }
+        return !existingLandlordEmails.containsEmail(submittedEmail)
     }
 
     fun isEmailNotLoggedInLandlord(): Boolean {
         val submittedEmail = emailAddress ?: return true
-        val ownEmail = loggedInLandlordEmail ?: return true
-        return !submittedEmail.equals(ownEmail, ignoreCase = true)
+        return !submittedEmail.isSameEmailAs(loggedInLandlordEmail)
     }
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/JointLandlordInvitationService.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/JointLandlordInvitationService.kt
@@ -67,7 +67,10 @@ class JointLandlordInvitationService(
         val alreadyInvitedEmails = getExistingInvitedEmails(propertyOwnership.id)
         val existingLandlordEmails = propertyOwnership.landlords.map { it.email }
         val emailsToInvite =
-            jointLandlordEmails.filter { it !in alreadyInvitedEmails && it !in existingLandlordEmails }
+            jointLandlordEmails.filter { candidateEmail ->
+                alreadyInvitedEmails.none { it.equals(candidateEmail, ignoreCase = true) } &&
+                    existingLandlordEmails.none { it.equals(candidateEmail, ignoreCase = true) }
+            }
 
         emailsToInvite.forEach { email ->
             val token = UUID.randomUUID()

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/JointLandlordInvitationService.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/JointLandlordInvitationService.kt
@@ -16,6 +16,7 @@ import uk.gov.communities.prsdb.webapp.database.entity.Landlord
 import uk.gov.communities.prsdb.webapp.database.entity.PropertyOwnership
 import uk.gov.communities.prsdb.webapp.database.repository.JointLandlordInvitationRepository
 import uk.gov.communities.prsdb.webapp.exceptions.PrsdbWebException
+import uk.gov.communities.prsdb.webapp.helpers.extensions.StringExtensions.Companion.containsEmail
 import uk.gov.communities.prsdb.webapp.models.viewModels.emailModels.JointLandlordInvitationConfirmationEmail
 import uk.gov.communities.prsdb.webapp.models.viewModels.emailModels.JointLandlordInvitationEmail
 import uk.gov.communities.prsdb.webapp.models.viewModels.emailModels.JointLandlordInvitationNotifyExistingEmail
@@ -68,8 +69,8 @@ class JointLandlordInvitationService(
         val existingLandlordEmails = propertyOwnership.landlords.map { it.email }
         val emailsToInvite =
             jointLandlordEmails.filter { candidateEmail ->
-                alreadyInvitedEmails.none { it.equals(candidateEmail, ignoreCase = true) } &&
-                    existingLandlordEmails.none { it.equals(candidateEmail, ignoreCase = true) }
+                !alreadyInvitedEmails.containsEmail(candidateEmail) &&
+                    !existingLandlordEmails.containsEmail(candidateEmail)
             }
 
         emailsToInvite.forEach { email ->

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/LandlordService.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/LandlordService.kt
@@ -100,7 +100,9 @@ class LandlordService(
 
         val existingEmail = landlordEntity.email
 
-        landlordUpdate.email?.let { landlordEntity.email = it }
+        val emailChanged = landlordUpdate.email != null && !landlordUpdate.email.isSameEmailAs(existingEmail)
+
+        if (emailChanged) landlordEntity.email = landlordUpdate.email
         landlordUpdate.name?.let { landlordEntity.name = it }
         landlordUpdate.phoneNumber?.let { landlordEntity.phoneNumber = it }
         landlordUpdate.address?.let {
@@ -112,6 +114,7 @@ class LandlordService(
             landlordUpdate,
             landlordEntity,
             existingEmail,
+            emailChanged,
         )
         return landlordEntity
     }
@@ -220,14 +223,13 @@ class LandlordService(
         landlordUpdate: LandlordUpdateModel,
         landlord: Landlord,
         oldEmail: String,
+        emailChanged: Boolean,
     ) {
-        val emailChangedMeaningfully = landlordUpdate.email?.let { !it.isSameEmailAs(oldEmail) } ?: false
-
         val updatedDetail =
             when {
                 landlordUpdate.name != null -> "name"
                 landlordUpdate.dateOfBirth != null -> "date of birth"
-                landlordUpdate.email != null -> if (emailChangedMeaningfully) "email address" else null
+                landlordUpdate.email != null -> if (emailChanged) "email address" else null
                 landlordUpdate.phoneNumber != null -> "telephone number"
                 landlordUpdate.address != null -> "contact address"
                 else -> null

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/LandlordService.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/LandlordService.kt
@@ -11,6 +11,8 @@ import uk.gov.communities.prsdb.webapp.database.entity.Landlord
 import uk.gov.communities.prsdb.webapp.database.repository.LandlordRepository
 import uk.gov.communities.prsdb.webapp.exceptions.PrsdbWebException
 import uk.gov.communities.prsdb.webapp.exceptions.RepositoryQueryTimeoutException
+import uk.gov.communities.prsdb.webapp.helpers.extensions.StringExtensions.Companion.isSameEmailAs
+import uk.gov.communities.prsdb.webapp.helpers.extensions.StringExtensions.Companion.toNormalizedEmail
 import uk.gov.communities.prsdb.webapp.models.dataModels.AddressDataModel
 import uk.gov.communities.prsdb.webapp.models.dataModels.RegistrationNumberDataModel
 import uk.gov.communities.prsdb.webapp.models.dataModels.updateModels.LandlordUpdateModel
@@ -219,17 +221,19 @@ class LandlordService(
         landlord: Landlord,
         oldEmail: String,
     ) {
+        val emailChangedMeaningfully = landlordUpdate.email?.let { !it.isSameEmailAs(oldEmail) } ?: false
+
         val updatedDetail =
             when {
                 landlordUpdate.name != null -> "name"
                 landlordUpdate.dateOfBirth != null -> "date of birth"
-                landlordUpdate.email != null -> "email address"
+                landlordUpdate.email != null -> if (emailChangedMeaningfully) "email address" else null
                 landlordUpdate.phoneNumber != null -> "telephone number"
                 landlordUpdate.address != null -> "contact address"
                 else -> null
             }
 
-        val emails = listOf(landlord.email, oldEmail).distinctBy { it.lowercase() }
+        val emails = listOf(landlord.email, oldEmail).distinctBy { it.toNormalizedEmail() }
 
         updatedDetail?.let { detail ->
             emails.forEach { email ->

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/LandlordService.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/LandlordService.kt
@@ -229,7 +229,7 @@ class LandlordService(
                 else -> null
             }
 
-        val emails = listOf(landlord.email, oldEmail).distinct()
+        val emails = listOf(landlord.email, oldEmail).distinctBy { it.lowercase() }
 
         updatedDetail?.let { detail ->
             emails.forEach { email ->

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/LandlordService.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/LandlordService.kt
@@ -11,7 +11,6 @@ import uk.gov.communities.prsdb.webapp.database.entity.Landlord
 import uk.gov.communities.prsdb.webapp.database.repository.LandlordRepository
 import uk.gov.communities.prsdb.webapp.exceptions.PrsdbWebException
 import uk.gov.communities.prsdb.webapp.exceptions.RepositoryQueryTimeoutException
-import uk.gov.communities.prsdb.webapp.helpers.extensions.StringExtensions.Companion.isSameEmailAs
 import uk.gov.communities.prsdb.webapp.helpers.extensions.StringExtensions.Companion.toNormalizedEmail
 import uk.gov.communities.prsdb.webapp.models.dataModels.AddressDataModel
 import uk.gov.communities.prsdb.webapp.models.dataModels.RegistrationNumberDataModel
@@ -100,9 +99,7 @@ class LandlordService(
 
         val existingEmail = landlordEntity.email
 
-        val emailChanged = landlordUpdate.email != null && !landlordUpdate.email.isSameEmailAs(existingEmail)
-
-        if (emailChanged) landlordEntity.email = landlordUpdate.email
+        landlordUpdate.email?.let { landlordEntity.email = it }
         landlordUpdate.name?.let { landlordEntity.name = it }
         landlordUpdate.phoneNumber?.let { landlordEntity.phoneNumber = it }
         landlordUpdate.address?.let {
@@ -114,7 +111,6 @@ class LandlordService(
             landlordUpdate,
             landlordEntity,
             existingEmail,
-            emailChanged,
         )
         return landlordEntity
     }
@@ -223,13 +219,12 @@ class LandlordService(
         landlordUpdate: LandlordUpdateModel,
         landlord: Landlord,
         oldEmail: String,
-        emailChanged: Boolean,
     ) {
         val updatedDetail =
             when {
                 landlordUpdate.name != null -> "name"
                 landlordUpdate.dateOfBirth != null -> "date of birth"
-                landlordUpdate.email != null -> if (emailChanged) "email address" else null
+                landlordUpdate.email != null -> "email address"
                 landlordUpdate.phoneNumber != null -> "telephone number"
                 landlordUpdate.address != null -> "contact address"
                 else -> null

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/helpers/extensions/StringExtensionsTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/helpers/extensions/StringExtensionsTests.kt
@@ -1,10 +1,15 @@
 package uk.gov.communities.prsdb.webapp.helpers.extensions
 
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.CsvSource
+import uk.gov.communities.prsdb.webapp.helpers.extensions.StringExtensions.Companion.containsEmail
+import uk.gov.communities.prsdb.webapp.helpers.extensions.StringExtensions.Companion.isSameEmailAs
 import uk.gov.communities.prsdb.webapp.helpers.extensions.StringExtensions.Companion.toNormalizedCurrencyString
+import uk.gov.communities.prsdb.webapp.helpers.extensions.StringExtensions.Companion.toNormalizedEmail
 import uk.gov.communities.prsdb.webapp.helpers.extensions.StringExtensions.Companion.toNormalizedIntegerString
 
 class StringExtensionsTests {
@@ -100,5 +105,54 @@ class StringExtensionsTests {
         expected: String,
     ) {
         assertEquals(expected, input.toNormalizedIntegerString())
+    }
+
+    @ParameterizedTest
+    @CsvSource(
+        "test@example.com, test@example.com",
+        "Test@Example.com, test@example.com",
+        "'  test@example.com  ', test@example.com",
+        "TEST@EXAMPLE.COM, test@example.com",
+    )
+    fun `toNormalizedEmail trims and lowercases`(
+        input: String,
+        expected: String,
+    ) {
+        assertEquals(expected, input.toNormalizedEmail())
+    }
+
+    @ParameterizedTest
+    @CsvSource(
+        "test@example.com, test@example.com",
+        "test@example.com, Test@Example.com",
+        "test@example.com, '  TEST@EXAMPLE.COM  '",
+    )
+    fun `isSameEmailAs returns true for emails differing only by case or surrounding whitespace`(
+        email: String,
+        other: String,
+    ) {
+        assertTrue(email.isSameEmailAs(other))
+    }
+
+    @Test
+    fun `isSameEmailAs returns false for different emails`() {
+        assertFalse("test@example.com".isSameEmailAs("other@example.com"))
+    }
+
+    @Test
+    fun `isSameEmailAs returns false when other is null`() {
+        assertFalse("test@example.com".isSameEmailAs(null))
+    }
+
+    @Test
+    fun `containsEmail returns true when an equivalent email is present ignoring case and whitespace`() {
+        val emails = listOf("first@example.com", "Second@Example.com")
+        assertTrue(emails.containsEmail("  SECOND@example.com  "))
+    }
+
+    @Test
+    fun `containsEmail returns false when no equivalent email is present`() {
+        val emails = listOf("first@example.com", "second@example.com")
+        assertFalse(emails.containsEmail("third@example.com"))
     }
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/models/requestModels/ConfirmedEmailRequestModelTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/models/requestModels/ConfirmedEmailRequestModelTests.kt
@@ -15,4 +15,10 @@ class ConfirmedEmailRequestModelTests {
         val confirmedEmail = ConfirmedEmailRequestModel("test", "test")
         Assertions.assertTrue(confirmedEmail.isConfirmEmailSameAsEmail())
     }
+
+    @Test
+    fun `ConfirmEmail is valid if the emails match ignoring case`() {
+        val confirmedEmail = ConfirmedEmailRequestModel("Test@Example.com", "test@example.com")
+        Assertions.assertTrue(confirmedEmail.isConfirmEmailSameAsEmail())
+    }
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/models/requestModels/formModels/InviteJointLandlordsFormModelTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/models/requestModels/formModels/InviteJointLandlordsFormModelTests.kt
@@ -117,4 +117,37 @@ class InviteJointLandlordsFormModelTests {
 
         assertTrue(formModel.isEmailNotLoggedInLandlord())
     }
+
+    @Test
+    fun `a user cannot invite their own logged-in email address in a different case`() {
+        val formModel =
+            InviteJointLandlordsFormModel().apply {
+                loggedInLandlordEmail = "me@example.com"
+                emailAddress = "ME@Example.com"
+            }
+
+        assertFalse(formModel.isEmailNotLoggedInLandlord())
+    }
+
+    @Test
+    fun `a user cannot invite an already invited email in a different case`() {
+        val formModel =
+            InviteJointLandlordsFormModel().apply {
+                invitedEmailAddresses = mutableListOf("first@example.com")
+                emailAddress = "First@Example.com"
+            }
+
+        assertFalse(formModel.isEmailNotAlreadyInvited())
+    }
+
+    @Test
+    fun `a user cannot invite an email already on the property in a different case`() {
+        val formModel =
+            InviteJointLandlordsFormModel().apply {
+                existingLandlordEmails = mutableListOf("landlord@example.com")
+                emailAddress = "Landlord@Example.com"
+            }
+
+        assertFalse(formModel.isEmailNotAlreadyOnProperty())
+    }
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/JointLandlordInvitationServiceTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/JointLandlordInvitationServiceTests.kt
@@ -507,6 +507,45 @@ class JointLandlordInvitationServiceTests {
         }
 
         @Test
+        fun `sendInvitationEmails skips emails already invited on the property ignoring case`() {
+            val jointLandlordEmails = listOf("Already.Invited@Example.com", "new@example.com")
+            val propertyOwnership = MockLandlordData.createPropertyOwnership(id = 123L)
+            val mockUri = URI("https://example.com/invite/test-token")
+
+            whenever(mockAbsoluteUrlProvider.buildJointLandlordInvitationUri(any())).thenReturn(mockUri)
+            whenever(mockJointLandlordInvitationRepository.findByRegisteredOwnershipId(123L))
+                .thenReturn(listOf(MockJointLandlordData.createJointLandlordInvitation(email = "already.invited@example.com")))
+
+            invitationService.sendInvitationEmails(jointLandlordEmails, propertyOwnership, invitingLandlord)
+
+            val emailCaptor = argumentCaptor<String>()
+            verify(mockInvitationEmailSender, times(1)).sendEmail(emailCaptor.capture(), any())
+            assertEquals(listOf("new@example.com"), emailCaptor.allValues)
+            verify(mockJointLandlordInvitationRepository, times(1)).save(any())
+        }
+
+        @Test
+        fun `sendInvitationEmails skips emails already a landlord on the property ignoring case`() {
+            val existingLandlord = MockLandlordData.createLandlord(email = "existing@example.com")
+            val propertyOwnership =
+                MockLandlordData.createPropertyOwnership(
+                    id = 123L,
+                    landlords = mutableSetOf(MockLandlordData.createLandlord(), existingLandlord),
+                )
+            val jointLandlordEmails = listOf("Existing@Example.com", "new@example.com")
+            val mockUri = URI("https://example.com/invite/test-token")
+
+            whenever(mockAbsoluteUrlProvider.buildJointLandlordInvitationUri(any())).thenReturn(mockUri)
+
+            invitationService.sendInvitationEmails(jointLandlordEmails, propertyOwnership, invitingLandlord)
+
+            val emailCaptor = argumentCaptor<String>()
+            verify(mockInvitationEmailSender, times(1)).sendEmail(emailCaptor.capture(), any())
+            assertEquals(listOf("new@example.com"), emailCaptor.allValues)
+            verify(mockJointLandlordInvitationRepository, times(1)).save(any())
+        }
+
+        @Test
         fun `sendInvitationEmails does not send any emails when all addresses are already invited`() {
             val jointLandlordEmails = listOf("already.invited@example.com")
             val propertyOwnership = MockLandlordData.createPropertyOwnership(id = 123L)

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/LandlordServiceTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/LandlordServiceTests.kt
@@ -20,6 +20,7 @@ import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.any
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.never
+import org.mockito.kotlin.times
 import org.mockito.kotlin.whenever
 import org.springframework.dao.QueryTimeoutException
 import org.springframework.data.domain.Page
@@ -541,6 +542,30 @@ class LandlordServiceTests {
                 eq(expectedEmailModel),
             )
         }
+    }
+
+    @Test
+    fun `when a landlord updates their email by case only, a single confirmation email is sent`() {
+        // Arrange
+        val userId = "my id"
+        val originalEmailAddress = "landlord@example.com"
+        val landlordEntity =
+            createLandlord(
+                name = "original name",
+                email = originalEmailAddress,
+                phoneNumber = "original phone number",
+                address = createAddress("original address"),
+                dateOfBirth = LocalDate.of(1991, 1, 1),
+            )
+        val updateModel = LandlordUpdateModel("Landlord@Example.com", null, null, null, null)
+        whenever(mockLandlordRepository.findByBaseUser_Id(userId)).thenReturn(landlordEntity)
+        whenever(absoluteUrlProvider.buildLandlordDashboardUri()).thenReturn(URI("example.com/landlord-dashboard"))
+
+        // Act
+        landlordService.updateLandlordForBaseUserId(userId, updateModel) {}
+
+        // Assert
+        verify(updateConfirmationSender, times(1)).sendEmail(any(), any())
     }
 
     @Test

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/LandlordServiceTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/LandlordServiceTests.kt
@@ -20,6 +20,7 @@ import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.any
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.never
+import org.mockito.kotlin.times
 import org.mockito.kotlin.whenever
 import org.springframework.dao.QueryTimeoutException
 import org.springframework.data.domain.Page
@@ -544,10 +545,11 @@ class LandlordServiceTests {
     }
 
     @Test
-    fun `when a landlord updates their email by case only, no confirmation email is sent and the stored email is unchanged`() {
+    fun `when a landlord updates their email by case only, a single confirmation email is sent and the new casing is stored`() {
         // Arrange
         val userId = "my id"
         val originalEmailAddress = "landlord@example.com"
+        val newCasingEmailAddress = "Landlord@Example.com"
         val landlordEntity =
             createLandlord(
                 name = "original name",
@@ -556,7 +558,7 @@ class LandlordServiceTests {
                 address = createAddress("original address"),
                 dateOfBirth = LocalDate.of(1991, 1, 1),
             )
-        val updateModel = LandlordUpdateModel("Landlord@Example.com", null, null, null, null)
+        val updateModel = LandlordUpdateModel(newCasingEmailAddress, null, null, null, null)
         whenever(mockLandlordRepository.findByBaseUser_Id(userId)).thenReturn(landlordEntity)
         whenever(absoluteUrlProvider.buildLandlordDashboardUri()).thenReturn(URI("example.com/landlord-dashboard"))
 
@@ -564,8 +566,9 @@ class LandlordServiceTests {
         val updatedLandlord = landlordService.updateLandlordForBaseUserId(userId, updateModel) {}
 
         // Assert
-        verify(updateConfirmationSender, never()).sendEmail(any(), any())
-        assertEquals(originalEmailAddress, updatedLandlord.email)
+        assertEquals(newCasingEmailAddress, updatedLandlord.email)
+        verify(updateConfirmationSender, times(1)).sendEmail(eq(newCasingEmailAddress), any())
+        verify(updateConfirmationSender, times(1)).sendEmail(any(), any())
     }
 
     @Test

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/LandlordServiceTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/LandlordServiceTests.kt
@@ -544,7 +544,7 @@ class LandlordServiceTests {
     }
 
     @Test
-    fun `when a landlord updates their email by case only, no confirmation email is sent`() {
+    fun `when a landlord updates their email by case only, no confirmation email is sent and the stored email is unchanged`() {
         // Arrange
         val userId = "my id"
         val originalEmailAddress = "landlord@example.com"
@@ -561,10 +561,11 @@ class LandlordServiceTests {
         whenever(absoluteUrlProvider.buildLandlordDashboardUri()).thenReturn(URI("example.com/landlord-dashboard"))
 
         // Act
-        landlordService.updateLandlordForBaseUserId(userId, updateModel) {}
+        val updatedLandlord = landlordService.updateLandlordForBaseUserId(userId, updateModel) {}
 
         // Assert
         verify(updateConfirmationSender, never()).sendEmail(any(), any())
+        assertEquals(originalEmailAddress, updatedLandlord.email)
     }
 
     @Test

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/LandlordServiceTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/LandlordServiceTests.kt
@@ -20,7 +20,6 @@ import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.any
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.never
-import org.mockito.kotlin.times
 import org.mockito.kotlin.whenever
 import org.springframework.dao.QueryTimeoutException
 import org.springframework.data.domain.Page
@@ -545,7 +544,7 @@ class LandlordServiceTests {
     }
 
     @Test
-    fun `when a landlord updates their email by case only, a single confirmation email is sent`() {
+    fun `when a landlord updates their email by case only, no confirmation email is sent`() {
         // Arrange
         val userId = "my id"
         val originalEmailAddress = "landlord@example.com"
@@ -565,7 +564,7 @@ class LandlordServiceTests {
         landlordService.updateLandlordForBaseUserId(userId, updateModel) {}
 
         // Assert
-        verify(updateConfirmationSender, times(1)).sendEmail(any(), any())
+        verify(updateConfirmationSender, never()).sendEmail(any(), any())
     }
 
     @Test


### PR DESCRIPTION
## Ticket number

PDJB-NONE

## Goal of change

Currently, there are a few places in the codebase we weren't checking email case when validating. This sorts them out.

## Description of main change(s)

Removed case sensitivity from JL email checks.
Removed case sensitivity from isConfirmEmailSameAsEmail
Removed case sensitivity from landlord service
Extracts some email logic into a helper

## Anything you'd like to highlight to the reviewer?

Arguably we should sort out some kind of conversion to lowercase upon saving emails, but this would break existing emails / make peoples emails show differently to how they were entered.

I've decided that if we update a landlord email in **case only**, we should send 1 email to them rather than 1 to each address, since you can still register in a case sensitive way. This PR just fixes all validation comparisons.

## Checklist

Delete any that are not applicable, and add explanation below for any that are applicable but haven't been done

- [x] Unit tests for new logic (e.g. new service methods) have been added
- [x] Test suite has been run in full locally and is passing
- [x] Branch has been rebased onto main and run locally, with everything working as expected (both for your new feature
  and any related functionality)
- [x] TODO comments referencing this JIRA ticket have been searched for and removed - if a future PR will address them,
  mention that here