### PR TITLE
Feat/pdjb-1272 update survey links for jl

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/constants/ExternalLinks.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/constants/ExternalLinks.kt
@@ -99,7 +99,7 @@ const val GOV_LEGAL_ADVICE_URL = "https://www.gov.uk/find-legal-advice"
 
 const val LANDLORD_REGISTRATION_SURVEY_URL =
     "https://forms.office.com/Pages/" +
-        "ResponsePage.aspx?id=EGg0v32c3kOociSi7zmVqB_dtrhMqbRMjKdHcjEPmsZUMjU1TzVWUlpQUEo2MllLSzZMOFQwS0FUNSQlQCN0PWcu"
+        "ResponsePage.aspx?id=EGg0v32c3kOociSi7zmVqIpl3LghCIRKlCwVik247GRUMFFDVVZKQU85N0oyRURSQ0dUNFpRRDRJSC4u"
 
 const val PROPERTY_REGISTRATION_SURVEY_URL =
     "https://forms.office.com/Pages/" +

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/AcceptOrRejectJointLandlordInvitationController.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/AcceptOrRejectJointLandlordInvitationController.kt
@@ -16,6 +16,7 @@ import uk.gov.communities.prsdb.webapp.constants.CONFIRMATION_PATH_SEGMENT
 import uk.gov.communities.prsdb.webapp.constants.JOINT_LANDLORDS
 import uk.gov.communities.prsdb.webapp.constants.JOINT_LANDLORD_INVITATION_PATH_SEGMENT
 import uk.gov.communities.prsdb.webapp.constants.LANDLORD_PATH_SEGMENT
+import uk.gov.communities.prsdb.webapp.constants.LANDLORD_REGISTRATION_SURVEY_URL
 import uk.gov.communities.prsdb.webapp.constants.TOKEN
 import uk.gov.communities.prsdb.webapp.controllers.AcceptOrRejectJointLandlordInvitationController.Companion.ACCEPT_OR_REJECT_JOINT_LANDLORD_INVITATION_ROUTE
 import uk.gov.communities.prsdb.webapp.exceptions.PrsdbWebException
@@ -88,6 +89,7 @@ class AcceptOrRejectJointLandlordInvitationController(
 
         model.addAttribute("addressParts", propertyAddress.split("\n"))
         model.addAttribute("propertyDetailsUrl", PropertyDetailsController.getPropertyDetailsPath(propertyOwnershipId))
+        model.addAttribute("landlordRegistrationSurveyUrl", LANDLORD_REGISTRATION_SURVEY_URL)
 
         return ModelAndView("acceptJointLandlordInvitationConfirmation")
     }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/RegisterPropertyController.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/RegisterPropertyController.kt
@@ -125,7 +125,6 @@ class RegisterPropertyController(
                 "Landlord ${principal.name} has no property ownerships at confirmation",
             )
         }
-        model.addAttribute("isFirstProperty", propertyCount == 1L)
         model.addAttribute("propertyRegistrationSurveyUrl", PROPERTY_REGISTRATION_SURVEY_URL)
         model.addAttribute("landlordDashboardUrl", LANDLORD_DASHBOARD_URL)
 

--- a/src/main/resources/messages/acceptOrRejectJointLandlordInvitation.yml
+++ b/src/main/resources/messages/acceptOrRejectJointLandlordInvitation.yml
@@ -71,4 +71,6 @@ confirmation:
     paragraph:
       one: "You’ve successfully told us that you’re a landlord for this property."
       two: "This means you’re now responsible for keeping the property’s details up to date. If something changes (for example, how much rent you charge), you’ll need to update the property record."
+  feedback:
+    body: 'Answer a few short questions about <strong>landlord registration</strong>.'
   viewPropertyRecord: View property record

--- a/src/main/resources/templates/acceptJointLandlordInvitationConfirmation.html
+++ b/src/main/resources/templates/acceptJointLandlordInvitationConfirmation.html
@@ -24,6 +24,12 @@
                 acceptOrRejectJointLandlordInvitation.confirmation.whatThisMeans.paragraph.two
             </p>
 
