### PR TITLE
Feature release to production #1

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -120,6 +120,7 @@ features:
     - name: "joint-landlords"
       enabled: false
       expiry-date: "2026-12-31"
+      release: "private-beta-release-2"
     - name: "subject-identifier-page"
       enabled: true
       expiry-date: "2027-03-30"
@@ -132,7 +133,7 @@ features:
       expiry-date: "2026-12-31"
   releases:
     - name: "private-beta-release-2"
-      enabled: false
+      enabled: true
 
 
 ---


### PR DESCRIPTION
## Release notes

Feature release to **production** — configuration only, no code changes.

- Enables the `private-beta-release-2` release group in production (`enabled: false` → `true`).
- Adds `joint-landlords` to `private-beta-release-2`, so the release now governs both `joint-landlords` and `compliance-actions-may2026-redesign`.

Net effect in production: both `joint-landlords` and `compliance-actions-may2026-redesign` become enabled.

The change originated on `main` in #1549 and was cherry-picked from that commit onto the `production` branch, so the diff is only the flag-config change (base `src/main/resources/application.yml`).

### Production approval required
Per the "Releasing to Prod" guidance in `ReadMe.md`, before merging confirm that **all tickets in the epics for both flags are approved ('Done' in Jira)**:
- `joint-landlords`
- `compliance-actions-may2026-redesign`

If any releasable ticket is not 'Done', **stop** and check in with the tech lead.

### Merge prerequisites
- Merge #1549 into `main` first — it keeps `main` the single source of truth.
- Confirm epic approval (above).
- Note the last merged PR to `production` beforehand, in case a rollback is needed.
- Merge this PR with a **normal merge (not squash)**, consistent with other merges into environment branches.
