### PR TITLE
PDJB-896: Migrate landlord registration tasks to composition model

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/acceptOrRejectJointLandlordInvitation/AcceptOrRejectJointLandlordInvitationJourneyFactory.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/acceptOrRejectJointLandlordInvitation/AcceptOrRejectJointLandlordInvitationJourneyFactory.kt
@@ -1,6 +1,5 @@
 package uk.gov.communities.prsdb.webapp.journeys.acceptOrRejectJointLandlordInvitation
 
-import kotlinx.datetime.Instant
 import org.springframework.beans.factory.ObjectFactory
 import uk.gov.communities.prsdb.webapp.annotations.webAnnotations.JourneyFrameworkComponent
 import uk.gov.communities.prsdb.webapp.annotations.webAnnotations.PrsdbWebService
@@ -26,56 +25,8 @@ import uk.gov.communities.prsdb.webapp.journeys.acceptOrRejectJointLandlordInvit
 import uk.gov.communities.prsdb.webapp.journeys.builders.JourneyBuilder.Companion.journey
 import uk.gov.communities.prsdb.webapp.journeys.hasOutcome
 import uk.gov.communities.prsdb.webapp.journeys.isComplete
-import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.states.LandlordRegistrationState
-import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.ConfirmIdentityStep
-import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.CountryOfResidenceStep
-import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.DateOfBirthStep
-import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.EmailStep
-import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.IdentityNotVerifiedStep
-import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.IdentityVerifyingStep
-import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.LandlordRegistrationCyaStep
-import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.LandlordTypeStep
-import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.LeadTrusteeDobStep
-import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.LeadTrusteeEmailStep
-import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.LeadTrusteeNameStep
-import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.LeadTrusteePhoneStep
-import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.NonEnglandOrWalesAddressStep
-import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.OrgAddressStep
-import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.OrgCharityNumberEnglandAndWalesStep
-import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.OrgCharityNumberNorthernIrelandStep
-import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.OrgCharityNumberScotlandStep
-import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.OrgCharityRegisteredWithStep
-import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.OrgCharityStep
-import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.OrgCompaniesHouseStep
-import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.OrgCompanyNumberStep
-import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.OrgDirectorsStep
-import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.OrgEmailStep
-import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.OrgGovBodyDetailsStep
-import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.OrgGovBodyMemberAddressStep
-import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.OrgGovBodyMemberDobStep
-import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.OrgGovBodyMemberListStep
-import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.OrgGovBodyMemberNameStep
-import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.OrgGovBodyMustProvideInfoStep
-import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.OrgGovBodyWhoToProvideStep
-import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.OrgLandlordCyaStep
-import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.OrgMainContactStep
-import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.OrgNameStep
-import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.OrgPhoneNumberStep
-import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.OrgTrusteesStep
-import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.OrgTypeStep
-import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.PhoneNumberStep
-import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.PrivacyNoticeStep
-import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.YourDetailsStep
-import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.tasks.IdentityTask
-import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.tasks.IndividualLandlordRegistrationTask
 import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.tasks.LandlordRegistrationTask
-import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.tasks.OrgLandlordRegistrationTask
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.FinishCyaJourneyStep
 import uk.gov.communities.prsdb.webapp.journeys.shared.YesOrNo
-import uk.gov.communities.prsdb.webapp.journeys.shared.stepConfig.NameStep
-import uk.gov.communities.prsdb.webapp.journeys.shared.tasks.LandlordAddressTask
-import uk.gov.communities.prsdb.webapp.journeys.shared.tasks.TrusteeAddressTask
-import uk.gov.communities.prsdb.webapp.models.dataModels.VerifiedIdentityDataModel
 
 @PrsdbWebService
 class AcceptOrRejectJointLandlordInvitationJourneyFactory(
@@ -89,7 +40,7 @@ class AcceptOrRejectJointLandlordInvitationJourneyFactory(
         return if (checkingAnswersFor == null) {
             mainJourneyMap(state)
         } else {
-            LandlordRegistrationTask.checkYourAnswersJourneyMap(state, checkingAnswersFor)
+            LandlordRegistrationTask.checkYourAnswersJourneyMap(state.landlordRegistrationTask, checkingAnswersFor)
         }
     }
 
@@ -129,7 +80,7 @@ class AcceptOrRejectJointLandlordInvitationJourneyFactory(
                     }
                 }
             }
