### PR TITLE
Release test to production #13

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/config/security/LandlordSecurityConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/config/security/LandlordSecurityConfig.kt
@@ -118,6 +118,8 @@ class LandlordSecurityConfig(
         http
             .securityMatcher(
                 "${RegisterLandlordController.LANDLORD_REGISTRATION_ROUTE}/${IdentityVerifyingStep.ROUTE_SEGMENT}",
+                "${AcceptOrRejectJointLandlordInvitationController.ACCEPT_OR_REJECT_JOINT_LANDLORD_INVITATION_ROUTE}/" +
+                    IdentityVerifyingStep.ROUTE_SEGMENT,
                 "/id-verification/**",
             ).authorizeHttpRequests { requests ->
                 requests

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/constants/ExternalLinks.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/constants/ExternalLinks.kt
@@ -99,7 +99,7 @@ const val GOV_LEGAL_ADVICE_URL = "https://www.gov.uk/find-legal-advice"
 
 const val LANDLORD_REGISTRATION_SURVEY_URL =
     "https://forms.office.com/Pages/" +
-        "ResponsePage.aspx?id=EGg0v32c3kOociSi7zmVqB_dtrhMqbRMjKdHcjEPmsZUMjU1TzVWUlpQUEo2MllLSzZMOFQwS0FUNSQlQCN0PWcu"
+        "ResponsePage.aspx?id=EGg0v32c3kOociSi7zmVqIpl3LghCIRKlCwVik247GRUMFFDVVZKQU85N0oyRURSQ0dUNFpRRDRJSC4u"
 
 const val PROPERTY_REGISTRATION_SURVEY_URL =
     "https://forms.office.com/Pages/" +

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/AcceptOrRejectJointLandlordInvitationController.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/AcceptOrRejectJointLandlordInvitationController.kt
@@ -16,6 +16,7 @@ import uk.gov.communities.prsdb.webapp.constants.CONFIRMATION_PATH_SEGMENT
 import uk.gov.communities.prsdb.webapp.constants.JOINT_LANDLORDS
 import uk.gov.communities.prsdb.webapp.constants.JOINT_LANDLORD_INVITATION_PATH_SEGMENT
 import uk.gov.communities.prsdb.webapp.constants.LANDLORD_PATH_SEGMENT
+import uk.gov.communities.prsdb.webapp.constants.LANDLORD_REGISTRATION_SURVEY_URL
 import uk.gov.communities.prsdb.webapp.constants.TOKEN
 import uk.gov.communities.prsdb.webapp.controllers.AcceptOrRejectJointLandlordInvitationController.Companion.ACCEPT_OR_REJECT_JOINT_LANDLORD_INVITATION_ROUTE
 import uk.gov.communities.prsdb.webapp.exceptions.PrsdbWebException
@@ -88,6 +89,7 @@ class AcceptOrRejectJointLandlordInvitationController(
 
         model.addAttribute("addressParts", propertyAddress.split("\n"))
         model.addAttribute("propertyDetailsUrl", PropertyDetailsController.getPropertyDetailsPath(propertyOwnershipId))
+        model.addAttribute("landlordRegistrationSurveyUrl", LANDLORD_REGISTRATION_SURVEY_URL)
 
         return ModelAndView("acceptJointLandlordInvitationConfirmation")
     }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/RegisterPropertyController.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/RegisterPropertyController.kt
@@ -125,7 +125,6 @@ class RegisterPropertyController(
                 "Landlord ${principal.name} has no property ownerships at confirmation",
             )
         }
-        model.addAttribute("isFirstProperty", propertyCount == 1L)
         model.addAttribute("propertyRegistrationSurveyUrl", PROPERTY_REGISTRATION_SURVEY_URL)
         model.addAttribute("landlordDashboardUrl", LANDLORD_DASHBOARD_URL)
 

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/LeavePropertyService.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/LeavePropertyService.kt
@@ -16,6 +16,7 @@ class LeavePropertyService(
     private val propertyOwnershipService: PropertyOwnershipService,
     private val session: HttpSession,
     private val confirmationEmailSender: EmailNotificationService<JointLandlordYouLeftConfirmation>,
+    private val swapToIndividualNudgeEmailService: SwapToIndividualNudgeEmailService,
 ) {
     fun getPropertyOwnershipIfUserCanLeave(
         propertyOwnershipId: Long,
@@ -47,6 +48,7 @@ class LeavePropertyService(
                     propertyAddress = propertyOwnership.address.toMultiLineAddress(),
                 ),
             )
+            swapToIndividualNudgeEmailService.sendNudgeEmailIfApplicable(propertyOwnership)
         }
     }
 

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/PropertyOwnershipService.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/PropertyOwnershipService.kt
@@ -39,7 +39,6 @@ class PropertyOwnershipService(
     private val licenseService: LicenseService,
     private val backLinkService: BackUrlStorageService,
     private val jointLandlordOtherLandlordLeftEmailService: JointLandlordOtherLandlordLeftEmailService,
-    private val swapToIndividualNudgeEmailService: SwapToIndividualNudgeEmailService,
 ) {
     @Transactional
     fun createPropertyOwnership(
@@ -383,7 +382,6 @@ class PropertyOwnershipService(
 
         runAfterTransactionCommits {
             jointLandlordOtherLandlordLeftEmailService.sendNotificationToRemainingLandlords(propertyOwnership, landlord)
-            swapToIndividualNudgeEmailService.sendNudgeEmailIfApplicable(propertyOwnership)
         }
     }
 

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -6,6 +6,7 @@ features:
     - name: "joint-landlords"
       enabled: true
       expiry-date: "2026-12-31"
+      release: "private-beta-release-2"
     - name: "subject-identifier-page"
       enabled: true
       expiry-date: "2027-03-30"
@@ -18,4 +19,4 @@ features:
       expiry-date: "2026-12-31"
   releases:
     - name: "private-beta-release-2"
-      enabled: false
+      enabled: true

--- a/src/main/resources/messages/acceptOrRejectJointLandlordInvitation.yml
+++ b/src/main/resources/messages/acceptOrRejectJointLandlordInvitation.yml
@@ -71,4 +71,6 @@ confirmation:
     paragraph:
       one: "You’ve successfully told us that you’re a landlord for this property."
       two: "This means you’re now responsible for keeping the property’s details up to date. If something changes (for example, how much rent you charge), you’ll need to update the property record."
+  feedback:
+    body: 'Answer a few short questions about <strong>landlord registration</strong>.'
   viewPropertyRecord: View property record

--- a/src/main/resources/templates/acceptJointLandlordInvitationConfirmation.html
+++ b/src/main/resources/templates/acceptJointLandlordInvitationConfirmation.html
@@ -24,6 +24,12 @@
                 acceptOrRejectJointLandlordInvitation.confirmation.whatThisMeans.paragraph.two
             </p>
 
+            <div th:replace="~{fragments/content/feedbackSurveyPanel :: feedbackSurveyPanel(
+                #{common.confirmationPage.feedback.heading},
+                #{acceptOrRejectJointLandlordInvitation.confirmation.feedback.body},
+                ${landlordRegistrationSurveyUrl})}">
+            </div>
+
             <p class="govuk-body">
                 <a class="govuk-link"
                    th:href="@{${propertyDetailsUrl}}"

