### PR TITLE
PDJB-1271: Fix extra nudge email sending

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/LeavePropertyService.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/LeavePropertyService.kt
@@ -16,6 +16,7 @@ class LeavePropertyService(
     private val propertyOwnershipService: PropertyOwnershipService,
     private val session: HttpSession,
     private val confirmationEmailSender: EmailNotificationService<JointLandlordYouLeftConfirmation>,
+    private val swapToIndividualNudgeEmailService: SwapToIndividualNudgeEmailService,
 ) {
     fun getPropertyOwnershipIfUserCanLeave(
         propertyOwnershipId: Long,
@@ -47,6 +48,7 @@ class LeavePropertyService(
                     propertyAddress = propertyOwnership.address.toMultiLineAddress(),
                 ),
             )
+            swapToIndividualNudgeEmailService.sendNudgeEmailIfApplicable(propertyOwnership)
         }
     }
 

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/PropertyOwnershipService.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/PropertyOwnershipService.kt
@@ -39,7 +39,6 @@ class PropertyOwnershipService(
     private val licenseService: LicenseService,
     private val backLinkService: BackUrlStorageService,
     private val jointLandlordOtherLandlordLeftEmailService: JointLandlordOtherLandlordLeftEmailService,
-    private val swapToIndividualNudgeEmailService: SwapToIndividualNudgeEmailService,
 ) {
     @Transactional
     fun createPropertyOwnership(
@@ -383,7 +382,6 @@ class PropertyOwnershipService(
 
         runAfterTransactionCommits {
             jointLandlordOtherLandlordLeftEmailService.sendNotificationToRemainingLandlords(propertyOwnership, landlord)
-            swapToIndividualNudgeEmailService.sendNudgeEmailIfApplicable(propertyOwnership)
         }
     }
 

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/LandlordDeregistrationJourneyTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/LandlordDeregistrationJourneyTests.kt
@@ -5,16 +5,24 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.jdbc.core.JdbcTemplate
+import org.springframework.test.context.bean.override.mockito.MockitoBean
 import uk.gov.communities.prsdb.webapp.integration.IntegrationTestWithMutableData.NestedIntegrationTestWithMutableData
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.BaseComponent.Companion.assertThat
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages.BasePage.Companion.assertPageIs
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.landlordDeregistrationJourneyPages.AreYouSureFormPageLandlordDeregistration
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.landlordDeregistrationJourneyPages.ConfirmationPageLandlordDeregistration
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.landlordDeregistrationJourneyPages.ReasonFormPageLandlordDeregistration
+import uk.gov.communities.prsdb.webapp.services.SwapToIndividualNudgeEmailService
 
 class LandlordDeregistrationJourneyTests : IntegrationTest() {
+    @MockitoBean
+    private lateinit var swapToIndividualNudgeEmailService: SwapToIndividualNudgeEmailService
+
     @Nested
     inner class LandlordWithProperties :
         NestedIntegrationTestWithMutableData("data-mockuser-landlord-with-properties-and-incomplete-property.sql") {
@@ -163,6 +171,19 @@ class LandlordDeregistrationJourneyTests : IntegrationTest() {
             assertEquals(0, soleCount)
             assertEquals(1, jointCount)
             assertEquals(1, coOwnerMembership)
+        }
+
+        @Test
+        fun `deregistering sends the swap to individual nudge email exactly once per jointly-owned property`(page: Page) {
+            val landlordDetailsPage = navigator.goToLandlordDetails()
+            landlordDetailsPage.deleteAccountButton.clickAndWait()
+            val areYouSurePage = assertPageIs(page, AreYouSureFormPageLandlordDeregistration::class)
+            areYouSurePage.submitWantsToProceed()
+            val reasonPage = assertPageIs(page, ReasonFormPageLandlordDeregistration::class)
+            reasonPage.form.submit()
+            assertPageIs(page, ConfirmationPageLandlordDeregistration::class)
+
+            verify(swapToIndividualNudgeEmailService, times(1)).sendNudgeEmailIfApplicable(any())
         }
     }
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/LeavePropertyServiceTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/LeavePropertyServiceTests.kt
@@ -32,6 +32,9 @@ class LeavePropertyServiceTests {
     @Mock
     private lateinit var emailSender: EmailNotificationService<EmailTemplateModel>
 
+    @Mock
+    private lateinit var mockSwapToIndividualNudgeEmailService: SwapToIndividualNudgeEmailService
+
     @InjectMocks
     private lateinit var leavePropertyService: LeavePropertyService
 
@@ -104,6 +107,19 @@ class LeavePropertyServiceTests {
         val sentEmail = emailCaptor.firstValue
         assertEquals("Alice", sentEmail.recipientName)
         assertEquals(address.toMultiLineAddress(), sentEmail.propertyAddress)
+    }
+
+    @Test
+    fun `leavePropertyOwnership sends swap to individual nudge email`() {
+        val landlord = MockLandlordData.createLandlord(name = "Alice", email = "alice@example.com")
+        val propertyOwnership =
+            MockLandlordData.createPropertyOwnership(
+                landlords = mutableSetOf(landlord, MockLandlordData.createLandlord(name = "Bob")),
+            )
+
+        leavePropertyService.leavePropertyOwnership(landlord, propertyOwnership)
+
+        verify(mockSwapToIndividualNudgeEmailService).sendNudgeEmailIfApplicable(propertyOwnership)
     }
 
     @Test

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/PropertyOwnershipServiceTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/PropertyOwnershipServiceTests.kt
@@ -74,9 +74,6 @@ class PropertyOwnershipServiceTests {
     @Mock
     private lateinit var mockEmailService: JointLandlordOtherLandlordLeftEmailService
 
-    @Mock
-    private lateinit var mockSwapToIndividualNudgeEmailService: SwapToIndividualNudgeEmailService
-
     @InjectMocks
     private lateinit var propertyOwnershipService: PropertyOwnershipService
 
@@ -1515,7 +1512,6 @@ class PropertyOwnershipServiceTests {
 
             assertFalse(propertyOwnership.landlords.any { it == landlord })
             verify(mockEmailService).sendNotificationToRemainingLandlords(propertyOwnership, landlord)
-            verify(mockSwapToIndividualNudgeEmailService).sendNudgeEmailIfApplicable(propertyOwnership)
         }
     }
 }

--- a/src/test/resources/data-mockuser-landlord-with-sole-and-joint-properties.sql
+++ b/src/test/resources/data-mockuser-landlord-with-sole-and-joint-properties.sql
@@ -24,9 +24,10 @@ VALUES (1, '09/13/24', '09/13/24', 1, 1, '09/13/2000', true, 07111111111, 'urn:f
 SELECT setval(pg_get_serial_sequence('landlord', 'id'), (SELECT MAX(id) FROM landlord));
 
 INSERT INTO property_ownership (id, is_active, ownership_type, current_num_households, current_num_tenants,
-                                registration_number_id, address_id, property_build_type, num_bedrooms, rent_amount)
-VALUES (1, true, 1, 0, 0, 3, 2, 1, null, null),
-       (2, true, 1, 1, 2, 4, 3, 1, 1, 123.12);
+                                registration_number_id, address_id, property_build_type, num_bedrooms, rent_amount,
+                                marked_joint_landlord)
+VALUES (1, true, 1, 0, 0, 3, 2, 1, null, null, false),
+       (2, true, 1, 1, 2, 4, 3, 1, 1, 123.12, true);
 SELECT setval(pg_get_serial_sequence('property_ownership', 'id'), (SELECT MAX(id) FROM property_ownership));
 
 INSERT INTO ownership_link (landlord_id, landlordship_id, created_date)


### PR DESCRIPTION
## Ticket number

[PDJB-1271](https://mhclgdigital.atlassian.net/browse/PDJB-1271)

## Goal of change

move the call for nudge emails out of shared method

## Description of main change(s)

there was an issue where the landlord deregister service was assuming `PropertyOwnershipService` didn't send any nudge emails, but in #1492 a nudge check was added to the service. this PR moves that nudge out to the calling service so landlord deregistration only sends one email

## Checklist

- [x] Unit tests for new logic (e.g. new service methods) have been added
- [x] Single page integration tests have been added for any unhappy-flow UI features, e.g. validation errors
- [x] Test suite has been run in full locally and is passing
- [x] Branch has been rebased onto main and run locally, with everything working as expected (both for your new feature
  and any related functionality)
- [x] TODO comments referencing this JIRA ticket have been searched for and removed - if a future PR will address them,
  mention that here
- [x] QA instructions have been added to the ticket (particularly if this is the last PR required to complete the ticket)
