### PR TITLE
PDJB-NONE: Enable disabled feature flags in test

### DIFF
--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -7,11 +7,11 @@ features:
       enabled: true
       expiry-date: "2027-03-30"
     - name: "pdjb-1097-organisation-landlord-registration"
-      enabled: false
+      enabled: true
       expiry-date: "2026-12-31"
     - name: "pdjb-939-property-registration-restructure-and-skipping"
-      enabled: false
+      enabled: true
       expiry-date: "2026-12-31"
     - name: "pdjb-1053-dashboard-nav-link"
-      enabled: false
+      enabled: true
       expiry-date: "2026-12-31"


### PR DESCRIPTION
## Ticket number

PDJB-NONE

## Goal of change

Enable the currently disabled feature flags in test without releasing unreleased code from `main`.

## Description of main change(s)

- Enables `pdjb-1097-organisation-landlord-registration`, `pdjb-939-property-registration-restructure-and-skipping`, and `pdjb-1053-dashboard-nav-link` in `application-test.yml`.
- Provides the standalone config commit for feature release to test #2; the change does not reach test until that release PR is merged.

## Anything you'd like to highlight to the reviewer?

This config-only PR must be merged to `main` before the corresponding feature-release PR is merged into `test`.

## Checklist

Config-only feature-flag change; no code, UI, tests, database schema, seed data, or email changes are applicable.