### PR TITLE
PDJB-990: Add feature flag for PDJB-939 skipping property registration fields

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/constants/FeatureFlagNames.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/constants/FeatureFlagNames.kt
@@ -18,6 +18,8 @@ const val COMPLIANCE_ACTIONS_MAY2026_REDESIGN = "compliance-actions-may2026-rede
 
 const val ORGANISATION_LANDLORD_REGISTRATION = "pdjb-1097-organisation-landlord-registration"
 
+const val ALLOW_SKIPPING_PROPERTY_REGISTRATION_FIELDS = "pdjb-939-allow-skipping-property-registration-fields"
+
 val featureFlagNames =
     listOf(
         FAILOVER_TEST_ENDPOINTS,
@@ -25,4 +27,5 @@ val featureFlagNames =
         SUBJECT_IDENTIFIER_PAGE,
         COMPLIANCE_ACTIONS_MAY2026_REDESIGN,
         ORGANISATION_LANDLORD_REGISTRATION,
+        ALLOW_SKIPPING_PROPERTY_REGISTRATION_FIELDS,
     )

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/LicensingTypeStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/LicensingTypeStepConfig.kt
@@ -1,6 +1,7 @@
 package uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps
 
 import uk.gov.communities.prsdb.webapp.annotations.webAnnotations.JourneyFrameworkComponent
+import uk.gov.communities.prsdb.webapp.config.managers.FeatureFlagManager
 import uk.gov.communities.prsdb.webapp.constants.enums.LicensingType
 import uk.gov.communities.prsdb.webapp.journeys.AbstractRequestableStepConfig
 import uk.gov.communities.prsdb.webapp.journeys.JourneyState
@@ -10,11 +11,14 @@ import uk.gov.communities.prsdb.webapp.models.viewModels.formModels.RadiosButton
 import uk.gov.communities.prsdb.webapp.models.viewModels.formModels.RadiosDividerViewModel
 
 @JourneyFrameworkComponent
