### PR TITLE
PDJB-NONE: Bump vulnerable transitive dependencies

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -33,6 +33,10 @@ repositories {
 
 // Override Spring Boot 3.5.16 managed versions to pick up security fixes ahead of the next Spring Boot release.
 extra["commons-lang3.version"] = "3.18.0"
+// GHSA-jhq6-gfmj-v8fx: logback object injection via HardenedObjectInputStream (fixed in 1.5.35).
+extra["logback.version"] = "1.5.35"
+// CVE-2026-54515 / GHSA-5jmj-h7xm-6q6v: jackson-databind case-insensitive @JsonIgnoreProperties bypass (fixed in 2.21.5).
+extra["jackson-bom.version"] = "2.21.5"
 
 dependencies {
     // Spring Boot Web


### PR DESCRIPTION
## Ticket number

PDJB-NONE

## Goal of change

Resolve open Dependabot alerts for transitive dependencies that Dependabot's automated PRs cannot fix on a Gradle project.

## Description of main change(s)

Overrides two Spring Boot-managed transitive dependency versions in `build.gradle.kts`, following the existing BOM property-override pattern:

- logback 1.5.34 → 1.5.35 (GHSA-jhq6-gfmj-v8fx — object injection via HardenedObjectInputStream)
- jackson-bom 2.21.4 → 2.21.5 (CVE-2026-54515 / GHSA-5jmj-h7xm-6q6v — case-insensitive `@JsonIgnoreProperties` bypass)

No Spring Boot upgrade was available to cover these (3.5.16 is the latest 3.x release).

## Anything you'd like to highlight to the reviewer?

The jackson advisory reports no `first_patched_version`, but 2.21.5 is the released fix for the affected 2.21.x range (confirmed on Maven Central).

## Checklist

- [ ] Test suite has been run in full locally and is passing

Unit tests (`testWithoutIntegration`) pass locally; the integration suite was not run locally (requires Docker) and will run in CI.