+            <div th:replace="~{fragments/content/feedbackSurveyPanel :: feedbackSurveyPanel(
+                #{common.confirmationPage.feedback.heading},
+                #{acceptOrRejectJointLandlordInvitation.confirmation.feedback.body},
+                ${landlordRegistrationSurveyUrl})}">
+            </div>
+
             <p class="govuk-body">
                 <a class="govuk-link"
                    th:href="@{${propertyDetailsUrl}}"

--- a/src/main/resources/templates/registerPropertyConfirmation.html
+++ b/src/main/resources/templates/registerPropertyConfirmation.html
@@ -43,13 +43,11 @@
                 </p>
             </th:block>
 
-            <th:block th:if="${isFirstProperty}">
-                <div th:replace="~{fragments/content/feedbackSurveyPanel :: feedbackSurveyPanel(
-                    #{common.confirmationPage.feedback.heading},
-                    #{registerProperty.confirmation.feedback.body},
-                    ${propertyRegistrationSurveyUrl})}">
-                </div>
-            </th:block>
+            <div th:replace="~{fragments/content/feedbackSurveyPanel :: feedbackSurveyPanel(
+                #{common.confirmationPage.feedback.heading},
+                #{registerProperty.confirmation.feedback.body},
+                ${propertyRegistrationSurveyUrl})}">
+            </div>
 
             <p class="govuk-body">
                 <a class="govuk-link"

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/controllers/RegisterPropertyControllerTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/controllers/RegisterPropertyControllerTests.kt
@@ -233,7 +233,7 @@ class RegisterPropertyControllerTests(
 
     @Test
     @WithMockUser(roles = ["LANDLORD"])
-    fun `getConfirmation returns isFirstProperty true when landlord has only one property`() {
+    fun `getConfirmation includes the survey URL in the model`() {
         val propertyRegistrationNumber = 0L
         val propertyOwnership =
             createPropertyOwnership(
@@ -250,35 +250,12 @@ class RegisterPropertyControllerTests(
                     .get("${RegisterPropertyController.PROPERTY_REGISTRATION_ROUTE}/$CONFIRMATION_PATH_SEGMENT")
                     .sessionAttr(PROPERTY_REGISTRATION_NUMBER, propertyRegistrationNumber),
             ).andExpect(MockMvcResultMatchers.status().isOk)
-            .andExpect(MockMvcResultMatchers.model().attribute("isFirstProperty", true))
             .andExpect(
                 MockMvcResultMatchers.model().attribute(
                     "propertyRegistrationSurveyUrl",
                     PROPERTY_REGISTRATION_SURVEY_URL,
                 ),
             )
-    }
-
-    @Test
-    @WithMockUser(roles = ["LANDLORD"])
-    fun `getConfirmation returns isFirstProperty false when landlord has multiple properties`() {
-        val propertyRegistrationNumber = 0L
-        val propertyOwnership =
-            createPropertyOwnership(
-                registrationNumber = RegistrationNumber(RegistrationNumberType.PROPERTY, propertyRegistrationNumber),
-            )
-
-        whenever(propertyConfirmationService.getLastPrnRegisteredThisSession()).thenReturn(propertyRegistrationNumber)
-        whenever(propertyOwnershipService.retrievePropertyOwnership(propertyRegistrationNumber)).thenReturn(propertyOwnership)
-        whenever(propertyOwnershipService.getPropertyCountForLandlord(any())).thenReturn(2)
-
-        mvc
-            .perform(
-                MockMvcRequestBuilders
-                    .get("${RegisterPropertyController.PROPERTY_REGISTRATION_ROUTE}/$CONFIRMATION_PATH_SEGMENT")
-                    .sessionAttr(PROPERTY_REGISTRATION_NUMBER, propertyRegistrationNumber),
-            ).andExpect(MockMvcResultMatchers.status().isOk)
-            .andExpect(MockMvcResultMatchers.model().attribute("isFirstProperty", false))
     }
 
     @Test

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/AcceptOrRejectJointLandlordInvitationJourneyTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/AcceptOrRejectJointLandlordInvitationJourneyTests.kt
@@ -54,6 +54,7 @@ class AcceptOrRejectJointLandlordInvitationJourneyTests : IntegrationTestWithMut
 
         val confirmationPage = assertPageIs(page, PropertyJoinedConfirmationPage::class)
         assertThat(confirmationPage.confirmationBanner.body).containsText("2 Fake Way")
+        assertThat(confirmationPage.surveyLink.locator).isVisible()
     }
 
     @Test
@@ -123,6 +124,7 @@ class AcceptOrRejectJointLandlordInvitationJourneyTests : IntegrationTestWithMut
 
             val confirmationPage = assertPageIs(page, PropertyJoinedConfirmationPage::class)
             assertThat(confirmationPage.confirmationBanner.body).containsText("2 Fake Way")
+            assertThat(confirmationPage.surveyLink.locator).isVisible()
         }
 
         @Test

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/LandlordRegistrationJourneyTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/LandlordRegistrationJourneyTests.kt
@@ -125,6 +125,7 @@ class LandlordRegistrationJourneyTests : IntegrationTestWithMutableData("data-mo
 
         val confirmationPage = assertPageIs(page, ConfirmationPageLandlordRegistration::class)
         assertEquals(createdLandlordRegNum.toString(), confirmationPage.confirmationBanner.registrationNumberText)
+        assertThat(confirmationPage.surveyLink).isVisible()
         confirmationPage.goToDashboardLink.clickAndWait()
         val dashboard = assertPageIs(page, LandlordDashboardPage::class)
 
@@ -187,6 +188,7 @@ class LandlordRegistrationJourneyTests : IntegrationTestWithMutableData("data-mo
 
         val confirmationPage = assertPageIs(page, ConfirmationPageLandlordRegistration::class)
         assertEquals(createdLandlordRegNum.toString(), confirmationPage.confirmationBanner.registrationNumberText)
+        assertThat(confirmationPage.surveyLink).isVisible()
         confirmationPage.goToDashboardLink.clickAndWait()
         assertPageIs(page, LandlordDashboardPage::class)
     }
@@ -241,6 +243,7 @@ class LandlordRegistrationJourneyTests : IntegrationTestWithMutableData("data-mo
 
         val confirmationPage = assertPageIs(page, ConfirmationPageLandlordRegistration::class)
         assertEquals(createdLandlordRegNum.toString(), confirmationPage.confirmationBanner.registrationNumberText)
+        assertThat(confirmationPage.surveyLink).isVisible()
         confirmationPage.goToDashboardLink.clickAndWait()
         assertPageIs(page, LandlordDashboardPage::class)
     }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/PropertyRegistrationJourneyTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/PropertyRegistrationJourneyTests.kt
@@ -509,6 +509,7 @@ class PropertyRegistrationJourneyTests : IntegrationTestWithMutableData("data-lo
         val expectedPropertyRegNum = RegistrationNumberDataModel.fromRegistrationNumber(propertyOwnershipCaptor.value.registrationNumber)
         assertEquals(expectedPropertyRegNum.toString(), confirmationPage.registrationNumberText)
         assertFalse(confirmationPage.whatYouNeedToDoNextHeading.isVisible)
+        assertTrue(confirmationPage.surveyLink.locator.isVisible)
         assertTrue(confirmationPage.goToDashboardLink.locator.isVisible)
 
         // Check confirmation email
@@ -698,6 +699,7 @@ class PropertyRegistrationJourneyTests : IntegrationTestWithMutableData("data-lo
         val expectedPropertyRegNum = RegistrationNumberDataModel.fromRegistrationNumber(propertyOwnershipCaptor.value.registrationNumber)
         assertEquals(expectedPropertyRegNum.toString(), confirmationPage.registrationNumberText)
         assertTrue(confirmationPage.whatYouNeedToDoNextHeading.isHidden)
+        assertTrue(confirmationPage.surveyLink.locator.isVisible)
         assertTrue(confirmationPage.goToDashboardLink.locator.isVisible)
 
         // Check confirmation email
@@ -969,6 +971,7 @@ class PropertyRegistrationJourneyTests : IntegrationTestWithMutableData("data-lo
         verify(propertyOwnershipRepository).save(propertyOwnershipCaptor.capture())
         val expectedPropertyRegNum = RegistrationNumberDataModel.fromRegistrationNumber(propertyOwnershipCaptor.value.registrationNumber)
         assertEquals(expectedPropertyRegNum.toString(), confirmationPage.registrationNumberText)
+        assertTrue(confirmationPage.surveyLink.locator.isVisible)
         assertTrue(confirmationPage.goToDashboardLink.locator.isVisible)
     }
 

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/acceptOrRejectJointLandlordInvitationJourneyPages/PropertyJoinedConfirmationPage.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/acceptOrRejectJointLandlordInvitationJourneyPages/PropertyJoinedConfirmationPage.kt
@@ -2,6 +2,7 @@ package uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.acceptOrRe
 
 import com.microsoft.playwright.Page
 import uk.gov.communities.prsdb.webapp.controllers.AcceptOrRejectJointLandlordInvitationController.Companion.JOINT_LANDLORD_INVITATION_ACCEPTED_CONFIRMATION_ROUTE
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.Button
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.ConfirmationBanner
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.Heading
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages.BasePage
@@ -11,4 +12,5 @@ class PropertyJoinedConfirmationPage(
 ) : BasePage(page, JOINT_LANDLORD_INVITATION_ACCEPTED_CONFIRMATION_ROUTE) {
     val heading = Heading(page.locator("main h1"))
     val confirmationBanner = ConfirmationBanner(page)
+    val surveyLink = Button.byText(page, "Go to survey")
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/landlordRegistrationJourneyPages/ConfirmationPageLandlordRegistration.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/landlordRegistrationJourneyPages/ConfirmationPageLandlordRegistration.kt
@@ -2,6 +2,7 @@ package uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.landlordRe
 
 import com.microsoft.playwright.Page
 import uk.gov.communities.prsdb.webapp.controllers.RegisterLandlordController
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.Button
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.ConfirmationBanner
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.Link
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages.BasePage
@@ -10,6 +11,7 @@ class ConfirmationPageLandlordRegistration(
     page: Page,
 ) : BasePage(page, RegisterLandlordController.LANDLORD_REGISTRATION_CONFIRMATION_ROUTE) {
     val confirmationBanner = LandlordRegistrationConfirmationBanner(page)
+    val surveyLink = Button.byText(page, "Go to survey")
     val goToDashboardLink = Link.byText(page, "Go to dashboard")
 
     class LandlordRegistrationConfirmationBanner(

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/propertyRegistrationJourneyPages/ConfirmationPagePropertyRegistration.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/propertyRegistrationJourneyPages/ConfirmationPagePropertyRegistration.kt
@@ -3,6 +3,7 @@ package uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyRe
 import com.microsoft.playwright.Page
 import uk.gov.communities.prsdb.webapp.constants.CONFIRMATION_PATH_SEGMENT
 import uk.gov.communities.prsdb.webapp.controllers.RegisterPropertyController
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.Button
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.Link
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages.BasePage
 
@@ -11,5 +12,6 @@ class ConfirmationPagePropertyRegistration(
 ) : BasePage(page, "${RegisterPropertyController.PROPERTY_REGISTRATION_ROUTE}/$CONFIRMATION_PATH_SEGMENT") {
     val registrationNumberText: String = page.locator(".govuk-inset-text").textContent().trim()
     val whatYouNeedToDoNextHeading = page.locator("h2:has-text('What you need to do next')")
+    val surveyLink = Button.byText(page, "Go to survey")
     val goToDashboardLink = Link.byText(page, "Go to dashboard")
 }


### PR DESCRIPTION
## Ticket number

PDJB-1272

## Goal of change

Update survey links ahead of joint landlords feature release

## Description of main change(s)

* Update Landlord registration survey link
* Add landlord registration survey link to accept joint landlord invitation confirmation page - matching what is shown on the landlord registration confirmation page
* Always show the property registration survey link on the property registration confirmation page (previously only showed this when it was the first property for the landlord)
* Update integration tests to assert that the survey link appears on the relevant pages

<img width="900" height="897" alt="image" src="https://github.com/user-attachments/assets/63ea36ae-fa65-4778-a9a3-3366977e3ca4" />


## Anything you'd like to highlight to the reviewer?

## Checklist

Delete any that are not applicable, and add explanation below for any that are applicable but haven't been done

- [x] Screenshots of any UI changes have been added
- [x] New journey steps have been added to the appropriate journey integration test(s)
- [x] Test suite has been run in full locally and is passing
- [x] Branch has been rebased onto main and run locally, with everything working as expected (both for your new feature
  and any related functionality)
- [x] QA instructions have been added to the ticket (particularly if this is the last PR required to complete the ticket)
