### PR TITLE
PDJB-1072: Correct joint landlord database metrics

### DIFF
--- a/docs/MetricsReadMe.md
+++ b/docs/MetricsReadMe.md
@@ -2,7 +2,7 @@
 
 The system operator metrics page (`/system-operator/metrics`) shows a single summary list combining:
 
-- **Service usage metrics** — landlord/property registration counts and time-to-first-property
+- **Service usage metrics** — landlord/property registration counts and registration-to-first-property-association
   percentiles, from the database (`MetricsService`).
 - **Journey completion rates** — from the Plausible Stats API (`PlausibleMetricsService`, see
   [AnalyticsReadMe](AnalyticsReadMe.md)).
@@ -26,10 +26,10 @@ The summary list contains the following rows, in display order:
 | 1 | Number of registrations (landlords) | Database (`MetricsService`) | Landlords created in the period. |
 | 2 | Landlords verified by One Login | Database (`MetricsService`) | Landlords created in the period with `isVerified = true`. |
 | 3 | Number of properties | Database (`MetricsService`) | Property ownerships created in the period. |
-| 4 | Number of landlords with at least 1 property | Database (`MetricsService`) | Distinct landlords owning a property created in the period. |
-| 5 | Median time between registration and first property | Database (`MetricsService`) | Median (p50) of registration→first-property durations; ignores joint landlords. |
-| 6 | 90th percentile time between registration and first property | Database (`MetricsService`) | p90 of the same durations. |
-| 7 | 95th percentile time between registration and first property | Database (`MetricsService`) | p95 of the same durations. |
+| 4 | Number of landlords with at least 1 property | Database (`MetricsService`) | Distinct landlords whose ownership link was created in the period. |
+| 5 | Median time between registration and first property registration or joining an existing property | Database (`MetricsService`) | Median (p50) of registration→earliest-ownership-link durations. |
+| 6 | 90th percentile time between registration and first property registration or joining an existing property | Database (`MetricsService`) | p90 of the same durations. |
+| 7 | 95th percentile time between registration and first property registration or joining an existing property | Database (`MetricsService`) | p95 of the same durations. |
 | 8 | Landlord registration completion rate | Plausible Stats API (`PlausibleMetricsService.getCompletionRates`) | Unique **visitors** at the confirmation page ÷ start page. |
 | 9 | Property registration completion rate | Plausible Stats API (`PlausibleMetricsService.getCompletionRates`) | **Page views** at confirmation ÷ start (a landlord may register several properties). |
 | 10 | Local council user registration completion rate | Plausible Stats API (`PlausibleMetricsService.getCompletionRates`) | Unique **visitors** at confirmation ÷ privacy-notice page. |

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/database/repository/PropertyOwnershipRepository.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/database/repository/PropertyOwnershipRepository.kt
@@ -64,21 +64,21 @@ interface PropertyOwnershipRepository :
     @Query(
         "SELECT COUNT(DISTINCT ol.landlord) FROM PropertyOwnership po " +
             "JOIN po.ownershipLinks ol " +
-            "WHERE po.createdDate BETWEEN :start AND :end",
+            "WHERE ol.createdDate BETWEEN :start AND :end",
     )