-            task(journey.landlordRegistrationTask) {
+            duplicableTask(journey.landlordRegistrationTask) {
                 parents { journey.acceptOrRejectStep.hasOutcome(YesOrNo.YES) }
                 nextStep { journey.markLandlordRegistrationCompleteStep }
             }
@@ -197,72 +148,13 @@ class AcceptOrRejectJointLandlordInvitationJourney(
     override val inviteUnavailableStep: InviteUnavailableStep,
     // Landlord registration task
     override val landlordRegistrationTask: LandlordRegistrationTask,
-    override val individualLandlordRegistrationTask: IndividualLandlordRegistrationTask,
-    override val orgLandlordRegistrationTask: OrgLandlordRegistrationTask,
-    // Landlord type step
-    override val landlordTypeStep: LandlordTypeStep,
-    // Privacy notice step
-    override val privacyNoticeStep: PrivacyNoticeStep,
-    // Identity task
-    override val identityTask: IdentityTask,
-    override val identityVerifyingStep: IdentityVerifyingStep,
-    override val confirmIdentityStep: ConfirmIdentityStep,
-    override val identityNotVerifiedStep: IdentityNotVerifiedStep,
-    override val nameStep: NameStep,
-    override val dateOfBirthStep: DateOfBirthStep,
-    // Landlord details steps
-    override val emailStep: EmailStep,
-    override val phoneNumberStep: PhoneNumberStep,
-    override val countryOfResidenceStep: CountryOfResidenceStep,
-    override val nonEnglandOrWalesAddressStep: NonEnglandOrWalesAddressStep,
-    // Address task
-    override val addressTask: LandlordAddressTask,
-    // Check your answers step
-    override val cyaStep: LandlordRegistrationCyaStep,
-    override val finishCyaStep: FinishCyaJourneyStep,
-    // Org landlord steps
-    override val yourDetailsStep: YourDetailsStep,
-    override val orgNameStep: OrgNameStep,
-    override val orgAddressStep: OrgAddressStep,
-    override val orgEmailStep: OrgEmailStep,
-    override val orgPhoneNumberStep: OrgPhoneNumberStep,
-    override val orgTypeStep: OrgTypeStep,
-    override val orgCompaniesHouseStep: OrgCompaniesHouseStep,
-    override val orgCompanyNumberStep: OrgCompanyNumberStep,
-    override val orgCharityStep: OrgCharityStep,
-    override val orgCharityRegisteredWithStep: OrgCharityRegisteredWithStep,
-    override val orgCharityNumberEnglandAndWalesStep: OrgCharityNumberEnglandAndWalesStep,
-    override val orgCharityNumberNorthernIrelandStep: OrgCharityNumberNorthernIrelandStep,
-    override val orgCharityNumberScotlandStep: OrgCharityNumberScotlandStep,
-    override val orgDirectorsStep: OrgDirectorsStep,
-    override val orgTrusteesStep: OrgTrusteesStep,
-    override val leadTrusteeNameStep: LeadTrusteeNameStep,
-    override val leadTrusteeEmailStep: LeadTrusteeEmailStep,
-    override val leadTrusteePhoneStep: LeadTrusteePhoneStep,
-    override val leadTrusteeDobStep: LeadTrusteeDobStep,
-    override val trusteeAddressTask: TrusteeAddressTask,
-    override val orgGovBodyDetailsStep: OrgGovBodyDetailsStep,
-    override val orgGovBodyMustProvideInfoStep: OrgGovBodyMustProvideInfoStep,
-    override val orgGovBodyWhoToProvideStep: OrgGovBodyWhoToProvideStep,
-    override val orgGovBodyMemberNameStep: OrgGovBodyMemberNameStep,
-    override val orgGovBodyMemberDobStep: OrgGovBodyMemberDobStep,
-    override val orgGovBodyMemberAddressStep: OrgGovBodyMemberAddressStep,
-    override val orgGovBodyMemberListStep: OrgGovBodyMemberListStep,
-    override val orgMainContactStep: OrgMainContactStep,
-    override val orgLandlordCyaStep: OrgLandlordCyaStep,
     journeyStateService: JourneyStateService,
-    override val stateFactory: ObjectFactory<AcceptOrRejectJointLandlordInvitationJourneyState>,
 ) : AbstractJourneyState(journeyStateService),
     AcceptOrRejectJointLandlordInvitationJourneyState {
+    override val checkingAnswersFor: String? get() = landlordRegistrationTask.checkingAnswersFor
+
     override var tokenIsValid: Boolean? by delegateProvider.nullableDelegate("tokenIsValid")
     var isStateInitialized: Boolean by delegateProvider.requiredDelegate("isStateInitialized", false)
-
-    override var verifiedIdentity: VerifiedIdentityDataModel? by delegateProvider.nullableDelegate("verifiedIdentity")
-    override var originalJourneyUpdated: Instant? by delegateProvider.nullableDelegate("originalJourneyUpdated")
-    override var cyaJourneys: Map<String, String> = mapOf()
-    override var checkingAnswersFor: String? by delegateProvider.nullableDelegate("checkingAnswersFor")
-
-    override var cyaUrlPath: String? by delegateProvider.nullableDelegate("cyaRouteSegment")
 
     override var userIsLandlord: Boolean? by delegateProvider.nullableDelegate("userIsLandlord")
     override var userCompletedLandlordRegistrationThisJourney: Boolean? by delegateProvider.nullableDelegate(
@@ -280,9 +172,10 @@ class AcceptOrRejectJointLandlordInvitationJourney(
     }
 }
 
-interface AcceptOrRejectJointLandlordInvitationJourneyState :
-    JourneyState,
-    LandlordRegistrationState {
+interface AcceptOrRejectJointLandlordInvitationJourneyState : JourneyState {
+    val landlordRegistrationTask: LandlordRegistrationTask
+    val checkingAnswersFor: String?
+
     val validateTokenStep: ValidateTokenStep
     val acceptOrRejectStep: AcceptOrRejectStep
     val checkUserRoleStep: CheckUserRoleStep

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/landlordRegistration/LandlordRegistrationJourneyFactory.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/landlordRegistration/LandlordRegistrationJourneyFactory.kt
@@ -1,66 +1,18 @@
 package uk.gov.communities.prsdb.webapp.journeys.landlordRegistration
 
-import kotlinx.datetime.Instant
 import org.springframework.beans.factory.ObjectFactory
 import uk.gov.communities.prsdb.webapp.annotations.webAnnotations.JourneyFrameworkComponent
 import uk.gov.communities.prsdb.webapp.controllers.RegisterLandlordController.Companion.LANDLORD_REGISTRATION_CONFIRMATION_ROUTE
 import uk.gov.communities.prsdb.webapp.controllers.RegisterLandlordController.Companion.LANDLORD_REGISTRATION_START_PAGE_ROUTE
 import uk.gov.communities.prsdb.webapp.journeys.AbstractJourneyState
 import uk.gov.communities.prsdb.webapp.journeys.Destination
+import uk.gov.communities.prsdb.webapp.journeys.JourneyState
 import uk.gov.communities.prsdb.webapp.journeys.JourneyStateService
 import uk.gov.communities.prsdb.webapp.journeys.StepLifecycleOrchestrator
 import uk.gov.communities.prsdb.webapp.journeys.builders.JourneyBuilder.Companion.journey
 import uk.gov.communities.prsdb.webapp.journeys.isComplete
-import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.states.LandlordRegistrationState
-import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.ConfirmIdentityStep
-import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.CountryOfResidenceStep
-import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.DateOfBirthStep
 import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.DeleteJourneyStep
-import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.EmailStep
-import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.IdentityNotVerifiedStep
-import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.IdentityVerifyingStep
-import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.LandlordRegistrationCyaStep
-import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.LandlordTypeStep
-import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.LeadTrusteeDobStep
-import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.LeadTrusteeEmailStep
-import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.LeadTrusteeNameStep
-import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.LeadTrusteePhoneStep
-import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.NonEnglandOrWalesAddressStep
-import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.OrgAddressStep
-import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.OrgCharityNumberEnglandAndWalesStep
-import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.OrgCharityNumberNorthernIrelandStep
-import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.OrgCharityNumberScotlandStep
-import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.OrgCharityRegisteredWithStep
-import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.OrgCharityStep
-import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.OrgCompaniesHouseStep
-import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.OrgCompanyNumberStep
-import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.OrgDirectorsStep
-import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.OrgEmailStep
-import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.OrgGovBodyDetailsStep
-import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.OrgGovBodyMemberAddressStep
-import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.OrgGovBodyMemberDobStep
-import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.OrgGovBodyMemberListStep
-import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.OrgGovBodyMemberNameStep
-import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.OrgGovBodyMustProvideInfoStep
-import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.OrgGovBodyWhoToProvideStep
-import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.OrgLandlordCyaStep
-import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.OrgMainContactStep
-import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.OrgNameStep
-import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.OrgPhoneNumberStep
-import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.OrgTrusteesStep
-import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.OrgTypeStep
-import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.PhoneNumberStep
-import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.PrivacyNoticeStep
-import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.YourDetailsStep
-import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.tasks.IdentityTask
-import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.tasks.IndividualLandlordRegistrationTask
 import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.tasks.LandlordRegistrationTask
-import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.tasks.OrgLandlordRegistrationTask
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.FinishCyaJourneyStep
-import uk.gov.communities.prsdb.webapp.journeys.shared.stepConfig.NameStep
-import uk.gov.communities.prsdb.webapp.journeys.shared.tasks.LandlordAddressTask
-import uk.gov.communities.prsdb.webapp.journeys.shared.tasks.TrusteeAddressTask
-import uk.gov.communities.prsdb.webapp.models.dataModels.VerifiedIdentityDataModel
 import java.security.Principal
 
 @JourneyFrameworkComponent("landlordRegistrationJourneyFactory")
@@ -74,20 +26,20 @@ class LandlordRegistrationJourneyFactory(
         return if (checkingAnswersFor == null) {
             mainJourneyMap(state)
         } else {
-            LandlordRegistrationTask.checkYourAnswersJourneyMap(state, checkingAnswersFor)
+            LandlordRegistrationTask.checkYourAnswersJourneyMap(state.landlordRegistrationTask, checkingAnswersFor)
         }
     }
 
     private fun mainJourneyMap(state: LandlordRegistrationJourneyState): Map<String, StepLifecycleOrchestrator> =
         journey(state) {
             configureFirst { backDestination { Destination.ExternalUrl(LANDLORD_REGISTRATION_START_PAGE_ROUTE) } }
-            unreachableStepStep { journey.privacyNoticeStep }
+            unreachableStepStep { journey.landlordRegistrationTask.privacyNoticeStep }
             configure {
                 withAdditionalContentProperty { "title" to "registerAsALandlord.title" }
             }
             section {
                 withHeadingMessageKey("registerAsALandlord.caption", shouldUseNumbering = false)
-                task(journey.landlordRegistrationTask) {
+                duplicableTask(journey.landlordRegistrationTask) {
                     initialStep()
                     nextStep { journey.deleteJourneyStep }
                 }
@@ -103,73 +55,12 @@ class LandlordRegistrationJourneyFactory(
 
 @JourneyFrameworkComponent("landlordRegistrationJourney")
 class LandlordRegistrationJourney(
-    // Top-level task
     override val landlordRegistrationTask: LandlordRegistrationTask,
-    override val individualLandlordRegistrationTask: IndividualLandlordRegistrationTask,
-    override val orgLandlordRegistrationTask: OrgLandlordRegistrationTask,
-    // Landlord type step
-    override val landlordTypeStep: LandlordTypeStep,
-    // Privacy notice step
-    override val privacyNoticeStep: PrivacyNoticeStep,
-    // Identity task
-    override val identityTask: IdentityTask,
-    override val identityVerifyingStep: IdentityVerifyingStep,
-    override val confirmIdentityStep: ConfirmIdentityStep,
-    override val identityNotVerifiedStep: IdentityNotVerifiedStep,
-    override val nameStep: NameStep,
-    override val dateOfBirthStep: DateOfBirthStep,
-    // Landlord details steps
-    override val emailStep: EmailStep,
-    override val phoneNumberStep: PhoneNumberStep,
-    override val countryOfResidenceStep: CountryOfResidenceStep,
-    override val nonEnglandOrWalesAddressStep: NonEnglandOrWalesAddressStep,
-    // Address task
-    override val addressTask: LandlordAddressTask,
-    // Check your answers step
-    override val cyaStep: LandlordRegistrationCyaStep,
-    override val finishCyaStep: FinishCyaJourneyStep,
-    // Org landlord steps
-    override val yourDetailsStep: YourDetailsStep,
-    override val orgNameStep: OrgNameStep,
-    override val orgAddressStep: OrgAddressStep,
-    override val orgEmailStep: OrgEmailStep,
-    override val orgPhoneNumberStep: OrgPhoneNumberStep,
-    override val orgTypeStep: OrgTypeStep,
-    override val orgCompaniesHouseStep: OrgCompaniesHouseStep,
-    override val orgCompanyNumberStep: OrgCompanyNumberStep,
-    override val orgCharityStep: OrgCharityStep,
-    override val orgCharityRegisteredWithStep: OrgCharityRegisteredWithStep,
-    override val orgCharityNumberEnglandAndWalesStep: OrgCharityNumberEnglandAndWalesStep,
-    override val orgCharityNumberNorthernIrelandStep: OrgCharityNumberNorthernIrelandStep,
-    override val orgCharityNumberScotlandStep: OrgCharityNumberScotlandStep,
-    override val orgDirectorsStep: OrgDirectorsStep,
-    override val orgTrusteesStep: OrgTrusteesStep,
-    override val leadTrusteeNameStep: LeadTrusteeNameStep,
-    override val leadTrusteeEmailStep: LeadTrusteeEmailStep,
-    override val leadTrusteePhoneStep: LeadTrusteePhoneStep,
-    override val leadTrusteeDobStep: LeadTrusteeDobStep,
-    override val trusteeAddressTask: TrusteeAddressTask,
-    override val orgGovBodyDetailsStep: OrgGovBodyDetailsStep,
-    override val orgGovBodyMustProvideInfoStep: OrgGovBodyMustProvideInfoStep,
-    override val orgGovBodyWhoToProvideStep: OrgGovBodyWhoToProvideStep,
-    override val orgGovBodyMemberNameStep: OrgGovBodyMemberNameStep,
-    override val orgGovBodyMemberDobStep: OrgGovBodyMemberDobStep,
-    override val orgGovBodyMemberAddressStep: OrgGovBodyMemberAddressStep,
-    override val orgGovBodyMemberListStep: OrgGovBodyMemberListStep,
-    override val orgMainContactStep: OrgMainContactStep,
-    override val orgLandlordCyaStep: OrgLandlordCyaStep,
-    // Infrastructure
     override val deleteJourneyStep: DeleteJourneyStep,
     journeyStateService: JourneyStateService,
-    override val stateFactory: ObjectFactory<LandlordRegistrationJourneyState>,
 ) : AbstractJourneyState(journeyStateService),
     LandlordRegistrationJourneyState {
-    override var verifiedIdentity: VerifiedIdentityDataModel? by delegateProvider.nullableDelegate("verifiedIdentity")
-    override var originalJourneyUpdated: Instant? by delegateProvider.nullableDelegate("originalJourneyUpdated")
-    override var cyaJourneys: Map<String, String> = mapOf()
-    override var checkingAnswersFor: String? by delegateProvider.nullableDelegate("checkingAnswersFor")
-
-    override var cyaUrlPath: String? by delegateProvider.nullableDelegate("cyaRouteSegment")
+    override val checkingAnswersFor: String? get() = landlordRegistrationTask.checkingAnswersFor
 
     override fun generateJourneyId(seed: Any?): String {
         val user = seed as? Principal
@@ -182,6 +73,8 @@ class LandlordRegistrationJourney(
     }
 }
 
-interface LandlordRegistrationJourneyState : LandlordRegistrationState {
+interface LandlordRegistrationJourneyState : JourneyState {
+    val landlordRegistrationTask: LandlordRegistrationTask
     val deleteJourneyStep: DeleteJourneyStep
+    val checkingAnswersFor: String?
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/landlordRegistration/LandlordRegistrationJourneyFactory.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/landlordRegistration/LandlordRegistrationJourneyFactory.kt
@@ -22,7 +22,7 @@ class LandlordRegistrationJourneyFactory(
     fun createJourneySteps(): Map<String, StepLifecycleOrchestrator> {
         val state = stateFactory.getObject()
 
-        val checkingAnswersFor = state.checkingAnswersFor
+        val checkingAnswersFor = state.landlordRegistrationTask.checkingAnswersFor
         return if (checkingAnswersFor == null) {
             mainJourneyMap(state)
         } else {
@@ -60,8 +60,6 @@ class LandlordRegistrationJourney(
     journeyStateService: JourneyStateService,
 ) : AbstractJourneyState(journeyStateService),
     LandlordRegistrationJourneyState {
-    override val checkingAnswersFor: String? get() = landlordRegistrationTask.checkingAnswersFor
-
     override fun generateJourneyId(seed: Any?): String {
         val user = seed as? Principal
         return super<AbstractJourneyState>.generateJourneyId(user?.let { generateSeedForUser(user) })
@@ -76,5 +74,4 @@ class LandlordRegistrationJourney(
 interface LandlordRegistrationJourneyState : JourneyState {
     val landlordRegistrationTask: LandlordRegistrationTask
     val deleteJourneyStep: DeleteJourneyStep
-    val checkingAnswersFor: String?
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/landlordRegistration/states/IndividualLandlordRegistrationState.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/landlordRegistration/states/IndividualLandlordRegistrationState.kt
@@ -1,0 +1,16 @@
+package uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.states
+
+import uk.gov.communities.prsdb.webapp.journeys.JourneyState
+import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.CountryOfResidenceStep
+import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.EmailStep
+import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.NonEnglandOrWalesAddressStep
+import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.PhoneNumberStep
+import uk.gov.communities.prsdb.webapp.journeys.shared.tasks.AddressTask
+
+interface IndividualLandlordRegistrationState : JourneyState {
+    val emailStep: EmailStep
+    val phoneNumberStep: PhoneNumberStep
+    val countryOfResidenceStep: CountryOfResidenceStep
+    val nonEnglandOrWalesAddressStep: NonEnglandOrWalesAddressStep
+    val addressTask: AddressTask
+}

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/landlordRegistration/states/LandlordRegistrationOrgLandlordState.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/landlordRegistration/states/LandlordRegistrationOrgLandlordState.kt
@@ -29,11 +29,9 @@ import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.
 import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.OrgTrusteesStep
 import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.OrgTypeStep
 import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.YourDetailsStep
-import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.tasks.OrgLandlordRegistrationTask
 import uk.gov.communities.prsdb.webapp.journeys.shared.tasks.AddressTask
 
 interface LandlordRegistrationOrgLandlordState : JourneyState {
-    val orgLandlordRegistrationTask: OrgLandlordRegistrationTask
     val yourDetailsStep: YourDetailsStep
     val orgNameStep: OrgNameStep
     val orgAddressStep: OrgAddressStep

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/landlordRegistration/states/LandlordRegistrationState.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/landlordRegistration/states/LandlordRegistrationState.kt
@@ -1,33 +1,21 @@
 package uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.states
 
-import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.CountryOfResidenceStep
-import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.EmailStep
 import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.LandlordRegistrationCyaStep
 import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.LandlordTypeStep
-import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.NonEnglandOrWalesAddressStep
-import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.PhoneNumberStep
 import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.PrivacyNoticeStep
 import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.tasks.IdentityTask
 import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.tasks.IndividualLandlordRegistrationTask
-import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.tasks.LandlordRegistrationTask
+import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.tasks.OrgLandlordRegistrationTask
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.FinishCyaJourneyStep
 import uk.gov.communities.prsdb.webapp.journeys.shared.states.CheckYourAnswersJourneyState
-import uk.gov.communities.prsdb.webapp.journeys.shared.tasks.AddressTask
 
 interface LandlordRegistrationState :
-    IdentityState,
-    LandlordRegistrationOrgLandlordState,
     CheckYourAnswersJourneyState {
-    val landlordRegistrationTask: LandlordRegistrationTask
     val individualLandlordRegistrationTask: IndividualLandlordRegistrationTask
+    val orgLandlordRegistrationTask: OrgLandlordRegistrationTask
     val landlordTypeStep: LandlordTypeStep
     val privacyNoticeStep: PrivacyNoticeStep
     val identityTask: IdentityTask
-    val emailStep: EmailStep
-    val phoneNumberStep: PhoneNumberStep
-    val countryOfResidenceStep: CountryOfResidenceStep
-    val nonEnglandOrWalesAddressStep: NonEnglandOrWalesAddressStep
-    val addressTask: AddressTask
     override val finishCyaStep: FinishCyaJourneyStep
     override val cyaStep: LandlordRegistrationCyaStep
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/landlordRegistration/stepConfig/LandlordRegistrationCyaStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/landlordRegistration/stepConfig/LandlordRegistrationCyaStepConfig.kt
@@ -33,15 +33,20 @@ class LandlordRegistrationCyaStepConfig(
     override fun afterStepDataIsAdded(state: LandlordRegistrationState) {
         landlordService.createLandlord(
             baseUserId = SecurityContextHolder.getContext().authentication.name,
-            name = state.getName(),
-            email = state.emailStep.formModel.notNullValue(EmailFormModel::emailAddress),
-            phoneNumber = state.phoneNumberStep.formModel.notNullValue(PhoneNumberFormModel::phoneNumber),
-            addressDataModel = state.addressTask.getAddress(),
+            name = state.identityTask.getName(),
+            email =
+                state.individualLandlordRegistrationTask.emailStep.formModel
+                    .notNullValue(EmailFormModel::emailAddress),
+            phoneNumber =
+                state.individualLandlordRegistrationTask.phoneNumberStep.formModel.notNullValue(
+                    PhoneNumberFormModel::phoneNumber,
+                ),
+            addressDataModel = state.individualLandlordRegistrationTask.addressTask.getAddress(),
             countryOfResidence = ENGLAND_OR_WALES,
-            isVerified = state.getIsIdentityVerified(),
+            isVerified = state.identityTask.getIsIdentityVerified(),
             hasAcceptedPrivacyNotice = state.privacyNoticeStep.formModel.notNullValue(PrivacyNoticeFormModel::agreesToPrivacyNotice),
             nonEnglandOrWalesAddress = null,
-            dateOfBirth = state.getDateOfBirth(),
+            dateOfBirth = state.identityTask.getDateOfBirth(),
         )
 
         securityContextService.refreshContext()
@@ -53,9 +58,7 @@ class LandlordRegistrationCyaStepConfig(
     override fun resolveNextDestination(
         state: LandlordRegistrationState,
         defaultDestination: Destination,
-    ): Destination {
-        return defaultDestination
-    }
+    ): Destination = defaultDestination
 
     private fun getSummaryList(state: LandlordRegistrationState) =
         getIdentityRows(state) +
@@ -63,26 +66,26 @@ class LandlordRegistrationCyaStepConfig(
             getAddressRows(state)
 
     private fun getIdentityRows(state: LandlordRegistrationState): List<SummaryListRowViewModel> {
-        val isIdentityVerified = state.getIsIdentityVerified()
+        val isIdentityVerified = state.identityTask.getIsIdentityVerified()
         return listOf(
             SummaryListRowViewModel.forCheckYourAnswersPage(
                 "registerAsALandlord.checkAnswers.rowHeading.name",
-                state.getName(),
+                state.identityTask.getName(),
                 if (isIdentityVerified) {
                     Destination.Nowhere()
                 } else {
-                    Destination.VisitableStep(state.nameStep, state.getCyaJourneyId(state.nameStep))
+                    Destination.VisitableStep(state.identityTask.nameStep, state.getCyaJourneyId(state.identityTask.nameStep))
                 },
             ),
             SummaryListRowViewModel.forCheckYourAnswersPage(
                 "registerAsALandlord.checkAnswers.rowHeading.dateOfBirth",
-                state.getDateOfBirth(),
+                state.identityTask.getDateOfBirth(),
                 if (isIdentityVerified) {
                     Destination.Nowhere()
                 } else {
                     Destination.VisitableStep(
-                        state.dateOfBirthStep,
-                        state.getCyaJourneyId(state.dateOfBirthStep),
+                        state.identityTask.dateOfBirthStep,
+                        state.getCyaJourneyId(state.identityTask.dateOfBirthStep),
                     )
                 },
             ),
@@ -93,18 +96,20 @@ class LandlordRegistrationCyaStepConfig(
         listOf(
             SummaryListRowViewModel.forCheckYourAnswersPage(
                 "registerAsALandlord.checkAnswers.rowHeading.email",
-                state.emailStep.formModel.notNullValue(EmailFormModel::emailAddress),
+                state.individualLandlordRegistrationTask.emailStep.formModel
+                    .notNullValue(EmailFormModel::emailAddress),
                 Destination.VisitableStep(
-                    state.emailStep,
-                    state.getCyaJourneyId(state.emailStep),
+                    state.individualLandlordRegistrationTask.emailStep,
+                    state.getCyaJourneyId(state.individualLandlordRegistrationTask.emailStep),
                 ),
             ),
             SummaryListRowViewModel.forCheckYourAnswersPage(
                 "registerAsALandlord.checkAnswers.rowHeading.telephoneNumber",
-                state.phoneNumberStep.formModel.notNullValue(PhoneNumberFormModel::phoneNumber),
+                state.individualLandlordRegistrationTask.phoneNumberStep.formModel
+                    .notNullValue(PhoneNumberFormModel::phoneNumber),
                 Destination.VisitableStep(
-                    state.phoneNumberStep,
-                    state.getCyaJourneyId(state.phoneNumberStep),
+                    state.individualLandlordRegistrationTask.phoneNumberStep,
+                    state.getCyaJourneyId(state.individualLandlordRegistrationTask.phoneNumberStep),
                 ),
             ),
         )
@@ -113,13 +118,23 @@ class LandlordRegistrationCyaStepConfig(
         listOf(
             SummaryListRowViewModel.forCheckYourAnswersPage(
                 "registerAsALandlord.checkAnswers.rowHeading.englandOrWalesResident",
-                state.countryOfResidenceStep.formModel.notNullValue(CountryOfResidenceFormModel::livesInEnglandOrWales),
-                Destination.VisitableStep(state.countryOfResidenceStep, state.getCyaJourneyId(state.countryOfResidenceStep)),
+                state.individualLandlordRegistrationTask.countryOfResidenceStep.formModel.notNullValue(
+                    CountryOfResidenceFormModel::livesInEnglandOrWales,
+                ),
+                Destination.VisitableStep(
+                    state.individualLandlordRegistrationTask.countryOfResidenceStep,
+                    state.getCyaJourneyId(state.individualLandlordRegistrationTask.countryOfResidenceStep),
+                ),
             ),
             SummaryListRowViewModel.forCheckYourAnswersPage(
                 "registerAsALandlord.checkAnswers.rowHeading.contactAddress",
-                state.addressTask.getAddress().singleLineAddress,
-                Destination.VisitableStep(state.addressTask.lookupAddressStep, state.getCyaJourneyId(state.addressTask.lookupAddressStep)),
+                state.individualLandlordRegistrationTask.addressTask
+                    .getAddress()
+                    .singleLineAddress,
+                Destination.VisitableStep(
+                    state.individualLandlordRegistrationTask.addressTask.lookupAddressStep,
+                    state.getCyaJourneyId(state.individualLandlordRegistrationTask.addressTask.lookupAddressStep),
+                ),
             ),
         )
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/landlordRegistration/tasks/IdentityTask.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/landlordRegistration/tasks/IdentityTask.kt
@@ -2,8 +2,9 @@ package uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.tasks
 
 import uk.gov.communities.prsdb.webapp.annotations.webAnnotations.JourneyFrameworkComponent
 import uk.gov.communities.prsdb.webapp.journeys.Destination
+import uk.gov.communities.prsdb.webapp.journeys.DuplicableTask
+import uk.gov.communities.prsdb.webapp.journeys.JourneyStateService
 import uk.gov.communities.prsdb.webapp.journeys.OrParents
-import uk.gov.communities.prsdb.webapp.journeys.Task
 import uk.gov.communities.prsdb.webapp.journeys.hasOutcome
 import uk.gov.communities.prsdb.webapp.journeys.isComplete
 import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.states.IdentityState
@@ -13,9 +14,22 @@ import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.
 import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.IdentityVerifiedMode
 import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.IdentityVerifyingStep
 import uk.gov.communities.prsdb.webapp.journeys.shared.stepConfig.NameStep
+import uk.gov.communities.prsdb.webapp.models.dataModels.VerifiedIdentityDataModel
 
 @JourneyFrameworkComponent
-class IdentityTask : Task<IdentityState>() {
+class IdentityTask(
+    journeyStateService: JourneyStateService,
+    override val identityVerifyingStep: IdentityVerifyingStep,
+    override val confirmIdentityStep: ConfirmIdentityStep,
+    override val identityNotVerifiedStep: IdentityNotVerifiedStep,
+    override val nameStep: NameStep,
+    override val dateOfBirthStep: DateOfBirthStep,
+) : DuplicableTask<IdentityState>(journeyStateService),
+    IdentityState {
+    override var verifiedIdentity: VerifiedIdentityDataModel? by delegateProvider.nullableDelegate("verifiedIdentity")
+
+    override val taskState get() = this
+
     override fun makeSubJourney(state: IdentityState) =
         subJourney(state) {
             step(journey.identityVerifyingStep) {

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/landlordRegistration/tasks/IndividualLandlordRegistrationTask.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/landlordRegistration/tasks/IndividualLandlordRegistrationTask.kt
@@ -1,20 +1,31 @@
 package uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.tasks
 
 import uk.gov.communities.prsdb.webapp.annotations.webAnnotations.JourneyFrameworkComponent
-import uk.gov.communities.prsdb.webapp.journeys.Task
+import uk.gov.communities.prsdb.webapp.journeys.DuplicableTask
+import uk.gov.communities.prsdb.webapp.journeys.JourneyStateService
 import uk.gov.communities.prsdb.webapp.journeys.hasOutcome
 import uk.gov.communities.prsdb.webapp.journeys.isComplete
-import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.states.LandlordRegistrationState
+import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.states.IndividualLandlordRegistrationState
 import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.CountryOfResidenceMode
 import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.CountryOfResidenceStep
 import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.EmailStep
 import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.NonEnglandOrWalesAddressStep
 import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.PhoneNumberStep
-import uk.gov.communities.prsdb.webapp.journeys.shared.stepConfig.AbstractCheckYourAnswersStep
+import uk.gov.communities.prsdb.webapp.journeys.shared.tasks.LandlordAddressTask
 
 @JourneyFrameworkComponent
-class IndividualLandlordRegistrationTask : Task<LandlordRegistrationState>() {
-    override fun makeSubJourney(state: LandlordRegistrationState) =
+class IndividualLandlordRegistrationTask(
+    journeyStateService: JourneyStateService,
+    override val emailStep: EmailStep,
+    override val phoneNumberStep: PhoneNumberStep,
+    override val countryOfResidenceStep: CountryOfResidenceStep,
+    override val nonEnglandOrWalesAddressStep: NonEnglandOrWalesAddressStep,
+    override val addressTask: LandlordAddressTask,
+) : DuplicableTask<IndividualLandlordRegistrationState>(journeyStateService),
+    IndividualLandlordRegistrationState {
+    override val taskState get() = this
+
+    override fun makeSubJourney(state: IndividualLandlordRegistrationState) =
         subJourney(state) {
             step(journey.emailStep) {
                 routeSegment(EmailStep.ROUTE_SEGMENT)
@@ -42,15 +53,10 @@ class IndividualLandlordRegistrationTask : Task<LandlordRegistrationState>() {
             }
             duplicableTask(journey.addressTask) {
                 parents { journey.countryOfResidenceStep.hasOutcome(CountryOfResidenceMode.ENGLAND_OR_WALES) }
-                nextStep { journey.cyaStep }
-            }
-            step(journey.cyaStep) {
-                routeSegment(AbstractCheckYourAnswersStep.ROUTE_SEGMENT)
-                parents { journey.addressTask.isComplete() }
                 nextStep { exitStep }
             }
             exitStep {
-                parents { journey.cyaStep.isComplete() }
+                parents { journey.addressTask.isComplete() }
             }
         }
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/landlordRegistration/tasks/LandlordRegistrationTask.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/landlordRegistration/tasks/LandlordRegistrationTask.kt
@@ -1,12 +1,15 @@
 package uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.tasks
 
+import kotlinx.datetime.Instant
+import org.springframework.beans.factory.ObjectFactory
 import uk.gov.communities.prsdb.webapp.annotations.webAnnotations.JourneyFrameworkComponent
 import uk.gov.communities.prsdb.webapp.config.managers.FeatureFlagManager
 import uk.gov.communities.prsdb.webapp.constants.ORGANISATION_LANDLORD_REGISTRATION
 import uk.gov.communities.prsdb.webapp.journeys.Destination
+import uk.gov.communities.prsdb.webapp.journeys.DuplicableTask
+import uk.gov.communities.prsdb.webapp.journeys.JourneyStateService
 import uk.gov.communities.prsdb.webapp.journeys.OrParents
 import uk.gov.communities.prsdb.webapp.journeys.StepLifecycleOrchestrator
-import uk.gov.communities.prsdb.webapp.journeys.Task
 import uk.gov.communities.prsdb.webapp.journeys.builders.JourneyBuilder.Companion.journey
 import uk.gov.communities.prsdb.webapp.journeys.builders.SubJourneyBuilder
 import uk.gov.communities.prsdb.webapp.journeys.hasOutcome
@@ -15,19 +18,39 @@ import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.states.Land
 import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.CountryOfResidenceStep
 import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.DateOfBirthStep
 import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.EmailStep
+import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.LandlordRegistrationCyaStep
 import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.LandlordTypeMode
 import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.LandlordTypeStep
 import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.PhoneNumberStep
 import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.PrivacyNoticeStep
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.FinishCyaJourneyStep
 import uk.gov.communities.prsdb.webapp.journeys.shared.states.CheckYourAnswersJourneyState.Companion.checkAnswerStep
 import uk.gov.communities.prsdb.webapp.journeys.shared.states.CheckYourAnswersJourneyState.Companion.duplicableCheckAnswerTask
+import uk.gov.communities.prsdb.webapp.journeys.shared.stepConfig.AbstractCheckYourAnswersStep
 import uk.gov.communities.prsdb.webapp.journeys.shared.stepConfig.LookupAddressStep
 import uk.gov.communities.prsdb.webapp.journeys.shared.stepConfig.NameStep
 
 @JourneyFrameworkComponent
 class LandlordRegistrationTask(
     private val featureFlagManager: FeatureFlagManager,
-) : Task<LandlordRegistrationState>() {
+    override val identityTask: IdentityTask,
+    override val individualLandlordRegistrationTask: IndividualLandlordRegistrationTask,
+    override val orgLandlordRegistrationTask: OrgLandlordRegistrationTask,
+    override val landlordTypeStep: LandlordTypeStep,
+    override val privacyNoticeStep: PrivacyNoticeStep,
+    override val cyaStep: LandlordRegistrationCyaStep,
+    override val finishCyaStep: FinishCyaJourneyStep,
+    journeyStateService: JourneyStateService,
+    override val stateFactory: ObjectFactory<LandlordRegistrationTask>,
+) : DuplicableTask<LandlordRegistrationState>(journeyStateService),
+    LandlordRegistrationState {
+    override var originalJourneyUpdated: Instant? by delegateProvider.nullableDelegate("originalJourneyUpdated")
+    override var cyaJourneys: Map<String, String> = mapOf()
+    override var checkingAnswersFor: String? by delegateProvider.nullableDelegate("checkingAnswersFor")
+    override var cyaUrlPath: String? by delegateProvider.nullableDelegate("cyaRouteSegment")
+
+    override val taskState get() = this
+
     override fun makeSubJourney(state: LandlordRegistrationState) =
         if (featureFlagManager.checkFeature(ORGANISATION_LANDLORD_REGISTRATION)) {
             makeOrgLandlordSubJourney(state)
@@ -41,16 +64,21 @@ class LandlordRegistrationTask(
                 routeSegment(PrivacyNoticeStep.ROUTE_SEGMENT)
                 nextStep { journey.identityTask.firstStep }
             }
-            task(journey.identityTask) {
+            duplicableTask(journey.identityTask) {
                 parents { journey.privacyNoticeStep.isComplete() }
                 nextStep { journey.individualLandlordRegistrationTask.firstStep }
             }
-            task(journey.individualLandlordRegistrationTask) {
+            duplicableTask(journey.individualLandlordRegistrationTask) {
                 parents { journey.identityTask.isComplete() }
+                nextStep { journey.cyaStep }
+            }
+            step(journey.cyaStep) {
+                routeSegment(AbstractCheckYourAnswersStep.ROUTE_SEGMENT)
+                parents { journey.individualLandlordRegistrationTask.isComplete() }
                 nextStep { exitStep }
             }
             exitStep {
-                parents { journey.individualLandlordRegistrationTask.isComplete() }
+                parents { journey.cyaStep.isComplete() }
             }
         }
 
@@ -60,7 +88,7 @@ class LandlordRegistrationTask(
                 routeSegment(PrivacyNoticeStep.ROUTE_SEGMENT)
                 nextStep { journey.identityTask.firstStep }
             }
-            task(journey.identityTask) {
+            duplicableTask(journey.identityTask) {
                 parents { journey.privacyNoticeStep.isComplete() }
                 nextStep { journey.landlordTypeStep }
             }
@@ -74,18 +102,23 @@ class LandlordRegistrationTask(
                     }
                 }
             }
-            task(journey.orgLandlordRegistrationTask) {
+            duplicableTask(journey.orgLandlordRegistrationTask) {
                 parents { journey.landlordTypeStep.hasOutcome(LandlordTypeMode.ORGANISATION) }
                 nextStep { exitStep }
             }
-            task(journey.individualLandlordRegistrationTask) {
+            duplicableTask(journey.individualLandlordRegistrationTask) {
                 parents { journey.landlordTypeStep.hasOutcome(LandlordTypeMode.INDIVIDUAL) }
+                nextStep { journey.cyaStep }
+            }
+            step(journey.cyaStep) {
+                routeSegment(AbstractCheckYourAnswersStep.ROUTE_SEGMENT)
+                parents { journey.individualLandlordRegistrationTask.isComplete() }
                 nextStep { exitStep }
             }
             exitStep {
                 parents {
                     OrParents(
-                        journey.individualLandlordRegistrationTask.isComplete(),
+                        journey.cyaStep.isComplete(),
                         journey.orgLandlordRegistrationTask.isComplete(),
                     )
                 }
@@ -105,30 +138,30 @@ class LandlordRegistrationTask(
                 configureFirst { backDestination { journey.returnToCyaPageDestination } }
                 when (checkingAnswersFor) {
                     NameStep.ROUTE_SEGMENT -> {
-                        checkAnswerStep(journey.nameStep, NameStep.ROUTE_SEGMENT)
+                        checkAnswerStep(journey.identityTask.nameStep, NameStep.ROUTE_SEGMENT)
                     }
 
                     DateOfBirthStep.ROUTE_SEGMENT -> {
-                        checkAnswerStep(journey.dateOfBirthStep, DateOfBirthStep.ROUTE_SEGMENT)
+                        checkAnswerStep(journey.identityTask.dateOfBirthStep, DateOfBirthStep.ROUTE_SEGMENT)
                     }
 
                     EmailStep.ROUTE_SEGMENT -> {
-                        checkAnswerStep(journey.emailStep, EmailStep.ROUTE_SEGMENT)
+                        checkAnswerStep(journey.individualLandlordRegistrationTask.emailStep, EmailStep.ROUTE_SEGMENT)
                     }
 
                     PhoneNumberStep.ROUTE_SEGMENT -> {
-                        checkAnswerStep(journey.phoneNumberStep, PhoneNumberStep.ROUTE_SEGMENT)
+                        checkAnswerStep(journey.individualLandlordRegistrationTask.phoneNumberStep, PhoneNumberStep.ROUTE_SEGMENT)
                     }
 
                     CountryOfResidenceStep.ROUTE_SEGMENT -> {
                         checkAnswerStep(
-                            journey.countryOfResidenceStep,
+                            journey.individualLandlordRegistrationTask.countryOfResidenceStep,
                             CountryOfResidenceStep.ROUTE_SEGMENT,
                         )
                     }
 
                     LookupAddressStep.ROUTE_SEGMENT -> {
-                        duplicableCheckAnswerTask(journey.addressTask, null)
+                        duplicableCheckAnswerTask(journey.individualLandlordRegistrationTask.addressTask, null)
                     }
                 }
                 step(journey.finishCyaStep) {

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/landlordRegistration/tasks/OrgLandlordRegistrationTask.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/landlordRegistration/tasks/OrgLandlordRegistrationTask.kt
@@ -3,8 +3,9 @@ package uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.tasks
 import uk.gov.communities.prsdb.webapp.annotations.webAnnotations.JourneyFrameworkComponent
 import uk.gov.communities.prsdb.webapp.constants.enums.CharityRegulator
 import uk.gov.communities.prsdb.webapp.journeys.Destination
+import uk.gov.communities.prsdb.webapp.journeys.DuplicableTask
+import uk.gov.communities.prsdb.webapp.journeys.JourneyStateService
 import uk.gov.communities.prsdb.webapp.journeys.OrParents
-import uk.gov.communities.prsdb.webapp.journeys.Task
 import uk.gov.communities.prsdb.webapp.journeys.hasOutcome
 import uk.gov.communities.prsdb.webapp.journeys.isComplete
 import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.states.LandlordRegistrationOrgLandlordState
@@ -41,7 +42,41 @@ import uk.gov.communities.prsdb.webapp.journeys.shared.tasks.TrusteeAddressTask
 import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.OrgGovBodyDetailsMode
 
 @JourneyFrameworkComponent
-class OrgLandlordRegistrationTask : Task<LandlordRegistrationOrgLandlordState>() {
+class OrgLandlordRegistrationTask(
+    journeyStateService: JourneyStateService,
+    override val yourDetailsStep: YourDetailsStep,
+    override val orgNameStep: OrgNameStep,
+    override val orgAddressStep: OrgAddressStep,
+    override val orgEmailStep: OrgEmailStep,
+    override val orgPhoneNumberStep: OrgPhoneNumberStep,
+    override val orgTypeStep: OrgTypeStep,
+    override val orgCompaniesHouseStep: OrgCompaniesHouseStep,
+    override val orgCompanyNumberStep: OrgCompanyNumberStep,
+    override val orgCharityStep: OrgCharityStep,
+    override val orgCharityRegisteredWithStep: OrgCharityRegisteredWithStep,
+    override val orgCharityNumberEnglandAndWalesStep: OrgCharityNumberEnglandAndWalesStep,
+    override val orgCharityNumberNorthernIrelandStep: OrgCharityNumberNorthernIrelandStep,
+    override val orgCharityNumberScotlandStep: OrgCharityNumberScotlandStep,
+    override val orgDirectorsStep: OrgDirectorsStep,
+    override val orgTrusteesStep: OrgTrusteesStep,
+    override val leadTrusteeNameStep: LeadTrusteeNameStep,
+    override val leadTrusteeEmailStep: LeadTrusteeEmailStep,
+    override val leadTrusteePhoneStep: LeadTrusteePhoneStep,
+    override val leadTrusteeDobStep: LeadTrusteeDobStep,
+    override val trusteeAddressTask: TrusteeAddressTask,
+    override val orgGovBodyDetailsStep: OrgGovBodyDetailsStep,
+    override val orgGovBodyMustProvideInfoStep: OrgGovBodyMustProvideInfoStep,
+    override val orgGovBodyWhoToProvideStep: OrgGovBodyWhoToProvideStep,
+    override val orgGovBodyMemberNameStep: OrgGovBodyMemberNameStep,
+    override val orgGovBodyMemberDobStep: OrgGovBodyMemberDobStep,
+    override val orgGovBodyMemberAddressStep: OrgGovBodyMemberAddressStep,
+    override val orgGovBodyMemberListStep: OrgGovBodyMemberListStep,
+    override val orgMainContactStep: OrgMainContactStep,
+    override val orgLandlordCyaStep: OrgLandlordCyaStep,
+) : DuplicableTask<LandlordRegistrationOrgLandlordState>(journeyStateService),
+    LandlordRegistrationOrgLandlordState {
+    override val taskState get() = this
+
     override fun makeSubJourney(state: LandlordRegistrationOrgLandlordState) =
         subJourney(state) {
             step(journey.yourDetailsStep) {


### PR DESCRIPTION
## Ticket number
PDJB-896

## Goal of change
Migrate the landlord-registration journey tasks from the inheritance-based state model to the new composition-based `DuplicableTask` model.

## Description of main change(s)
- Each landlord-registration task (`IdentityTask`, `IndividualLandlordRegistrationTask`, `OrgLandlordRegistrationTask`, and the root `LandlordRegistrationTask`) is now "self-stated": it extends `DuplicableTask` and implements its own narrow state interface, owning its steps/sub-tasks by composition rather than inheriting an aggregate state interface.
- Tasks that need another task''s data now compose that task and read `state.someTask.member` instead of sharing a union state interface.
- The cross-cutting CYA machinery is hoisted onto the root task; the two journey state classes (`LandlordRegistrationJourney`, `AcceptOrRejectJointLandlordInvitationJourney`) are trimmed to compose the root task and forward `checkingAnswersFor`.
- Behaviour-preserving: tasks are bound with a null route prefix so all delegate storage keys and URLs are unchanged.

## Anything you''d like to highlight to the reviewer?
This is the first of several PRs migrating all journeys to composition. Highest-risk area is the CYA flow, especially its reuse from the Accept/Reject joint-landlord-invitation journey - covered by the passing integration suites.

## Checklist
- [x] Test suite has been run in full locally and is passing (landlord-registration + accept/reject suites: 151/151)