### PR TITLE
PDJB-1169: Part 1: Allow for types of landlord

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/application/IncompletePropertiesReminderTaskApplicationRunner.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/application/IncompletePropertiesReminderTaskApplicationRunner.kt
@@ -10,6 +10,7 @@ import org.springframework.context.ApplicationContext
 import uk.gov.communities.prsdb.webapp.annotations.taskAnnotations.PrsdbScheduledTask
 import uk.gov.communities.prsdb.webapp.annotations.taskAnnotations.PrsdbTaskService
 import uk.gov.communities.prsdb.webapp.constants.INCOMPLETE_PROPERTY_AGE_WHEN_REMINDER_EMAIL_DUE_IN_DAYS
+import uk.gov.communities.prsdb.webapp.database.entity.IndividualLandlord
 import uk.gov.communities.prsdb.webapp.exceptions.PersistentEmailSendException
 import uk.gov.communities.prsdb.webapp.exceptions.TrackEmailSentException
 import uk.gov.communities.prsdb.webapp.exceptions.TransientEmailSentException
@@ -60,9 +61,12 @@ class IncompletePropertiesReminderTaskLogic(
         for (page in 0..<pagesOfProperties) {
             val incompleteProperties = incompletePropertiesService.getIncompletePropertiesDueReminderPage(cutoffDate, page)
             incompleteProperties.forEach { property ->
+                // TODO: PDJB-1274: Update emails to account for org landlord
+                val landlord = property.landlord
+                require(landlord is IndividualLandlord)
                 try {
                     emailSender.sendEmail(
-                        property.landlord.email,
+                        landlord.email,
                         IncompletePropertyReminderEmail(
                             singleLineAddress =
                                 property.savedJourneyState.getPropertyRegistrationSingleLineAddress(),

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/application/IncompletePropertiesReminderTaskApplicationRunner.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/application/IncompletePropertiesReminderTaskApplicationRunner.kt
@@ -63,7 +63,7 @@ class IncompletePropertiesReminderTaskLogic(
             incompleteProperties.forEach { property ->
                 // TODO: PDJB-1274: Update emails to account for org landlord
                 val landlord = property.landlord
-                require(landlord is IndividualLandlord)
+                check(landlord is IndividualLandlord)
                 try {
                     emailSender.sendEmail(
                         landlord.email,

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/constants/enums/LandlordType.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/constants/enums/LandlordType.kt
@@ -1,0 +1,6 @@
+package uk.gov.communities.prsdb.webapp.constants.enums
+
+enum class LandlordType {
+    INDIVIDUAL,
+    ORGANISATION,
+}

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/constants/enums/LandlordType.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/constants/enums/LandlordType.kt
@@ -1,5 +1,9 @@
 package uk.gov.communities.prsdb.webapp.constants.enums
 
+// Beware reordering the enum values, they are used as the discriminator value for landlords when saved in the database.
+// We expect:
+// - INDIVIDAL: "0"
+// - ORGANISATION: "1"
 enum class LandlordType {
     INDIVIDUAL,
     ORGANISATION,

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/LandlordController.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/LandlordController.kt
@@ -44,6 +44,7 @@ class LandlordController(
     @GetMapping
     fun index(): CharSequence = "redirect:$LANDLORD_DASHBOARD_URL"
 
+    // TODO: PDJB-1278: Update landlord dashboard for org landlords
     @GetMapping("/$DASHBOARD_PATH_SEGMENT")
     fun landlordDashboard(
         model: Model,

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/LandlordDetailsController.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/LandlordDetailsController.kt
@@ -79,7 +79,7 @@ class LandlordDetailsController(
 
         val lastModifiedDate = DateTimeHelper.getDateInUK(landlord.getMostRecentlyUpdated().toKotlinInstant())
 
-        val landlordViewModel = LandlordViewModel(landlord = landlord, withChangeLinks = false)
+        val landlordViewModel = LandlordViewModel(baseLandlord = landlord, withChangeLinks = false)
 
         model.addAttribute("name", landlordViewModel.name)
         model.addAttribute("lastModifiedDate", lastModifiedDate)

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/database/dao/NftDataSeederDao.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/database/dao/NftDataSeederDao.kt
@@ -66,8 +66,8 @@ class NftDataSeederDao(
             """
             INSERT INTO landlord 
             (id, created_date, last_modified_date, subject_identifier, name, email, phone_number, address_id, date_of_birth, 
-             registration_number_id, has_responded_to_feedback, is_verified, country_of_residence, is_active, has_accepted_privacy_notice) 
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, '${ENGLAND_OR_WALES}', true, true)
+             registration_number_id, has_responded_to_feedback, is_verified, country_of_residence, is_active, has_accepted_privacy_notice, landlord_type) 
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, '${ENGLAND_OR_WALES}', true, true, 0)
             """
         return connection.prepareStatement(query)
     }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/database/entity/IndividualLandlord.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/database/entity/IndividualLandlord.kt
@@ -1,0 +1,104 @@
+package uk.gov.communities.prsdb.webapp.database.entity
+
+import jakarta.persistence.Column
+import jakarta.persistence.DiscriminatorValue
+import jakarta.persistence.Entity
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+import jakarta.persistence.OneToMany
+import jakarta.persistence.OneToOne
+import uk.gov.communities.prsdb.webapp.constants.ENGLAND_OR_WALES
+import java.time.LocalDate
+
+@Entity
+@DiscriminatorValue("0")
+class IndividualLandlord() : Landlord() {
+    @OneToOne(optional = false)
+    @JoinColumn(name = "subject_identifier", nullable = false, unique = true)
+    lateinit var baseUser: PrsdbUser
+        private set
+
+    @Column(nullable = false)
+    lateinit var name: String
+
+    @Column(nullable = false)
+    lateinit var email: String
+
+    @Column(nullable = false)
+    lateinit var phoneNumber: String
+
+    @ManyToOne(optional = false)
+    @JoinColumn(name = "address_id", nullable = false)
+    lateinit var address: Address
+
+    @Column(nullable = false)
+    lateinit var countryOfResidence: String
+        private set
+
+    @Column(length = 1000)
+    var nonEnglandOrWalesAddress: String? = null
+        private set
+
+    var dateOfBirth: LocalDate? = null
+
+    @Column(nullable = false)
+    var isActive: Boolean = false
+        private set
+
+    @Column(nullable = false)
+    var isVerified: Boolean = false
+        private set
+
+    @Column(nullable = false)
+    var hasAcceptedPrivacyNotice: Boolean = false
+        private set
+
+    @Column(nullable = false)
+    var hasRespondedToFeedback: Boolean = false
+
+    @OneToMany(mappedBy = "landlord", orphanRemoval = true)
+    private var ownershipLinks: MutableSet<OwnershipLink> = mutableSetOf()
+
+    val landlordships: Set<PropertyOwnership> get() = ownershipLinks.map { it.propertyOwnership }.toSet()
+
+    @OneToMany(
+        mappedBy = "landlord",
+        orphanRemoval = true,
+    )
+    private lateinit var landlordIncompleteProperties: MutableSet<LandlordIncompleteProperties>
+
+    val incompleteProperties: List<SavedJourneyState>
+        get() = landlordIncompleteProperties.map { it.savedJourneyState }.toList()
+
+    constructor(
+        baseUser: PrsdbUser,
+        name: String,
+        email: String,
+        phoneNumber: String,
+        address: Address,
+        registrationNumber: RegistrationNumber,
+        countryOfResidence: String,
+        isVerified: Boolean,
+        hasAcceptedPrivacyNotice: Boolean,
+        nonEnglandOrWalesAddress: String?,
+        dateOfBirth: LocalDate?,
+    ) : this() {
+        this.baseUser = baseUser
+        this.name = name
+        this.email = email
+        this.phoneNumber = phoneNumber
+        this.address = address
+        this.registrationNumber = registrationNumber
+        this.countryOfResidence = countryOfResidence
+        this.isVerified = isVerified
+        this.hasAcceptedPrivacyNotice = hasAcceptedPrivacyNotice
+        this.nonEnglandOrWalesAddress = nonEnglandOrWalesAddress
+        this.dateOfBirth = dateOfBirth
+        this.isActive = true
+    }
+
+    fun isEnglandOrWalesResident(): Boolean = countryOfResidence == ENGLAND_OR_WALES
+
+    val shouldSeeFeedback: Boolean
+        get() = !hasRespondedToFeedback
+}

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/database/entity/IndividualLandlord.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/database/entity/IndividualLandlord.kt
@@ -56,11 +56,6 @@ class IndividualLandlord() : Landlord() {
     @Column(nullable = false)
     var hasRespondedToFeedback: Boolean = false
 
-    @OneToMany(mappedBy = "landlord", orphanRemoval = true)
-    private var ownershipLinks: MutableSet<OwnershipLink> = mutableSetOf()
-
-    val landlordships: Set<PropertyOwnership> get() = ownershipLinks.map { it.propertyOwnership }.toSet()
-
     @OneToMany(
         mappedBy = "landlord",
         orphanRemoval = true,

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/database/entity/IndividualLandlord.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/database/entity/IndividualLandlord.kt
@@ -53,6 +53,7 @@ class IndividualLandlord() : Landlord() {
     var hasAcceptedPrivacyNotice: Boolean = false
         private set
 
+    // TODO: PDJB-1294: Remove this
     @Column(nullable = false)
     var hasRespondedToFeedback: Boolean = false
 

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/database/entity/Landlord.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/database/entity/Landlord.kt
@@ -1,114 +1,26 @@
 package uk.gov.communities.prsdb.webapp.database.entity
 
-import jakarta.persistence.Column
+import jakarta.persistence.DiscriminatorColumn
+import jakarta.persistence.DiscriminatorType
 import jakarta.persistence.Entity
 import jakarta.persistence.GeneratedValue
 import jakarta.persistence.GenerationType
 import jakarta.persistence.Id
+import jakarta.persistence.Inheritance
+import jakarta.persistence.InheritanceType
 import jakarta.persistence.JoinColumn
-import jakarta.persistence.ManyToOne
-import jakarta.persistence.OneToMany
 import jakarta.persistence.OneToOne
-import uk.gov.communities.prsdb.webapp.constants.ENGLAND_OR_WALES
-import java.time.LocalDate
 
 @Entity
-class Landlord() : ModifiableAuditableEntity() {
+@Inheritance(strategy = InheritanceType.SINGLE_TABLE)
+@DiscriminatorColumn(name = "landlord_type", discriminatorType = DiscriminatorType.INTEGER)
+abstract class Landlord : ModifiableAuditableEntity() {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     val id: Long = 0
 
     @OneToOne(optional = false)
-    @JoinColumn(name = "subject_identifier", nullable = false, unique = true)
-    lateinit var baseUser: PrsdbUser
-        private set
-
-    @Column(nullable = false)
-    lateinit var name: String
-
-    @Column(nullable = false)
-    lateinit var email: String
-
-    @Column(nullable = false)
-    lateinit var phoneNumber: String
-
-    @ManyToOne(optional = false)
-    @JoinColumn(name = "address_id", nullable = false)
-    lateinit var address: Address
-
-    @Column(nullable = false)
-    lateinit var countryOfResidence: String
-        private set
-
-    @Column(length = 1000)
-    var nonEnglandOrWalesAddress: String? = null
-        private set
-
-    var dateOfBirth: LocalDate? = null
-
-    @OneToOne(optional = false)
     @JoinColumn(name = "registration_number_id", nullable = false, unique = true)
     lateinit var registrationNumber: RegistrationNumber
-        private set
-
-    @Column(nullable = false)
-    var isActive: Boolean = false
-        private set
-
-    @Column(nullable = false)
-    var isVerified: Boolean = false
-        private set
-
-    @Column(nullable = false)
-    var hasAcceptedPrivacyNotice: Boolean = false
-        private set
-
-    @Column(nullable = false)
-    var hasRespondedToFeedback: Boolean = false
-
-    @OneToMany(mappedBy = "landlord", orphanRemoval = true)
-    private var ownershipLinks: MutableSet<OwnershipLink> = mutableSetOf()
-
-    val landlordships: Set<PropertyOwnership> get() = ownershipLinks.map { it.propertyOwnership }.toSet()
-
-    @OneToMany(
-        mappedBy = "landlord",
-        orphanRemoval = true,
-    )
-    private lateinit var landlordIncompleteProperties: MutableSet<LandlordIncompleteProperties>
-
-    val incompleteProperties: List<SavedJourneyState>
-        get() = landlordIncompleteProperties.map { it.savedJourneyState }.toList()
-
-    constructor(
-        baseUser: PrsdbUser,
-        name: String,
-        email: String,
-        phoneNumber: String,
-        address: Address,
-        registrationNumber: RegistrationNumber,
-        countryOfResidence: String,
-        isVerified: Boolean,
-        hasAcceptedPrivacyNotice: Boolean,
-        nonEnglandOrWalesAddress: String?,
-        dateOfBirth: LocalDate?,
-    ) : this() {
-        this.baseUser = baseUser
-        this.name = name
-        this.email = email
-        this.phoneNumber = phoneNumber
-        this.address = address
-        this.registrationNumber = registrationNumber
-        this.countryOfResidence = countryOfResidence
-        this.isVerified = isVerified
-        this.hasAcceptedPrivacyNotice = hasAcceptedPrivacyNotice
-        this.nonEnglandOrWalesAddress = nonEnglandOrWalesAddress
-        this.dateOfBirth = dateOfBirth
-        this.isActive = true
-    }
-
-    fun isEnglandOrWalesResident(): Boolean = countryOfResidence == ENGLAND_OR_WALES
-
-    val shouldSeeFeedback: Boolean
-        get() = !hasRespondedToFeedback
+        protected set
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/database/entity/Landlord.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/database/entity/Landlord.kt
@@ -9,6 +9,7 @@ import jakarta.persistence.Id
 import jakarta.persistence.Inheritance
 import jakarta.persistence.InheritanceType
 import jakarta.persistence.JoinColumn
+import jakarta.persistence.OneToMany
 import jakarta.persistence.OneToOne
 
 @Entity
@@ -23,4 +24,9 @@ abstract class Landlord : ModifiableAuditableEntity() {
     @JoinColumn(name = "registration_number_id", nullable = false, unique = true)
     lateinit var registrationNumber: RegistrationNumber
         protected set
+
+    @OneToMany(mappedBy = "landlord", orphanRemoval = true)
+    private var ownershipLinks: MutableSet<OwnershipLink> = mutableSetOf()
+
+    val landlordships: Set<PropertyOwnership> get() = ownershipLinks.map { it.propertyOwnership }.toSet()
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/database/repository/LandlordIncompletePropertiesRepository.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/database/repository/LandlordIncompletePropertiesRepository.kt
@@ -4,6 +4,8 @@ import org.springframework.data.domain.Page
 import org.springframework.data.domain.PageRequest
 import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
 import uk.gov.communities.prsdb.webapp.database.entity.LandlordIncompleteProperties
 import java.time.Instant
 
@@ -17,9 +19,16 @@ interface LandlordIncompletePropertiesRepository : JpaRepository<LandlordIncompl
     @Suppress("ktlint:standard:function-naming")
     fun countBySavedJourneyState_CreatedDateBefore(cutoffDate: Instant): Long
 
+    // TODO: PDJB-1275: Update assumption one base user per landlord
+    // Once this is complete we should be able to remove the query
+    @Query(
+        "SELECT lip FROM LandlordIncompleteProperties lip " +
+            "JOIN TREAT(lip.landlord AS IndividualLandlord) l " +
+            "WHERE l.baseUser.id = :principalName",
+    )
     @Suppress("ktlint:standard:function-naming")
     fun findByLandlord_BaseUser_Id(
-        principalName: String,
+        @Param("principalName") principalName: String,
         pageable: Pageable,
     ): Page<LandlordIncompleteProperties>
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/database/repository/LandlordRepository.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/database/repository/LandlordRepository.kt
@@ -1,17 +1,20 @@
 package uk.gov.communities.prsdb.webapp.database.repository
 
 import org.springframework.data.jpa.repository.JpaRepository
-import uk.gov.communities.prsdb.webapp.database.entity.Landlord
+import uk.gov.communities.prsdb.webapp.database.entity.IndividualLandlord
 import java.time.Instant
 
+// TODO: PDJB-1275: Update checks for landlord users to account for multiple users representing a landlord
 // The underscore tells JPA to access fields relating to the referenced table
 @Suppress("ktlint:standard:function-naming")
 interface LandlordRepository :
-    JpaRepository<Landlord?, Long?>,
+    JpaRepository<IndividualLandlord?, Long?>,
     LandlordSearchRepository {
-    fun findByRegistrationNumber_Number(registrationNumber: Long): Landlord?
+    // TODO: PDJB-1275: Update checks for landlord users to account for multiple users representing a landlord
+    fun findByRegistrationNumber_Number(registrationNumber: Long): IndividualLandlord?
 
-    fun findByBaseUser_Id(subjectId: String): Landlord?
+    // TODO: PDJB-1275: Update checks for landlord users to account for multiple users representing a landlord
+    fun findByBaseUser_Id(subjectId: String): IndividualLandlord?
 
     fun deleteByBaseUser_Id(subjectId: String)
 

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/database/repository/PropertyComplianceRepository.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/database/repository/PropertyComplianceRepository.kt
@@ -1,13 +1,26 @@
 package uk.gov.communities.prsdb.webapp.database.repository
 
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
 import uk.gov.communities.prsdb.webapp.database.entity.PropertyCompliance
 
 @Suppress("ktlint:standard:function-naming")
 interface PropertyComplianceRepository : JpaRepository<PropertyCompliance, Long> {
     fun findByPropertyOwnership_Id(propertyOwnershipId: Long): PropertyCompliance?
 
-    fun findAllByPropertyOwnership_OwnershipLinks_Landlord_BaseUser_Id(landlordBaseUserId: String): List<PropertyCompliance>
+    // TODO: PDJB-1275: Update assumption one base user per landlord
+    // Once this is complete we should be able to remove the query
+    @Query(
+        "SELECT pc FROM PropertyCompliance pc " +
+            "JOIN pc.propertyOwnership po " +
+            "JOIN po.ownershipLinks ol " +
+            "JOIN TREAT(ol.landlord AS IndividualLandlord) l " +
+            "WHERE l.baseUser.id = :landlordBaseUserId",
+    )
+    fun findAllByPropertyOwnership_OwnershipLinks_Landlord_BaseUser_Id(
+        @Param("landlordBaseUserId") landlordBaseUserId: String,
+    ): List<PropertyCompliance>
 
     fun deleteByPropertyOwnership_IdIn(propertyOwnershipIds: List<Long>)
 

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/database/repository/PropertyOwnershipRepository.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/database/repository/PropertyOwnershipRepository.kt
@@ -13,7 +13,17 @@ interface PropertyOwnershipRepository :
     PropertyOwnershipSearchRepository {
     fun existsByIsActiveTrueAndAddress_Uprn(uprn: Long): Boolean
 
-    fun findAllByOwnershipLinks_Landlord_BaseUser_IdAndIsActiveTrue(userId: String): List<PropertyOwnership>
+    // TODO: PDJB-1275: Update assumption one base user per landlord
+    // Once this is complete we should be able to remove the query
+    @Query(
+        "SELECT po FROM PropertyOwnership po " +
+            "JOIN po.ownershipLinks ol " +
+            "JOIN TREAT(ol.landlord AS IndividualLandlord) l " +
+            "WHERE l.baseUser.id = :userId AND po.isActive = true",
+    )
+    fun findAllByOwnershipLinks_Landlord_BaseUser_IdAndIsActiveTrue(
+        @Param("userId") userId: String,
+    ): List<PropertyOwnership>
 
     fun findAllByOwnershipLinks_Landlord_IdAndIsActiveTrue(landlordId: Long): List<PropertyOwnership>
 
@@ -21,11 +31,29 @@ interface PropertyOwnershipRepository :
 
     fun findByIdAndIsActiveTrue(id: Long): PropertyOwnership?
 
-    fun existsByOwnershipLinks_Landlord_BaseUser_IdAndIsActiveTrue(userId: String): Boolean
+    // TODO: PDJB-1275: Update assumption one base user per landlord
+    // Once this is complete we should be able to remove the query
+    @Query(
+        "SELECT CASE WHEN COUNT(po) > 0 THEN true ELSE false END FROM PropertyOwnership po " +
+            "JOIN po.ownershipLinks ol " +
+            "JOIN TREAT(ol.landlord AS IndividualLandlord) l " +
+            "WHERE l.baseUser.id = :userId AND po.isActive = true",
+    )
+    fun existsByOwnershipLinks_Landlord_BaseUser_IdAndIsActiveTrue(
+        @Param("userId") userId: String,
+    ): Boolean
 
+    // TODO: PDJB-1275: Update assumption one base user per landlord
+    // Once this is complete we should be able to remove the query
+    @Query(
+        "SELECT CASE WHEN COUNT(po) > 0 THEN true ELSE false END FROM PropertyOwnership po " +
+            "JOIN po.ownershipLinks ol " +
+            "JOIN TREAT(ol.landlord AS IndividualLandlord) l " +
+            "WHERE l.baseUser.id = :userId AND po.isActive = true AND po.address.uprn = :uprn",
+    )
     fun existsByOwnershipLinks_Landlord_BaseUser_IdAndIsActiveTrueAndAddress_Uprn(
-        userId: String,
-        uprn: Long,
+        @Param("userId") userId: String,
+        @Param("uprn") uprn: Long,
     ): Boolean
 
     fun countByCreatedDateBetween(
@@ -55,5 +83,15 @@ interface PropertyOwnershipRepository :
         @Param("end") end: Instant,
     ): List<Array<Instant>>
 
-    fun countByOwnershipLinks_Landlord_BaseUser_Id(userId: String): Long
+    // TODO: PDJB-1275: Update assumption one base user per landlord
+    // Once this is complete we should be able to remove the query
+    @Query(
+        "SELECT COUNT(po) FROM PropertyOwnership po " +
+            "JOIN po.ownershipLinks ol " +
+            "JOIN TREAT(ol.landlord AS IndividualLandlord) l " +
+            "WHERE l.baseUser.id = :userId",
+    )
+    fun countByOwnershipLinks_Landlord_BaseUser_Id(
+        @Param("userId") userId: String,
+    ): Long
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/acceptOrRejectJointLandlordInvitation/steps/ConfirmYouAreALandlordForThisPropertyStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/acceptOrRejectJointLandlordInvitation/steps/ConfirmYouAreALandlordForThisPropertyStepConfig.kt
@@ -109,7 +109,7 @@ class ConfirmYouAreALandlordForThisPropertyStepConfig(
             .filter { it.id != acceptingLandlord.id }
             // TODO: PDJB-1274: Update emails to account for org landlord
             .forEach { landlord ->
-                require(landlord is IndividualLandlord)
+                check(landlord is IndividualLandlord)
                 otherLandlordEmailSender.sendEmail(
                     landlord.email,
                     JointLandlordInvitationAcceptedOtherLandlordEmail(

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/acceptOrRejectJointLandlordInvitation/steps/ConfirmYouAreALandlordForThisPropertyStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/acceptOrRejectJointLandlordInvitation/steps/ConfirmYouAreALandlordForThisPropertyStepConfig.kt
@@ -2,7 +2,7 @@ package uk.gov.communities.prsdb.webapp.journeys.acceptOrRejectJointLandlordInvi
 
 import org.springframework.security.core.context.SecurityContextHolder
 import uk.gov.communities.prsdb.webapp.annotations.webAnnotations.JourneyFrameworkComponent
-import uk.gov.communities.prsdb.webapp.database.entity.Landlord
+import uk.gov.communities.prsdb.webapp.database.entity.IndividualLandlord
 import uk.gov.communities.prsdb.webapp.database.entity.PropertyOwnership
 import uk.gov.communities.prsdb.webapp.exceptions.PrsdbWebException
 import uk.gov.communities.prsdb.webapp.journeys.AbstractRequestableStepConfig
@@ -76,7 +76,7 @@ class ConfirmYouAreALandlordForThisPropertyStepConfig(
         }
     }
 
-    private fun getLoggedInLandlord(): Landlord {
+    private fun getLoggedInLandlord(): IndividualLandlord {
         val baseUserId = SecurityContextHolder.getContext().authentication.name
         val landlord =
             landlordService.retrieveLandlordByBaseUserId(baseUserId)
@@ -88,7 +88,7 @@ class ConfirmYouAreALandlordForThisPropertyStepConfig(
 
     private fun sendAcceptanceEmails(
         propertyOwnership: PropertyOwnership,
-        acceptingLandlord: Landlord,
+        acceptingLandlord: IndividualLandlord,
     ) {
         val propertyAddress = propertyOwnership.address.toMultiLineAddress()
         val propertyRecordUrl = absoluteUrlProvider.buildPropertyDetailsUri(propertyOwnership.id).toString()
@@ -107,7 +107,9 @@ class ConfirmYouAreALandlordForThisPropertyStepConfig(
 
         propertyOwnership.landlords
             .filter { it.id != acceptingLandlord.id }
+            // TODO: PDJB-1274: Update emails to account for org landlord
             .forEach { landlord ->
+                require(landlord is IndividualLandlord)
                 otherLandlordEmailSender.sendEmail(
                     landlord.email,
                     JointLandlordInvitationAcceptedOtherLandlordEmail(

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/acceptOrRejectJointLandlordInvitation/steps/SendRejectionEmailsStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/acceptOrRejectJointLandlordInvitation/steps/SendRejectionEmailsStepConfig.kt
@@ -1,6 +1,7 @@
 package uk.gov.communities.prsdb.webapp.journeys.acceptOrRejectJointLandlordInvitation.steps
 
 import uk.gov.communities.prsdb.webapp.annotations.webAnnotations.JourneyFrameworkComponent
+import uk.gov.communities.prsdb.webapp.database.entity.IndividualLandlord
 import uk.gov.communities.prsdb.webapp.journeys.AbstractInternalStepConfig
 import uk.gov.communities.prsdb.webapp.journeys.JourneyStep
 import uk.gov.communities.prsdb.webapp.journeys.acceptOrRejectJointLandlordInvitation.AcceptOrRejectJointLandlordInvitationJourneyState
@@ -26,7 +27,9 @@ class SendRejectionEmailsStepConfig(
 
         invitationService.addRejectedPropertyAddressToSession(propertyAddress)
 
+        // TODO: PDJB-1274: Update emails to account for org landlord
         invitation.registeredOwnership.landlords.forEach { landlord ->
+            require(landlord is IndividualLandlord)
             rejectionEmailSender.sendEmail(
                 landlord.email,
                 JointLandlordInvitationRejectionEmail(

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/acceptOrRejectJointLandlordInvitation/steps/SendRejectionEmailsStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/acceptOrRejectJointLandlordInvitation/steps/SendRejectionEmailsStepConfig.kt
@@ -29,7 +29,7 @@ class SendRejectionEmailsStepConfig(
 
         // TODO: PDJB-1274: Update emails to account for org landlord
         invitation.registeredOwnership.landlords.forEach { landlord ->
-            require(landlord is IndividualLandlord)
+            check(landlord is IndividualLandlord)
             rejectionEmailSender.sendEmail(
                 landlord.email,
                 JointLandlordInvitationRejectionEmail(

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/cancelJointLandlordInvitation/stepConfig/CancelInvitationStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/cancelJointLandlordInvitation/stepConfig/CancelInvitationStepConfig.kt
@@ -2,6 +2,7 @@ package uk.gov.communities.prsdb.webapp.journeys.cancelJointLandlordInvitation.s
 
 import org.springframework.security.core.context.SecurityContextHolder
 import uk.gov.communities.prsdb.webapp.annotations.webAnnotations.JourneyFrameworkComponent
+import uk.gov.communities.prsdb.webapp.database.entity.IndividualLandlord
 import uk.gov.communities.prsdb.webapp.journeys.AbstractInternalStepConfig
 import uk.gov.communities.prsdb.webapp.journeys.Destination
 import uk.gov.communities.prsdb.webapp.journeys.JourneyStep
@@ -64,7 +65,9 @@ class CancelInvitationStepConfig(
         // Email the other landlords
         propertyOwnership.landlords
             .filterNot { cancellerLandlord.id == it.id }
+            // TODO: PDJB-1274: Update emails to account for org landlord
             .forEach {
+                require(it is IndividualLandlord)
                 otherLandlordEmailSender.sendEmail(
                     it.email,
                     JointLandlordInvitationCancellationOtherLandlordEmail(

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/cancelJointLandlordInvitation/stepConfig/CancelInvitationStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/cancelJointLandlordInvitation/stepConfig/CancelInvitationStepConfig.kt
@@ -67,7 +67,7 @@ class CancelInvitationStepConfig(
             .filterNot { cancellerLandlord.id == it.id }
             // TODO: PDJB-1274: Update emails to account for org landlord
             .forEach {
-                require(it is IndividualLandlord)
+                check(it is IndividualLandlord)
                 otherLandlordEmailSender.sendEmail(
                     it.email,
                     JointLandlordInvitationCancellationOtherLandlordEmail(

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/landlordRegistration/stepConfig/LandlordTypeStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/landlordRegistration/stepConfig/LandlordTypeStepConfig.kt
@@ -1,10 +1,10 @@
 package uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig
 
 import uk.gov.communities.prsdb.webapp.annotations.webAnnotations.JourneyFrameworkComponent
+import uk.gov.communities.prsdb.webapp.constants.enums.LandlordType
 import uk.gov.communities.prsdb.webapp.journeys.AbstractRequestableStepConfig
 import uk.gov.communities.prsdb.webapp.journeys.JourneyState
 import uk.gov.communities.prsdb.webapp.journeys.JourneyStep.RequestableStep
-import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.LandlordType
 import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.LandlordTypeFormModel
 import uk.gov.communities.prsdb.webapp.models.viewModels.formModels.RadiosButtonViewModel
 

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyDeregistration/stepConfig/ConfirmStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyDeregistration/stepConfig/ConfirmStepConfig.kt
@@ -58,7 +58,7 @@ class ConfirmStepConfig(
         // TODO: PDJB-1274: Update emails to account for org landlord
         val landlordContacts =
             propertyOwnership.landlords.map { landlord ->
-                require(landlord is IndividualLandlord)
+                check(landlord is IndividualLandlord)
                 landlord.name to landlord.email
             }
         val cancelledInvitationEmailAddresses =

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyDeregistration/stepConfig/ConfirmStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyDeregistration/stepConfig/ConfirmStepConfig.kt
@@ -2,6 +2,7 @@ package uk.gov.communities.prsdb.webapp.journeys.propertyDeregistration.stepConf
 
 import uk.gov.communities.prsdb.webapp.annotations.webAnnotations.JourneyFrameworkComponent
 import uk.gov.communities.prsdb.webapp.controllers.PropertyDetailsController
+import uk.gov.communities.prsdb.webapp.database.entity.IndividualLandlord
 import uk.gov.communities.prsdb.webapp.journeys.AbstractRequestableStepConfig
 import uk.gov.communities.prsdb.webapp.journeys.Destination
 import uk.gov.communities.prsdb.webapp.journeys.JourneyStep.RequestableStep
@@ -54,7 +55,12 @@ class ConfirmStepConfig(
                 "There should be no joint landlords on the property if this step of deregistration is reached",
             )
         }
-        val landlordContacts = propertyOwnership.landlords.map { it.name to it.email }
+        // TODO: PDJB-1274: Update emails to account for org landlord
+        val landlordContacts =
+            propertyOwnership.landlords.map { landlord ->
+                require(landlord is IndividualLandlord)
+                landlord.name to landlord.email
+            }
         val cancelledInvitationEmailAddresses =
             jointLandlordInvitationService.getPendingInvitations(propertyOwnership).map { it.invitedEmail }
         val singleLineAddress = propertyOwnership.address.singleLineAddress

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyDeregistration/stepConfig/ReasonStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyDeregistration/stepConfig/ReasonStepConfig.kt
@@ -40,7 +40,7 @@ class ReasonStepConfig(
         // primaryLandlord here arbitrary picks the landlord who registered their account first as a temporary measure.
         val soleLandlord = propertyOwnership.landlords.minBy { it.id }
         // TODO: PDJB-1274: Update emails to account for org landlord
-        require(soleLandlord is IndividualLandlord)
+        check(soleLandlord is IndividualLandlord)
         val soleLandlordEmailAddress = soleLandlord.email
         val propertyRegistrationNumber = propertyOwnership.registrationNumber
         val propertyAddress = propertyOwnership.address.singleLineAddress

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyDeregistration/stepConfig/ReasonStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyDeregistration/stepConfig/ReasonStepConfig.kt
@@ -1,6 +1,7 @@
 package uk.gov.communities.prsdb.webapp.journeys.propertyDeregistration.stepConfig
 
 import uk.gov.communities.prsdb.webapp.annotations.webAnnotations.JourneyFrameworkComponent
+import uk.gov.communities.prsdb.webapp.database.entity.IndividualLandlord
 import uk.gov.communities.prsdb.webapp.journeys.AbstractRequestableStepConfig
 import uk.gov.communities.prsdb.webapp.journeys.Destination
 import uk.gov.communities.prsdb.webapp.journeys.JourneyStep.RequestableStep
@@ -38,6 +39,8 @@ class ReasonStepConfig(
         // TODO PDJB-319 - this should be deleted
         // primaryLandlord here arbitrary picks the landlord who registered their account first as a temporary measure.
         val soleLandlord = propertyOwnership.landlords.minBy { it.id }
+        // TODO: PDJB-1274: Update emails to account for org landlord
+        require(soleLandlord is IndividualLandlord)
         val soleLandlordEmailAddress = soleLandlord.email
         val propertyRegistrationNumber = propertyOwnership.registrationNumber
         val propertyAddress = propertyOwnership.address.singleLineAddress

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/PropertyRegistrationJourneyFactory.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/PropertyRegistrationJourneyFactory.kt
@@ -524,6 +524,7 @@ class PropertyRegistrationJourney(
 
     override val loggedInLandlordEmail: String?
         get() =
+            // TODO: PDJB-1274: Update emails to account for org landlord
             landlordService
                 .retrieveLandlordByBaseUserId(SecurityContextHolder.getContext().authentication.name)
                 ?.email

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/update/inviteJointLandlord/InviteJointLandlordJourneyFactory.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/update/inviteJointLandlord/InviteJointLandlordJourneyFactory.kt
@@ -7,6 +7,7 @@ import uk.gov.communities.prsdb.webapp.constants.CONFIRMATION_PATH_SEGMENT
 import uk.gov.communities.prsdb.webapp.constants.LANDLORD_DETAILS_FRAGMENT
 import uk.gov.communities.prsdb.webapp.controllers.InviteJointLandlordController
 import uk.gov.communities.prsdb.webapp.controllers.PropertyDetailsController
+import uk.gov.communities.prsdb.webapp.database.entity.IndividualLandlord
 import uk.gov.communities.prsdb.webapp.exceptions.PrsdbWebException
 import uk.gov.communities.prsdb.webapp.journeys.AbstractPropertyOwnershipUpdateJourneyState
 import uk.gov.communities.prsdb.webapp.journeys.Destination
@@ -189,8 +190,9 @@ class InviteJointLandlordJourney(
     override val existingInvitedEmails: List<String>
         get() = jointLandlordInvitationService.getExistingInvitedEmails(propertyId)
 
+    // TODO: PDJB-1274: Update emails to account for org landlord
     override val existingLandlordEmails: List<String>
-        get() = propertyOwnershipService.getPropertyOwnership(propertyId).landlords.map { it.email }
+        get() = propertyOwnershipService.getPropertyOwnership(propertyId).landlords.map { (it as IndividualLandlord).email }
 }
 
 interface InviteJointLandlordJourneyState :

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/switchToIndividual/stepConfig/CompleteSwitchToIndividualStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/switchToIndividual/stepConfig/CompleteSwitchToIndividualStepConfig.kt
@@ -44,7 +44,7 @@ class CompleteSwitchToIndividualStepConfig(
 
         // TODO: PDJB-1274: Update emails to account for org landlord
         val landlord = propertyOwnership.landlords.first()
-        require(landlord is IndividualLandlord)
+        check(landlord is IndividualLandlord)
         switchToIndividualConfirmationEmailSender.sendEmail(
             landlord.email,
             SwitchToIndividualConfirmationEmail(landlordName = landlord.name, propertyAddress = propertyAddress),

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/switchToIndividual/stepConfig/CompleteSwitchToIndividualStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/switchToIndividual/stepConfig/CompleteSwitchToIndividualStepConfig.kt
@@ -4,6 +4,7 @@ import jakarta.servlet.http.HttpSession
 import jakarta.transaction.Transactional
 import uk.gov.communities.prsdb.webapp.annotations.webAnnotations.JourneyFrameworkComponent
 import uk.gov.communities.prsdb.webapp.constants.SWITCHED_TO_INDIVIDUAL_PROPERTY_ID
+import uk.gov.communities.prsdb.webapp.database.entity.IndividualLandlord
 import uk.gov.communities.prsdb.webapp.exceptions.PrsdbWebException
 import uk.gov.communities.prsdb.webapp.journeys.AbstractInternalStepConfig
 import uk.gov.communities.prsdb.webapp.journeys.Destination
@@ -41,7 +42,9 @@ class CompleteSwitchToIndividualStepConfig(
         propertyOwnershipService.markAsNotJointLandlord(propertyOwnership)
         jointLandlordInvitationService.removeInvitations(pendingInvitations)
 
+        // TODO: PDJB-1274: Update emails to account for org landlord
         val landlord = propertyOwnership.landlords.first()
+        require(landlord is IndividualLandlord)
         switchToIndividualConfirmationEmailSender.sendEmail(
             landlord.email,
             SwitchToIndividualConfirmationEmail(landlordName = landlord.name, propertyAddress = propertyAddress),

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/requestModels/formModels/DateOfBirthFormModel.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/requestModels/formModels/DateOfBirthFormModel.kt
@@ -1,6 +1,5 @@
 package uk.gov.communities.prsdb.webapp.models.requestModels.formModels
 
-import uk.gov.communities.prsdb.webapp.database.entity.Landlord
 import uk.gov.communities.prsdb.webapp.exceptions.NotNullFormModelValueIsNullException
 import uk.gov.communities.prsdb.webapp.helpers.DateTimeHelper
 import uk.gov.communities.prsdb.webapp.validation.ConstraintDescriptor
@@ -200,13 +199,4 @@ class DateOfBirthFormModel : DateFormModel() {
         toLocalDateOrNull() ?: throw NotNullFormModelValueIsNullException(
             "DateOfBirthFormModel date fields are null or invalid when a valid date was expected",
         )
-
-    companion object {
-        fun fromLandlord(landlord: Landlord): DateOfBirthFormModel =
-            DateOfBirthFormModel().apply {
-                day = landlord.dateOfBirth?.dayOfMonth.toString()
-                month = landlord.dateOfBirth?.monthValue.toString()
-                year = landlord.dateOfBirth?.year.toString()
-            }
-    }
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/requestModels/formModels/EmailFormModel.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/requestModels/formModels/EmailFormModel.kt
@@ -1,6 +1,5 @@
 package uk.gov.communities.prsdb.webapp.models.requestModels.formModels
 
-import uk.gov.communities.prsdb.webapp.database.entity.Landlord
 import uk.gov.communities.prsdb.webapp.database.entity.LocalCouncilInvitation
 import uk.gov.communities.prsdb.webapp.validation.ConstraintDescriptor
 import uk.gov.communities.prsdb.webapp.validation.EmailConstraintValidator
@@ -25,8 +24,6 @@ class EmailFormModel : FormModel {
     var emailAddress: String? = null
 
     companion object {
-        fun fromLandlord(landlord: Landlord): EmailFormModel = EmailFormModel().apply { emailAddress = landlord.email }
-
         fun fromLocalCouncilInvitation(invitation: LocalCouncilInvitation): EmailFormModel =
             EmailFormModel().apply {
                 emailAddress =

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/requestModels/formModels/LandlordTypeFormModel.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/requestModels/formModels/LandlordTypeFormModel.kt
@@ -1,5 +1,6 @@
 package uk.gov.communities.prsdb.webapp.models.requestModels.formModels
 
+import uk.gov.communities.prsdb.webapp.constants.enums.LandlordType
 import uk.gov.communities.prsdb.webapp.validation.ConstraintDescriptor
 import uk.gov.communities.prsdb.webapp.validation.IsValidPrioritised
 import uk.gov.communities.prsdb.webapp.validation.NotNullConstraintValidator
@@ -17,8 +18,3 @@ class LandlordTypeFormModel(
     )
     var landlordType: LandlordType? = null,
 ) : FormModel
-
-enum class LandlordType {
-    INDIVIDUAL,
-    ORGANISATION,
-}

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/requestModels/formModels/LookupAddressFormModel.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/requestModels/formModels/LookupAddressFormModel.kt
@@ -1,6 +1,5 @@
 package uk.gov.communities.prsdb.webapp.models.requestModels.formModels
 
-import uk.gov.communities.prsdb.webapp.database.entity.Landlord
 import uk.gov.communities.prsdb.webapp.validation.ConstraintDescriptor
 import uk.gov.communities.prsdb.webapp.validation.IsValidPrioritised
 import uk.gov.communities.prsdb.webapp.validation.NotBlankConstraintValidator
@@ -27,15 +26,4 @@ class LookupAddressFormModel : FormModel {
         ],
     )
     var houseNameOrNumber: String? = null
-
-    companion object {
-        fun fromLandlord(landlord: Landlord): LookupAddressFormModel =
-            LookupAddressFormModel().apply {
-                // We default to singleLineAddress not because that's useful data, but because we want this form to
-                // be considered valid, and thus its journey Step to be satisfied, in the case that a manual address was
-                // provided rather than address lookup terms.
-                postcode = landlord.address.postcode ?: landlord.address.singleLineAddress
-                houseNameOrNumber = landlord.address.buildingName ?: landlord.address.buildingNumber ?: landlord.address.singleLineAddress
-            }
-    }
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/requestModels/formModels/ManualAddressFormModel.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/requestModels/formModels/ManualAddressFormModel.kt
@@ -1,6 +1,5 @@
 package uk.gov.communities.prsdb.webapp.models.requestModels.formModels
 
-import uk.gov.communities.prsdb.webapp.database.entity.Landlord
 import uk.gov.communities.prsdb.webapp.validation.ConstraintDescriptor
 import uk.gov.communities.prsdb.webapp.validation.IsValidPrioritised
 import uk.gov.communities.prsdb.webapp.validation.NotBlankConstraintValidator
@@ -41,13 +40,4 @@ class ManualAddressFormModel : FormModel {
         ],
     )
     var postcode: String? = null
-
-    companion object {
-        fun fromLandlord(landlord: Landlord): ManualAddressFormModel =
-            ManualAddressFormModel().apply {
-                addressLineOne = landlord.address.singleLineAddress
-                townOrCity = landlord.address.townName
-                postcode = landlord.address.postcode
-            }
-    }
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/requestModels/formModels/NameFormModel.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/requestModels/formModels/NameFormModel.kt
@@ -1,6 +1,5 @@
 package uk.gov.communities.prsdb.webapp.models.requestModels.formModels
 
-import uk.gov.communities.prsdb.webapp.database.entity.Landlord
 import uk.gov.communities.prsdb.webapp.validation.ConstraintDescriptor
 import uk.gov.communities.prsdb.webapp.validation.IsValidPrioritised
 import uk.gov.communities.prsdb.webapp.validation.NotBlankConstraintValidator
@@ -17,8 +16,4 @@ class NameFormModel : FormModel {
         ],
     )
     var name: String? = null
-
-    companion object {
-        fun fromLandlord(landlord: Landlord): NameFormModel = NameFormModel().apply { name = landlord.name }
-    }
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/requestModels/formModels/PhoneNumberFormModel.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/requestModels/formModels/PhoneNumberFormModel.kt
@@ -1,6 +1,5 @@
 package uk.gov.communities.prsdb.webapp.models.requestModels.formModels
 
-import uk.gov.communities.prsdb.webapp.database.entity.Landlord
 import uk.gov.communities.prsdb.webapp.validation.ConstraintDescriptor
 import uk.gov.communities.prsdb.webapp.validation.IsValidPrioritised
 import uk.gov.communities.prsdb.webapp.validation.NotBlankConstraintValidator
@@ -22,8 +21,4 @@ class PhoneNumberFormModel : FormModel {
         ],
     )
     var phoneNumber: String? = null
-
-    companion object {
-        fun fromLandlord(landlord: Landlord): PhoneNumberFormModel = PhoneNumberFormModel().apply { phoneNumber = landlord.phoneNumber }
-    }
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/requestModels/formModels/SelectAddressFormModel.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/requestModels/formModels/SelectAddressFormModel.kt
@@ -1,16 +1,10 @@
 package uk.gov.communities.prsdb.webapp.models.requestModels.formModels
 
 import jakarta.validation.constraints.NotNull
-import uk.gov.communities.prsdb.webapp.database.entity.Landlord
 import uk.gov.communities.prsdb.webapp.validation.IsValidPrioritised
 
 @IsValidPrioritised
 class SelectAddressFormModel : FormModel {
     @NotNull(message = "forms.selectAddress.error.missing")
     var address: String? = null
-
-    companion object {
-        fun fromLandlord(landlord: Landlord): SelectAddressFormModel =
-            SelectAddressFormModel().apply { address = landlord.address.getSelectedAddress() }
-    }
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/summaryModels/LandlordViewModel.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/summaryModels/LandlordViewModel.kt
@@ -6,6 +6,7 @@ import uk.gov.communities.prsdb.webapp.controllers.UpdateLandlordDateOfBirthCont
 import uk.gov.communities.prsdb.webapp.controllers.UpdateLandlordEmailController.Companion.UPDATE_EMAIL_ROUTE
 import uk.gov.communities.prsdb.webapp.controllers.UpdateLandlordNameController.Companion.UPDATE_NAME_ROUTE
 import uk.gov.communities.prsdb.webapp.controllers.UpdateLandlordPhoneNumberController.Companion.UPDATE_PHONE_NUMBER_ROUTE
+import uk.gov.communities.prsdb.webapp.database.entity.IndividualLandlord
 import uk.gov.communities.prsdb.webapp.database.entity.Landlord
 import uk.gov.communities.prsdb.webapp.helpers.DateTimeHelper
 import uk.gov.communities.prsdb.webapp.helpers.converters.MessageKeyConverter
@@ -18,10 +19,13 @@ import uk.gov.communities.prsdb.webapp.journeys.shared.stepConfig.NameStep
 import uk.gov.communities.prsdb.webapp.models.dataModels.RegistrationNumberDataModel
 
 class LandlordViewModel(
-    private val landlord: Landlord,
+    baseLandlord: Landlord,
     private val withChangeLinks: Boolean = true,
 ) {
-    private val isEnglandOrWalesResident = landlord.isEnglandOrWalesResident()
+    // TODO: PDJB-1251: Update landlord details view for org landlord
+    private val landlord = baseLandlord as IndividualLandlord
+
+    private val isEnglandOrWalesResident = this.landlord.isEnglandOrWalesResident()
 
     private val changeLinkMessageKey = "forms.links.change"
 

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/summaryModels/LandlordViewModel.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/summaryModels/LandlordViewModel.kt
@@ -25,7 +25,7 @@ class LandlordViewModel(
     // TODO: PDJB-1251: Update landlord details view for org landlord
     private val landlord = baseLandlord as IndividualLandlord
 
-    private val isEnglandOrWalesResident = this.landlord.isEnglandOrWalesResident()
+    private val isEnglandOrWalesResident = landlord.isEnglandOrWalesResident()
 
     private val changeLinkMessageKey = "forms.links.change"
 

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/summaryModels/PropertyDetailsLandlordViewModelBuilder.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/summaryModels/PropertyDetailsLandlordViewModelBuilder.kt
@@ -15,7 +15,7 @@ class PropertyDetailsLandlordViewModelBuilder {
             landlordDetailsUrl: String = LandlordDetailsController.LANDLORD_DETAILS_FOR_LANDLORD_ROUTE,
         ): List<SummaryListRowViewModel> {
             // TODO: PDJB-1269: Remove JL dead code
-            require(landlord is IndividualLandlord)
+            check(landlord is IndividualLandlord)
             return mutableListOf<SummaryListRowViewModel>()
                 .apply {
                     addRow(
@@ -65,7 +65,7 @@ class PropertyDetailsLandlordViewModelBuilder {
             landlords
                 // TODO: PDJB-1276: Update landlord tab landlord view for org landlords
                 .map { landlord ->
-                    require(landlord is IndividualLandlord)
+                    check(landlord is IndividualLandlord)
                     landlord
                 }.sortedWith(compareByDescending<IndividualLandlord> { it.baseUser.id == currentUserId }.thenBy { it.name })
                 .map { landlord ->
@@ -111,7 +111,7 @@ class PropertyDetailsLandlordViewModelBuilder {
             landlords
                 // TODO: PDJB-1277: Update landlord tab local authority view for org landlords
                 .map { landlord ->
-                    require(landlord is IndividualLandlord)
+                    check(landlord is IndividualLandlord)
                     landlord
                 }.sortedBy { it.name }
                 .map { landlord ->

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/summaryModels/PropertyDetailsLandlordViewModelBuilder.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/summaryModels/PropertyDetailsLandlordViewModelBuilder.kt
@@ -2,6 +2,7 @@ package uk.gov.communities.prsdb.webapp.models.viewModels.summaryModels
 
 import uk.gov.communities.prsdb.webapp.controllers.LandlordDetailsController
 import uk.gov.communities.prsdb.webapp.controllers.LeavePropertyController
+import uk.gov.communities.prsdb.webapp.database.entity.IndividualLandlord
 import uk.gov.communities.prsdb.webapp.database.entity.Landlord
 import uk.gov.communities.prsdb.webapp.helpers.converters.MessageKeyConverter
 import uk.gov.communities.prsdb.webapp.helpers.extensions.addRow
@@ -12,8 +13,10 @@ class PropertyDetailsLandlordViewModelBuilder {
         fun fromEntity(
             landlord: Landlord,
             landlordDetailsUrl: String = LandlordDetailsController.LANDLORD_DETAILS_FOR_LANDLORD_ROUTE,
-        ): List<SummaryListRowViewModel> =
-            mutableListOf<SummaryListRowViewModel>()
+        ): List<SummaryListRowViewModel> {
+            // TODO: PDJB-1269: Remove JL dead code
+            require(landlord is IndividualLandlord)
+            return mutableListOf<SummaryListRowViewModel>()
                 .apply {
                     addRow(
                         "landlordDetails.personalDetails.name",
@@ -52,6 +55,7 @@ class PropertyDetailsLandlordViewModelBuilder {
                         )
                     }
                 }.toList()
+        }
 
         fun buildSummaryCards(
             landlords: Set<Landlord>,
@@ -59,7 +63,11 @@ class PropertyDetailsLandlordViewModelBuilder {
             propertyOwnershipId: Long,
         ): List<SummaryCardViewModel> =
             landlords
-                .sortedWith(compareByDescending<Landlord> { it.baseUser.id == currentUserId }.thenBy { it.name })
+                // TODO: PDJB-1276: Update landlord tab landlord view for org landlords
+                .map { landlord ->
+                    require(landlord is IndividualLandlord)
+                    landlord
+                }.sortedWith(compareByDescending<IndividualLandlord> { it.baseUser.id == currentUserId }.thenBy { it.name })
                 .map { landlord ->
                     val isCurrentUser = landlord.baseUser.id == currentUserId
                     if (isCurrentUser) {
@@ -84,7 +92,7 @@ class PropertyDetailsLandlordViewModelBuilder {
                     }
                 }
 
-        private fun buildLandlordCardRows(landlord: Landlord): List<SummaryListRowViewModel> =
+        private fun buildLandlordCardRows(landlord: IndividualLandlord): List<SummaryListRowViewModel> =
             listOf(
                 SummaryListRowViewModel(
                     fieldHeading = "landlordDetails.personalDetails.lrn",
@@ -101,7 +109,11 @@ class PropertyDetailsLandlordViewModelBuilder {
             landlordDetailsUrlProvider: (Landlord) -> String,
         ): List<SummaryCardViewModel> =
             landlords
-                .sortedBy { it.name }
+                // TODO: PDJB-1277: Update landlord tab local authority view for org landlords
+                .map { landlord ->
+                    require(landlord is IndividualLandlord)
+                    landlord
+                }.sortedBy { it.name }
                 .map { landlord ->
                     SummaryCardViewModel(
                         title = landlord.name,
@@ -117,7 +129,7 @@ class PropertyDetailsLandlordViewModelBuilder {
                     )
                 }
 
-        private fun buildLocalCouncilCardRows(landlord: Landlord): List<SummaryListRowViewModel> =
+        private fun buildLocalCouncilCardRows(landlord: IndividualLandlord): List<SummaryListRowViewModel> =
             listOf(
                 SummaryListRowViewModel(
                     fieldHeading = "landlordDetails.personalDetails.lrn",

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/JointLandlordInvitationExpiryEmailService.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/JointLandlordInvitationExpiryEmailService.kt
@@ -65,7 +65,7 @@ class JointLandlordInvitationExpiryEmailServiceImplFlagOn(
 
         // TODO: PDJB-1274: Update emails to account for org landlord
         propertyOwnership.landlords.forEach { recipient ->
-            require(recipient is IndividualLandlord)
+            check(recipient is IndividualLandlord)
             expiryEmailNotificationService.sendEmail(
                 recipient.email,
                 JointLandlordInvitationExpiryEmail(

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/JointLandlordInvitationExpiryEmailService.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/JointLandlordInvitationExpiryEmailService.kt
@@ -6,6 +6,7 @@ import uk.gov.communities.prsdb.webapp.annotations.webAnnotations.PrsdbFlip
 import uk.gov.communities.prsdb.webapp.constants.JOINT_LANDLORDS
 import uk.gov.communities.prsdb.webapp.constants.JOINT_LANDLORD_INVITATION_LIFETIME_IN_DAYS
 import uk.gov.communities.prsdb.webapp.constants.enums.JointLandlordInvitationStatus
+import uk.gov.communities.prsdb.webapp.database.entity.IndividualLandlord
 import uk.gov.communities.prsdb.webapp.database.entity.JointLandlordInvitation
 import uk.gov.communities.prsdb.webapp.database.repository.JointLandlordInvitationRepository
 import uk.gov.communities.prsdb.webapp.exceptions.PersistentEmailSendException
@@ -62,7 +63,9 @@ class JointLandlordInvitationExpiryEmailServiceImplFlagOn(
         val propertyAddress = propertyOwnership.address.toMultiLineAddress()
         val propertyRecordUri = absoluteUrlProvider.buildPropertyDetailsUri(propertyOwnership.id)
 
+        // TODO: PDJB-1274: Update emails to account for org landlord
         propertyOwnership.landlords.forEach { recipient ->
+            require(recipient is IndividualLandlord)
             expiryEmailNotificationService.sendEmail(
                 recipient.email,
                 JointLandlordInvitationExpiryEmail(

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/JointLandlordInvitationService.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/JointLandlordInvitationService.kt
@@ -11,6 +11,7 @@ import uk.gov.communities.prsdb.webapp.constants.JOINT_LANDLORD_INVITATION_EMAIL
 import uk.gov.communities.prsdb.webapp.constants.JOINT_LANDLORD_INVITATION_REJECTION_PROPERTY_ADDRESS
 import uk.gov.communities.prsdb.webapp.constants.JOINT_LANDLORD_INVITATION_TOKEN_WITH_ACCEPTANCE_JOURNEY_IDS
 import uk.gov.communities.prsdb.webapp.constants.enums.JointLandlordInvitationStatus
+import uk.gov.communities.prsdb.webapp.database.entity.IndividualLandlord
 import uk.gov.communities.prsdb.webapp.database.entity.JointLandlordInvitation
 import uk.gov.communities.prsdb.webapp.database.entity.Landlord
 import uk.gov.communities.prsdb.webapp.database.entity.PropertyOwnership
@@ -60,13 +61,21 @@ class JointLandlordInvitationService(
         propertyOwnership: PropertyOwnership,
         invitingLandlord: Landlord,
     ) {
+        // TODO: PDJB-1274: Update emails to account for org landlord
+        require(invitingLandlord is IndividualLandlord)
         val senderName = invitingLandlord.name
         val propertyAddress = propertyOwnership.address.toMultiLineAddress()
 
         // Re-check against the current state of the database when finishing the journey. The form-level checks happen
         // when an email is submitted, so without this a concurrent journey could invite the same email twice.
         val alreadyInvitedEmails = getExistingInvitedEmails(propertyOwnership.id)
-        val existingLandlordEmails = propertyOwnership.landlords.map { it.email }
+        // TODO: PDJB-1279: Update joint landlord flow to account for org landlords
+        val registeredLandlords =
+            propertyOwnership.landlords.map { landlord ->
+                require(landlord is IndividualLandlord)
+                landlord
+            }
+        val existingLandlordEmails = registeredLandlords.map { it.email }
         val emailsToInvite =
             jointLandlordEmails.filter { candidateEmail ->
                 !alreadyInvitedEmails.containsEmail(candidateEmail) &&
@@ -109,7 +118,7 @@ class JointLandlordInvitationService(
                 ),
             )
 
-            val existingJointLandlords = propertyOwnership.landlords.filter { it.id != invitingLandlord.id }
+            val existingJointLandlords = registeredLandlords.filter { it.id != invitingLandlord.id }
             existingJointLandlords.forEach { landlord ->
                 notifyExistingEmailSender.sendEmail(
                     landlord.email,
@@ -130,6 +139,8 @@ class JointLandlordInvitationService(
         propertyOwnership: PropertyOwnership,
         invitingLandlord: Landlord,
     ): String {
+        // TODO: PDJB-1279: Update joint landlord flow to account for org landlords
+        require(invitingLandlord is IndividualLandlord)
         val invitation =
             invitationRepository
                 .findById(invitationId)
@@ -210,7 +221,13 @@ class JointLandlordInvitationService(
                 ResponseStatusException(HttpStatus.NOT_FOUND, "Invitation with id $invitationId was not found")
             }
 
-        if (invitation.registeredOwnership.landlords.none { it.baseUser.id == baseUserId }) {
+        // TODO: PDJB-1275: Update authorisation checks to account for org landlords
+        if (
+            invitation.registeredOwnership.landlords.none { landlord ->
+                require(landlord is IndividualLandlord)
+                landlord.baseUser.id == baseUserId
+            }
+        ) {
             throw ResponseStatusException(HttpStatus.FORBIDDEN, "User is not authorized to modify this invitation")
         }
 
@@ -236,7 +253,13 @@ class JointLandlordInvitationService(
             throw ResponseStatusException(HttpStatus.BAD_REQUEST, "Invitation is not pending")
         }
         val propertyOwnership = invitation.registeredOwnership
-        if (propertyOwnership.landlords.none { it.baseUser.id == baseUserId }) {
+        // TODO: PDJB-1275: Update authorisation checks to account for org landlords
+        if (
+            propertyOwnership.landlords.none { landlord ->
+                require(landlord is IndividualLandlord)
+                landlord.baseUser.id == baseUserId
+            }
+        ) {
             throw ResponseStatusException(HttpStatus.FORBIDDEN, "Not authorized to cancel this invitation")
         }
         return invitation

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/JointLandlordInvitationService.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/JointLandlordInvitationService.kt
@@ -62,7 +62,7 @@ class JointLandlordInvitationService(
         invitingLandlord: Landlord,
     ) {
         // TODO: PDJB-1274: Update emails to account for org landlord
-        require(invitingLandlord is IndividualLandlord)
+        check(invitingLandlord is IndividualLandlord)
         val senderName = invitingLandlord.name
         val propertyAddress = propertyOwnership.address.toMultiLineAddress()
 
@@ -72,7 +72,7 @@ class JointLandlordInvitationService(
         // TODO: PDJB-1279: Update joint landlord flow to account for org landlords
         val registeredLandlords =
             propertyOwnership.landlords.map { landlord ->
-                require(landlord is IndividualLandlord)
+                check(landlord is IndividualLandlord)
                 landlord
             }
         val existingLandlordEmails = registeredLandlords.map { it.email }
@@ -140,7 +140,7 @@ class JointLandlordInvitationService(
         invitingLandlord: Landlord,
     ): String {
         // TODO: PDJB-1279: Update joint landlord flow to account for org landlords
-        require(invitingLandlord is IndividualLandlord)
+        check(invitingLandlord is IndividualLandlord)
         val invitation =
             invitationRepository
                 .findById(invitationId)
@@ -224,7 +224,7 @@ class JointLandlordInvitationService(
         // TODO: PDJB-1275: Update authorisation checks to account for org landlords
         if (
             invitation.registeredOwnership.landlords.none { landlord ->
-                require(landlord is IndividualLandlord)
+                check(landlord is IndividualLandlord)
                 landlord.baseUser.id == baseUserId
             }
         ) {
@@ -256,7 +256,7 @@ class JointLandlordInvitationService(
         // TODO: PDJB-1275: Update authorisation checks to account for org landlords
         if (
             propertyOwnership.landlords.none { landlord ->
-                require(landlord is IndividualLandlord)
+                check(landlord is IndividualLandlord)
                 landlord.baseUser.id == baseUserId
             }
         ) {

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/JointLandlordOtherLandlordLeftEmailService.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/JointLandlordOtherLandlordLeftEmailService.kt
@@ -4,6 +4,7 @@ import org.springframework.context.annotation.Primary
 import uk.gov.communities.prsdb.webapp.annotations.webAnnotations.PrsdbFlip
 import uk.gov.communities.prsdb.webapp.annotations.webAnnotations.PrsdbWebService
 import uk.gov.communities.prsdb.webapp.constants.JOINT_LANDLORDS
+import uk.gov.communities.prsdb.webapp.database.entity.IndividualLandlord
 import uk.gov.communities.prsdb.webapp.database.entity.Landlord
 import uk.gov.communities.prsdb.webapp.database.entity.PropertyOwnership
 import uk.gov.communities.prsdb.webapp.models.viewModels.emailModels.JointLandlordOtherLandlordLeftNotification
@@ -36,7 +37,10 @@ class JointLandlordOtherLandlordLeftEmailServiceImplFlagOn(
         propertyOwnership: PropertyOwnership,
         previousLandlord: Landlord,
     ) {
+        // TODO: PDJB-1274: Update emails to account for org landlord
+        require(previousLandlord is IndividualLandlord)
         propertyOwnership.landlords.forEach { otherLandlord ->
+            require(otherLandlord is IndividualLandlord)
             otherLandlordLeftEmailService.sendEmail(
                 otherLandlord.email,
                 JointLandlordOtherLandlordLeftNotification(

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/JointLandlordOtherLandlordLeftEmailService.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/JointLandlordOtherLandlordLeftEmailService.kt
@@ -38,9 +38,9 @@ class JointLandlordOtherLandlordLeftEmailServiceImplFlagOn(
         previousLandlord: Landlord,
     ) {
         // TODO: PDJB-1274: Update emails to account for org landlord
-        require(previousLandlord is IndividualLandlord)
+        check(previousLandlord is IndividualLandlord)
         propertyOwnership.landlords.forEach { otherLandlord ->
-            require(otherLandlord is IndividualLandlord)
+            check(otherLandlord is IndividualLandlord)
             otherLandlordLeftEmailService.sendEmail(
                 otherLandlord.email,
                 JointLandlordOtherLandlordLeftNotification(

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/LandlordService.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/LandlordService.kt
@@ -182,7 +182,7 @@ class LandlordService(
 
     // TODO: PDJB-1294: Remove this
     fun setHasRespondedToFeedback(landlord: Landlord): Landlord {
-        require(landlord is IndividualLandlord)
+        check(landlord is IndividualLandlord)
         landlord.hasRespondedToFeedback = true
         return landlordRepository.save(landlord)
     }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/LandlordService.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/LandlordService.kt
@@ -7,6 +7,7 @@ import org.springframework.data.domain.PageRequest
 import uk.gov.communities.prsdb.webapp.annotations.webAnnotations.PrsdbWebService
 import uk.gov.communities.prsdb.webapp.constants.MAX_ENTRIES_IN_LANDLORDS_SEARCH_PAGE
 import uk.gov.communities.prsdb.webapp.constants.enums.RegistrationNumberType
+import uk.gov.communities.prsdb.webapp.database.entity.IndividualLandlord
 import uk.gov.communities.prsdb.webapp.database.entity.Landlord
 import uk.gov.communities.prsdb.webapp.database.repository.LandlordRepository
 import uk.gov.communities.prsdb.webapp.exceptions.PrsdbWebException
@@ -39,10 +40,12 @@ class LandlordService(
         return landlordRepository.findByRegistrationNumber_Number(regNum.number)
     }
 
-    fun retrieveLandlordByBaseUserId(baseUserId: String): Landlord? = landlordRepository.findByBaseUser_Id(baseUserId)
+    // TODO: PDJB-1275: Update checks for landlord users to account for multiple users representing a landlord
+    fun retrieveLandlordByBaseUserId(baseUserId: String): IndividualLandlord? = landlordRepository.findByBaseUser_Id(baseUserId)
 
     fun retrieveLandlordById(id: Long): Landlord? = landlordRepository.findById(id).orElse(null)
 
+    // TODO: PDJB-1180: Update to potentially save an org landlord to the database
     @Transactional
     fun createLandlord(
         baseUserId: String,
@@ -62,7 +65,7 @@ class LandlordService(
 
         val landlord =
             landlordRepository.save(
-                Landlord(
+                IndividualLandlord(
                     baseUser,
                     name,
                     email,
@@ -96,6 +99,7 @@ class LandlordService(
     ): Landlord {
         checkUpdateIsValid()
         val landlordEntity = retrieveLandlordByBaseUserId(baseUserId)!!
+        // TODO: PDJB-1274: Update emails to account for org landlord
 
         val existingEmail = landlordEntity.email
 
@@ -177,6 +181,7 @@ class LandlordService(
     }
 
     fun setHasRespondedToFeedback(landlord: Landlord): Landlord {
+        require(landlord is IndividualLandlord)
         landlord.hasRespondedToFeedback = true
         return landlordRepository.save(landlord)
     }
@@ -217,7 +222,7 @@ class LandlordService(
 
     private fun sendUpdateConfirmationEmail(
         landlordUpdate: LandlordUpdateModel,
-        landlord: Landlord,
+        landlord: IndividualLandlord,
         oldEmail: String,
     ) {
         val updatedDetail =
@@ -249,7 +254,10 @@ class LandlordService(
         }
     }
 
-    fun getLandlordUserShouldSeeFeedbackPages(baseUserId: String) =
-        retrieveLandlordByBaseUserId(baseUserId)?.shouldSeeFeedback
-            ?: throw PrsdbWebException("User with id $baseUserId was not found in the Landlord repository")
+    fun getLandlordUserShouldSeeFeedbackPages(baseUserId: String): Boolean {
+        val landlord =
+            retrieveLandlordByBaseUserId(baseUserId)
+                ?: throw PrsdbWebException("User with id $baseUserId was not found in the Landlord repository")
+        return landlord.shouldSeeFeedback
+    }
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/LandlordService.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/LandlordService.kt
@@ -180,6 +180,7 @@ class LandlordService(
         ) {}
     }
 
+    // TODO: PDJB-1294: Remove this
     fun setHasRespondedToFeedback(landlord: Landlord): Landlord {
         require(landlord is IndividualLandlord)
         landlord.hasRespondedToFeedback = true
@@ -254,6 +255,7 @@ class LandlordService(
         }
     }
 
+    // TODO: PDJB-1294: Remove this
     fun getLandlordUserShouldSeeFeedbackPages(baseUserId: String): Boolean {
         val landlord =
             retrieveLandlordByBaseUserId(baseUserId)

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/LeavePropertyService.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/LeavePropertyService.kt
@@ -5,6 +5,7 @@ import org.springframework.http.HttpStatus
 import org.springframework.web.server.ResponseStatusException
 import uk.gov.communities.prsdb.webapp.annotations.webAnnotations.PrsdbWebService
 import uk.gov.communities.prsdb.webapp.constants.PROPERTIES_LEFT_THIS_SESSION
+import uk.gov.communities.prsdb.webapp.database.entity.IndividualLandlord
 import uk.gov.communities.prsdb.webapp.database.entity.Landlord
 import uk.gov.communities.prsdb.webapp.database.entity.PropertyOwnership
 import uk.gov.communities.prsdb.webapp.helpers.TransactionHelper
@@ -22,7 +23,12 @@ class LeavePropertyService(
         baseUserId: String,
     ): PropertyOwnership {
         val propertyOwnership = propertyOwnershipService.getPropertyOwnership(propertyOwnershipId)
-        val isLandlordOnProperty = propertyOwnership.landlords.any { it.baseUser.id == baseUserId }
+        val isLandlordOnProperty =
+            // TODO: PDJB-1275: Update authorisation checks to account for org landlords
+            propertyOwnership.landlords.any { landlord ->
+                require(landlord is IndividualLandlord)
+                landlord.baseUser.id == baseUserId
+            }
         val isJointlyOwned = propertyOwnership.landlords.size >= 2
         if (!isLandlordOnProperty || !isJointlyOwned) {
             throw ResponseStatusException(
@@ -37,6 +43,7 @@ class LeavePropertyService(
         landlord: Landlord,
         propertyOwnership: PropertyOwnership,
     ) {
+        require(landlord is IndividualLandlord)
         propertyOwnershipService.removeLandlord(propertyOwnership, landlord)
 
         TransactionHelper.runAfterTransactionCommits {

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/LeavePropertyService.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/LeavePropertyService.kt
@@ -26,7 +26,7 @@ class LeavePropertyService(
         val isLandlordOnProperty =
             // TODO: PDJB-1275: Update authorisation checks to account for org landlords
             propertyOwnership.landlords.any { landlord ->
-                require(landlord is IndividualLandlord)
+                check(landlord is IndividualLandlord)
                 landlord.baseUser.id == baseUserId
             }
         val isJointlyOwned = propertyOwnership.landlords.size >= 2
@@ -43,7 +43,7 @@ class LeavePropertyService(
         landlord: Landlord,
         propertyOwnership: PropertyOwnership,
     ) {
-        require(landlord is IndividualLandlord)
+        check(landlord is IndividualLandlord)
         propertyOwnershipService.removeLandlord(propertyOwnership, landlord)
 
         TransactionHelper.runAfterTransactionCommits {

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/PropertyComplianceService.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/PropertyComplianceService.kt
@@ -12,6 +12,7 @@ import uk.gov.communities.prsdb.webapp.constants.PROVIDE_LATER_DEADLINE_DAYS
 import uk.gov.communities.prsdb.webapp.constants.enums.CertificateType
 import uk.gov.communities.prsdb.webapp.constants.enums.EpcExemptionReason
 import uk.gov.communities.prsdb.webapp.constants.enums.MeesExemptionReason
+import uk.gov.communities.prsdb.webapp.database.entity.IndividualLandlord
 import uk.gov.communities.prsdb.webapp.database.entity.PropertyCompliance
 import uk.gov.communities.prsdb.webapp.database.repository.FileUploadRepository
 import uk.gov.communities.prsdb.webapp.database.repository.PropertyComplianceRepository
@@ -365,11 +366,17 @@ class PropertyComplianceService(
         val propertyOwnership = propertyCompliance.propertyOwnership
 
         val loggedInBaseUserId = SecurityContextHolder.getContext().authentication.name
+        // TODO: PDJB-1275: Update authorisation checks to account for org landlords
         val landlord =
-            propertyOwnership.landlords.singleOrNull { it.baseUser.id == loggedInBaseUserId }
+            propertyOwnership.landlords.singleOrNull { landlord ->
+                require(landlord is IndividualLandlord)
+                landlord.baseUser.id == loggedInBaseUserId
+            }
                 ?: throw PrsdbWebException(
                     "No landlord matching the logged in user $loggedInBaseUserId was found for property ${propertyOwnership.id}",
                 )
+        // TODO: PDJB-1274: Update emails to account for org landlord
+        require(landlord is IndividualLandlord)
 
         complianceUpdateConfirmationSender.sendEmail(
             landlord.email,
@@ -387,8 +394,15 @@ class PropertyComplianceService(
             ),
         )
 
-        val otherLandlords = propertyOwnership.landlords.filter { it.baseUser.id != loggedInBaseUserId }
+        // TODO: PDJB-1275: Update authorisation checks to account for org landlords
+        val otherLandlords =
+            propertyOwnership.landlords.filter { otherLandlord ->
+                require(otherLandlord is IndividualLandlord)
+                otherLandlord.baseUser.id != loggedInBaseUserId
+            }
+        // TODO: PDJB-1274: Update emails to account for org landlord
         otherLandlords.forEach { otherLandlord ->
+            require(otherLandlord is IndividualLandlord)
             complianceUpdateConfirmationSender.sendEmail(
                 otherLandlord.email,
                 ComplianceUpdateConfirmationEmail(

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/PropertyComplianceService.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/PropertyComplianceService.kt
@@ -367,16 +367,21 @@ class PropertyComplianceService(
 
         val loggedInBaseUserId = SecurityContextHolder.getContext().authentication.name
         // TODO: PDJB-1275: Update authorisation checks to account for org landlords
+        val landlords =
+            propertyOwnership.landlords
+                .map {
+                    check(it is IndividualLandlord)
+                    it
+                }
         val landlord =
-            propertyOwnership.landlords.singleOrNull { landlord ->
-                check(landlord is IndividualLandlord)
-                landlord.baseUser.id == loggedInBaseUserId
-            }
+            landlords
+                .singleOrNull { landlord ->
+                    landlord.baseUser.id == loggedInBaseUserId
+                }
                 ?: throw PrsdbWebException(
                     "No landlord matching the logged in user $loggedInBaseUserId was found for property ${propertyOwnership.id}",
                 )
         // TODO: PDJB-1274: Update emails to account for org landlord
-        check(landlord is IndividualLandlord)
 
         complianceUpdateConfirmationSender.sendEmail(
             landlord.email,
@@ -396,13 +401,11 @@ class PropertyComplianceService(
 
         // TODO: PDJB-1275: Update authorisation checks to account for org landlords
         val otherLandlords =
-            propertyOwnership.landlords.filter { otherLandlord ->
-                check(otherLandlord is IndividualLandlord)
+            landlords.filter { otherLandlord ->
                 otherLandlord.baseUser.id != loggedInBaseUserId
             }
         // TODO: PDJB-1274: Update emails to account for org landlord
         otherLandlords.forEach { otherLandlord ->
-            check(otherLandlord is IndividualLandlord)
             complianceUpdateConfirmationSender.sendEmail(
                 otherLandlord.email,
                 ComplianceUpdateConfirmationEmail(

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/PropertyComplianceService.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/PropertyComplianceService.kt
@@ -369,14 +369,14 @@ class PropertyComplianceService(
         // TODO: PDJB-1275: Update authorisation checks to account for org landlords
         val landlord =
             propertyOwnership.landlords.singleOrNull { landlord ->
-                require(landlord is IndividualLandlord)
+                check(landlord is IndividualLandlord)
                 landlord.baseUser.id == loggedInBaseUserId
             }
                 ?: throw PrsdbWebException(
                     "No landlord matching the logged in user $loggedInBaseUserId was found for property ${propertyOwnership.id}",
                 )
         // TODO: PDJB-1274: Update emails to account for org landlord
-        require(landlord is IndividualLandlord)
+        check(landlord is IndividualLandlord)
 
         complianceUpdateConfirmationSender.sendEmail(
             landlord.email,
@@ -397,12 +397,12 @@ class PropertyComplianceService(
         // TODO: PDJB-1275: Update authorisation checks to account for org landlords
         val otherLandlords =
             propertyOwnership.landlords.filter { otherLandlord ->
-                require(otherLandlord is IndividualLandlord)
+                check(otherLandlord is IndividualLandlord)
                 otherLandlord.baseUser.id != loggedInBaseUserId
             }
         // TODO: PDJB-1274: Update emails to account for org landlord
         otherLandlords.forEach { otherLandlord ->
-            require(otherLandlord is IndividualLandlord)
+            check(otherLandlord is IndividualLandlord)
             complianceUpdateConfirmationSender.sendEmail(
                 otherLandlord.email,
                 ComplianceUpdateConfirmationEmail(

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/PropertyOwnershipService.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/PropertyOwnershipService.kt
@@ -15,6 +15,7 @@ import uk.gov.communities.prsdb.webapp.constants.enums.PropertyType
 import uk.gov.communities.prsdb.webapp.constants.enums.RegistrationNumberType
 import uk.gov.communities.prsdb.webapp.constants.enums.RentFrequency
 import uk.gov.communities.prsdb.webapp.database.entity.Address
+import uk.gov.communities.prsdb.webapp.database.entity.IndividualLandlord
 import uk.gov.communities.prsdb.webapp.database.entity.Landlord
 import uk.gov.communities.prsdb.webapp.database.entity.License
 import uk.gov.communities.prsdb.webapp.database.entity.PropertyOwnership
@@ -97,7 +98,8 @@ class PropertyOwnershipService(
 
         val isLocalCouncil = localCouncilDataService.getIsLocalCouncilUser(baseUserId)
 
-        val isLandlord = propertyOwnership.landlords.any { it.baseUser.id == baseUserId }
+        // TODO: PDJB-1275: Update authorisation checks to account for org landlords
+        val isLandlord = propertyOwnership.landlords.any { (it as IndividualLandlord).baseUser.id == baseUserId }
 
         if (!isLocalCouncil && !isLandlord) {
             throw ResponseStatusException(
@@ -124,7 +126,8 @@ class PropertyOwnershipService(
     fun getIsLandlord(
         propertyOwnershipId: Long,
         baseUserId: String,
-    ): Boolean = getPropertyOwnership(propertyOwnershipId).landlords.any { it.baseUser.id == baseUserId }
+        // TODO: PDJB-1275: Update authorisation checks to account for org landlords
+    ): Boolean = getPropertyOwnership(propertyOwnershipId).landlords.any { (it as IndividualLandlord).baseUser.id == baseUserId }
 
     fun getRegisteredPropertiesForLandlordUser(
         baseUserId: String,

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/PropertyRegistrationService.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/PropertyRegistrationService.kt
@@ -12,6 +12,7 @@ import uk.gov.communities.prsdb.webapp.constants.enums.MeesExemptionReason
 import uk.gov.communities.prsdb.webapp.constants.enums.OwnershipType
 import uk.gov.communities.prsdb.webapp.constants.enums.PropertyType
 import uk.gov.communities.prsdb.webapp.constants.enums.RentFrequency
+import uk.gov.communities.prsdb.webapp.database.entity.IndividualLandlord
 import uk.gov.communities.prsdb.webapp.database.entity.Landlord
 import uk.gov.communities.prsdb.webapp.database.entity.PropertyOwnership
 import uk.gov.communities.prsdb.webapp.database.repository.LandlordRepository
@@ -74,6 +75,7 @@ class PropertyRegistrationService(
         val landlord =
             landlordRepository.findByBaseUser_Id(baseUserId)
                 ?: throw EntityNotFoundException("User not registered as a landlord")
+        // TODO: PDJB-1274: Update emails to account for org landlord
 
         val propertyOwnership =
             createPropertyOwnershipAndRelatedEntities(
@@ -173,7 +175,7 @@ class PropertyRegistrationService(
     }
 
     private fun sendConfirmationEmails(
-        landlord: Landlord,
+        landlord: IndividualLandlord,
         propertyOwnership: PropertyOwnership,
         addressModel: AddressDataModel,
         jointLandlordEmails: List<String>?,

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/PropertyUpdateEmailService.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/PropertyUpdateEmailService.kt
@@ -2,7 +2,7 @@ package uk.gov.communities.prsdb.webapp.services
 
 import org.springframework.security.core.context.SecurityContextHolder
 import uk.gov.communities.prsdb.webapp.annotations.webAnnotations.PrsdbWebService
-import uk.gov.communities.prsdb.webapp.database.entity.Landlord
+import uk.gov.communities.prsdb.webapp.database.entity.IndividualLandlord
 import uk.gov.communities.prsdb.webapp.exceptions.PrsdbWebException
 import uk.gov.communities.prsdb.webapp.models.dataModels.RegistrationNumberDataModel
 import uk.gov.communities.prsdb.webapp.models.viewModels.emailModels.JointLandlordPropertyUpdateNotificationEmail
@@ -38,7 +38,9 @@ class PropertyUpdateEmailService(
         val otherLandlords = propertyOwnership.landlords.filter { it.id != actingLandlord.id }
         if (otherLandlords.isNotEmpty()) {
             val propertyRecordUrl = absoluteUrlProvider.buildPropertyDetailsUri(propertyOwnership.id).toString()
+            // TODO: PDJB-1274: Update emails to account for org landlord
             otherLandlords.forEach { landlord ->
+                require(landlord is IndividualLandlord)
                 notificationEmailService.sendEmail(
                     landlord.email,
                     JointLandlordPropertyUpdateNotificationEmail(
@@ -52,8 +54,9 @@ class PropertyUpdateEmailService(
         }
     }
 
-    private fun getActingLandlord(): Landlord {
+    private fun getActingLandlord(): IndividualLandlord {
         val baseUserId = SecurityContextHolder.getContext().authentication.name
+        // TODO: PDJB-1274: Update emails to account for org landlord
         return landlordService.retrieveLandlordByBaseUserId(baseUserId)
             ?: throw PrsdbWebException("Landlord record not found for logged in user with baseUserId $baseUserId")
     }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/PropertyUpdateEmailService.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/PropertyUpdateEmailService.kt
@@ -40,7 +40,7 @@ class PropertyUpdateEmailService(
             val propertyRecordUrl = absoluteUrlProvider.buildPropertyDetailsUri(propertyOwnership.id).toString()
             // TODO: PDJB-1274: Update emails to account for org landlord
             otherLandlords.forEach { landlord ->
-                require(landlord is IndividualLandlord)
+                check(landlord is IndividualLandlord)
                 notificationEmailService.sendEmail(
                     landlord.email,
                     JointLandlordPropertyUpdateNotificationEmail(

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/SwapToIndividualNudgeEmailService.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/SwapToIndividualNudgeEmailService.kt
@@ -44,7 +44,7 @@ class SwapToIndividualNudgeEmailServiceImplFlagOn(
 
         // TODO: PDJB-1274: Update emails to account for org landlord
         val soleLandlord = propertyOwnership.landlords.single()
-        require(soleLandlord is IndividualLandlord)
+        check(soleLandlord is IndividualLandlord)
         val propertyAddress = propertyOwnership.address.toMultiLineAddress()
         val propertyRecordUrl = absoluteUrlProvider.buildPropertyDetailsUri(propertyOwnership.id).toString()
 

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/SwapToIndividualNudgeEmailService.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/SwapToIndividualNudgeEmailService.kt
@@ -5,6 +5,7 @@ import org.springframework.stereotype.Service
 import uk.gov.communities.prsdb.webapp.annotations.webAnnotations.PrsdbFlip
 import uk.gov.communities.prsdb.webapp.constants.JOINT_LANDLORDS
 import uk.gov.communities.prsdb.webapp.constants.enums.JointLandlordInvitationStatus
+import uk.gov.communities.prsdb.webapp.database.entity.IndividualLandlord
 import uk.gov.communities.prsdb.webapp.database.entity.PropertyOwnership
 import uk.gov.communities.prsdb.webapp.database.repository.JointLandlordInvitationRepository
 import uk.gov.communities.prsdb.webapp.models.viewModels.emailModels.SwapToIndividualNudgeEmail
@@ -41,7 +42,9 @@ class SwapToIndividualNudgeEmailServiceImplFlagOn(
             invitations.any { it.status == JointLandlordInvitationStatus.EXPIRED && !it.invitationExpiredEmailSent }
         if (hasUnprocessedExpiredInvitations) return
 
+        // TODO: PDJB-1274: Update emails to account for org landlord
         val soleLandlord = propertyOwnership.landlords.single()
+        require(soleLandlord is IndividualLandlord)
         val propertyAddress = propertyOwnership.address.toMultiLineAddress()
         val propertyRecordUrl = absoluteUrlProvider.buildPropertyDetailsUri(propertyOwnership.id).toString()
 

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/VirusNotificationEmailHandler.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/VirusNotificationEmailHandler.kt
@@ -4,6 +4,7 @@ import kotlinx.serialization.json.Json
 import org.springframework.beans.factory.annotation.Value
 import uk.gov.communities.prsdb.webapp.annotations.taskAnnotations.PrsdbTaskService
 import uk.gov.communities.prsdb.webapp.constants.enums.CertificateType
+import uk.gov.communities.prsdb.webapp.database.entity.IndividualLandlord
 import uk.gov.communities.prsdb.webapp.database.entity.PropertyOwnership
 import uk.gov.communities.prsdb.webapp.database.entity.VirusScanCallback
 import uk.gov.communities.prsdb.webapp.database.repository.PropertyOwnershipRepository
@@ -41,7 +42,9 @@ class VirusNotificationEmailHandler(
         if (emailAddress != null) {
             emailNotificationService.sendEmail(emailAddress, email)
         } else {
+            // TODO: PDJB-1274: Update emails to account for org landlord
             ownership.landlords.forEach { landlord ->
+                require(landlord is IndividualLandlord)
                 emailNotificationService.sendEmail(landlord.email, email)
             }
         }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/VirusNotificationEmailHandler.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/VirusNotificationEmailHandler.kt
@@ -44,7 +44,7 @@ class VirusNotificationEmailHandler(
         } else {
             // TODO: PDJB-1274: Update emails to account for org landlord
             ownership.landlords.forEach { landlord ->
-                require(landlord is IndividualLandlord)
+                check(landlord is IndividualLandlord)
                 emailNotificationService.sendEmail(landlord.email, email)
             }
         }

--- a/src/main/resources/db/migrations/V1_36_0__add_landlord_type_column.sql
+++ b/src/main/resources/db/migrations/V1_36_0__add_landlord_type_column.sql
@@ -1,0 +1,2 @@
+ALTER TABLE landlord
+    ADD COLUMN landlord_type SMALLINT NOT NULL DEFAULT 0;

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/organisationLandlordRegistrationJourneyPages/LandlordTypePageLandlordRegistration.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/organisationLandlordRegistrationJourneyPages/LandlordTypePageLandlordRegistration.kt
@@ -1,12 +1,12 @@
 package uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.organisationLandlordRegistrationJourneyPages
 
 import com.microsoft.playwright.Page
+import uk.gov.communities.prsdb.webapp.constants.enums.LandlordType
 import uk.gov.communities.prsdb.webapp.controllers.RegisterLandlordController.Companion.LANDLORD_REGISTRATION_ROUTE
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.FormWithSectionHeader
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.Radios
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages.BasePage
 import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.LandlordTypeStep
-import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.LandlordType
 
 class LandlordTypePageLandlordRegistration(
     page: Page,

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/acceptOrRejectJointLandlordInvitation/steps/ConfirmYouAreALandlordForThisPropertyStepConfigTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/acceptOrRejectJointLandlordInvitation/steps/ConfirmYouAreALandlordForThisPropertyStepConfigTests.kt
@@ -19,8 +19,8 @@ import org.mockito.kotlin.whenever
 import org.springframework.security.core.Authentication
 import org.springframework.security.core.context.SecurityContext
 import org.springframework.security.core.context.SecurityContextHolder
+import uk.gov.communities.prsdb.webapp.database.entity.IndividualLandlord
 import uk.gov.communities.prsdb.webapp.database.entity.JointLandlordInvitation
-import uk.gov.communities.prsdb.webapp.database.entity.Landlord
 import uk.gov.communities.prsdb.webapp.database.entity.PropertyOwnership
 import uk.gov.communities.prsdb.webapp.journeys.acceptOrRejectJointLandlordInvitation.AcceptOrRejectJointLandlordInvitationJourneyState
 import uk.gov.communities.prsdb.webapp.models.dataModels.RegistrationNumberDataModel
@@ -281,7 +281,7 @@ class ConfirmYouAreALandlordForThisPropertyStepConfigTests {
 
     private fun setupValidTokenWithLandlord(
         invitation: JointLandlordInvitation = MockJointLandlordData.createJointLandlordInvitation(),
-    ): Landlord {
+    ): IndividualLandlord {
         setupValidTokenWithInvitation(invitation)
         val landlord = MockLandlordData.createLandlord(baseUser = MockLandlordData.createPrsdbUser(baseUserId))
         whenever(mockLandlordService.retrieveLandlordByBaseUserId(baseUserId)).thenReturn(landlord)
@@ -290,7 +290,7 @@ class ConfirmYouAreALandlordForThisPropertyStepConfigTests {
     }
 
     private fun setupValidTokenWithLandlordAndOwnership(
-        acceptingLandlord: Landlord,
+        acceptingLandlord: IndividualLandlord,
         propertyOwnership: PropertyOwnership,
     ) {
         val invitation = MockJointLandlordData.createJointLandlordInvitation(propertyOwnership = propertyOwnership)

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/acceptOrRejectJointLandlordInvitation/steps/SendRejectionEmailsStepConfigTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/acceptOrRejectJointLandlordInvitation/steps/SendRejectionEmailsStepConfigTests.kt
@@ -9,8 +9,8 @@ import org.mockito.kotlin.eq
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import uk.gov.communities.prsdb.webapp.database.entity.Address
+import uk.gov.communities.prsdb.webapp.database.entity.IndividualLandlord
 import uk.gov.communities.prsdb.webapp.database.entity.JointLandlordInvitation
-import uk.gov.communities.prsdb.webapp.database.entity.Landlord
 import uk.gov.communities.prsdb.webapp.database.entity.PropertyOwnership
 import uk.gov.communities.prsdb.webapp.journeys.acceptOrRejectJointLandlordInvitation.AcceptOrRejectJointLandlordInvitationJourneyState
 import uk.gov.communities.prsdb.webapp.models.viewModels.emailModels.JointLandlordInvitationRejectionEmail
@@ -40,11 +40,11 @@ class SendRejectionEmailsStepConfigTests {
         // Arrange
         val stepConfig = setupStepConfig()
 
-        val landlord1 = mock<Landlord>()
+        val landlord1 = mock<IndividualLandlord>()
         whenever(landlord1.name).thenReturn("Lois Lane")
         whenever(landlord1.email).thenReturn("lois@example.com")
 
-        val landlord2 = mock<Landlord>()
+        val landlord2 = mock<IndividualLandlord>()
         whenever(landlord2.name).thenReturn("Clark Kent")
         whenever(landlord2.email).thenReturn("clark@example.com")
 
@@ -100,7 +100,7 @@ class SendRejectionEmailsStepConfigTests {
         val mockAddress = mock<Address>()
         whenever(mockAddress.toMultiLineAddress()).thenReturn("Flat 1\n11 Elm Drive\nLondon\nNW8 2DK")
 
-        val landlord = mock<Landlord>()
+        val landlord = mock<IndividualLandlord>()
         whenever(landlord.name).thenReturn("Lois Lane")
         whenever(landlord.email).thenReturn("lois@example.com")
 

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/switchToIndividual/stepConfig/CompleteSwitchToIndividualStepConfigTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/switchToIndividual/stepConfig/CompleteSwitchToIndividualStepConfigTests.kt
@@ -12,6 +12,7 @@ import org.mockito.kotlin.eq
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import uk.gov.communities.prsdb.webapp.constants.SWITCHED_TO_INDIVIDUAL_PROPERTY_ID
+import uk.gov.communities.prsdb.webapp.database.entity.IndividualLandlord
 import uk.gov.communities.prsdb.webapp.exceptions.PrsdbWebException
 import uk.gov.communities.prsdb.webapp.journeys.shared.Complete
 import uk.gov.communities.prsdb.webapp.journeys.switchToIndividual.SwitchToIndividualJourneyState
@@ -164,7 +165,7 @@ class CompleteSwitchToIndividualStepConfigTests {
         stepConfig.afterStepIsReached(mockState)
 
         verify(mockSwitchToIndividualConfirmationEmailSender).sendEmail(
-            eq(propertyOwnership.landlords.first().email),
+            eq((propertyOwnership.landlords.first() as IndividualLandlord).email),
             any<SwitchToIndividualConfirmationEmail>(),
         )
     }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/JointLandlordInvitationServiceTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/JointLandlordInvitationServiceTests.kt
@@ -28,8 +28,8 @@ import uk.gov.communities.prsdb.webapp.constants.JOINT_LANDLORD_INVITATION_EMAIL
 import uk.gov.communities.prsdb.webapp.constants.JOINT_LANDLORD_INVITATION_LIFETIME_IN_DAYS
 import uk.gov.communities.prsdb.webapp.constants.JOINT_LANDLORD_INVITATION_TOKEN_WITH_ACCEPTANCE_JOURNEY_IDS
 import uk.gov.communities.prsdb.webapp.constants.enums.JointLandlordInvitationStatus
+import uk.gov.communities.prsdb.webapp.database.entity.IndividualLandlord
 import uk.gov.communities.prsdb.webapp.database.entity.JointLandlordInvitation
-import uk.gov.communities.prsdb.webapp.database.entity.Landlord
 import uk.gov.communities.prsdb.webapp.database.repository.JointLandlordInvitationRepository
 import uk.gov.communities.prsdb.webapp.exceptions.PrsdbWebException
 import uk.gov.communities.prsdb.webapp.models.viewModels.emailModels.JointLandlordInvitationConfirmationEmail
@@ -51,7 +51,7 @@ class JointLandlordInvitationServiceTests {
     private lateinit var mockAbsoluteUrlProvider: AbsoluteUrlProvider
     private lateinit var mockHttpSession: HttpSession
     private lateinit var invitationService: JointLandlordInvitationService
-    private lateinit var invitingLandlord: Landlord
+    private lateinit var invitingLandlord: IndividualLandlord
 
     @BeforeEach
     fun setup() {

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/LandlordServiceTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/LandlordServiceTests.kt
@@ -29,7 +29,7 @@ import org.springframework.data.domain.PageRequest
 import uk.gov.communities.prsdb.webapp.constants.ENGLAND_OR_WALES
 import uk.gov.communities.prsdb.webapp.constants.enums.RegistrationNumberType
 import uk.gov.communities.prsdb.webapp.database.entity.Address
-import uk.gov.communities.prsdb.webapp.database.entity.Landlord
+import uk.gov.communities.prsdb.webapp.database.entity.IndividualLandlord
 import uk.gov.communities.prsdb.webapp.database.entity.PrsdbUser
 import uk.gov.communities.prsdb.webapp.database.entity.RegistrationNumber
 import uk.gov.communities.prsdb.webapp.database.repository.LandlordRepository
@@ -96,7 +96,7 @@ class LandlordServiceTests {
     @Test
     fun `retrieveLandlordByRegNum returns a landlord given its registration number`() {
         val regNumDataModel = RegistrationNumberDataModel(RegistrationNumberType.LANDLORD, 0L)
-        val expectedLandlord = Landlord()
+        val expectedLandlord = IndividualLandlord()
 
         whenever(mockLandlordRepository.findByRegistrationNumber_Number(regNumDataModel.number)).thenReturn(
             expectedLandlord,
@@ -128,7 +128,7 @@ class LandlordServiceTests {
     @Test
     fun `retrieveLandlordByBaseUserId returns a landlord given its base user ID`() {
         val baseUserId = "baseUserId"
-        val expectedLandlord = Landlord()
+        val expectedLandlord = IndividualLandlord()
 
         whenever(mockLandlordRepository.findByBaseUser_Id(baseUserId)).thenReturn(expectedLandlord)
 
@@ -157,7 +157,7 @@ class LandlordServiceTests {
         val registrationNumber = RegistrationNumber(RegistrationNumberType.LANDLORD, 1233456)
 
         val expectedLandlord =
-            Landlord(
+            IndividualLandlord(
                 baseUser,
                 "name",
                 "example@email.com",
@@ -193,7 +193,7 @@ class LandlordServiceTests {
             )
 
         // Assert
-        val landlordCaptor = captor<Landlord>()
+        val landlordCaptor = captor<IndividualLandlord>()
         verify(mockLandlordRepository).save(landlordCaptor.capture())
         assertTrue(ReflectionEquals(expectedLandlord, "id").matches(landlordCaptor.value))
 
@@ -566,7 +566,7 @@ class LandlordServiceTests {
         val updatedLandlord = landlordService.updateLandlordForBaseUserId(userId, updateModel) {}
 
         // Assert
-        assertEquals(newCasingEmailAddress, updatedLandlord.email)
+        assertEquals(newCasingEmailAddress, (updatedLandlord as IndividualLandlord).email)
         verify(updateConfirmationSender, times(1)).sendEmail(eq(newCasingEmailAddress), any())
         verify(updateConfirmationSender, times(1)).sendEmail(any(), any())
     }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/PropertyOwnershipServiceTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/PropertyOwnershipServiceTests.kt
@@ -35,6 +35,8 @@ import uk.gov.communities.prsdb.webapp.constants.enums.PropertyType
 import uk.gov.communities.prsdb.webapp.constants.enums.RegistrationNumberType
 import uk.gov.communities.prsdb.webapp.constants.enums.RentFrequency
 import uk.gov.communities.prsdb.webapp.controllers.PropertyDetailsController
+import uk.gov.communities.prsdb.webapp.database.entity.IndividualLandlord
+import uk.gov.communities.prsdb.webapp.database.entity.Landlord
 import uk.gov.communities.prsdb.webapp.database.entity.License
 import uk.gov.communities.prsdb.webapp.database.entity.LocalCouncil
 import uk.gov.communities.prsdb.webapp.database.entity.PropertyCompliance
@@ -295,7 +297,7 @@ class PropertyOwnershipServiceTests {
     @Nested
     inner class GetLandlordRegisteredPropertiesDetails {
         private val currentLandlord = MockLandlordData.createLandlord()
-        private val registeredLandlords = mutableSetOf(currentLandlord)
+        private val registeredLandlords: MutableSet<Landlord> = mutableSetOf(currentLandlord)
         private val localCouncil = LocalCouncil(11, "DERBYSHIRE DALES DISTRICT COUNCIL", "1045")
         private val expectedPropertyLicence = "forms.checkPropertyAnswers.propertyDetails.noLicensing"
         private val expectedIsTenantedMessageKey = "commonText.no"
@@ -474,9 +476,11 @@ class PropertyOwnershipServiceTests {
         fun `returns property ownership when user is only landlord`() {
             val propertyOwnership = MockLandlordData.createPropertyOwnership()
             val principalName =
-                propertyOwnership
-                    .landlords
-                    .first()
+                (
+                    propertyOwnership
+                        .landlords
+                        .first() as IndividualLandlord
+                )
                     .baseUser
                     .id
 

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/testHelpers/builders/LandlordStateSessionBuilder.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/testHelpers/builders/LandlordStateSessionBuilder.kt
@@ -4,6 +4,7 @@ import kotlinx.serialization.json.Json
 import kotlinx.serialization.serializer
 import org.mockito.Mockito.mock
 import uk.gov.communities.prsdb.webapp.constants.enums.CharityRegulator
+import uk.gov.communities.prsdb.webapp.constants.enums.LandlordType
 import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.EmailStep
 import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.LandlordTypeStep
 import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.LeadTrusteeDobStep
@@ -28,7 +29,6 @@ import uk.gov.communities.prsdb.webapp.models.dataModels.AddressDataModel
 import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.CharityRegisteredWithFormModel
 import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.EmailFormModel
 import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.LandlordPrivacyNoticeFormModel
-import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.LandlordType
 import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.LandlordTypeFormModel
 import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.LeadTrusteeNameFormModel
 import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.LeadTrusteePhoneFormModel

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/testHelpers/mockObjects/MockLandlordData.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/testHelpers/mockObjects/MockLandlordData.kt
@@ -8,6 +8,7 @@ import uk.gov.communities.prsdb.webapp.constants.enums.PropertyType
 import uk.gov.communities.prsdb.webapp.constants.enums.RegistrationNumberType
 import uk.gov.communities.prsdb.webapp.constants.enums.RentFrequency
 import uk.gov.communities.prsdb.webapp.database.entity.Address
+import uk.gov.communities.prsdb.webapp.database.entity.IndividualLandlord
 import uk.gov.communities.prsdb.webapp.database.entity.Landlord
 import uk.gov.communities.prsdb.webapp.database.entity.LandlordIncompleteProperties
 import uk.gov.communities.prsdb.webapp.database.entity.License
@@ -52,9 +53,9 @@ class MockLandlordData {
             createdDate: Instant = Instant.now(),
             propertyOwnerships: Set<PropertyOwnership> = emptySet(),
             incompleteProperties: List<SavedJourneyState> = emptyList(),
-        ): Landlord {
+        ): IndividualLandlord {
             val landlord =
-                Landlord(
+                IndividualLandlord(
                     baseUser = baseUser,
                     name = name,
                     email = email,


### PR DESCRIPTION
## Ticket number

[PDJB-1169](https://mhclgdigital.atlassian.net/browse/PDJB-1169)

## Goal of change

update the database to allow for us to have different types of landlord. for now individual landlord is the only implementor, to be joined by organisation landlord later

## Description of main change(s)

makes Landlord an abstract class. it's implemented by the new IndividualLandlord. uses a single table and the discriminator JPA methods to allow JPA to figure out what kind of landlord is in the table

this is different than the design we originally decided on, as it doesn't split into two separate tables. I went this way as splitting into two tables had some tricky consequences (landlords no longer had a definitive ID). I think we can still get a clean application divide this way, which I'll explore further in the next PR to add org landlords

for now updates the code to just assume that all landlords are individual landlords, adds a series of TODOs that need to be resolved to make org landlords work. most of these tickets are under the [PDJB-1207](https://mhclgdigital.atlassian.net/browse/PDJB-1207) epic

## Anything you'd like to highlight to the reviewer?

this cannot be gated behind a feature flag as it includes database changes. however, there shouldn't be any logic changes included in the PR, just fixups to class types to make it still compile, except where commented otherwise

## Checklist

Delete any that are not applicable, and add explanation below for any that are applicable but haven't been done

- [x] Unit tests for new logic (e.g. new service methods) have been added
- [x] Test suite has been run in full locally and is passing
- [x] Branch has been rebased onto main and run locally, with everything working as expected (both for your new feature
  and any related functionality)
- [x] TODO comments referencing this JIRA ticket have been searched for and removed - if a future PR will address them,
  mention that here
- [x] Seed data has been updated as needed for your feature to be tested without having to e.g. register a new property
- [x] `NftDataSeeder` has been updated to reflect any changes to the database schema
- [ ] QA instructions have been added to the ticket (particularly if this is the last PR required to complete the ticket)