-    fun countDistinctLandlordsWithPropertyCreatedBetween(
+    fun countDistinctLandlordsWithOwnershipLinkCreatedBetween(
         @Param("start") start: Instant,
         @Param("end") end: Instant,
     ): Long
 
     @Query(
-        "SELECT l.createdDate, MIN(po.createdDate) FROM PropertyOwnership po " +
+        "SELECT l.createdDate, MIN(ol.createdDate) FROM PropertyOwnership po " +
             "JOIN po.ownershipLinks ol " +
             "JOIN ol.landlord l " +
             "GROUP BY l.id, l.createdDate " +
-            "HAVING MIN(po.createdDate) BETWEEN :start AND :end",
+            "HAVING MIN(ol.createdDate) BETWEEN :start AND :end",
     )
-    fun findLandlordAndFirstPropertyCreatedDates(
+    fun findLandlordAndFirstOwnershipLinkCreatedDates(
         @Param("start") start: Instant,
         @Param("end") end: Instant,
     ): List<Array<Instant>>

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/MetricsService.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/MetricsService.kt
@@ -18,7 +18,7 @@ class MetricsService(
 ) {
     @Transactional
     fun getMetrics(period: ReportingPeriod): MetricsDataModel {
-        val timesToFirstProperty = getTimesToFirstProperty(period)
+        val timesToFirstPropertyOwnership = getTimesToFirstPropertyOwnership(period)
         return MetricsDataModel(
             numberOfLandlordRegistrations =
                 individualLandlordRepository.countByCreatedDateBetween(period.start, period.end),
@@ -27,18 +27,21 @@ class MetricsService(
             numberOfProperties =
                 propertyOwnershipRepository.countByCreatedDateBetween(period.start, period.end),
             numberOfLandlordsWithAProperty =
-                propertyOwnershipRepository.countDistinctLandlordsWithPropertyCreatedBetween(period.start, period.end),
-            medianTimeToFirstProperty = percentile(timesToFirstProperty, 0.5),
-            p90TimeToFirstProperty = percentile(timesToFirstProperty, 0.9),
-            p95TimeToFirstProperty = percentile(timesToFirstProperty, 0.95),
+                propertyOwnershipRepository.countDistinctLandlordsWithOwnershipLinkCreatedBetween(
+                    period.start,
+                    period.end,
+                ),
+            medianTimeToFirstProperty = percentile(timesToFirstPropertyOwnership, 0.5),
+            p90TimeToFirstProperty = percentile(timesToFirstPropertyOwnership, 0.9),
+            p95TimeToFirstProperty = percentile(timesToFirstPropertyOwnership, 0.95),
         )
     }
 
-    private fun getTimesToFirstProperty(period: ReportingPeriod): List<Duration> =
+    private fun getTimesToFirstPropertyOwnership(period: ReportingPeriod): List<Duration> =
         propertyOwnershipRepository
-            .findLandlordAndFirstPropertyCreatedDates(period.start, period.end)
-            .map { (landlordCreatedDate, firstPropertyCreatedDate) ->
-                Duration.between(landlordCreatedDate, firstPropertyCreatedDate)
+            .findLandlordAndFirstOwnershipLinkCreatedDates(period.start, period.end)
+            .map { (landlordCreatedDate, firstOwnershipLinkCreatedDate) ->
+                Duration.between(landlordCreatedDate, firstOwnershipLinkCreatedDate)
             }
 
     private fun percentile(

--- a/src/main/resources/data-metrics-local.sql
+++ b/src/main/resources/data-metrics-local.sql
@@ -187,13 +187,14 @@ ON CONFLICT DO NOTHING;
 -- The 2031 reporting period demonstrates both joint-landlord metrics cases:
 --   * landlord 2002 joins a property that was registered before the period;
 --   * landlords 2004 and 2005 join a property after it was registered in the period.
+-- The older owner and property use 2029 dates to stay isolated from the 2030 cohort.
 -- Every landlord gaining their first property during 2031 does so exactly two days
 -- after registering. Query 1/1/2031 to 31/12/2031 to expect 4 registrations,
 -- 4 verified landlords, 1 property, 4 landlords gaining a property, and
 -- median / p90 / p95 = 2 days.
 -- =============================================================================
 INSERT INTO prsdb_user (id, created_date)
-VALUES ('metrics-joint-user-1', TIMESTAMPTZ '2030-12-01 09:00:00+00'),
+VALUES ('metrics-joint-user-1', TIMESTAMPTZ '2029-12-01 09:00:00+00'),
        ('metrics-joint-user-2', TIMESTAMPTZ '2031-01-01 09:00:00+00'),
        ('metrics-joint-user-3', TIMESTAMPTZ '2031-02-01 09:00:00+00'),
        ('metrics-joint-user-4', TIMESTAMPTZ '2031-02-04 09:00:00+00'),
@@ -201,29 +202,29 @@ VALUES ('metrics-joint-user-1', TIMESTAMPTZ '2030-12-01 09:00:00+00'),
 ON CONFLICT DO NOTHING;
 
 INSERT INTO address (id, created_date, single_line_address, local_council_id, postcode, building_number)
-VALUES (2001, TIMESTAMPTZ '2030-12-01 09:00:00+00', '1 Joint Metrics Landlord Street, JM1 1AA', NULL, 'JM1 1AA', '1'),
+VALUES (2001, TIMESTAMPTZ '2029-12-01 09:00:00+00', '1 Joint Metrics Landlord Street, JM1 1AA', NULL, 'JM1 1AA', '1'),
        (2002, TIMESTAMPTZ '2031-01-01 09:00:00+00', '2 Joint Metrics Landlord Street, JM1 1AA', NULL, 'JM1 1AA', '2'),
        (2003, TIMESTAMPTZ '2031-02-01 09:00:00+00', '3 Joint Metrics Landlord Street, JM1 1AA', NULL, 'JM1 1AA', '3'),
        (2004, TIMESTAMPTZ '2031-02-04 09:00:00+00', '4 Joint Metrics Landlord Street, JM1 1AA', NULL, 'JM1 1AA', '4'),
        (2005, TIMESTAMPTZ '2031-02-05 09:00:00+00', '5 Joint Metrics Landlord Street, JM1 1AA', NULL, 'JM1 1AA', '5'),
-       (2201, TIMESTAMPTZ '2030-12-03 09:00:00+00', '1 Joint Metrics Property Road, JM2 2BB', NULL, 'JM2 2BB', '1'),
+       (2201, TIMESTAMPTZ '2029-12-03 09:00:00+00', '1 Joint Metrics Property Road, JM2 2BB', NULL, 'JM2 2BB', '1'),
        (2202, TIMESTAMPTZ '2031-02-03 09:00:00+00', '2 Joint Metrics Property Road, JM2 2BB', NULL, 'JM2 2BB', '2')
 ON CONFLICT DO NOTHING;
 
 INSERT INTO registration_number (id, created_date, number, type)
-VALUES (2001, TIMESTAMPTZ '2030-12-01 09:00:00+00', 900002000001, 1),
+VALUES (2001, TIMESTAMPTZ '2029-12-01 09:00:00+00', 900002000001, 1),
        (2002, TIMESTAMPTZ '2031-01-01 09:00:00+00', 900002000002, 1),
        (2003, TIMESTAMPTZ '2031-02-01 09:00:00+00', 900002000003, 1),
        (2004, TIMESTAMPTZ '2031-02-04 09:00:00+00', 900002000004, 1),
        (2005, TIMESTAMPTZ '2031-02-05 09:00:00+00', 900002000005, 1),
-       (2201, TIMESTAMPTZ '2030-12-03 09:00:00+00', 900002200001, 0),
+       (2201, TIMESTAMPTZ '2029-12-03 09:00:00+00', 900002200001, 0),
        (2202, TIMESTAMPTZ '2031-02-03 09:00:00+00', 900002200002, 0)
 ON CONFLICT DO NOTHING;
 
 INSERT INTO landlord (id, created_date, last_modified_date, registration_number_id, individual_address_id, individual_date_of_birth,
                       individual_is_active, individual_phone_number, individual_subject_identifier, individual_name, individual_email, individual_country_of_residence, individual_is_verified,
                       individual_has_accepted_privacy_notice)
-VALUES (2001, TIMESTAMPTZ '2030-12-01 09:00:00+00', NULL, 2001, 2001, DATE '1980-01-01', true, '07300002001', 'metrics-joint-user-1', 'Joint Metrics Landlord 1', 'metrics.joint.1@example.com', 'England or Wales', true, true),
+VALUES (2001, TIMESTAMPTZ '2029-12-01 09:00:00+00', NULL, 2001, 2001, DATE '1980-01-01', true, '07300002001', 'metrics-joint-user-1', 'Joint Metrics Landlord 1', 'metrics.joint.1@example.com', 'England or Wales', true, true),
        (2002, TIMESTAMPTZ '2031-01-01 09:00:00+00', NULL, 2002, 2002, DATE '1980-01-02', true, '07300002002', 'metrics-joint-user-2', 'Joint Metrics Landlord 2', 'metrics.joint.2@example.com', 'England or Wales', true, true),
        (2003, TIMESTAMPTZ '2031-02-01 09:00:00+00', NULL, 2003, 2003, DATE '1980-01-03', true, '07300002003', 'metrics-joint-user-3', 'Joint Metrics Landlord 3', 'metrics.joint.3@example.com', 'England or Wales', true, true),
        (2004, TIMESTAMPTZ '2031-02-04 09:00:00+00', NULL, 2004, 2004, DATE '1980-01-04', true, '07300002004', 'metrics-joint-user-4', 'Joint Metrics Landlord 4', 'metrics.joint.4@example.com', 'England or Wales', true, true),
@@ -233,12 +234,12 @@ ON CONFLICT DO NOTHING;
 INSERT INTO property_ownership (id, is_active, ownership_type, current_num_households, current_num_tenants,
                                registration_number_id, address_id, created_date, last_modified_date, license_id,
                                property_build_type, num_bedrooms, marked_joint_landlord, is_occupied)
-VALUES (2201, true, 1, 1, 2, 2201, 2201, TIMESTAMPTZ '2030-12-03 09:00:00+00', NULL, NULL, 1, 2, true, true),
+VALUES (2201, true, 1, 1, 2, 2201, 2201, TIMESTAMPTZ '2029-12-03 09:00:00+00', NULL, NULL, 1, 2, true, true),
        (2202, true, 1, 1, 2, 2202, 2202, TIMESTAMPTZ '2031-02-03 09:00:00+00', NULL, NULL, 1, 2, true, true)
 ON CONFLICT DO NOTHING;
 
 INSERT INTO ownership_link (landlord_id, landlordship_id, created_date)
-VALUES (2001, 2201, TIMESTAMPTZ '2030-12-03 09:00:00+00'),
+VALUES (2001, 2201, TIMESTAMPTZ '2029-12-03 09:00:00+00'),
        (2002, 2201, TIMESTAMPTZ '2031-01-03 09:00:00+00'),
        (2003, 2202, TIMESTAMPTZ '2031-02-03 09:00:00+00'),
        (2004, 2202, TIMESTAMPTZ '2031-02-06 09:00:00+00'),

--- a/src/main/resources/data-metrics-local.sql
+++ b/src/main/resources/data-metrics-local.sql
@@ -181,6 +181,70 @@ FROM generate_series(1, 100) AS s(i)
 JOIN property_ownership po ON po.id = 1600 + i
 ON CONFLICT DO NOTHING;
 
+-- =============================================================================
+-- Metrics test cohort 3: joint landlords joining existing properties
+-- =============================================================================
+-- The 2031 reporting period demonstrates both joint-landlord metrics cases:
+--   * landlord 2002 joins a property that was registered before the period;
+--   * landlords 2004 and 2005 join a property after it was registered in the period.
+-- Every landlord gaining their first property during 2031 does so exactly two days
+-- after registering. Query 1/1/2031 to 31/12/2031 to expect 4 registrations,
+-- 4 verified landlords, 1 property, 4 landlords gaining a property, and
+-- median / p90 / p95 = 2 days.
+-- =============================================================================
+INSERT INTO prsdb_user (id, created_date)
+VALUES ('metrics-joint-user-1', TIMESTAMPTZ '2030-12-01 09:00:00+00'),
+       ('metrics-joint-user-2', TIMESTAMPTZ '2031-01-01 09:00:00+00'),
+       ('metrics-joint-user-3', TIMESTAMPTZ '2031-02-01 09:00:00+00'),
+       ('metrics-joint-user-4', TIMESTAMPTZ '2031-02-04 09:00:00+00'),
+       ('metrics-joint-user-5', TIMESTAMPTZ '2031-02-05 09:00:00+00')
+ON CONFLICT DO NOTHING;
+
+INSERT INTO address (id, created_date, single_line_address, local_council_id, postcode, building_number)
+VALUES (2001, TIMESTAMPTZ '2030-12-01 09:00:00+00', '1 Joint Metrics Landlord Street, JM1 1AA', NULL, 'JM1 1AA', '1'),
+       (2002, TIMESTAMPTZ '2031-01-01 09:00:00+00', '2 Joint Metrics Landlord Street, JM1 1AA', NULL, 'JM1 1AA', '2'),
+       (2003, TIMESTAMPTZ '2031-02-01 09:00:00+00', '3 Joint Metrics Landlord Street, JM1 1AA', NULL, 'JM1 1AA', '3'),
+       (2004, TIMESTAMPTZ '2031-02-04 09:00:00+00', '4 Joint Metrics Landlord Street, JM1 1AA', NULL, 'JM1 1AA', '4'),
+       (2005, TIMESTAMPTZ '2031-02-05 09:00:00+00', '5 Joint Metrics Landlord Street, JM1 1AA', NULL, 'JM1 1AA', '5'),
+       (2201, TIMESTAMPTZ '2030-12-03 09:00:00+00', '1 Joint Metrics Property Road, JM2 2BB', NULL, 'JM2 2BB', '1'),
+       (2202, TIMESTAMPTZ '2031-02-03 09:00:00+00', '2 Joint Metrics Property Road, JM2 2BB', NULL, 'JM2 2BB', '2')
+ON CONFLICT DO NOTHING;
+
+INSERT INTO registration_number (id, created_date, number, type)
+VALUES (2001, TIMESTAMPTZ '2030-12-01 09:00:00+00', 900002000001, 1),
+       (2002, TIMESTAMPTZ '2031-01-01 09:00:00+00', 900002000002, 1),
+       (2003, TIMESTAMPTZ '2031-02-01 09:00:00+00', 900002000003, 1),
+       (2004, TIMESTAMPTZ '2031-02-04 09:00:00+00', 900002000004, 1),
+       (2005, TIMESTAMPTZ '2031-02-05 09:00:00+00', 900002000005, 1),
+       (2201, TIMESTAMPTZ '2030-12-03 09:00:00+00', 900002200001, 0),
+       (2202, TIMESTAMPTZ '2031-02-03 09:00:00+00', 900002200002, 0)
+ON CONFLICT DO NOTHING;
+
+INSERT INTO landlord (id, created_date, last_modified_date, registration_number_id, individual_address_id, individual_date_of_birth,
+                      individual_is_active, individual_phone_number, individual_subject_identifier, individual_name, individual_email, individual_country_of_residence, individual_is_verified,
+                      individual_has_accepted_privacy_notice)
+VALUES (2001, TIMESTAMPTZ '2030-12-01 09:00:00+00', NULL, 2001, 2001, DATE '1980-01-01', true, '07300002001', 'metrics-joint-user-1', 'Joint Metrics Landlord 1', 'metrics.joint.1@example.com', 'England or Wales', true, true),
+       (2002, TIMESTAMPTZ '2031-01-01 09:00:00+00', NULL, 2002, 2002, DATE '1980-01-02', true, '07300002002', 'metrics-joint-user-2', 'Joint Metrics Landlord 2', 'metrics.joint.2@example.com', 'England or Wales', true, true),
+       (2003, TIMESTAMPTZ '2031-02-01 09:00:00+00', NULL, 2003, 2003, DATE '1980-01-03', true, '07300002003', 'metrics-joint-user-3', 'Joint Metrics Landlord 3', 'metrics.joint.3@example.com', 'England or Wales', true, true),
+       (2004, TIMESTAMPTZ '2031-02-04 09:00:00+00', NULL, 2004, 2004, DATE '1980-01-04', true, '07300002004', 'metrics-joint-user-4', 'Joint Metrics Landlord 4', 'metrics.joint.4@example.com', 'England or Wales', true, true),
+       (2005, TIMESTAMPTZ '2031-02-05 09:00:00+00', NULL, 2005, 2005, DATE '1980-01-05', true, '07300002005', 'metrics-joint-user-5', 'Joint Metrics Landlord 5', 'metrics.joint.5@example.com', 'England or Wales', true, true)
+ON CONFLICT DO NOTHING;
+
+INSERT INTO property_ownership (id, is_active, ownership_type, current_num_households, current_num_tenants,
+                               registration_number_id, address_id, created_date, last_modified_date, license_id,
+                               property_build_type, num_bedrooms, marked_joint_landlord, is_occupied)
+VALUES (2201, true, 1, 1, 2, 2201, 2201, TIMESTAMPTZ '2030-12-03 09:00:00+00', NULL, NULL, 1, 2, true, true),
+       (2202, true, 1, 1, 2, 2202, 2202, TIMESTAMPTZ '2031-02-03 09:00:00+00', NULL, NULL, 1, 2, true, true)
+ON CONFLICT DO NOTHING;
+
+INSERT INTO ownership_link (landlord_id, landlordship_id, created_date)
+VALUES (2001, 2201, TIMESTAMPTZ '2030-12-03 09:00:00+00'),
+       (2002, 2201, TIMESTAMPTZ '2031-01-03 09:00:00+00'),
+       (2003, 2202, TIMESTAMPTZ '2031-02-03 09:00:00+00'),
+       (2004, 2202, TIMESTAMPTZ '2031-02-06 09:00:00+00'),
+       (2005, 2202, TIMESTAMPTZ '2031-02-07 09:00:00+00')
+ON CONFLICT DO NOTHING;
+
 -- Reset the sequences past the metrics cohorts so records created manually in the app
 -- (e.g. while testing) get ids above the seeded ones rather than colliding with them.
 SELECT setval(pg_get_serial_sequence('address', 'id'), (SELECT MAX(id) FROM address));

--- a/src/main/resources/messages/metrics.yml
+++ b/src/main/resources/messages/metrics.yml
@@ -17,9 +17,9 @@ rows:
   verifiedLandlords: Landlords verified by One Login
   properties: Number of properties
   landlordsWithProperty: Number of landlords with at least 1 property
-  medianTimeToFirstProperty: Median time between registration and first property (does not account for joint landlords)
-  p90TimeToFirstProperty: 90th percentile time between registration and first property (does not account for joint landlords)
-  p95TimeToFirstProperty: 95th percentile time between registration and first property (does not account for joint landlords)
+  medianTimeToFirstProperty: Median time between registration and first property registration or joining an existing property
+  p90TimeToFirstProperty: 90th percentile time between registration and first property registration or joining an existing property
+  p95TimeToFirstProperty: 95th percentile time between registration and first property registration or joining an existing property
   landlordRegistrationCompletionRate: Landlord registration completion rate
   propertyRegistrationCompletionRate: Property registration completion rate
   localCouncilUserRegistrationCompletionRate: Local council user registration completion rate

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/MetricsSinglePageTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/MetricsSinglePageTests.kt
@@ -130,6 +130,28 @@ class MetricsSinglePageTests : IntegrationTestWithImmutableData("data-metrics-lo
     }
 
     @Test
+    fun `the 2031 cohort counts joint landlord joins and reports positive durations`(page: Page) {
+        val metricsPage = navigator.goToMetricsPage()
+
+        metricsPage.submitDateRange("1", "1", "2031", "31", "12", "2031")
+
+        val reloadedPage = assertPageIs(page, MetricsPage::class)
+        assertThat(reloadedPage.metricsList.rowValue(0)).containsText("4")
+        assertThat(reloadedPage.metricsList.rowValue(1)).containsText("4")
+        assertThat(reloadedPage.metricsList.rowValue(2)).containsText("1")
+        assertThat(reloadedPage.metricsList.rowValue(3)).containsText("4")
+        assertThat(reloadedPage.metricsList.rowValue(4)).containsText("2 days")
+        assertThat(reloadedPage.metricsList.rowValue(5)).containsText("2 days")
+        assertThat(reloadedPage.metricsList.rowValue(6)).containsText("2 days")
+        assertThat(reloadedPage.metricsList.rowKey(4))
+            .containsText("Median time between registration and first property registration or joining an existing property")
+        assertThat(reloadedPage.metricsList.rowKey(5))
+            .containsText("90th percentile time between registration and first property registration or joining an existing property")
+        assertThat(reloadedPage.metricsList.rowKey(6))
+            .containsText("95th percentile time between registration and first property registration or joining an existing property")
+    }
+
+    @Test
     fun `submitting a valid date range renders the CloudWatch utilisation and error rate rows from the local stub`(page: Page) {
         val metricsPage = navigator.goToMetricsPage()
 

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/MetricsServiceTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/MetricsServiceTests.kt
@@ -34,7 +34,7 @@ class MetricsServiceTests {
         whenever(individualLandlordRepository.countByCreatedDateBetween(any(), any())).thenReturn(0L)
         whenever(individualLandlordRepository.countByIsVerifiedTrueAndCreatedDateBetween(any(), any())).thenReturn(0L)
         whenever(propertyOwnershipRepository.countByCreatedDateBetween(any(), any())).thenReturn(0L)
-        whenever(propertyOwnershipRepository.countDistinctLandlordsWithPropertyCreatedBetween(any(), any())).thenReturn(0L)
+        whenever(propertyOwnershipRepository.countDistinctLandlordsWithOwnershipLinkCreatedBetween(any(), any())).thenReturn(0L)
     }
 
     private fun durationsOfDays(vararg days: Long): List<Array<Instant>> = days.map { arrayOf(start, start.plus(Duration.ofDays(it))) }
@@ -44,8 +44,8 @@ class MetricsServiceTests {
         whenever(individualLandlordRepository.countByCreatedDateBetween(start, end)).thenReturn(7L)
         whenever(individualLandlordRepository.countByIsVerifiedTrueAndCreatedDateBetween(start, end)).thenReturn(5L)
         whenever(propertyOwnershipRepository.countByCreatedDateBetween(start, end)).thenReturn(4L)
-        whenever(propertyOwnershipRepository.countDistinctLandlordsWithPropertyCreatedBetween(start, end)).thenReturn(3L)
-        whenever(propertyOwnershipRepository.findLandlordAndFirstPropertyCreatedDates(start, end))
+        whenever(propertyOwnershipRepository.countDistinctLandlordsWithOwnershipLinkCreatedBetween(start, end)).thenReturn(3L)
+        whenever(propertyOwnershipRepository.findLandlordAndFirstOwnershipLinkCreatedDates(start, end))
             .thenReturn(emptyList())
 
         val metrics = metricsService.getMetrics(period)
@@ -59,7 +59,7 @@ class MetricsServiceTests {
     @Test
     fun `getMetrics returns null time-to-first-property percentiles when there is no data`() {
         stubCounts()
-        whenever(propertyOwnershipRepository.findLandlordAndFirstPropertyCreatedDates(any(), any()))
+        whenever(propertyOwnershipRepository.findLandlordAndFirstOwnershipLinkCreatedDates(any(), any()))
             .thenReturn(emptyList())
 
         val metrics = metricsService.getMetrics(period)
@@ -72,7 +72,7 @@ class MetricsServiceTests {
     @Test
     fun `getMetrics returns the single value for every percentile when there is one data point`() {
         stubCounts()
-        whenever(propertyOwnershipRepository.findLandlordAndFirstPropertyCreatedDates(any(), any()))
+        whenever(propertyOwnershipRepository.findLandlordAndFirstOwnershipLinkCreatedDates(any(), any()))
             .thenReturn(durationsOfDays(7))
 
         val metrics = metricsService.getMetrics(period)
@@ -86,7 +86,7 @@ class MetricsServiceTests {
     fun `getMetrics computes median p90 and p95 with linear interpolation`() {
         stubCounts()
         // Eleven values 10,20,...,110 days, supplied unsorted to confirm sorting.
-        whenever(propertyOwnershipRepository.findLandlordAndFirstPropertyCreatedDates(any(), any()))
+        whenever(propertyOwnershipRepository.findLandlordAndFirstOwnershipLinkCreatedDates(any(), any()))
             .thenReturn(durationsOfDays(110, 30, 70, 10, 90, 50, 20, 100, 40, 80, 60))
 
         val metrics = metricsService.getMetrics(period)
@@ -102,7 +102,7 @@ class MetricsServiceTests {
         stubCounts()
         // Three landlords whose first property followed registration after 27 minutes,
         // 1 day 3 hours 42 minutes, and 2 days 12 hours 38 minutes respectively.
-        whenever(propertyOwnershipRepository.findLandlordAndFirstPropertyCreatedDates(any(), any()))
+        whenever(propertyOwnershipRepository.findLandlordAndFirstOwnershipLinkCreatedDates(any(), any()))
             .thenReturn(
                 listOf(
                     arrayOf(start, start.plus(Duration.ofMinutes(27))),


### PR DESCRIPTION
## Ticket number

PDJB-1072

## Goal of change

Ensure system-operator metrics count joint landlords when they join a property and do not derive first-property durations from dates before landlord registration.

## Description of main change(s)

- Counts landlords when their ownership link is created, including joins to existing properties.
- Calculates duration percentiles from landlord registration to the earliest ownership link and updates the dashboard wording and documentation.
- Adds a database-backed 2031 regression cohort covering joint landlords joining both older and newly registered properties.

## Anything you'd like to highlight to the reviewer?

Ownership links are currently deleted when a joint landlord leaves, so retaining historical joins remains out of scope for this fix.

## Checklist

- [x] Unit tests for new logic (e.g. new service methods) have been added
- [ ] Test suite has been run in full locally and is passing
- [x] Branch has been rebased onto main and run locally, with everything working as expected (both for your new feature and any related functionality)
- [x] TODO comments referencing this JIRA ticket have been searched for and removed - no matching comments were found
- [x] Seed data has been updated as needed for your feature to be tested without having to e.g. register a new property
- [ ] QA instructions have been added to the ticket (particularly if this is the last PR required to complete the ticket)
- [x] This feature is not behind a feature flag. I've checked that this is appropriate and we're happy with this code becoming live as soon as we release