--- a/src/main/resources/templates/registerPropertyConfirmation.html
+++ b/src/main/resources/templates/registerPropertyConfirmation.html
@@ -43,13 +43,11 @@
                 </p>
             </th:block>
 
-            <th:block th:if="${isFirstProperty}">
-                <div th:replace="~{fragments/content/feedbackSurveyPanel :: feedbackSurveyPanel(
-                    #{common.confirmationPage.feedback.heading},
-                    #{registerProperty.confirmation.feedback.body},
-                    ${propertyRegistrationSurveyUrl})}">
-                </div>
-            </th:block>
+            <div th:replace="~{fragments/content/feedbackSurveyPanel :: feedbackSurveyPanel(
+                #{common.confirmationPage.feedback.heading},
+                #{registerProperty.confirmation.feedback.body},
+                ${propertyRegistrationSurveyUrl})}">
+            </div>
 
             <p class="govuk-body">
                 <a class="govuk-link"

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/controllers/AcceptOrRejectJointLandlordInvitationControllerTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/controllers/AcceptOrRejectJointLandlordInvitationControllerTests.kt
@@ -26,6 +26,7 @@ import uk.gov.communities.prsdb.webapp.journeys.StepLifecycleOrchestrator
 import uk.gov.communities.prsdb.webapp.journeys.acceptOrRejectJointLandlordInvitation.AcceptOrRejectJointLandlordInvitationJourneyFactory
 import uk.gov.communities.prsdb.webapp.journeys.acceptOrRejectJointLandlordInvitation.steps.CheckUserRoleStep
 import uk.gov.communities.prsdb.webapp.journeys.acceptOrRejectJointLandlordInvitation.steps.ValidateTokenStep
