### PR TITLE
PDJB-1154: Add lead trustee phone number page

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/landlordRegistration/stepConfig/LeadTrusteePhoneStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/landlordRegistration/stepConfig/LeadTrusteePhoneStepConfig.kt
@@ -5,15 +5,20 @@ import uk.gov.communities.prsdb.webapp.journeys.AbstractRequestableStepConfig
 import uk.gov.communities.prsdb.webapp.journeys.JourneyState
 import uk.gov.communities.prsdb.webapp.journeys.JourneyStep.RequestableStep
 import uk.gov.communities.prsdb.webapp.journeys.shared.Complete
-import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.NoInputFormModel
+import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.LeadTrusteePhoneFormModel
 
 @JourneyFrameworkComponent
-class LeadTrusteePhoneStepConfig : AbstractRequestableStepConfig<Complete, NoInputFormModel, JourneyState>() {
-    override val formModelClass = NoInputFormModel::class
+class LeadTrusteePhoneStepConfig : AbstractRequestableStepConfig<Complete, LeadTrusteePhoneFormModel, JourneyState>() {
+    override val formModelClass = LeadTrusteePhoneFormModel::class
 
-    override fun getStepSpecificContent(state: JourneyState) = mapOf("todoComment" to "TODO: PDJB-1154 - Lead trustee phone number")
+    override fun getStepSpecificContent(state: JourneyState) =
+        mapOf(
+            "fieldSetHeading" to "registerAsALandlord.leadTrusteePhone.fieldSetHeading",
+            "submitButtonText" to "forms.buttons.continue",
+            "hint" to "forms.phoneNumber.hint",
+        )
 
-    override fun chooseTemplate(state: JourneyState) = "forms/todo"
+    override fun chooseTemplate(state: JourneyState) = "forms/phoneNumberForm"
 
     override fun mode(state: JourneyState) = getFormModelFromStateOrNull(state)?.let { Complete.COMPLETE }
 }
@@ -21,7 +26,7 @@ class LeadTrusteePhoneStepConfig : AbstractRequestableStepConfig<Complete, NoInp
 @JourneyFrameworkComponent
 final class LeadTrusteePhoneStep(
     stepConfig: LeadTrusteePhoneStepConfig,
-) : RequestableStep<Complete, NoInputFormModel, JourneyState>(stepConfig) {
+) : RequestableStep<Complete, LeadTrusteePhoneFormModel, JourneyState>(stepConfig) {
     companion object {
         const val ROUTE_SEGMENT = "lead-trustee-phone"
     }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/requestModels/formModels/LeadTrusteePhoneFormModel.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/requestModels/formModels/LeadTrusteePhoneFormModel.kt
@@ -1,0 +1,19 @@
+package uk.gov.communities.prsdb.webapp.models.requestModels.formModels
+
+import uk.gov.communities.prsdb.webapp.validation.ConstraintDescriptor
+import uk.gov.communities.prsdb.webapp.validation.IsValidPrioritised
+import uk.gov.communities.prsdb.webapp.validation.NotBlankConstraintValidator
+import uk.gov.communities.prsdb.webapp.validation.ValidatedBy
+
+@IsValidPrioritised
+class LeadTrusteePhoneFormModel : FormModel {
+    @ValidatedBy(
+        constraints = [
+            ConstraintDescriptor(
+                messageKey = "registerAsALandlord.leadTrusteePhone.error.missing",
+                validatorType = NotBlankConstraintValidator::class,
+            ),
+        ],
+    )
+    var phoneNumber: String? = null
+}

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/requestModels/formModels/LeadTrusteePhoneFormModel.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/requestModels/formModels/LeadTrusteePhoneFormModel.kt
@@ -3,6 +3,7 @@ package uk.gov.communities.prsdb.webapp.models.requestModels.formModels
 import uk.gov.communities.prsdb.webapp.validation.ConstraintDescriptor
 import uk.gov.communities.prsdb.webapp.validation.IsValidPrioritised
 import uk.gov.communities.prsdb.webapp.validation.NotBlankConstraintValidator
+import uk.gov.communities.prsdb.webapp.validation.PhoneNumberConstraintValidator
 import uk.gov.communities.prsdb.webapp.validation.ValidatedBy
 
 @IsValidPrioritised
@@ -12,6 +13,10 @@ class LeadTrusteePhoneFormModel : FormModel {
             ConstraintDescriptor(
                 messageKey = "registerAsALandlord.leadTrusteePhone.error.missing",
                 validatorType = NotBlankConstraintValidator::class,
+            ),
+            ConstraintDescriptor(
+                messageKey = "forms.phoneNumber.error.invalidFormat",
+                validatorType = PhoneNumberConstraintValidator::class,
             ),
         ],
     )

--- a/src/main/resources/messages/registerAsALandlord.yml
+++ b/src/main/resources/messages/registerAsALandlord.yml
@@ -90,6 +90,10 @@ orgPhoneNumber:
   fieldSetHeading: What is your organisation’s phone number?
   error:
     missing: Enter a phone number including the country code for international numbers
+leadTrusteePhone:
+  fieldSetHeading: What is the trustee’s phone number?
+  error:
+    missing: Enter a phone number including the country code for international numbers
 orgType:
   fieldSetHeading: What type of organisation are you registering?
   fieldSetHint: Select all that apply

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/LandlordRegistrationJourneyTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/LandlordRegistrationJourneyTests.kt
@@ -318,9 +318,8 @@ class LandlordRegistrationJourneyTests : IntegrationTestWithMutableData("data-mo
         val leadTrusteeEmailPage = assertPageIs(page, LeadTrusteeEmailFormPageLandlordRegistration::class)
         leadTrusteeEmailPage.form.submit()
 
-        // TODO: PDJB-1154 - Submit real lead trustee phone data once the step is implemented
         val leadTrusteePhonePage = assertPageIs(page, LeadTrusteePhoneFormPageLandlordRegistration::class)
-        leadTrusteePhonePage.form.submit()
+        leadTrusteePhonePage.submitPhoneNumber("07123456789")
 
         // TODO: PDJB-1163 - Submit real lead trustee DoB data once the step is implemented
         val leadTrusteeDobPage = assertPageIs(page, LeadTrusteeDobFormPageLandlordRegistration::class)

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/OrganisationLandlordRegistrationSinglePageTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/OrganisationLandlordRegistrationSinglePageTests.kt
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.Test
 import uk.gov.communities.prsdb.webapp.constants.ORGANISATION_LANDLORD_REGISTRATION
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.BaseComponent.Companion.assertThat
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages.BasePage.Companion.assertPageIs
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.landlordRegistrationJourneyPages.LeadTrusteeDobFormPageLandlordRegistration
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.landlordRegistrationJourneyPages.OrgEmailFormPageLandlordRegistration
 
 class OrganisationLandlordRegistrationSinglePageTests : IntegrationTestWithImmutableData("data-mockuser-not-landlord.sql") {
@@ -248,6 +249,31 @@ class OrganisationLandlordRegistrationSinglePageTests : IntegrationTestWithImmut
             orgPhoneNumberPage.submitPhoneNumber("0")
             assertThat(orgPhoneNumberPage.form.getErrorMessage())
                 .containsText("Enter a phone number including the country code for international numbers")
+        }
+    }
+
+    @Nested
+    inner class LeadTrusteePhoneStep {
+        @Test
+        fun `the lead trustee phone number page renders the heading as a label`() {
+            val leadTrusteePhonePage = navigator.skipToOrgLandlordRegistrationLeadTrusteePhonePage()
+
+            assertThat(leadTrusteePhonePage.pageHeading).containsText("What is the trustee’s phone number?")
+        }
+
+        @Test
+        fun `submitting an empty lead trustee phone number returns an error`() {
+            val leadTrusteePhonePage = navigator.skipToOrgLandlordRegistrationLeadTrusteePhonePage()
+            leadTrusteePhonePage.submitPhoneNumber("")
+            assertThat(leadTrusteePhonePage.form.getErrorMessage())
+                .containsText("Enter a phone number including the country code for international numbers")
+        }
+
+        @Test
+        fun `submitting a valid lead trustee phone number advances to the lead trustee date of birth step`(page: Page) {
+            val leadTrusteePhonePage = navigator.skipToOrgLandlordRegistrationLeadTrusteePhonePage()
+            leadTrusteePhonePage.submitPhoneNumber("07123456789")
+            assertPageIs(page, LeadTrusteeDobFormPageLandlordRegistration::class)
         }
     }
 

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/OrganisationLandlordRegistrationSinglePageTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/OrganisationLandlordRegistrationSinglePageTests.kt
@@ -270,6 +270,14 @@ class OrganisationLandlordRegistrationSinglePageTests : IntegrationTestWithImmut
         }
 
         @Test
