### PR TITLE
Feature release to nft #1

### DIFF
--- a/src/main/resources/application-nft.yml
+++ b/src/main/resources/application-nft.yml
@@ -6,6 +6,7 @@ features:
     - name: "joint-landlords"
       enabled: false
       expiry-date: "2026-12-31"
+      release: "private-beta-release-2"
     - name: "subject-identifier-page"
       enabled: true
       expiry-date: "2027-03-30"
@@ -18,4 +19,4 @@ features:
       expiry-date: "2026-12-31"
   releases:
     - name: "private-beta-release-2"
-      enabled: false
+      enabled: true


### PR DESCRIPTION
## Release notes

Feature release to **nft** — configuration only, no code changes.

- Enables the `private-beta-release-2` release group in nft (`enabled: false` → `true`).
- Adds `joint-landlords` to `private-beta-release-2`, so the release now governs both `joint-landlords` and `compliance-actions-may2026-redesign`.

Net effect in nft: both `joint-landlords` and `compliance-actions-may2026-redesign` become enabled.

The change originated on `main` in #1549 and was cherry-picked from that commit onto the `nft` branch, so the diff is only the flag-config change (`src/main/resources/application-nft.yml`).

### Merge prerequisites
- Merge #1549 into `main` first — it keeps `main` the single source of truth.
- Merge this PR with a **normal merge (not squash)**, consistent with other merges into environment branches.
