### PR TITLE
PDJB-109: Add joint-landlords to private-beta-release-2 and enable it in test, nft and production

### DIFF
--- a/src/main/resources/application-nft.yml
+++ b/src/main/resources/application-nft.yml
@@ -6,6 +6,7 @@ features:
     - name: "joint-landlords"
       enabled: false
       expiry-date: "2026-12-31"
+      release: "private-beta-release-2"
     - name: "subject-identifier-page"
       enabled: true
       expiry-date: "2027-03-30"
@@ -18,4 +19,4 @@ features:
       expiry-date: "2026-12-31"
   releases:
     - name: "private-beta-release-2"
-      enabled: false
+      enabled: true

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -6,6 +6,7 @@ features:
     - name: "joint-landlords"
       enabled: true
       expiry-date: "2026-12-31"
+      release: "private-beta-release-2"
     - name: "subject-identifier-page"
       enabled: true
       expiry-date: "2027-03-30"
@@ -18,4 +19,4 @@ features:
       expiry-date: "2026-12-31"
   releases:
     - name: "private-beta-release-2"
-      enabled: false
+      enabled: true

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -120,6 +120,7 @@ features:
     - name: "joint-landlords"
       enabled: false
       expiry-date: "2026-12-31"
+      release: "private-beta-release-2"
     - name: "subject-identifier-page"
       enabled: true
       expiry-date: "2027-03-30"
@@ -132,7 +133,7 @@ features:
       expiry-date: "2026-12-31"
   releases:
     - name: "private-beta-release-2"
-      enabled: false
+      enabled: true
 
 
 ---


### PR DESCRIPTION
## Ticket number

PDJB-109

## Goal of change

Prepare to feature-release the `private-beta-release-2` group — now including `joint-landlords` — to test, nft and production.

## Description of main change(s)

Config-only change to feature-flag values (no code changes). One commit per environment so each can be cherry-picked into its environment's feature-release PR:

- Adds `joint-landlords` to the `private-beta-release-2` release group (alongside `compliance-actions-may2026-redesign`), so it is now managed by the release.
- Sets `private-beta-release-2` to `enabled: true` in each environment's flag file:
  - `src/main/resources/application-test.yml` (test)
  - `src/main/resources/application-nft.yml` (nft)
  - `src/main/resources/application.yml` base (production)

The change is inert on integration (which overrides these values) and stays inert for test/nft/production until each environment's feature-release PR is merged. Authoring it on `main` first keeps `main` the single source of truth so the next code release stays consistent.

## Anything you'd like to highlight to the reviewer?

- This is the `main` prerequisite for three feature-release PRs (one per environment); each branches from its environment branch and cherry-picks only that environment's commit.
- Releasing `private-beta-release-2` turns on both `joint-landlords` and `compliance-actions-may2026-redesign` wherever it is enabled.
- Production release requires the flags' epic tickets to be approved ('Done') per the "Releasing to Prod" guidance in `ReadMe.md`.

## Checklist

Config-only feature-flag change — no code, UI, tests, DB schema or email changes, so the checklist items above are not applicable.