+        fun `submitting a invalid lead trustee phone number returns an error`() {
+            val leadTrusteePhonePage = navigator.skipToOrgLandlordRegistrationLeadTrusteePhonePage()
+            leadTrusteePhonePage.submitPhoneNumber("07189")
+            assertThat(leadTrusteePhonePage.form.getErrorMessage())
+                .containsText("Enter a phone number including the country code for international numbers")
+        }
+
+        @Test
         fun `submitting a valid lead trustee phone number advances to the lead trustee date of birth step`(page: Page) {
             val leadTrusteePhonePage = navigator.skipToOrgLandlordRegistrationLeadTrusteePhonePage()
             leadTrusteePhonePage.submitPhoneNumber("07123456789")

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/OrganisationLandlordRegistrationSinglePageTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/OrganisationLandlordRegistrationSinglePageTests.kt
@@ -270,7 +270,7 @@ class OrganisationLandlordRegistrationSinglePageTests : IntegrationTestWithImmut
         }
 
         @Test
-        fun `submitting a invalid lead trustee phone number returns an error`() {
+        fun `submitting an invalid lead trustee phone number returns an error`() {
             val leadTrusteePhonePage = navigator.skipToOrgLandlordRegistrationLeadTrusteePhonePage()
             leadTrusteePhonePage.submitPhoneNumber("07189")
             assertThat(leadTrusteePhonePage.form.getErrorMessage())

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/Navigator.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/Navigator.kt
@@ -88,6 +88,7 @@ import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.landlordReg
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.landlordRegistrationJourneyPages.CountryOfResidenceFormPageLandlordRegistration
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.landlordRegistrationJourneyPages.DateOfBirthFormPageLandlordRegistration
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.landlordRegistrationJourneyPages.EmailFormPageLandlordRegistration
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.landlordRegistrationJourneyPages.LeadTrusteePhoneFormPageLandlordRegistration
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.landlordRegistrationJourneyPages.LookupAddressFormPageLandlordRegistration
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.landlordRegistrationJourneyPages.ManualAddressFormPageLandlordRegistration
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.landlordRegistrationJourneyPages.NameFormPageLandlordRegistration
@@ -175,6 +176,7 @@ import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.
 import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.DateOfBirthStep
 import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.EmailStep
 import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.LandlordTypeStep
+import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.LeadTrusteePhoneStep
 import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.OrgAddressStep
 import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.OrgCharityNumberEnglandAndWalesStep
 import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.OrgCharityNumberNorthernIrelandStep
@@ -354,6 +356,12 @@ class Navigator(
         setJourneyStateInSession(LandlordStateSessionBuilder.beforeOrgPhoneNumber().build())
         navigateToLandlordRegistrationJourneyStep(OrgPhoneNumberStep.ROUTE_SEGMENT)
         return createValidPage(page, OrgPhoneNumberFormPageLandlordRegistration::class)
+    }
+
+    fun skipToOrgLandlordRegistrationLeadTrusteePhonePage(): LeadTrusteePhoneFormPageLandlordRegistration {
+        setJourneyStateInSession(LandlordStateSessionBuilder.beforeLeadTrusteePhone().build())
+        navigateToLandlordRegistrationJourneyStep(LeadTrusteePhoneStep.ROUTE_SEGMENT)
+        return createValidPage(page, LeadTrusteePhoneFormPageLandlordRegistration::class)
     }
 
     fun skipToLandlordRegistrationPhoneNumberPage(): PhoneNumberFormPageLandlordRegistration {

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/landlordRegistrationJourneyPages/LeadTrusteePhoneFormPageLandlordRegistration.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/landlordRegistrationJourneyPages/LeadTrusteePhoneFormPageLandlordRegistration.kt
@@ -1,14 +1,13 @@
 package uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.landlordRegistrationJourneyPages
 
+import com.microsoft.playwright.Locator
 import com.microsoft.playwright.Page
 import uk.gov.communities.prsdb.webapp.controllers.RegisterLandlordController.Companion.LANDLORD_REGISTRATION_ROUTE
-import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.PostForm
-import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages.BasePage
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages.PhoneNumberFormPage
 import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.LeadTrusteePhoneStep
 
-// TODO: PDJB-1154 - Update this placeholder page object once the lead trustee phone step is implemented
 class LeadTrusteePhoneFormPageLandlordRegistration(
     page: Page,
-) : BasePage(page, "$LANDLORD_REGISTRATION_ROUTE/${LeadTrusteePhoneStep.ROUTE_SEGMENT}") {
-    val form = PostForm(page)
+) : PhoneNumberFormPage(page, "$LANDLORD_REGISTRATION_ROUTE/${LeadTrusteePhoneStep.ROUTE_SEGMENT}") {
+    val pageHeading: Locator? = page.locator("h1 label")
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/testHelpers/builders/LandlordStateSessionBuilder.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/testHelpers/builders/LandlordStateSessionBuilder.kt
@@ -28,6 +28,7 @@ import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.EmailForm
 import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.LandlordPrivacyNoticeFormModel
 import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.LandlordType
 import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.LandlordTypeFormModel
+import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.LeadTrusteePhoneFormModel
 import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.ManualAddressFormModel
 import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.NoInputFormModel
 import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.OrgCharityFormModel
@@ -144,7 +145,7 @@ class LandlordStateSessionBuilder(
     }
 
     fun withLeadTrusteePhone(): LandlordStateSessionBuilder {
-        withSubmittedValue(LeadTrusteePhoneStep.ROUTE_SEGMENT, NoInputFormModel())
+        withSubmittedValue(LeadTrusteePhoneStep.ROUTE_SEGMENT, LeadTrusteePhoneFormModel().apply { phoneNumber = "07123456789" })
         return self()
     }
 


### PR DESCRIPTION
## Ticket number

PDJB-1154

## Goal of change

Lets an organisational landlord provide the lead trustee's phone number during organisation landlord registration.

<img width="1511" height="829" alt="Screenshot 2026-07-03 at 17 08 51" src="https://github.com/user-attachments/assets/7b951ea0-087b-4473-980a-66b1f5005777" />
<img width="1511" height="821" alt="Screenshot 2026-07-03 at 17 08 39" src="https://github.com/user-attachments/assets/f8065c62-d6b3-44b0-b654-e5ac28020088" />


## Description of main change(s)

- Implements the "What is the trustee's phone number?" page, replacing the placeholder stub for the `lead-trustee-phone` step (already wired between the lead trustee email and date of birth steps).
- Adds `LeadTrusteePhoneFormModel` (required-field validation) and the `registerAsALandlord.leadTrusteePhone` messages, reusing the shared `forms/phoneNumberForm` template. Also applies `PhoneNumberConstraintValidator`
- Updates the state builder, navigator, page object and journey/single-page tests to cover the new step.

## Anything you'd like to highlight to the reviewer?

- **Heading uses the Figma copy "What is the trustee's phone number?"** (no "lead"), which differs from the AC wording "lead trustee's phone number". Used Figma as the source of truth for copy; happy to switch if preferred.
- No persistence yet — the value is captured in journey state only, consistent with the other lead-trustee steps and the org landlord CYA page, which remain stubs.

## Checklist

- [x] Screenshots of any UI changes have been added
- [x] Single page integration tests have been added for any unhappy-flow UI features, e.g. validation errors
- [x] New journey steps have been added to the appropriate journey integration test(s)
- [x] Test suite has been run in full locally and is passing — ran the targeted step-config, single-page and journey tests + `ktlintCheck` (all passing)
- [x] TODO comments referencing this JIRA ticket have been searched for and removed
- [ ] QA instructions have been added to the ticket
