### PR TITLE
PDJB-311: Change Go to dashboard button to link on leave property confirmation

### DIFF
--- a/src/main/resources/templates/leavePropertyConfirmation.html
+++ b/src/main/resources/templates/leavePropertyConfirmation.html
@@ -12,9 +12,11 @@
         <p class="govuk-body" th:text="#{leaveProperty.confirmation.paragraph.two}">
             leaveProperty.confirmation.paragraph.two
         </p>
-        <a th:replace="~{fragments/buttons/primaryButtonLink :: primaryButtonLink(@{${landlordDashboardUrl}}, #{common.confirmationPage.goToDashboard})}">
-            common.confirmationPage.goToDashboard
-        </a>
+        <p class="govuk-body">
+            <a class="govuk-link"
+               th:href="@{${landlordDashboardUrl}}"
+               th:text="#{common.confirmationPage.goToDashboard}">common.confirmationPage.goToDashboard</a>
+        </p>
     </div>
 </main>
 </html>

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/LeavePropertyJourneyTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/LeavePropertyJourneyTests.kt
@@ -39,7 +39,7 @@ class LeavePropertyJourneyTests : IntegrationTestWithMutableData("data-mockuser-
             .assertThat(confirmationPage.confirmationBanner)
             .containsText("No longer registered as a landlord for 3 Imaginary Street")
 
-        confirmationPage.goToDashboardButton.clickAndWait()
+        confirmationPage.goToDashboardLink.clickAndWait()
         val dashboard = assertPageIs(page, LandlordDashboardPage::class)
 
         dashboard.viewPropertyRecordsButton.clickAndWait()

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/leavePropertyJourneyPages/ConfirmationPageLeaveProperty.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/leavePropertyJourneyPages/ConfirmationPageLeaveProperty.kt
@@ -3,8 +3,8 @@ package uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.leavePrope
 import com.microsoft.playwright.Page
 import uk.gov.communities.prsdb.webapp.constants.CONFIRMATION_PATH_SEGMENT
 import uk.gov.communities.prsdb.webapp.controllers.LeavePropertyController
-import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.Button
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.ConfirmationBanner
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.Link
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages.BasePage
 
 class ConfirmationPageLeaveProperty(
@@ -16,5 +16,5 @@ class ConfirmationPageLeaveProperty(
             "/$CONFIRMATION_PATH_SEGMENT",
     ) {
     val confirmationBanner = ConfirmationBanner(page)
-    val goToDashboardButton = Button.byText(page, "Go to Dashboard")
+    val goToDashboardLink = Link.byText(page, "Go to dashboard")
 }


### PR DESCRIPTION
## Ticket number

PDJB-311

## Goal of change

Fix QA catch where the "Go to dashboard" call-to-action on the leave-property confirmation page rendered as a button instead of a link.

## Description of main change(s)

- Change the "Go to dashboard" action on the leave-property confirmation page from a primary button to a standard `govuk-link`, matching the other confirmation pages and the Figma design.
- Update the leave-property confirmation page object and journey integration test to reference the link.

## Checklist

- [x] New journey steps have been added to the appropriate journey integration test(s)
- [x] TODO comments referencing this JIRA ticket have been searched for and removed - if a future PR will address them, mention that here (the remaining `TODO PDJB-311` in `DeregisterStepConfig.kt` concerns email content and is out of scope for this presentational fix)