+import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.IdentityVerifyingStep
 import uk.gov.communities.prsdb.webapp.services.JointLandlordInvitationService
 
 @WebMvcTest(AcceptOrRejectJointLandlordInvitationController::class)
@@ -44,6 +45,16 @@ class AcceptOrRejectJointLandlordInvitationControllerTests(
     private val validToken = "test-token-123"
     private val journeyId = "test-journey-id"
     private val placeholderModelAndView = ModelAndView("placeholder", mapOf("title" to "placeholder"))
+
+    @Test
+    fun `verify-identity step routes an unauthenticated user through the id verification filter chain`() {
+        mvc
+            .get("$ACCEPT_OR_REJECT_JOINT_LANDLORD_INVITATION_ROUTE/${IdentityVerifyingStep.ROUTE_SEGMENT}")
+            .andExpect {
+                status { is3xxRedirection() }
+                redirectedUrlPattern("**/id-verification/oauth2/authorize/one-login")
+            }
+    }
 
     @Nested
     inner class StartJourney {

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/controllers/RegisterPropertyControllerTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/controllers/RegisterPropertyControllerTests.kt
@@ -233,7 +233,7 @@ class RegisterPropertyControllerTests(
 
     @Test
     @WithMockUser(roles = ["LANDLORD"])
-    fun `getConfirmation returns isFirstProperty true when landlord has only one property`() {
+    fun `getConfirmation includes the survey URL in the model`() {
         val propertyRegistrationNumber = 0L
         val propertyOwnership =
             createPropertyOwnership(
@@ -250,35 +250,12 @@ class RegisterPropertyControllerTests(
                     .get("${RegisterPropertyController.PROPERTY_REGISTRATION_ROUTE}/$CONFIRMATION_PATH_SEGMENT")
                     .sessionAttr(PROPERTY_REGISTRATION_NUMBER, propertyRegistrationNumber),
             ).andExpect(MockMvcResultMatchers.status().isOk)
-            .andExpect(MockMvcResultMatchers.model().attribute("isFirstProperty", true))
             .andExpect(
                 MockMvcResultMatchers.model().attribute(
                     "propertyRegistrationSurveyUrl",
                     PROPERTY_REGISTRATION_SURVEY_URL,
                 ),
             )
-    }
-
-    @Test
-    @WithMockUser(roles = ["LANDLORD"])
-    fun `getConfirmation returns isFirstProperty false when landlord has multiple properties`() {
-        val propertyRegistrationNumber = 0L
-        val propertyOwnership =
-            createPropertyOwnership(
-                registrationNumber = RegistrationNumber(RegistrationNumberType.PROPERTY, propertyRegistrationNumber),
-            )
-
-        whenever(propertyConfirmationService.getLastPrnRegisteredThisSession()).thenReturn(propertyRegistrationNumber)
-        whenever(propertyOwnershipService.retrievePropertyOwnership(propertyRegistrationNumber)).thenReturn(propertyOwnership)
-        whenever(propertyOwnershipService.getPropertyCountForLandlord(any())).thenReturn(2)
-
-        mvc
-            .perform(
-                MockMvcRequestBuilders
-                    .get("${RegisterPropertyController.PROPERTY_REGISTRATION_ROUTE}/$CONFIRMATION_PATH_SEGMENT")
-                    .sessionAttr(PROPERTY_REGISTRATION_NUMBER, propertyRegistrationNumber),
-            ).andExpect(MockMvcResultMatchers.status().isOk)
-            .andExpect(MockMvcResultMatchers.model().attribute("isFirstProperty", false))
     }
 
     @Test

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/AcceptOrRejectJointLandlordInvitationJourneyTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/AcceptOrRejectJointLandlordInvitationJourneyTests.kt
@@ -54,6 +54,7 @@ class AcceptOrRejectJointLandlordInvitationJourneyTests : IntegrationTestWithMut
 
         val confirmationPage = assertPageIs(page, PropertyJoinedConfirmationPage::class)
         assertThat(confirmationPage.confirmationBanner.body).containsText("2 Fake Way")
+        assertThat(confirmationPage.surveyLink.locator).isVisible()
     }
 
     @Test
@@ -123,6 +124,7 @@ class AcceptOrRejectJointLandlordInvitationJourneyTests : IntegrationTestWithMut
 
             val confirmationPage = assertPageIs(page, PropertyJoinedConfirmationPage::class)
             assertThat(confirmationPage.confirmationBanner.body).containsText("2 Fake Way")
+            assertThat(confirmationPage.surveyLink.locator).isVisible()
         }
 
         @Test

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/LandlordDeregistrationJourneyTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/LandlordDeregistrationJourneyTests.kt
@@ -5,16 +5,24 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.jdbc.core.JdbcTemplate
+import org.springframework.test.context.bean.override.mockito.MockitoBean
 import uk.gov.communities.prsdb.webapp.integration.IntegrationTestWithMutableData.NestedIntegrationTestWithMutableData
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.BaseComponent.Companion.assertThat
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages.BasePage.Companion.assertPageIs
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.landlordDeregistrationJourneyPages.AreYouSureFormPageLandlordDeregistration
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.landlordDeregistrationJourneyPages.ConfirmationPageLandlordDeregistration
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.landlordDeregistrationJourneyPages.ReasonFormPageLandlordDeregistration
+import uk.gov.communities.prsdb.webapp.services.SwapToIndividualNudgeEmailService
 
 class LandlordDeregistrationJourneyTests : IntegrationTest() {
+    @MockitoBean
+    private lateinit var swapToIndividualNudgeEmailService: SwapToIndividualNudgeEmailService
+
     @Nested
     inner class LandlordWithProperties :
         NestedIntegrationTestWithMutableData("data-mockuser-landlord-with-properties-and-incomplete-property.sql") {
@@ -163,6 +171,19 @@ class LandlordDeregistrationJourneyTests : IntegrationTest() {
             assertEquals(0, soleCount)
             assertEquals(1, jointCount)
             assertEquals(1, coOwnerMembership)
+        }
+
+        @Test
+        fun `deregistering sends the swap to individual nudge email exactly once per jointly-owned property`(page: Page) {
+            val landlordDetailsPage = navigator.goToLandlordDetails()
+            landlordDetailsPage.deleteAccountButton.clickAndWait()
+            val areYouSurePage = assertPageIs(page, AreYouSureFormPageLandlordDeregistration::class)
+            areYouSurePage.submitWantsToProceed()
+            val reasonPage = assertPageIs(page, ReasonFormPageLandlordDeregistration::class)
+            reasonPage.form.submit()
+            assertPageIs(page, ConfirmationPageLandlordDeregistration::class)
+
+            verify(swapToIndividualNudgeEmailService, times(1)).sendNudgeEmailIfApplicable(any())
         }
     }
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/LandlordRegistrationJourneyTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/LandlordRegistrationJourneyTests.kt
@@ -124,6 +124,7 @@ class LandlordRegistrationJourneyTests : IntegrationTestWithMutableData("data-mo
 
         val confirmationPage = assertPageIs(page, ConfirmationPageLandlordRegistration::class)
         assertEquals(createdLandlordRegNum.toString(), confirmationPage.confirmationBanner.registrationNumberText)
+        assertThat(confirmationPage.surveyLink).isVisible()
         confirmationPage.goToDashboardLink.clickAndWait()
         val dashboard = assertPageIs(page, LandlordDashboardPage::class)
 
@@ -186,6 +187,7 @@ class LandlordRegistrationJourneyTests : IntegrationTestWithMutableData("data-mo
 
         val confirmationPage = assertPageIs(page, ConfirmationPageLandlordRegistration::class)
         assertEquals(createdLandlordRegNum.toString(), confirmationPage.confirmationBanner.registrationNumberText)
+        assertThat(confirmationPage.surveyLink).isVisible()
         confirmationPage.goToDashboardLink.clickAndWait()
         assertPageIs(page, LandlordDashboardPage::class)
     }
@@ -240,6 +242,7 @@ class LandlordRegistrationJourneyTests : IntegrationTestWithMutableData("data-mo
 
         val confirmationPage = assertPageIs(page, ConfirmationPageLandlordRegistration::class)
         assertEquals(createdLandlordRegNum.toString(), confirmationPage.confirmationBanner.registrationNumberText)
+        assertThat(confirmationPage.surveyLink).isVisible()
         confirmationPage.goToDashboardLink.clickAndWait()
         assertPageIs(page, LandlordDashboardPage::class)
     }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/PropertyRegistrationJourneyTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/PropertyRegistrationJourneyTests.kt
@@ -509,6 +509,7 @@ class PropertyRegistrationJourneyTests : IntegrationTestWithMutableData("data-lo
         val expectedPropertyRegNum = RegistrationNumberDataModel.fromRegistrationNumber(propertyOwnershipCaptor.value.registrationNumber)
         assertEquals(expectedPropertyRegNum.toString(), confirmationPage.registrationNumberText)
         assertFalse(confirmationPage.whatYouNeedToDoNextHeading.isVisible)
+        assertTrue(confirmationPage.surveyLink.locator.isVisible)
         assertTrue(confirmationPage.goToDashboardLink.locator.isVisible)
 
         // Check confirmation email
@@ -698,6 +699,7 @@ class PropertyRegistrationJourneyTests : IntegrationTestWithMutableData("data-lo
         val expectedPropertyRegNum = RegistrationNumberDataModel.fromRegistrationNumber(propertyOwnershipCaptor.value.registrationNumber)
         assertEquals(expectedPropertyRegNum.toString(), confirmationPage.registrationNumberText)
         assertTrue(confirmationPage.whatYouNeedToDoNextHeading.isHidden)
+        assertTrue(confirmationPage.surveyLink.locator.isVisible)
         assertTrue(confirmationPage.goToDashboardLink.locator.isVisible)
 
         // Check confirmation email
@@ -969,6 +971,7 @@ class PropertyRegistrationJourneyTests : IntegrationTestWithMutableData("data-lo
         verify(propertyOwnershipRepository).save(propertyOwnershipCaptor.capture())
         val expectedPropertyRegNum = RegistrationNumberDataModel.fromRegistrationNumber(propertyOwnershipCaptor.value.registrationNumber)
         assertEquals(expectedPropertyRegNum.toString(), confirmationPage.registrationNumberText)
+        assertTrue(confirmationPage.surveyLink.locator.isVisible)
         assertTrue(confirmationPage.goToDashboardLink.locator.isVisible)
     }
 

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/acceptOrRejectJointLandlordInvitationJourneyPages/PropertyJoinedConfirmationPage.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/acceptOrRejectJointLandlordInvitationJourneyPages/PropertyJoinedConfirmationPage.kt
@@ -2,6 +2,7 @@ package uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.acceptOrRe
 
 import com.microsoft.playwright.Page
 import uk.gov.communities.prsdb.webapp.controllers.AcceptOrRejectJointLandlordInvitationController.Companion.JOINT_LANDLORD_INVITATION_ACCEPTED_CONFIRMATION_ROUTE
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.Button
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.ConfirmationBanner
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.Heading
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages.BasePage
@@ -11,4 +12,5 @@ class PropertyJoinedConfirmationPage(
 ) : BasePage(page, JOINT_LANDLORD_INVITATION_ACCEPTED_CONFIRMATION_ROUTE) {
     val heading = Heading(page.locator("main h1"))
     val confirmationBanner = ConfirmationBanner(page)
+    val surveyLink = Button.byText(page, "Go to survey")
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/landlordRegistrationJourneyPages/ConfirmationPageLandlordRegistration.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/landlordRegistrationJourneyPages/ConfirmationPageLandlordRegistration.kt
@@ -2,6 +2,7 @@ package uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.landlordRe
 
 import com.microsoft.playwright.Page
 import uk.gov.communities.prsdb.webapp.controllers.RegisterLandlordController
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.Button
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.ConfirmationBanner
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.Link
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages.BasePage
@@ -10,6 +11,7 @@ class ConfirmationPageLandlordRegistration(
     page: Page,
 ) : BasePage(page, RegisterLandlordController.LANDLORD_REGISTRATION_CONFIRMATION_ROUTE) {
     val confirmationBanner = LandlordRegistrationConfirmationBanner(page)
+    val surveyLink = Button.byText(page, "Go to survey")
     val goToDashboardLink = Link.byText(page, "Go to dashboard")
 
     class LandlordRegistrationConfirmationBanner(

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/propertyRegistrationJourneyPages/ConfirmationPagePropertyRegistration.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/propertyRegistrationJourneyPages/ConfirmationPagePropertyRegistration.kt
@@ -3,6 +3,7 @@ package uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyRe
 import com.microsoft.playwright.Page
 import uk.gov.communities.prsdb.webapp.constants.CONFIRMATION_PATH_SEGMENT
 import uk.gov.communities.prsdb.webapp.controllers.RegisterPropertyController
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.Button
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.Link
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages.BasePage
 
@@ -11,5 +12,6 @@ class ConfirmationPagePropertyRegistration(
 ) : BasePage(page, "${RegisterPropertyController.PROPERTY_REGISTRATION_ROUTE}/$CONFIRMATION_PATH_SEGMENT") {
     val registrationNumberText: String = page.locator(".govuk-inset-text").textContent().trim()
     val whatYouNeedToDoNextHeading = page.locator("h2:has-text('What you need to do next')")
+    val surveyLink = Button.byText(page, "Go to survey")
     val goToDashboardLink = Link.byText(page, "Go to dashboard")
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/LeavePropertyServiceTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/LeavePropertyServiceTests.kt
@@ -32,6 +32,9 @@ class LeavePropertyServiceTests {
     @Mock
     private lateinit var emailSender: EmailNotificationService<EmailTemplateModel>
 
+    @Mock
+    private lateinit var mockSwapToIndividualNudgeEmailService: SwapToIndividualNudgeEmailService
+
     @InjectMocks
     private lateinit var leavePropertyService: LeavePropertyService
 
@@ -104,6 +107,19 @@ class LeavePropertyServiceTests {
         val sentEmail = emailCaptor.firstValue
         assertEquals("Alice", sentEmail.recipientName)
         assertEquals(address.toMultiLineAddress(), sentEmail.propertyAddress)
+    }
+
+    @Test
+    fun `leavePropertyOwnership sends swap to individual nudge email`() {
+        val landlord = MockLandlordData.createLandlord(name = "Alice", email = "alice@example.com")
+        val propertyOwnership =
+            MockLandlordData.createPropertyOwnership(
+                landlords = mutableSetOf(landlord, MockLandlordData.createLandlord(name = "Bob")),
+            )
+
+        leavePropertyService.leavePropertyOwnership(landlord, propertyOwnership)
+
+        verify(mockSwapToIndividualNudgeEmailService).sendNudgeEmailIfApplicable(propertyOwnership)
     }
 
     @Test

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/PropertyOwnershipServiceTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/PropertyOwnershipServiceTests.kt
@@ -74,9 +74,6 @@ class PropertyOwnershipServiceTests {
     @Mock
     private lateinit var mockEmailService: JointLandlordOtherLandlordLeftEmailService
 
-    @Mock
-    private lateinit var mockSwapToIndividualNudgeEmailService: SwapToIndividualNudgeEmailService
-
     @InjectMocks
     private lateinit var propertyOwnershipService: PropertyOwnershipService
 
@@ -1515,7 +1512,6 @@ class PropertyOwnershipServiceTests {
 
             assertFalse(propertyOwnership.landlords.any { it == landlord })
             verify(mockEmailService).sendNotificationToRemainingLandlords(propertyOwnership, landlord)
-            verify(mockSwapToIndividualNudgeEmailService).sendNudgeEmailIfApplicable(propertyOwnership)
         }
     }
 }

--- a/src/test/resources/data-mockuser-landlord-with-sole-and-joint-properties.sql
+++ b/src/test/resources/data-mockuser-landlord-with-sole-and-joint-properties.sql
@@ -24,9 +24,10 @@ VALUES (1, '09/13/24', '09/13/24', 1, 1, '09/13/2000', true, 07111111111, 'urn:f
 SELECT setval(pg_get_serial_sequence('landlord', 'id'), (SELECT MAX(id) FROM landlord));
 
 INSERT INTO property_ownership (id, is_active, ownership_type, current_num_households, current_num_tenants,
-                                registration_number_id, address_id, property_build_type, num_bedrooms, rent_amount)
-VALUES (1, true, 1, 0, 0, 3, 2, 1, null, null),
-       (2, true, 1, 1, 2, 4, 3, 1, 1, 123.12);
+                                registration_number_id, address_id, property_build_type, num_bedrooms, rent_amount,
+                                marked_joint_landlord)
+VALUES (1, true, 1, 0, 0, 3, 2, 1, null, null, false),
+       (2, true, 1, 1, 2, 4, 3, 1, 1, 123.12, true);
 SELECT setval(pg_get_serial_sequence('property_ownership', 'id'), (SELECT MAX(id) FROM property_ownership));
 
 INSERT INTO ownership_link (landlord_id, landlordship_id, created_date)


### PR DESCRIPTION
## Release notes

PDJB-109: Add joint-landlords to the private-beta-release-2 feature flag group (TEST ONLY)
PDJB-1270: Add identity verification (IDV) to the joint landlord journey
PDJB-1271: Fix extra nudge email sending
PDJB-1272: Update survey links for the joint landlord journey
PDJB-NONE: Config-only feature release enabling the private-beta-release-2 flag group (joint-landlords, compliance-actions-may2026-redesign) in test; hotfix for joint landlord changes

### Release notes / manual steps
- No database migrations in this release.
- The only config change (`application-test.yml`) enabled the `private-beta-release-2` flag group in **test only**. 