### PR TITLE
PDJB-1290: Add another functionality for governing body

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/landlordRegistration/states/LandlordRegistrationOrgLandlordState.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/landlordRegistration/states/LandlordRegistrationOrgLandlordState.kt
@@ -26,7 +26,9 @@ import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.
 import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.OrgNameStep
 import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.OrgPhoneNumberStep
 import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.OrgTypeStep
+import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.RemoveGovBodyMemberStep
 import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.SaveGovBodyMemberStep
+import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.SetStateForGovBodyMemberEditStep
 import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.YourDetailsStep
 import uk.gov.communities.prsdb.webapp.journeys.shared.tasks.AddressTask
 import uk.gov.communities.prsdb.webapp.models.dataModels.GoverningBodyMemberDataModel
@@ -61,6 +63,9 @@ interface LandlordRegistrationOrgLandlordState : JourneyState {
     val orgGovBodyMemberListStep: OrgGovBodyMemberListStep
     val hasAnyGovBodyMembersStep: HasAnyGovBodyMembersStep
     val saveGovBodyMemberStep: SaveGovBodyMemberStep
+    val setStateForGovBodyMemberEditStep: SetStateForGovBodyMemberEditStep
+    val removeGovBodyMemberStep: RemoveGovBodyMemberStep
     var governingBodyMembersMap: Map<Int, GoverningBodyMemberDataModel>?
     var nextGoverningBodyMemberId: Int?
+    var editingGovBodyMemberId: Int?
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/landlordRegistration/stepConfig/OrgGovBodyMemberDobStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/landlordRegistration/stepConfig/OrgGovBodyMemberDobStepConfig.kt
@@ -1,32 +1,52 @@
 package uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig
 
 import uk.gov.communities.prsdb.webapp.annotations.webAnnotations.JourneyFrameworkComponent
+import uk.gov.communities.prsdb.webapp.constants.FORM_MODEL_ATTR_NAME
 import uk.gov.communities.prsdb.webapp.journeys.AbstractRequestableStepConfig
-import uk.gov.communities.prsdb.webapp.journeys.JourneyState
 import uk.gov.communities.prsdb.webapp.journeys.JourneyStep.RequestableStep
+import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.states.LandlordRegistrationOrgLandlordState
 import uk.gov.communities.prsdb.webapp.journeys.shared.Complete
 import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.OrgGovBodyMemberDobFormModel
 
 @JourneyFrameworkComponent
-class OrgGovBodyMemberDobStepConfig : AbstractRequestableStepConfig<Complete, OrgGovBodyMemberDobFormModel, JourneyState>() {
+class OrgGovBodyMemberDobStepConfig :
+    AbstractRequestableStepConfig<Complete, OrgGovBodyMemberDobFormModel, LandlordRegistrationOrgLandlordState>() {
     override val formModelClass = OrgGovBodyMemberDobFormModel::class
 
-    override fun getStepSpecificContent(state: JourneyState) =
+    override fun getStepSpecificContent(state: LandlordRegistrationOrgLandlordState) =
         mapOf(
             "fieldSetHeading" to "registerAsALandlord.orgGovBodyMemberDob.fieldSetHeading",
             "fieldSetHint" to "registerAsALandlord.orgGovBodyMemberDob.fieldSetHint",
             "submitButtonText" to "forms.buttons.continue",
         )
 
-    override fun chooseTemplate(state: JourneyState) = "forms/dateForm"
+    override fun resolvePageContent(
+        state: LandlordRegistrationOrgLandlordState,
+        defaultContent: Map<String, Any?>,
+    ): Map<String, Any?> {
+        val formModel = defaultContent[FORM_MODEL_ATTR_NAME] as? OrgGovBodyMemberDobFormModel
+        if (!formModel?.day.isNullOrBlank()) return defaultContent
 
-    override fun mode(state: JourneyState) = getFormModelFromStateOrNull(state)?.let { Complete.COMPLETE }
+        val editingMember = getEditingMemberOrNull(state) ?: return defaultContent
+        val prepopulatedFormModel = formModel ?: OrgGovBodyMemberDobFormModel()
+        prepopulatedFormModel.day = editingMember.dateOfBirth.dayOfMonth.toString()
+        prepopulatedFormModel.month = editingMember.dateOfBirth.monthNumber.toString()
+        prepopulatedFormModel.year = editingMember.dateOfBirth.year.toString()
+        return defaultContent + (FORM_MODEL_ATTR_NAME to prepopulatedFormModel)
+    }
+
+    override fun chooseTemplate(state: LandlordRegistrationOrgLandlordState) = "forms/dateForm"
+
+    override fun mode(state: LandlordRegistrationOrgLandlordState) = getFormModelFromStateOrNull(state)?.let { Complete.COMPLETE }
+
+    private fun getEditingMemberOrNull(state: LandlordRegistrationOrgLandlordState) =
+        state.editingGovBodyMemberId?.let { state.governingBodyMembersMap?.get(it) }
 }
 
 @JourneyFrameworkComponent
 final class OrgGovBodyMemberDobStep(
     stepConfig: OrgGovBodyMemberDobStepConfig,
-) : RequestableStep<Complete, OrgGovBodyMemberDobFormModel, JourneyState>(stepConfig) {
+) : RequestableStep<Complete, OrgGovBodyMemberDobFormModel, LandlordRegistrationOrgLandlordState>(stepConfig) {
     companion object {
         const val ROUTE_SEGMENT = "organisation-governing-body-member-dob"
     }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/landlordRegistration/stepConfig/OrgGovBodyMemberListStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/landlordRegistration/stepConfig/OrgGovBodyMemberListStepConfig.kt
@@ -29,6 +29,12 @@ class OrgGovBodyMemberListStepConfig(
             "addAnotherUrl" to Destination(state.orgGovBodyWhoToProvideStep).toUrlStringOrNull(),
         )
 
+    override fun afterStepIsReached(state: LandlordRegistrationOrgLandlordState) {
+        // ensure that if you ever get to this page we reset any state that is used by one of the buttons.
+        // this means we can be certain all the buttons will always work even if you use the browser back buttons.
+        state.editingGovBodyMemberId = null
+    }
+
     private fun getMemberRows(state: LandlordRegistrationOrgLandlordState): List<SummaryListRowViewModel> {
         val membersMap = state.governingBodyMembersMap ?: emptyMap()
         return membersMap

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/landlordRegistration/stepConfig/OrgGovBodyMemberListStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/landlordRegistration/stepConfig/OrgGovBodyMemberListStepConfig.kt
@@ -1,17 +1,21 @@
 package uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig
 
 import uk.gov.communities.prsdb.webapp.annotations.webAnnotations.JourneyFrameworkComponent
+import uk.gov.communities.prsdb.webapp.exceptions.PrsdbWebException
 import uk.gov.communities.prsdb.webapp.journeys.AbstractRequestableStepConfig
+import uk.gov.communities.prsdb.webapp.journeys.Destination
 import uk.gov.communities.prsdb.webapp.journeys.JourneyStep.RequestableStep
 import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.states.LandlordRegistrationOrgLandlordState
 import uk.gov.communities.prsdb.webapp.journeys.shared.Complete
 import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.NoInputFormModel
 import uk.gov.communities.prsdb.webapp.models.viewModels.summaryModels.SummaryListRowActionsViewModel
 import uk.gov.communities.prsdb.webapp.models.viewModels.summaryModels.SummaryListRowViewModel
+import uk.gov.communities.prsdb.webapp.services.CollectionKeyParameterService
 
 @JourneyFrameworkComponent
-class OrgGovBodyMemberListStepConfig :
-    AbstractRequestableStepConfig<Complete, NoInputFormModel, LandlordRegistrationOrgLandlordState>() {
+class OrgGovBodyMemberListStepConfig(
+    private val urlParameterService: CollectionKeyParameterService,
+) : AbstractRequestableStepConfig<Complete, NoInputFormModel, LandlordRegistrationOrgLandlordState>() {
     override val formModelClass = NoInputFormModel::class
 
     override fun getStepSpecificContent(state: LandlordRegistrationOrgLandlordState) =
@@ -23,8 +27,7 @@ class OrgGovBodyMemberListStepConfig :
             "submitButtonText" to "forms.buttons.saveAndContinue",
             "addAnotherButtonText" to "forms.orgGovBodyMemberList.buttons.addAnother",
             "summaryListData" to getMemberRows(state),
-            // TODO: PDJB-1290 - Replace with real "add another" URL once implemented
-            "addAnotherUrl" to "#",
+            "addAnotherUrl" to Destination(state.orgGovBodyWhoToProvideStep).toUrlStringOrNull(),
         )
 
     private fun getMemberRows(state: LandlordRegistrationOrgLandlordState): List<SummaryListRowViewModel> {
@@ -32,17 +35,33 @@ class OrgGovBodyMemberListStepConfig :
         return membersMap
             .toList()
             .sortedBy { it.first }
-            .mapIndexed { displayIndex, (_, member) ->
+            .mapIndexed { displayIndex, (internalIndex, member) ->
                 SummaryListRowViewModel(
                     fieldHeading = "forms.orgGovBodyMemberList.memberName",
                     fieldValue = member.name,
                     optionalFieldHeadingParam = displayIndex + 1,
                     actions =
                         listOf(
-                            // TODO: PDJB-1290 - Replace with real change URL
-                            SummaryListRowActionsViewModel(text = "forms.links.change", url = "#"),
-                            // TODO: PDJB-1290 - Replace with real remove URL
-                            SummaryListRowActionsViewModel(text = "forms.links.remove", url = "#"),
+                            SummaryListRowActionsViewModel(
+                                text = "forms.links.change",
+                                url =
+                                    Destination(state.setStateForGovBodyMemberEditStep)
+                                        .withUrlParameter(urlParameterService.createParameterPair(internalIndex))
+                                        .toUrlStringOrNull()
+                                        ?: throw PrsdbWebException(
+                                            "Unable to generate change URL for governing body member $internalIndex",
+                                        ),
+                            ),
+                            SummaryListRowActionsViewModel(
+                                text = "forms.links.remove",
+                                url =
+                                    Destination(state.removeGovBodyMemberStep)
+                                        .withUrlParameter(urlParameterService.createParameterPair(internalIndex))
+                                        .toUrlStringOrNull()
+                                        ?: throw PrsdbWebException(
+                                            "Unable to generate remove URL for governing body member $internalIndex",
+                                        ),
+                            ),
                         ),
                 )
             }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/landlordRegistration/stepConfig/OrgGovBodyMemberListStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/landlordRegistration/stepConfig/OrgGovBodyMemberListStepConfig.kt
@@ -1,14 +1,13 @@
 package uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig
 
 import uk.gov.communities.prsdb.webapp.annotations.webAnnotations.JourneyFrameworkComponent
-import uk.gov.communities.prsdb.webapp.exceptions.PrsdbWebException
 import uk.gov.communities.prsdb.webapp.journeys.AbstractRequestableStepConfig
 import uk.gov.communities.prsdb.webapp.journeys.Destination
 import uk.gov.communities.prsdb.webapp.journeys.JourneyStep.RequestableStep
 import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.states.LandlordRegistrationOrgLandlordState
 import uk.gov.communities.prsdb.webapp.journeys.shared.Complete
 import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.NoInputFormModel
-import uk.gov.communities.prsdb.webapp.models.viewModels.summaryModels.SummaryListRowActionsViewModel
+import uk.gov.communities.prsdb.webapp.models.viewModels.summaryModels.SummaryListRowActionsInputWithDestination
 import uk.gov.communities.prsdb.webapp.models.viewModels.summaryModels.SummaryListRowViewModel
 import uk.gov.communities.prsdb.webapp.services.CollectionKeyParameterService
 
@@ -36,33 +35,25 @@ class OrgGovBodyMemberListStepConfig(
             .toList()
             .sortedBy { it.first }
             .mapIndexed { displayIndex, (internalIndex, member) ->
-                SummaryListRowViewModel(
+                SummaryListRowViewModel.forCheckYourAnswersPage(
                     fieldHeading = "forms.orgGovBodyMemberList.memberName",
                     fieldValue = member.name,
-                    optionalFieldHeadingParam = displayIndex + 1,
                     actions =
                         listOf(
-                            SummaryListRowActionsViewModel(
+                            SummaryListRowActionsInputWithDestination(
                                 text = "forms.links.change",
-                                url =
+                                destination =
                                     Destination(state.setStateForGovBodyMemberEditStep)
-                                        .withUrlParameter(urlParameterService.createParameterPair(internalIndex))
-                                        .toUrlStringOrNull()
-                                        ?: throw PrsdbWebException(
-                                            "Unable to generate change URL for governing body member $internalIndex",
-                                        ),
+                                        .withUrlParameter(urlParameterService.createParameterPair(internalIndex)),
                             ),
-                            SummaryListRowActionsViewModel(
+                            SummaryListRowActionsInputWithDestination(
                                 text = "forms.links.remove",
-                                url =
+                                destination =
                                     Destination(state.removeGovBodyMemberStep)
-                                        .withUrlParameter(urlParameterService.createParameterPair(internalIndex))
-                                        .toUrlStringOrNull()
-                                        ?: throw PrsdbWebException(
-                                            "Unable to generate remove URL for governing body member $internalIndex",
-                                        ),
+                                        .withUrlParameter(urlParameterService.createParameterPair(internalIndex)),
                             ),
                         ),
+                    optionalFieldHeadingParam = displayIndex + 1,
                 )
             }
     }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/landlordRegistration/stepConfig/OrgGovBodyMemberNameStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/landlordRegistration/stepConfig/OrgGovBodyMemberNameStepConfig.kt
@@ -1,31 +1,49 @@
 package uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig
 
 import uk.gov.communities.prsdb.webapp.annotations.webAnnotations.JourneyFrameworkComponent
+import uk.gov.communities.prsdb.webapp.constants.FORM_MODEL_ATTR_NAME
 import uk.gov.communities.prsdb.webapp.journeys.AbstractRequestableStepConfig
-import uk.gov.communities.prsdb.webapp.journeys.JourneyState
 import uk.gov.communities.prsdb.webapp.journeys.JourneyStep.RequestableStep
+import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.states.LandlordRegistrationOrgLandlordState
 import uk.gov.communities.prsdb.webapp.journeys.shared.Complete
 import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.GoverningBodyMemberNameFormModel
 
 @JourneyFrameworkComponent
-class OrgGovBodyMemberNameStepConfig : AbstractRequestableStepConfig<Complete, GoverningBodyMemberNameFormModel, JourneyState>() {
+class OrgGovBodyMemberNameStepConfig :
+    AbstractRequestableStepConfig<Complete, GoverningBodyMemberNameFormModel, LandlordRegistrationOrgLandlordState>() {
     override val formModelClass = GoverningBodyMemberNameFormModel::class
 
-    override fun getStepSpecificContent(state: JourneyState) =
+    override fun getStepSpecificContent(state: LandlordRegistrationOrgLandlordState) =
         mapOf(
             "fieldSetHeading" to "forms.orgGovBodyMemberName.fieldSetHeading",
             "submitButtonText" to "forms.buttons.continue",
         )
 
-    override fun chooseTemplate(state: JourneyState) = "forms/nameForm"
+    override fun resolvePageContent(
+        state: LandlordRegistrationOrgLandlordState,
+        defaultContent: Map<String, Any?>,
+    ): Map<String, Any?> {
+        val formModel = defaultContent[FORM_MODEL_ATTR_NAME] as? GoverningBodyMemberNameFormModel
+        if (!formModel?.name.isNullOrBlank()) return defaultContent
 
-    override fun mode(state: JourneyState) = getFormModelFromStateOrNull(state)?.let { Complete.COMPLETE }
+        val editingMember = getEditingMemberOrNull(state) ?: return defaultContent
+        val prepopulatedFormModel = formModel ?: GoverningBodyMemberNameFormModel()
+        prepopulatedFormModel.name = editingMember.name
+        return defaultContent + (FORM_MODEL_ATTR_NAME to prepopulatedFormModel)
+    }
+
+    override fun chooseTemplate(state: LandlordRegistrationOrgLandlordState) = "forms/nameForm"
+
+    override fun mode(state: LandlordRegistrationOrgLandlordState) = getFormModelFromStateOrNull(state)?.let { Complete.COMPLETE }
+
+    private fun getEditingMemberOrNull(state: LandlordRegistrationOrgLandlordState) =
+        state.editingGovBodyMemberId?.let { state.governingBodyMembersMap?.get(it) }
 }
 
 @JourneyFrameworkComponent
 final class OrgGovBodyMemberNameStep(
     stepConfig: OrgGovBodyMemberNameStepConfig,
-) : RequestableStep<Complete, GoverningBodyMemberNameFormModel, JourneyState>(stepConfig) {
+) : RequestableStep<Complete, GoverningBodyMemberNameFormModel, LandlordRegistrationOrgLandlordState>(stepConfig) {
     companion object {
         const val ROUTE_SEGMENT = "organisation-governing-body-member-name"
     }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/landlordRegistration/stepConfig/OrgGovBodyWhoToProvideStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/landlordRegistration/stepConfig/OrgGovBodyWhoToProvideStepConfig.kt
@@ -1,19 +1,21 @@
 package uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig
 
 import uk.gov.communities.prsdb.webapp.annotations.webAnnotations.JourneyFrameworkComponent
+import uk.gov.communities.prsdb.webapp.constants.FORM_MODEL_ATTR_NAME
 import uk.gov.communities.prsdb.webapp.constants.enums.GoverningBodyMemberType
 import uk.gov.communities.prsdb.webapp.journeys.AbstractRequestableStepConfig
-import uk.gov.communities.prsdb.webapp.journeys.JourneyState
 import uk.gov.communities.prsdb.webapp.journeys.JourneyStep.RequestableStep
+import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.states.LandlordRegistrationOrgLandlordState
 import uk.gov.communities.prsdb.webapp.journeys.shared.Complete
 import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.OrgGovBodyWhoToProvideFormModel
 import uk.gov.communities.prsdb.webapp.models.viewModels.formModels.RadiosButtonViewModel
 
 @JourneyFrameworkComponent
-class OrgGovBodyWhoToProvideStepConfig : AbstractRequestableStepConfig<Complete, OrgGovBodyWhoToProvideFormModel, JourneyState>() {
+class OrgGovBodyWhoToProvideStepConfig :
+    AbstractRequestableStepConfig<Complete, OrgGovBodyWhoToProvideFormModel, LandlordRegistrationOrgLandlordState>() {
     override val formModelClass = OrgGovBodyWhoToProvideFormModel::class
 
-    override fun getStepSpecificContent(state: JourneyState) =
+    override fun getStepSpecificContent(state: LandlordRegistrationOrgLandlordState) =
         mapOf(
             "fieldSetHeading" to "registerAsALandlord.orgGovBodyWhoToProvide.fieldSetHeading",
             "fieldName" to "whoToProvide",
@@ -38,15 +40,34 @@ class OrgGovBodyWhoToProvideStepConfig : AbstractRequestableStepConfig<Complete,
                 ),
         )
 
-    override fun chooseTemplate(state: JourneyState) = "forms/orgGovBodyWhoToProvideForm"
+    override fun resolvePageContent(
+        state: LandlordRegistrationOrgLandlordState,
+        defaultContent: Map<String, Any?>,
+    ): Map<String, Any?> {
+        val formModel = defaultContent[FORM_MODEL_ATTR_NAME] as? OrgGovBodyWhoToProvideFormModel
+        if (formModel?.whoToProvide != null) return defaultContent
 
-    override fun mode(state: JourneyState) = getFormModelFromStateOrNull(state)?.whoToProvide?.let { Complete.COMPLETE }
+        val editingMember = getEditingMemberOrNull(state) ?: return defaultContent
+        val prepopulatedFormModel = formModel ?: OrgGovBodyWhoToProvideFormModel()
+        prepopulatedFormModel.whoToProvide = editingMember.type
+        return defaultContent + (FORM_MODEL_ATTR_NAME to prepopulatedFormModel)
+    }
+
+    override fun chooseTemplate(state: LandlordRegistrationOrgLandlordState) = "forms/orgGovBodyWhoToProvideForm"
+
+    override fun mode(state: LandlordRegistrationOrgLandlordState) =
+        getFormModelFromStateOrNull(
+            state,
+        )?.whoToProvide?.let { Complete.COMPLETE }
+
+    private fun getEditingMemberOrNull(state: LandlordRegistrationOrgLandlordState) =
+        state.editingGovBodyMemberId?.let { state.governingBodyMembersMap?.get(it) }
 }
 
 @JourneyFrameworkComponent
 final class OrgGovBodyWhoToProvideStep(
     stepConfig: OrgGovBodyWhoToProvideStepConfig,
-) : RequestableStep<Complete, OrgGovBodyWhoToProvideFormModel, JourneyState>(stepConfig) {
+) : RequestableStep<Complete, OrgGovBodyWhoToProvideFormModel, LandlordRegistrationOrgLandlordState>(stepConfig) {
     companion object {
         const val ROUTE_SEGMENT = "organisation-governing-body-who-to-provide"
     }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/landlordRegistration/stepConfig/RemoveGovBodyMemberStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/landlordRegistration/stepConfig/RemoveGovBodyMemberStepConfig.kt
@@ -1,0 +1,48 @@
+package uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig
+
+import uk.gov.communities.prsdb.webapp.annotations.webAnnotations.JourneyFrameworkComponent
+import uk.gov.communities.prsdb.webapp.journeys.AbstractRequestableStepConfig
+import uk.gov.communities.prsdb.webapp.journeys.JourneyStep
+import uk.gov.communities.prsdb.webapp.journeys.StepLifecycleOrchestrator.RedirectingStepLifecycleOrchestrator
+import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.states.LandlordRegistrationOrgLandlordState
+import uk.gov.communities.prsdb.webapp.journeys.shared.AnyMembers
+import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.NoInputFormModel
+import uk.gov.communities.prsdb.webapp.services.CollectionKeyParameterService
+
+@JourneyFrameworkComponent
+class RemoveGovBodyMemberStepConfig(
+    private val collectionKeyParameterService: CollectionKeyParameterService,
+) : AbstractRequestableStepConfig<AnyMembers, NoInputFormModel, LandlordRegistrationOrgLandlordState>() {
+    override val formModelClass = NoInputFormModel::class
+
+    override fun getStepLifecycleOrchestrator(journeyStep: JourneyStep<*, *, *>) = RedirectingStepLifecycleOrchestrator(journeyStep)
+
+    override fun getStepSpecificContent(state: LandlordRegistrationOrgLandlordState): Map<String, Any?> = emptyMap()
+
+    override fun chooseTemplate(state: LandlordRegistrationOrgLandlordState): String = ""
+
+    override fun beforeAttemptingToReachStep(state: LandlordRegistrationOrgLandlordState): Boolean {
+        val keyToRemove = collectionKeyParameterService.getParameterOrNull()
+        val currentMap = state.governingBodyMembersMap ?: emptyMap()
+        return keyToRemove != null && keyToRemove in currentMap.keys
+    }
+
+    override fun afterStepIsReached(state: LandlordRegistrationOrgLandlordState) {
+        val keyToRemove = collectionKeyParameterService.getParameterOrNull() ?: return
+        val currentMap = state.governingBodyMembersMap?.toMutableMap() ?: return
+        currentMap.remove(keyToRemove)
+        state.governingBodyMembersMap = currentMap
+    }
+
+    override fun mode(state: LandlordRegistrationOrgLandlordState): AnyMembers =
+        if (state.governingBodyMembersMap.isNullOrEmpty()) AnyMembers.NO_MEMBERS else AnyMembers.SOME_MEMBERS
+}
+
+@JourneyFrameworkComponent
+final class RemoveGovBodyMemberStep(
+    stepConfig: RemoveGovBodyMemberStepConfig,
+) : JourneyStep.RequestableStep<AnyMembers, NoInputFormModel, LandlordRegistrationOrgLandlordState>(stepConfig) {
+    companion object {
+        const val ROUTE_SEGMENT = "remove-governing-body-member"
+    }
+}

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/landlordRegistration/stepConfig/SaveGovBodyMemberStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/landlordRegistration/stepConfig/SaveGovBodyMemberStepConfig.kt
@@ -32,7 +32,13 @@ class SaveGovBodyMemberStepConfig : AbstractInternalStepConfig<Complete, Landlor
         val address = state.govBodyMemberAddressTask.getAddress()
 
         val currentMap = state.governingBodyMembersMap?.toMutableMap() ?: mutableMapOf()
-        val nextKey = state.nextGoverningBodyMemberId ?: ((currentMap.keys.maxOrNull() ?: 0) + 1)
+
+        val targetKey =
+            state.editingGovBodyMemberId ?: run {
+                val nextKey = state.nextGoverningBodyMemberId ?: ((currentMap.keys.maxOrNull() ?: 0) + 1)
+                state.nextGoverningBodyMemberId = nextKey + 1
+                nextKey
+            }
 
         val member =
             GoverningBodyMemberDataModel(
@@ -42,9 +48,9 @@ class SaveGovBodyMemberStepConfig : AbstractInternalStepConfig<Complete, Landlor
                 address = address,
             )
 
-        currentMap[nextKey] = member
+        currentMap[targetKey] = member
         state.governingBodyMembersMap = currentMap
-        state.nextGoverningBodyMemberId = nextKey + 1
+        state.editingGovBodyMemberId = null
 
         // Clear the individual step form data so the next member starts fresh
         state.orgGovBodyWhoToProvideStep.clearFormData()

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/landlordRegistration/stepConfig/SetStateForGovBodyMemberEditStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/landlordRegistration/stepConfig/SetStateForGovBodyMemberEditStepConfig.kt
@@ -1,0 +1,45 @@
+package uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig
+
+import uk.gov.communities.prsdb.webapp.annotations.webAnnotations.JourneyFrameworkComponent
+import uk.gov.communities.prsdb.webapp.journeys.AbstractRequestableStepConfig
+import uk.gov.communities.prsdb.webapp.journeys.JourneyStep
+import uk.gov.communities.prsdb.webapp.journeys.StepLifecycleOrchestrator.RedirectingStepLifecycleOrchestrator
+import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.states.LandlordRegistrationOrgLandlordState
+import uk.gov.communities.prsdb.webapp.journeys.shared.Complete
+import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.NoInputFormModel
+import uk.gov.communities.prsdb.webapp.services.CollectionKeyParameterService
+
+@JourneyFrameworkComponent
+class SetStateForGovBodyMemberEditStepConfig(
+    private val collectionKeyParameterService: CollectionKeyParameterService,
+) : AbstractRequestableStepConfig<Complete, NoInputFormModel, LandlordRegistrationOrgLandlordState>() {
+    override val formModelClass = NoInputFormModel::class
+
+    override fun getStepLifecycleOrchestrator(journeyStep: JourneyStep<*, *, *>) = RedirectingStepLifecycleOrchestrator(journeyStep)
+
+    override fun getStepSpecificContent(state: LandlordRegistrationOrgLandlordState): Map<String, Any?> = emptyMap()
+
+    override fun chooseTemplate(state: LandlordRegistrationOrgLandlordState): String = ""
+
+    override fun beforeAttemptingToReachStep(state: LandlordRegistrationOrgLandlordState): Boolean {
+        val keyToEdit = collectionKeyParameterService.getParameterOrNull()
+        val currentMap = state.governingBodyMembersMap ?: emptyMap()
+        return keyToEdit != null && keyToEdit in currentMap.keys
+    }
+
+    override fun afterStepIsReached(state: LandlordRegistrationOrgLandlordState) {
+        val keyToEdit = collectionKeyParameterService.getParameterOrNull() ?: return
+        state.editingGovBodyMemberId = keyToEdit
+    }
+
+    override fun mode(state: LandlordRegistrationOrgLandlordState): Complete = Complete.COMPLETE
+}
+
+@JourneyFrameworkComponent
+final class SetStateForGovBodyMemberEditStep(
+    stepConfig: SetStateForGovBodyMemberEditStepConfig,
+) : JourneyStep.RequestableStep<Complete, NoInputFormModel, LandlordRegistrationOrgLandlordState>(stepConfig) {
+    companion object {
+        const val ROUTE_SEGMENT = "load-governing-body-member-for-edit"
+    }
+}

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/landlordRegistration/tasks/OrgLandlordRegistrationTask.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/landlordRegistration/tasks/OrgLandlordRegistrationTask.kt
@@ -34,7 +34,9 @@ import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.
 import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.OrgNameStep
 import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.OrgPhoneNumberStep
 import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.OrgTypeStep
+import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.RemoveGovBodyMemberStep
 import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.SaveGovBodyMemberStep
+import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.SetStateForGovBodyMemberEditStep
 import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.YourDetailsStep
 import uk.gov.communities.prsdb.webapp.journeys.shared.AnyMembers
 import uk.gov.communities.prsdb.webapp.journeys.shared.YesOrNo
@@ -73,6 +75,8 @@ class OrgLandlordRegistrationTask(
     override val orgGovBodyMemberListStep: OrgGovBodyMemberListStep,
     override val hasAnyGovBodyMembersStep: HasAnyGovBodyMembersStep,
     override val saveGovBodyMemberStep: SaveGovBodyMemberStep,
+    override val setStateForGovBodyMemberEditStep: SetStateForGovBodyMemberEditStep,
+    override val removeGovBodyMemberStep: RemoveGovBodyMemberStep,
     override val orgMainContactStep: OrgMainContactStep,
     override val orgLandlordCyaStep: OrgLandlordCyaStep,
 ) : DuplicableTask<LandlordRegistrationOrgLandlordState>(journeyStateService),
@@ -83,6 +87,7 @@ class OrgLandlordRegistrationTask(
         "governingBodyMembersMap",
     )
     override var nextGoverningBodyMemberId: Int? by delegateProvider.nullableDelegate("nextGoverningBodyMemberId")
+    override var editingGovBodyMemberId: Int? by delegateProvider.nullableDelegate("editingGovBodyMemberId")
 
     override fun makeSubJourney(state: LandlordRegistrationOrgLandlordState) =
         subJourney(state) {
@@ -225,9 +230,31 @@ class OrgLandlordRegistrationTask(
                     }
                 }
             }
+            step(journey.setStateForGovBodyMemberEditStep) {
+                routeSegment(SetStateForGovBodyMemberEditStep.ROUTE_SEGMENT)
+                parents { journey.hasAnyGovBodyMembersStep.hasOutcome(AnyMembers.SOME_MEMBERS) }
+                nextStep { journey.orgGovBodyWhoToProvideStep }
+            }
+            step(journey.removeGovBodyMemberStep) {
+                routeSegment(RemoveGovBodyMemberStep.ROUTE_SEGMENT)
+                parents { journey.hasAnyGovBodyMembersStep.hasOutcome(AnyMembers.SOME_MEMBERS) }
+                nextStep { mode ->
+                    when (mode) {
+                        AnyMembers.SOME_MEMBERS -> journey.orgGovBodyMemberListStep
+                        AnyMembers.NO_MEMBERS -> journey.orgGovBodyDetailsStep
+                    }
+                }
+            }
             step(journey.orgGovBodyWhoToProvideStep) {
                 routeSegment(OrgGovBodyWhoToProvideStep.ROUTE_SEGMENT)
-                parents { journey.hasAnyGovBodyMembersStep.hasOutcome(AnyMembers.NO_MEMBERS) }
+                parents { journey.orgGovBodyDetailsStep.hasOutcome(OrgGovBodyDetailsMode.HAS_DETAILS) }
+                backDestination {
+                    if (journey.governingBodyMembersMap.isNullOrEmpty()) {
+                        Destination(journey.orgGovBodyDetailsStep)
+                    } else {
+                        Destination(journey.orgGovBodyMemberListStep)
+                    }
+                }
                 nextStep { journey.orgGovBodyMemberNameStep }
             }
             step(journey.orgGovBodyMemberNameStep) {

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/LandlordRegistrationJourneyTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/LandlordRegistrationJourneyTests.kt
@@ -2,6 +2,7 @@ package uk.gov.communities.prsdb.webapp.integration
 
 import com.google.i18n.phonenumbers.PhoneNumberUtil
 import com.microsoft.playwright.Page
+import com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -13,6 +14,7 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean
 import uk.gov.communities.prsdb.webapp.constants.MANUAL_ADDRESS_CHOSEN
 import uk.gov.communities.prsdb.webapp.constants.ORGANISATION_LANDLORD_REGISTRATION
 import uk.gov.communities.prsdb.webapp.constants.enums.CharityRegulator
+import uk.gov.communities.prsdb.webapp.constants.enums.GoverningBodyMemberType
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.BaseComponent.Companion.assertThat
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.LandlordDashboardPage
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages.BasePage.Companion.assertPageIs
@@ -40,6 +42,12 @@ import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.landlordReg
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.landlordRegistrationJourneyPages.OrgCompaniesHouseFormPageLandlordRegistration
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.landlordRegistrationJourneyPages.OrgEmailFormPageLandlordRegistration
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.landlordRegistrationJourneyPages.OrgGovBodyDetailsFormPageLandlordRegistration
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.landlordRegistrationJourneyPages.OrgGovBodyMemberDobFormPageLandlordRegistration
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.landlordRegistrationJourneyPages.OrgGovBodyMemberListFormPageLandlordRegistration
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.landlordRegistrationJourneyPages.OrgGovBodyMemberLookupAddressFormPageLandlordRegistration
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.landlordRegistrationJourneyPages.OrgGovBodyMemberNameFormPageLandlordRegistration
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.landlordRegistrationJourneyPages.OrgGovBodyMemberSelectAddressFormPageLandlordRegistration
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.landlordRegistrationJourneyPages.OrgGovBodyWhoToProvideFormPageLandlordRegistration
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.landlordRegistrationJourneyPages.OrgLandlordCyaPageLandlordRegistration
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.landlordRegistrationJourneyPages.OrgMainContactFormPageLandlordRegistration
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.landlordRegistrationJourneyPages.OrgNameFormPageLandlordRegistration
@@ -340,7 +348,48 @@ class LandlordRegistrationJourneyTests : IntegrationTestWithMutableData("data-mo
         val companiesHousePage = assertPageIs(page, OrgCompaniesHouseFormPageLandlordRegistration::class)
         companiesHousePage.submitNo()
 
-        assertPageIs(page, OrgGovBodyDetailsFormPageLandlordRegistration::class)
+        val govBodyDetailsPage = assertPageIs(page, OrgGovBodyDetailsFormPageLandlordRegistration::class)
+        govBodyDetailsPage.submitHasDetails()
+
+        val whoToProvidePage = assertPageIs(page, OrgGovBodyWhoToProvideFormPageLandlordRegistration::class)
+        whoToProvidePage.submitWhoToProvide(GoverningBodyMemberType.TRUSTEE)
+
+        val namePage = assertPageIs(page, OrgGovBodyMemberNameFormPageLandlordRegistration::class)
+        namePage.submitName("Alice Smith")
+
+        val dobPage = assertPageIs(page, OrgGovBodyMemberDobFormPageLandlordRegistration::class)
+        dobPage.submitDate("10", "3", "1985")
+
+        val lookupAddressPage = assertPageIs(page, OrgGovBodyMemberLookupAddressFormPageLandlordRegistration::class)
+        lookupAddressPage.submitPostcodeAndBuildingNameOrNumber("EG1 2AA", "1")
+
+        val selectAddressPage = assertPageIs(page, OrgGovBodyMemberSelectAddressFormPageLandlordRegistration::class)
+        selectAddressPage.selectAddressAndSubmit("1 PRSDB Square, EG1 2AA")
+
+        val memberListPage = assertPageIs(page, OrgGovBodyMemberListFormPageLandlordRegistration::class)
+        assertThat(memberListPage.heading).containsText("added 1 person")
+        memberListPage.addAnotherButton.click()
+
+        val whoToProvidePage2 = assertPageIs(page, OrgGovBodyWhoToProvideFormPageLandlordRegistration::class)
+        whoToProvidePage2.submitWhoToProvide(GoverningBodyMemberType.DIRECTOR)
+
+        val namePage2 = assertPageIs(page, OrgGovBodyMemberNameFormPageLandlordRegistration::class)
+        namePage2.submitName("Bob Jones")
+
+        val dobPage2 = assertPageIs(page, OrgGovBodyMemberDobFormPageLandlordRegistration::class)
+        dobPage2.submitDate("15", "6", "1975")
+
+        val lookupAddressPage2 = assertPageIs(page, OrgGovBodyMemberLookupAddressFormPageLandlordRegistration::class)
+        lookupAddressPage2.submitPostcodeAndBuildingNameOrNumber("EG1 2AA", "1")
+
+        val selectAddressPage2 = assertPageIs(page, OrgGovBodyMemberSelectAddressFormPageLandlordRegistration::class)
+        selectAddressPage2.selectAddressAndSubmit("1 PRSDB Square, EG1 2AA")
+
+        val updatedListPage = assertPageIs(page, OrgGovBodyMemberListFormPageLandlordRegistration::class)
+        assertThat(updatedListPage.heading).containsText("added 2 people")
+        updatedListPage.form.submit()
+
+        assertPageIs(page, OrgMainContactFormPageLandlordRegistration::class)
     }
 
     @Test
@@ -366,4 +415,118 @@ class LandlordRegistrationJourneyTests : IntegrationTestWithMutableData("data-mo
 
         assertPageIs(page, OrgCompaniesHouseFormPageLandlordRegistration::class)
     }
+
+    @Test
+    fun `adding another governing body member from the list page completes the flow and shows both members`(page: Page) {
+        featureFlagManager.enable(ORGANISATION_LANDLORD_REGISTRATION)
+
+        val memberListPage =
+            navigator.skipToOrgLandlordRegistrationGovBodyMemberListPage(
+                mapOf(1 to createTestGovBodyMember("Alice Smith")),
+            )
+
+        memberListPage.addAnotherButton.click()
+
+        val whoToProvidePage = assertPageIs(page, OrgGovBodyWhoToProvideFormPageLandlordRegistration::class)
+        whoToProvidePage.submitWhoToProvide(GoverningBodyMemberType.TRUSTEE)
+
+        val namePage = assertPageIs(page, OrgGovBodyMemberNameFormPageLandlordRegistration::class)
+        namePage.submitName("Bob Jones")
+
+        val dobPage = assertPageIs(page, OrgGovBodyMemberDobFormPageLandlordRegistration::class)
+        dobPage.submitDate("10", "3", "1975")
+
+        val lookupAddressPage = assertPageIs(page, OrgGovBodyMemberLookupAddressFormPageLandlordRegistration::class)
+        lookupAddressPage.submitPostcodeAndBuildingNameOrNumber("EG1 2AA", "1")
+
+        val selectAddressPage = assertPageIs(page, OrgGovBodyMemberSelectAddressFormPageLandlordRegistration::class)
+        selectAddressPage.selectAddressAndSubmit("1 PRSDB Square, EG1 2AA")
+
+        val updatedListPage = assertPageIs(page, OrgGovBodyMemberListFormPageLandlordRegistration::class)
+        assertThat(updatedListPage.heading).containsText("added 2 people")
+        assertThat(updatedListPage.summaryList.getRowByIndex(0).value).containsText("Alice Smith")
+        assertThat(updatedListPage.summaryList.getRowByIndex(1).value).containsText("Bob Jones")
+    }
+
+    @Test
+    fun `changing a governing body member updates their details in the list`(page: Page) {
+        featureFlagManager.enable(ORGANISATION_LANDLORD_REGISTRATION)
+
+        val memberListPage =
+            navigator.skipToOrgLandlordRegistrationGovBodyMemberListPage(
+                mapOf(
+                    1 to createTestGovBodyMember("Alice Smith"),
+                    2 to createTestGovBodyMember("Bob Jones"),
+                ),
+            )
+
+        memberListPage.summaryList
+            .getRowByIndex(0)
+            .actions
+            .getActionLink("Change")
+            .clickAndWait()
+
+        val whoToProvidePage = assertPageIs(page, OrgGovBodyWhoToProvideFormPageLandlordRegistration::class)
+        whoToProvidePage.submitWhoToProvide(GoverningBodyMemberType.DIRECTOR)
+
+        val namePage = assertPageIs(page, OrgGovBodyMemberNameFormPageLandlordRegistration::class)
+        namePage.submitName("Alice Johnson")
+
+        val dobPage = assertPageIs(page, OrgGovBodyMemberDobFormPageLandlordRegistration::class)
+        dobPage.submitDate("15", "6", "1980")
+
+        val lookupAddressPage = assertPageIs(page, OrgGovBodyMemberLookupAddressFormPageLandlordRegistration::class)
+        lookupAddressPage.submitPostcodeAndBuildingNameOrNumber("EG1 2AA", "1")
+
+        val selectAddressPage = assertPageIs(page, OrgGovBodyMemberSelectAddressFormPageLandlordRegistration::class)
+        selectAddressPage.selectAddressAndSubmit("1 PRSDB Square, EG1 2AA")
+
+        val updatedListPage = assertPageIs(page, OrgGovBodyMemberListFormPageLandlordRegistration::class)
+        assertThat(updatedListPage.heading).containsText("added 2 people")
+        assertThat(updatedListPage.summaryList.getRowByIndex(0).value).containsText("Alice Johnson")
+        assertThat(updatedListPage.summaryList.getRowByIndex(1).value).containsText("Bob Jones")
+    }
+
+    @Test
+    fun `removing governing body members one by one updates the list correctly`(page: Page) {
+        featureFlagManager.enable(ORGANISATION_LANDLORD_REGISTRATION)
+
+        val memberListPage =
+            navigator.skipToOrgLandlordRegistrationGovBodyMemberListPage(
+                mapOf(
+                    1 to createTestGovBodyMember("Alice Smith"),
+                    2 to createTestGovBodyMember("Bob Jones"),
+                ),
+            )
+
+        assertThat(memberListPage.heading).containsText("added 2 people")
+
+        memberListPage.summaryList
+            .getRowByIndex(1)
+            .actions
+            .getActionLink("Remove")
+            .clickAndWait()
+
+        val afterFirstRemoval = assertPageIs(page, OrgGovBodyMemberListFormPageLandlordRegistration::class)
+        assertThat(afterFirstRemoval.heading).containsText("added 1 person")
+        assertThat(afterFirstRemoval.summaryList.getRowByIndex(0).value).containsText("Alice Smith")
+
+        afterFirstRemoval.summaryList
+            .getRowByIndex(0)
+            .actions
+            .getActionLink("Remove")
+            .clickAndWait()
+
+        assertPageIs(page, OrgGovBodyDetailsFormPageLandlordRegistration::class)
+    }
+
+    private fun createTestGovBodyMember(name: String) =
+        uk.gov.communities.prsdb.webapp.models.dataModels.GoverningBodyMemberDataModel(
+            name = name,
+            type = GoverningBodyMemberType.DIRECTOR,
+            dateOfBirth = kotlinx.datetime.LocalDate(1970, 1, 1),
+            address =
+                uk.gov.communities.prsdb.webapp.models.dataModels
+                    .AddressDataModel(singleLineAddress = "Test Address"),
+        )
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/LandlordRegistrationJourneyTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/LandlordRegistrationJourneyTests.kt
@@ -15,6 +15,7 @@ import uk.gov.communities.prsdb.webapp.constants.MANUAL_ADDRESS_CHOSEN
 import uk.gov.communities.prsdb.webapp.constants.ORGANISATION_LANDLORD_REGISTRATION
 import uk.gov.communities.prsdb.webapp.constants.enums.CharityRegulator
 import uk.gov.communities.prsdb.webapp.constants.enums.GoverningBodyMemberType
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.BackLink
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.BaseComponent.Companion.assertThat
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.LandlordDashboardPage
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages.BasePage.Companion.assertPageIs
@@ -518,6 +519,48 @@ class LandlordRegistrationJourneyTests : IntegrationTestWithMutableData("data-mo
             .clickAndWait()
 
         assertPageIs(page, OrgGovBodyDetailsFormPageLandlordRegistration::class)
+    }
+
+    @Test
+    fun `pressing back after starting to edit resets editing state and allows adding a new member`(page: Page) {
+        featureFlagManager.enable(ORGANISATION_LANDLORD_REGISTRATION)
+
+        val memberListPage =
+            navigator.skipToOrgLandlordRegistrationGovBodyMemberListPage(
+                mapOf(1 to createTestGovBodyMember("Alice Smith")),
+            )
+
+        memberListPage.summaryList
+            .getRowByIndex(0)
+            .actions
+            .getActionLink("Change")
+            .clickAndWait()
+
+        assertPageIs(page, OrgGovBodyWhoToProvideFormPageLandlordRegistration::class)
+        BackLink.default(page).clickAndWait()
+
+        val returnedListPage = assertPageIs(page, OrgGovBodyMemberListFormPageLandlordRegistration::class)
+        returnedListPage.addAnotherButton.click()
+
+        val whoToProvidePage = assertPageIs(page, OrgGovBodyWhoToProvideFormPageLandlordRegistration::class)
+        whoToProvidePage.submitWhoToProvide(GoverningBodyMemberType.TRUSTEE)
+
+        val namePage = assertPageIs(page, OrgGovBodyMemberNameFormPageLandlordRegistration::class)
+        namePage.submitName("Bob Jones")
+
+        val dobPage = assertPageIs(page, OrgGovBodyMemberDobFormPageLandlordRegistration::class)
+        dobPage.submitDate("10", "3", "1975")
+
+        val lookupAddressPage = assertPageIs(page, OrgGovBodyMemberLookupAddressFormPageLandlordRegistration::class)
+        lookupAddressPage.submitPostcodeAndBuildingNameOrNumber("EG1 2AA", "1")
+
+        val selectAddressPage = assertPageIs(page, OrgGovBodyMemberSelectAddressFormPageLandlordRegistration::class)
+        selectAddressPage.selectAddressAndSubmit("1 PRSDB Square, EG1 2AA")
+
+        val updatedListPage = assertPageIs(page, OrgGovBodyMemberListFormPageLandlordRegistration::class)
+        assertThat(updatedListPage.heading).containsText("added 2 people")
+        assertThat(updatedListPage.summaryList.getRowByIndex(0).value).containsText("Alice Smith")
+        assertThat(updatedListPage.summaryList.getRowByIndex(1).value).containsText("Bob Jones")
     }
 
     private fun createTestGovBodyMember(name: String) =

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/landlordRegistrationJourneyPages/OrgGovBodyMemberListFormPageLandlordRegistration.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/landlordRegistrationJourneyPages/OrgGovBodyMemberListFormPageLandlordRegistration.kt
@@ -14,6 +14,7 @@ class OrgGovBodyMemberListFormPageLandlordRegistration(
     val heading = Heading(page.locator("h1"))
     val form = PostForm(page)
     val summaryList = GovBodyMemberSummaryList(page)
+    val addAnotherButton = page.locator("a.govuk-button--secondary")
 
     class GovBodyMemberSummaryList(
         page: Page,

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/landlordRegistration/stepConfig/OrgGovBodyMemberListStepConfigTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/landlordRegistration/stepConfig/OrgGovBodyMemberListStepConfigTests.kt
@@ -1,0 +1,30 @@
+package uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig
+
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.verify
+import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.states.LandlordRegistrationOrgLandlordState
+import uk.gov.communities.prsdb.webapp.services.CollectionKeyParameterService
+import uk.gov.communities.prsdb.webapp.testHelpers.mockObjects.AlwaysTrueValidator
+
+@ExtendWith(MockitoExtension::class)
+class OrgGovBodyMemberListStepConfigTests {
+    @Mock
+    lateinit var mockState: LandlordRegistrationOrgLandlordState
+
+    @Mock
+    lateinit var urlParameterService: CollectionKeyParameterService
+
+    @Test
+    fun `afterStepIsReached resets editingGovBodyMemberId to null`() {
+        val stepConfig = OrgGovBodyMemberListStepConfig(urlParameterService)
+        stepConfig.routeSegment = OrgGovBodyMemberListStep.ROUTE_SEGMENT
+        stepConfig.validator = AlwaysTrueValidator()
+
+        stepConfig.afterStepIsReached(mockState)
+
+        verify(mockState).editingGovBodyMemberId = null
+    }
+}


### PR DESCRIPTION
## Ticket number

[PDJB-1290](https://mhclgdigital.atlassian.net/browse/PDJB-1290)

## Goal of change

make the edit, remove, add another buttons work for governing body for organisation landlord

## Description of main change(s)

adds some internal steps with routes for deleting gov members and setting up the form fields to edit an existing gov member

sets the back button urls as required

links these buttons back up

since the add gov member journey normally clears the previous questions by default the 'add another' button already just works

for the edit steps, we override `resolvePageContent` to prefill content from the state map. this is what JL flow does as well. the alternative would be setting up the state directly and relying on the existing function that prefills forms from the state. this way is a bit more verbose but requires less manipulation of the state

## Anything you'd like to highlight to the reviewer?

check that the config for the surrounding task looks correct and I've wired the steps properly together

tests are failing right now, due to a known issue with duplicable tasks. will run again when the fix is merged in which should resolve pipeline. happy to have this reviewed in the meantime

## Checklist

- Single page integration tests have been added for any unhappy-flow UI features, e.g. validation errors (no changes to single pages, all journey tests)
- [x] New journey steps have been added to the appropriate journey integration test(s)
- [x] Test suite has been run in full locally and is passing
- [x] Branch has been rebased onto main and run locally, with everything working as expected (both for your new feature
  and any related functionality)
- [x] TODO comments referencing this JIRA ticket have been searched for and removed - if a future PR will address them,
  mention that here
- [x] QA instructions have been added to the ticket (particularly if this is the last PR required to complete the ticket)
- [x] This feature is behind a feature flag. I've checked that there will be no change in function if the feature flag is disabled