-class LicensingTypeStepConfig : AbstractRequestableStepConfig<LicensingTypeMode, LicensingTypeFormModel, JourneyState>() {
+class LicensingTypeStepConfig(
+    private val featureFlagManager: FeatureFlagManager,
+) : AbstractRequestableStepConfig<LicensingTypeMode, LicensingTypeFormModel, JourneyState>() {
     override val formModelClass = LicensingTypeFormModel::class
 
-    override fun getStepSpecificContent(state: JourneyState) =
-        mapOf(
+    override fun getStepSpecificContent(state: JourneyState): Map<String, Any?> {
+        // TODO(PDJB-990): add a 'Provide this later' button to the licensing page behind the FF: pdjb-939-allow-skipping-property-registration-fields/ALLOW_SKIPPING_PROPERTY_REGISTRATION_FIELDS
+        return mapOf(
             "fieldSetHeading" to "forms.licensingType.fieldSetHeading",
             "fieldSetHint" to "forms.licensingType.fieldSetHint",
             "radioOptions" to
@@ -41,6 +45,7 @@ class LicensingTypeStepConfig : AbstractRequestableStepConfig<LicensingTypeMode,
                     ),
                 ),
         )
+    }
 
     override fun chooseTemplate(state: JourneyState): String = "forms/licensingTypeForm"
 

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/tasks/LicensingTask.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/tasks/LicensingTask.kt
@@ -1,6 +1,7 @@
 package uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks
 
 import uk.gov.communities.prsdb.webapp.annotations.webAnnotations.JourneyFrameworkComponent
+import uk.gov.communities.prsdb.webapp.config.managers.FeatureFlagManager
 import uk.gov.communities.prsdb.webapp.journeys.OrParents
 import uk.gov.communities.prsdb.webapp.journeys.Task
 import uk.gov.communities.prsdb.webapp.journeys.hasOutcome
@@ -13,9 +14,12 @@ import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.Licen
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.SelectiveLicenceStep
 
 @JourneyFrameworkComponent
-class LicensingTask : Task<LicensingState>() {
+class LicensingTask(
+    private val featureFlagManager: FeatureFlagManager,
+) : Task<LicensingState>() {
     override fun makeSubJourney(state: LicensingState) =
         subJourney(state) {
+            // TODO(PDJB-990): route to the 'provide details about licensing later' page when 'Provide this later' is selected behind the FF: pdjb-939-allow-skipping-property-registration-fields/ALLOW_SKIPPING_PROPERTY_REGISTRATION_FIELDS
             step(journey.licensingTypeStep) {
                 routeSegment(LicensingTypeStep.ROUTE_SEGMENT)
                 nextStep { mode ->

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/shared/helpers/LicensingDetailsHelper.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/shared/helpers/LicensingDetailsHelper.kt
@@ -1,6 +1,7 @@
 package uk.gov.communities.prsdb.webapp.journeys.shared.helpers
 
 import uk.gov.communities.prsdb.webapp.annotations.webAnnotations.PrsdbWebService
+import uk.gov.communities.prsdb.webapp.config.managers.FeatureFlagManager
 import uk.gov.communities.prsdb.webapp.constants.enums.LicensingType
 import uk.gov.communities.prsdb.webapp.exceptions.NotNullFormModelValueIsNullException.Companion.notNullValue
 import uk.gov.communities.prsdb.webapp.journeys.Destination
@@ -10,11 +11,14 @@ import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.Licensing
 import uk.gov.communities.prsdb.webapp.models.viewModels.summaryModels.SummaryListRowViewModel
 
 @PrsdbWebService
-class LicensingDetailsHelper {
+class LicensingDetailsHelper(
+    private val featureFlagManager: FeatureFlagManager,
+) {
     fun <T> getCheckYourAnswersSummaryList(
         state: T,
-    ): List<SummaryListRowViewModel> where T : LicensingState, T : CheckYourAnswersJourneyState =
-        state.licensingTypeStep.formModel.notNullValue(LicensingTypeFormModel::licensingType).let { licensingType ->
+    ): List<SummaryListRowViewModel> where T : LicensingState, T : CheckYourAnswersJourneyState {
+        // TODO(PDJB-990): show 'Provide this later' in the licensing CYA row (property registration only) behind the FF: pdjb-939-allow-skipping-property-registration-fields/ALLOW_SKIPPING_PROPERTY_REGISTRATION_FIELDS
+        return state.licensingTypeStep.formModel.notNullValue(LicensingTypeFormModel::licensingType).let { licensingType ->
             listOfNotNull(
                 SummaryListRowViewModel.forCheckYourAnswersPage(
                     "forms.checkPropertyAnswers.propertyDetails.licensingType",
@@ -35,4 +39,5 @@ class LicensingDetailsHelper {
                 },
             )
         }
+    }
 }

--- a/src/main/resources/application-integration.yml
+++ b/src/main/resources/application-integration.yml
@@ -17,7 +17,7 @@ features:
       enabled: true
       expiry-date: "2026-12-31"
     - name: "pdjb-939-allow-skipping-property-registration-fields"
-      enabled: false
+      enabled: true
       expiry-date: "2026-12-31"
   releases:
     - name: "private-beta-release-2"

--- a/src/main/resources/application-integration.yml
+++ b/src/main/resources/application-integration.yml
@@ -16,6 +16,9 @@ features:
     - name: "pdjb-1097-organisation-landlord-registration"
       enabled: true
       expiry-date: "2026-12-31"
+    - name: "pdjb-939-allow-skipping-property-registration-fields"
+      enabled: false
+      expiry-date: "2026-12-31"
   releases:
     - name: "private-beta-release-2"
       enabled: true

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -116,7 +116,7 @@ features:
       enabled: true
       expiry-date: "2026-12-31"
     - name: "pdjb-939-allow-skipping-property-registration-fields"
-      enabled: false
+      enabled: true
       expiry-date: "2026-12-31"
   releases:
     - name: "private-beta-release-2"

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -115,6 +115,9 @@ features:
     - name: "pdjb-1097-organisation-landlord-registration"
       enabled: true
       expiry-date: "2026-12-31"
+    - name: "pdjb-939-allow-skipping-property-registration-fields"
+      enabled: false
+      expiry-date: "2026-12-31"
   releases:
     - name: "private-beta-release-2"
       enabled: true

--- a/src/main/resources/application-nft.yml
+++ b/src/main/resources/application-nft.yml
@@ -16,6 +16,9 @@ features:
     - name: "pdjb-1097-organisation-landlord-registration"
       enabled: false
       expiry-date: "2026-12-31"
+    - name: "pdjb-939-allow-skipping-property-registration-fields"
+      enabled: false
+      expiry-date: "2026-12-31"
   releases:
     - name: "private-beta-release-2"
       enabled: false

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -16,6 +16,9 @@ features:
     - name: "pdjb-1097-organisation-landlord-registration"
       enabled: false
       expiry-date: "2026-12-31"
+    - name: "pdjb-939-allow-skipping-property-registration-fields"
+      enabled: false
+      expiry-date: "2026-12-31"
   releases:
     - name: "private-beta-release-2"
       enabled: false

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -130,6 +130,9 @@ features:
     - name: "pdjb-1097-organisation-landlord-registration"
       enabled: false
       expiry-date: "2026-12-31"
+    - name: "pdjb-939-allow-skipping-property-registration-fields"
+      enabled: false
+      expiry-date: "2026-12-31"
   releases:
     - name: "private-beta-release-2"
       enabled: false

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/shared/helpers/LicensingDetailsHelperTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/shared/helpers/LicensingDetailsHelperTests.kt
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.Test
 import org.mockito.Mockito.mock
 import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.whenever
+import uk.gov.communities.prsdb.webapp.config.managers.FeatureFlagManager
 import uk.gov.communities.prsdb.webapp.constants.enums.LicensingType
 import uk.gov.communities.prsdb.webapp.journeys.JourneyState
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.LicensingState
@@ -17,7 +18,9 @@ import uk.gov.communities.prsdb.webapp.models.viewModels.summaryModels.SummaryLi
 import kotlin.test.assertEquals
 
 class LicensingDetailsHelperTests {
-    private val licensingDetailsHelper = LicensingDetailsHelper()
+    private val featureFlagManager = mock<FeatureFlagManager>()
+
+    private val licensingDetailsHelper = LicensingDetailsHelper(featureFlagManager)
 
     private val childJourneyId = "childJourneyId"
 

--- a/src/test/resources/application-integration.yml
+++ b/src/test/resources/application-integration.yml
@@ -17,7 +17,7 @@ features:
       enabled: true
       expiry-date: "2026-12-31"
     - name: "pdjb-939-allow-skipping-property-registration-fields"
-      enabled: false
+      enabled: true
       expiry-date: "2026-12-31"
   releases:
     - name: "private-beta-release-2"

--- a/src/test/resources/application-integration.yml
+++ b/src/test/resources/application-integration.yml
@@ -16,6 +16,9 @@ features:
     - name: "pdjb-1097-organisation-landlord-registration"
       enabled: true
       expiry-date: "2026-12-31"
+    - name: "pdjb-939-allow-skipping-property-registration-fields"
+      enabled: false
+      expiry-date: "2026-12-31"
   releases:
     - name: "private-beta-release-2"
       enabled: true

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -86,6 +86,9 @@ features:
     - name: "pdjb-1097-organisation-landlord-registration"
       enabled: false
       expiry-date: "2026-12-31"
+    - name: "pdjb-939-allow-skipping-property-registration-fields"
+      enabled: false
+      expiry-date: "2026-12-31"
   releases:
     - name: "private-beta-release-2"
       enabled: false


### PR DESCRIPTION
## Ticket number

PDJB-990

## Goal of change

Introduces the `pdjb-939-allow-skipping-property-registration-fields` feature flag that PDJB-990's "provide licensing details later" work will sit behind.

## Description of main change(s)

- Registers the new `ALLOW_SKIPPING_PROPERTY_REGISTRATION_FIELDS` flag (`pdjb-939-allow-skipping-property-registration-fields`) in `FeatureFlagNames.kt` and across all profile YAML configs (default, local, nft, test, integration, plus test resources), disabled by default
- Injects `FeatureFlagManager` into the three licensing components the flagged behaviour will touch — `LicensingTypeStepConfig`, `LicensingTask` and `LicensingDetailsHelper` — with `TODO(PDJB-990)` markers for the button, routing, and CYA row changes to follow
- No functional/behavioural change: the flag is off and no conditional logic is implemented yet

## Anything you'd like to highlight to the reviewer?

`LicensingDetailsHelper` is shared by both the registration and update journeys, but the PDJB-990 CYA change should apply to registration only — flagged in the TODO for a follow-up PR.

## Checklist

- [x] Test suite has been run in full locally and is passing
