### PR TITLE
PDJB-1036: Display AWS cost per transaction

### DIFF
--- a/.github/workflows/build-and-deploy-integration.yml
+++ b/.github/workflows/build-and-deploy-integration.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - main
-      - feat/PDJB-1036-cost-per-transaction-metric
 
 jobs:
   build-and-deploy-integration:

--- a/.github/workflows/build-and-deploy-integration.yml
+++ b/.github/workflows/build-and-deploy-integration.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - main
+      - feat/PDJB-1036-cost-per-transaction-metric
 
 jobs:
   build-and-deploy-integration:

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -139,7 +139,7 @@
         "filename": ".github\\workflows\\build-and-deploy-integration.yml",
         "hashed_secret": "3e26d6750975d678acb8fa35a0f69237881576b0",
         "is_verified": false,
-        "line_number": 14,
+        "line_number": 15,
         "is_secret": false
       }
     ],
@@ -364,5 +364,5 @@
       }
     ]
   },
-  "generated_at": "2026-07-20T10:52:17Z"
+  "generated_at": "2026-07-20T12:50:30Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -139,7 +139,7 @@
         "filename": ".github\\workflows\\build-and-deploy-integration.yml",
         "hashed_secret": "3e26d6750975d678acb8fa35a0f69237881576b0",
         "is_verified": false,
-        "line_number": 14,
+        "line_number": 15,
         "is_secret": false
       }
     ],
@@ -364,5 +364,5 @@
       }
     ]
   },
-  "generated_at": "2026-07-20T10:52:17Z"
+  "generated_at": "2026-07-21T09:45:31Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -179,7 +179,7 @@
         "filename": "build.gradle.kts",
         "hashed_secret": "54119f2d56461004a7b3d3c428ccae35fd6b53b4",
         "is_verified": false,
-        "line_number": 190,
+        "line_number": 192,
         "is_secret": false
       }
     ],
@@ -364,5 +364,5 @@
       }
     ]
   },
-  "generated_at": "2026-07-15T13:29:21Z"
+  "generated_at": "2026-07-20T10:52:17Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -139,7 +139,7 @@
         "filename": ".github\\workflows\\build-and-deploy-integration.yml",
         "hashed_secret": "3e26d6750975d678acb8fa35a0f69237881576b0",
         "is_verified": false,
-        "line_number": 15,
+        "line_number": 14,
         "is_secret": false
       }
     ],
@@ -364,5 +364,5 @@
       }
     ]
   },
-  "generated_at": "2026-07-21T09:45:31Z"
+  "generated_at": "2026-07-20T10:52:17Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -139,7 +139,7 @@
         "filename": ".github\\workflows\\build-and-deploy-integration.yml",
         "hashed_secret": "3e26d6750975d678acb8fa35a0f69237881576b0",
         "is_verified": false,
-        "line_number": 15,
+        "line_number": 14,
         "is_secret": false
       }
     ],
@@ -364,5 +364,5 @@
       }
     ]
   },
-  "generated_at": "2026-07-20T12:50:30Z"
+  "generated_at": "2026-07-20T10:52:17Z"
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -77,6 +77,7 @@ dependencies {
     implementation("software.amazon.awssdk:s3-transfer-manager")
     implementation("software.amazon.awssdk:aws-crt-client")
     implementation("software.amazon.awssdk:cloudwatch")
+    implementation("software.amazon.awssdk:costexplorer")
 
     // Development
     developmentOnly("org.springframework.boot:spring-boot-devtools")

--- a/docs/MetricsReadMe.md
+++ b/docs/MetricsReadMe.md
@@ -78,9 +78,8 @@ The deployed `AwsCostExplorerMetricsClient` calls Cost Explorer's `GetCostAndUsa
 `us-east-1`. Its query is account-wide: it has no tag, service, or resource filter and no grouping. It
 uses `DAILY` granularity and the `UnblendedCost` metric.
 
-The request intentionally omits `BillingViewArn`, so Cost Explorer uses the hosting environment
-account's primary billing view. For a member or standalone account, that view contains the costs for
-that account, which is the dashboard's required scope.
+The request intentionally omits `BillingViewArn`. Cost Explorer therefore returns the costs available
+to the hosting AWS account, which is the dashboard's required scope.
 
 The dashboard reporting range is inclusive in UK time. Cost Explorer's end date is exclusive, so the
 client sends the selected end date plus one day. It follows all pagination tokens, sums the returned daily
@@ -99,13 +98,15 @@ Current-month data usually takes about 24 hours to appear and refreshes at least
 current-month values may remain estimated until AWS completes billing reconciliation after month end. A
 management account can also restrict a member account's access.
 
-Infrastructure PR [`communitiesuk/prsdb-infra#309`](https://github.com/communitiesuk/prsdb-infra/pull/309)
-grants `ce:GetCostAndUsage` only for
-`arn:aws:billing::<environment-account-id>:billingview/primary`, matching the client's implicit
-primary-view request. The application does not enumerate or inspect billing views and does not use the
-billing console, so it does not require `billing:ListBillingViews`, `billing:GetBillingView`, or legacy
-`aws-portal:ViewBilling`. The infra policy must be deployed before the live query can succeed. Enabling
-the account and populating data still require verification in the target environment.
+Live integration testing showed that, when `BillingViewArn` is omitted, AWS authorizes
+`ce:GetCostAndUsage` against `arn:aws:ce:us-east-1:<account-id>:/GetCostAndUsage`. Infrastructure PR
+[`communitiesuk/prsdb-infra#309`](https://github.com/communitiesuk/prsdb-infra/pull/309) must therefore
+grant only the `ce:GetCostAndUsage` action with `Resource = "*"`. The wildcard resource applies only to
+that action; it does not grant any other Cost Explorer or billing actions. The application does not
+enumerate or inspect billing views and does not use the billing console, so it does not require
+`billing:ListBillingViews`, `billing:GetBillingView`, or legacy `aws-portal:ViewBilling`. The infra
+policy must be deployed before the live query can succeed. Enabling the account and populating data
+still require verification in the target environment.
 
 ## CloudWatch infrastructure metrics
 

--- a/docs/MetricsReadMe.md
+++ b/docs/MetricsReadMe.md
@@ -104,9 +104,7 @@ Live integration testing showed that, when `BillingViewArn` is omitted, AWS auth
 grant only the `ce:GetCostAndUsage` action with `Resource = "*"`. The wildcard resource applies only to
 that action; it does not grant any other Cost Explorer or billing actions. The application does not
 enumerate or inspect billing views and does not use the billing console, so it does not require
-`billing:ListBillingViews`, `billing:GetBillingView`, or legacy `aws-portal:ViewBilling`. The infra
-policy must be deployed before the live query can succeed. Enabling the account and populating data
-still require verification in the target environment.
+`billing:ListBillingViews`, `billing:GetBillingView`, or legacy `aws-portal:ViewBilling`.
 
 ## CloudWatch infrastructure metrics
 

--- a/docs/MetricsReadMe.md
+++ b/docs/MetricsReadMe.md
@@ -8,10 +8,12 @@ The system operator metrics page (`/system-operator/metrics`) shows a single sum
   [AnalyticsReadMe](AnalyticsReadMe.md)).
 - **Transaction counts** — completed transactions from the Plausible `Transaction` custom event
   (`PlausibleMetricsService`), described below.
+- **Cost metrics** — account-wide AWS costs from Cost Explorer (`CostExplorerMetricsService`), described
+  below. Cost per transaction combines the Cost Explorer cost with the Plausible transaction count.
 - **Infrastructure metrics** — from Amazon CloudWatch (`CloudWatchMetricsService`), described below.
 
 The page (`MetricsController`) shows no rows until the operator submits a **reporting period** (From/To
-dates); on submit, the four services are queried for that period and their results are rendered as one
+dates); on submit, five metric queries are run for that period and their results are rendered as one
 combined summary list (`getMetricRows`). Counts are formatted as integers, durations via
 `MetricsDurationHelper`, and rates/utilisations as `0.00%`. Any value that is missing — or whose upstream
 call failed — renders as **"No data"** rather than erroring the page. Row labels come from
@@ -19,7 +21,7 @@ call failed — renders as **"No data"** rather than erroring the page. Row labe
 
 ## Dashboard rows
 
-The summary list contains the following rows, in display order:
+The summary list contains 19 rows, in display order:
 
 | # | Dashboard label | Source | Derivation |
 |---|-----------------|--------|------------|
@@ -40,6 +42,8 @@ The summary list contains the following rows, in display order:
 | 15 | Client error rate (HTTP 4xx) | CloudWatch (`CloudWatchMetricsService`) | See below. |
 | 16 | Server error rate (HTTP 5xx) | CloudWatch (`CloudWatchMetricsService`) | See below. |
 | 17 | Total number of transactions | Plausible (`PlausibleMetricsService.getTransactionCounts`) | See [Transaction counts](#transaction-counts). |
+| 18 | Total AWS cost | Cost Explorer (`CostExplorerMetricsService`) | Account-wide daily `UnblendedCost` summed for the selected period. |
+| 19 | Cost per transaction | Cost Explorer and Plausible (`CostExplorerMetricsService`, `PlausibleMetricsService.getTransactionCounts`) | Total AWS cost ÷ total transactions; **No data** when the transaction count is zero. |
 
 > **Completion rates** use visitors for landlord and local council user registration but page views for
 > property registration, because a single landlord may register multiple properties. This is surfaced on
@@ -67,6 +71,33 @@ deregistration step itself has no button to tag.
 minimal (a landlord with no properties leaving the service) and there is no clean solution that avoids
 over-counting. Landlord deregistrations where the landlord *does* have properties, and all property
 deregistrations, are counted as normal.
+
+## Cost and cost per transaction
+
+The deployed `AwsCostExplorerMetricsClient` calls Cost Explorer's `GetCostAndUsage` operation in
+`us-east-1`. Its query is account-wide: it has no tag, service, or resource filter and no grouping. It
+uses `DAILY` granularity and the `UnblendedCost` metric.
+
+The dashboard reporting range is inclusive in UK time. Cost Explorer's end date is exclusive, so the
+client sends the selected end date plus one day. It follows all pagination tokens, sums the returned daily
+cost strings with `BigDecimal`, and returns one consistent currency unit. Valid zero and negative costs
+are preserved.
+
+Costs are displayed to two decimal places as `amount CURRENCY`. If any returned daily result is estimated,
+both the total-cost and cost-per-transaction rows are marked `(estimated)`. A cost-source failure or an
+invalid response makes both rows **"No data"** without hiding the other metrics. When the transaction
+count is zero, the total AWS cost still displays, while cost per transaction is **"No data"**.
+
+### Operational prerequisites
+
+Cost Explorer must be enabled manually in AWS Billing and Cost Management; it cannot be enabled by API.
+Current-month data usually takes about 24 hours to appear and refreshes at least daily. Recent and
+current-month values may remain estimated until AWS completes billing reconciliation after month end. A
+management account can also restrict a member account's access.
+
+Infrastructure PR [`communitiesuk/prsdb-infra#309`](https://github.com/communitiesuk/prsdb-infra/pull/309)
+grants only `ce:GetCostAndUsage` and must be deployed before the live query can succeed. Enabling the
+account and populating data still require verification in the target environment.
 
 ## CloudWatch infrastructure metrics
 
@@ -135,3 +166,14 @@ exactly one bean is active at a time:
 
 So when you run locally you always get the stub, and **no AWS credentials are required**. Real
 CloudWatch is only called in deployed (non-`local`) environments.
+
+There are also two implementations of `CostExplorerMetricsClient`, selected by Spring profile so that
+exactly one bean is active at a time:
+
+| Implementation                   | Profile expression | Behaviour                                                   |
+|----------------------------------|--------------------|-------------------------------------------------------------|
+| `StubCostExplorerMetricsClient`  | `local`            | Returns `123.45 USD` marked as estimated.                   |
+| `AwsCostExplorerMetricsClient`   | `!local`           | Calls Cost Explorer through the AWS SDK.                     |
+
+The local stub does not confirm that Cost Explorer is enabled or populated in any environment; the AWS
+client is used only in deployed (non-`local`) environments.

--- a/docs/MetricsReadMe.md
+++ b/docs/MetricsReadMe.md
@@ -78,6 +78,10 @@ The deployed `AwsCostExplorerMetricsClient` calls Cost Explorer's `GetCostAndUsa
 `us-east-1`. Its query is account-wide: it has no tag, service, or resource filter and no grouping. It
 uses `DAILY` granularity and the `UnblendedCost` metric.
 
+The request intentionally omits `BillingViewArn`, so Cost Explorer uses the hosting environment
+account's primary billing view. For a member or standalone account, that view contains the costs for
+that account, which is the dashboard's required scope.
+
 The dashboard reporting range is inclusive in UK time. Cost Explorer's end date is exclusive, so the
 client sends the selected end date plus one day. It follows all pagination tokens, sums the returned daily
 cost strings with `BigDecimal`, and returns one consistent currency unit. Valid zero and negative costs
@@ -96,8 +100,12 @@ current-month values may remain estimated until AWS completes billing reconcilia
 management account can also restrict a member account's access.
 
 Infrastructure PR [`communitiesuk/prsdb-infra#309`](https://github.com/communitiesuk/prsdb-infra/pull/309)
-grants only `ce:GetCostAndUsage` and must be deployed before the live query can succeed. Enabling the
-account and populating data still require verification in the target environment.
+grants `ce:GetCostAndUsage` only for
+`arn:aws:billing::<environment-account-id>:billingview/primary`, matching the client's implicit
+primary-view request. The application does not enumerate or inspect billing views and does not use the
+billing console, so it does not require `billing:ListBillingViews`, `billing:GetBillingView`, or legacy
+`aws-portal:ViewBilling`. The infra policy must be deployed before the live query can succeed. Enabling
+the account and populating data still require verification in the target environment.
 
 ## CloudWatch infrastructure metrics
 

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/clients/AwsCostExplorerMetricsClient.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/clients/AwsCostExplorerMetricsClient.kt
@@ -6,10 +6,10 @@ import software.amazon.awssdk.services.costexplorer.model.DateInterval
 import software.amazon.awssdk.services.costexplorer.model.GetCostAndUsageRequest
 import software.amazon.awssdk.services.costexplorer.model.Granularity
 import uk.gov.communities.prsdb.webapp.annotations.webAnnotations.PrsdbWebService
+import uk.gov.communities.prsdb.webapp.helpers.DateTimeHelper.Companion.UK_ZONE
 import uk.gov.communities.prsdb.webapp.models.dataModels.CostExplorerCostDataModel
 import uk.gov.communities.prsdb.webapp.models.dataModels.ReportingPeriod
 import java.math.BigDecimal
-import java.time.ZoneId
 
 @Profile("!local")
 @PrsdbWebService
@@ -81,6 +81,5 @@ class AwsCostExplorerMetricsClient(
 
     companion object {
         private const val UNBLENDED_COST = "UnblendedCost"
-        private val UK_ZONE = ZoneId.of("Europe/London")
     }
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/clients/AwsCostExplorerMetricsClient.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/clients/AwsCostExplorerMetricsClient.kt
@@ -1,0 +1,86 @@
+package uk.gov.communities.prsdb.webapp.clients
+
+import org.springframework.context.annotation.Profile
+import software.amazon.awssdk.services.costexplorer.CostExplorerClient
+import software.amazon.awssdk.services.costexplorer.model.DateInterval
+import software.amazon.awssdk.services.costexplorer.model.GetCostAndUsageRequest
+import software.amazon.awssdk.services.costexplorer.model.Granularity
+import uk.gov.communities.prsdb.webapp.annotations.webAnnotations.PrsdbWebService
+import uk.gov.communities.prsdb.webapp.models.dataModels.CostExplorerCostDataModel
+import uk.gov.communities.prsdb.webapp.models.dataModels.ReportingPeriod
+import java.math.BigDecimal
+import java.time.ZoneId
+
+@Profile("!local")
+@PrsdbWebService
+class AwsCostExplorerMetricsClient(
+    private val sdkClient: CostExplorerClient,
+) : CostExplorerMetricsClient {
+    override fun getCost(period: ReportingPeriod): CostExplorerCostDataModel? {
+        var totalAmount = BigDecimal.ZERO
+        var currencyCode: String? = null
+        var isEstimated = false
+        var hasMetricValue = false
+        var nextPageToken: String? = null
+
+        do {
+            val response = sdkClient.getCostAndUsage(buildRequest(period, nextPageToken))
+
+            for (result in response.resultsByTime()) {
+                val metric = result.total()[UNBLENDED_COST] ?: return invalidResponse("UnblendedCost was missing")
+                val amount = metric.amount()?.toBigDecimalOrNull() ?: return invalidResponse("amount was malformed")
+                val unit = metric.unit()?.takeIf { it.isNotBlank() } ?: return invalidResponse("unit was blank")
+
+                if (currencyCode != null && currencyCode != unit) {
+                    return invalidResponse("units were inconsistent")
+                }
+
+                totalAmount += amount
+                currencyCode = unit
+                isEstimated = isEstimated || result.estimated()
+                hasMetricValue = true
+            }
+
+            nextPageToken = response.nextPageToken()
+        } while (!nextPageToken.isNullOrBlank())
+
+        if (!hasMetricValue || currencyCode == null) {
+            return invalidResponse("no usable metric values were returned")
+        }
+
+        return CostExplorerCostDataModel(totalAmount, currencyCode, isEstimated)
+    }
+
+    private fun buildRequest(
+        period: ReportingPeriod,
+        nextPageToken: String?,
+    ): GetCostAndUsageRequest {
+        val request =
+            GetCostAndUsageRequest
+                .builder()
+                .timePeriod(
+                    DateInterval
+                        .builder()
+                        .start(period.start.atZone(UK_ZONE).toLocalDate().toString())
+                        .end(period.end.atZone(UK_ZONE).toLocalDate().plusDays(1).toString())
+                        .build(),
+                ).granularity(Granularity.DAILY)
+                .metrics(UNBLENDED_COST)
+
+        if (!nextPageToken.isNullOrBlank()) {
+            request.nextPageToken(nextPageToken)
+        }
+
+        return request.build()
+    }
+
+    private fun invalidResponse(reason: String): Nothing? {
+        println("Failed to parse Cost Explorer metrics: $reason")
+        return null
+    }
+
+    companion object {
+        private const val UNBLENDED_COST = "UnblendedCost"
+        private val UK_ZONE = ZoneId.of("Europe/London")
+    }
+}

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/clients/CostExplorerMetricsClient.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/clients/CostExplorerMetricsClient.kt
@@ -1,0 +1,8 @@
+package uk.gov.communities.prsdb.webapp.clients
+
+import uk.gov.communities.prsdb.webapp.models.dataModels.CostExplorerCostDataModel
+import uk.gov.communities.prsdb.webapp.models.dataModels.ReportingPeriod
+
+interface CostExplorerMetricsClient {
+    fun getCost(period: ReportingPeriod): CostExplorerCostDataModel?
+}

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/clients/StubCostExplorerMetricsClient.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/clients/StubCostExplorerMetricsClient.kt
@@ -1,0 +1,13 @@
+package uk.gov.communities.prsdb.webapp.clients
+
+import org.springframework.context.annotation.Profile
+import uk.gov.communities.prsdb.webapp.annotations.webAnnotations.PrsdbWebService
+import uk.gov.communities.prsdb.webapp.models.dataModels.CostExplorerCostDataModel
+import uk.gov.communities.prsdb.webapp.models.dataModels.ReportingPeriod
+import java.math.BigDecimal
+
+@Profile("local")
+@PrsdbWebService
+class StubCostExplorerMetricsClient : CostExplorerMetricsClient {
+    override fun getCost(period: ReportingPeriod): CostExplorerCostDataModel = CostExplorerCostDataModel(BigDecimal("123.45"), "USD", true)
+}

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/config/CostExplorerConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/config/CostExplorerConfig.kt
@@ -1,0 +1,20 @@
+package uk.gov.communities.prsdb.webapp.config
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Profile
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider
+import software.amazon.awssdk.regions.Region
+import software.amazon.awssdk.services.costexplorer.CostExplorerClient
+import uk.gov.communities.prsdb.webapp.annotations.webAnnotations.PrsdbWebConfiguration
+
+@Profile("!local")
+@PrsdbWebConfiguration("prsdbCostExplorerConfig")
+class CostExplorerConfig {
+    @Bean
+    fun costExplorerClient(credentialsProvider: AwsCredentialsProvider): CostExplorerClient =
+        CostExplorerClient
+            .builder()
+            .region(Region.US_EAST_1)
+            .credentialsProvider(credentialsProvider)
+            .build()
+}

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/MetricsController.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/MetricsController.kt
@@ -14,14 +14,18 @@ import uk.gov.communities.prsdb.webapp.constants.METRICS_PATH_SEGMENT
 import uk.gov.communities.prsdb.webapp.constants.SYSTEM_OPERATOR_PATH_SEGMENT
 import uk.gov.communities.prsdb.webapp.helpers.MetricsDurationHelper
 import uk.gov.communities.prsdb.webapp.models.dataModels.CloudWatchMetricsDataModel
+import uk.gov.communities.prsdb.webapp.models.dataModels.CostMetricsDataModel
 import uk.gov.communities.prsdb.webapp.models.dataModels.JourneyCompletionRatesDataModel
 import uk.gov.communities.prsdb.webapp.models.dataModels.MetricsDataModel
 import uk.gov.communities.prsdb.webapp.models.dataModels.ReportingPeriod
 import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.MetricsDateRangeFormModel
 import uk.gov.communities.prsdb.webapp.models.viewModels.summaryModels.SummaryListRowViewModel
 import uk.gov.communities.prsdb.webapp.services.CloudWatchMetricsService
+import uk.gov.communities.prsdb.webapp.services.CostExplorerMetricsService
 import uk.gov.communities.prsdb.webapp.services.MetricsService
 import uk.gov.communities.prsdb.webapp.services.PlausibleMetricsService
+import java.math.BigDecimal
+import java.math.RoundingMode
 import java.text.NumberFormat
 import java.time.Duration
 import java.util.Locale
@@ -33,6 +37,7 @@ class MetricsController(
     private val metricsService: MetricsService,
     private val plausibleMetricsService: PlausibleMetricsService,
     private val cloudWatchMetricsService: CloudWatchMetricsService,
+    private val costExplorerMetricsService: CostExplorerMetricsService,
     private val messageSource: MessageSource,
 ) {
     @GetMapping
@@ -51,11 +56,13 @@ class MetricsController(
         val metricRows =
             getReportingPeriodOrNull(bindingResult, formModel)
                 ?.let { period ->
+                    val totalTransactions = plausibleMetricsService.getTransactionCounts(period)
                     getMetricRows(
                         metricsService.getMetrics(period),
                         plausibleMetricsService.getCompletionRates(period),
                         cloudWatchMetricsService.getMetrics(period),
-                        plausibleMetricsService.getTransactionCounts(period),
+                        totalTransactions,
+                        costExplorerMetricsService.getMetrics(period, totalTransactions),
                     )
                 }
                 ?: emptyList()
@@ -78,6 +85,7 @@ class MetricsController(
         completionRates: JourneyCompletionRatesDataModel,
         cloudWatch: CloudWatchMetricsDataModel,
         totalTransactions: Long,
+        costMetrics: CostMetricsDataModel,
     ): List<SummaryListRowViewModel> =
         listOf(
             countRow("metrics.rows.landlordRegistrations", metrics.numberOfLandlordRegistrations),
@@ -100,6 +108,8 @@ class MetricsController(
             percentRow("metrics.rows.cloudFrontClientErrorRate", cloudWatch.cloudFrontClientErrorRate),
             percentRow("metrics.rows.cloudFrontServerErrorRate", cloudWatch.cloudFrontServerErrorRate),
             countRow("metrics.rows.totalTransactions", totalTransactions),
+            costRow("metrics.rows.totalAwsCost", costMetrics.totalCost, costMetrics),
+            costRow("metrics.rows.costPerTransaction", costMetrics.costPerTransaction, costMetrics),
         )
 
     private fun percentRow(
@@ -128,6 +138,36 @@ class MetricsController(
             fieldHeading = headingKey,
             fieldValue = NumberFormat.getIntegerInstance(Locale.UK).format(count),
         )
+
+    private fun costRow(
+        headingKey: String,
+        amount: BigDecimal?,
+        costMetrics: CostMetricsDataModel,
+    ): SummaryListRowViewModel {
+        val currencyCode = costMetrics.currencyCode
+        if (amount == null || currencyCode == null) {
+            return SummaryListRowViewModel(
+                fieldHeading = headingKey,
+                fieldValue = "metrics.saveAndReturn.noData",
+            )
+        }
+
+        val formattedCost =
+            "${
+                NumberFormat.getNumberInstance(Locale.UK).apply {
+                    isGroupingUsed = true
+                    minimumFractionDigits = 2
+                    maximumFractionDigits = 2
+                    roundingMode = RoundingMode.HALF_UP
+                }.format(amount)
+            } $currencyCode"
+
+        return SummaryListRowViewModel(
+            fieldHeading = headingKey,
+            fieldValue = if (costMetrics.isEstimated) "metrics.cost.estimated" else formattedCost,
+            optionalFieldValueParam = if (costMetrics.isEstimated) formattedCost else null,
+        )
+    }
 
     private fun durationRow(
         headingKey: String,

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/helpers/DateTimeHelper.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/helpers/DateTimeHelper.kt
@@ -27,8 +27,12 @@ class DateTimeHelper(
     fun isDateInPast(date: LocalDate): Boolean = date < getCurrentDateInUK()
 
     companion object {
+        private const val UK_TIME_ZONE_ID = "Europe/London"
+        val UK_ZONE: ZoneId = ZoneId.of(UK_TIME_ZONE_ID)
+        private val UK_TIME_ZONE = TimeZone.of(UK_TIME_ZONE_ID)
+
         fun getDateInUK(instant: Instant): LocalDate {
-            val dateTimeInUK = instant.toLocalDateTime(TimeZone.of("Europe/London"))
+            val dateTimeInUK = instant.toLocalDateTime(UK_TIME_ZONE)
             return dateTimeInUK.date
         }
 
@@ -50,8 +54,7 @@ class DateTimeHelper(
         fun getJavaInstantFromLocalDate(localDate: java.time.LocalDate): java.time.Instant =
             localDate.atStartOfDay(ZoneId.systemDefault()).toInstant()
 
-        fun getEndOfDayInstantInUK(date: java.time.LocalDate): java.time.Instant =
-            date.atTime(LocalTime.MAX).atZone(ZoneId.of("Europe/London")).toInstant()
+        fun getEndOfDayInstantInUK(date: java.time.LocalDate): java.time.Instant = date.atTime(LocalTime.MAX).atZone(UK_ZONE).toInstant()
 
         fun java.time.LocalDate.toInstant(): java.time.Instant = getJavaInstantFromLocalDate(this)
 

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/dataModels/CostExplorerCostDataModel.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/dataModels/CostExplorerCostDataModel.kt
@@ -1,0 +1,9 @@
+package uk.gov.communities.prsdb.webapp.models.dataModels
+
+import java.math.BigDecimal
+
+data class CostExplorerCostDataModel(
+    val amount: BigDecimal,
+    val currencyCode: String,
+    val isEstimated: Boolean,
+)

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/dataModels/CostMetricsDataModel.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/dataModels/CostMetricsDataModel.kt
@@ -1,0 +1,10 @@
+package uk.gov.communities.prsdb.webapp.models.dataModels
+
+import java.math.BigDecimal
+
+data class CostMetricsDataModel(
+    val totalCost: BigDecimal? = null,
+    val costPerTransaction: BigDecimal? = null,
+    val currencyCode: String? = null,
+    val isEstimated: Boolean = false,
+)

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/dataModels/ReportingPeriod.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/dataModels/ReportingPeriod.kt
@@ -5,15 +5,12 @@ import uk.gov.communities.prsdb.webapp.helpers.DateTimeHelper
 import java.time.Clock
 import java.time.Instant
 import java.time.LocalDate
-import java.time.ZoneId
 
 data class ReportingPeriod(
     val start: Instant,
     val end: Instant,
 ) {
     companion object {
-        private val UK_ZONE = ZoneId.of("Europe/London")
-
         /**
          * Builds an inclusive reporting period for the given date range, interpreted in UK time:
          * the period starts at 00:00:00 on the [from] date and ends at the last instant of the [to] date.
@@ -28,7 +25,7 @@ data class ReportingPeriod(
             val now = clock.instant()
             val todayInUk = DateTimeHelper(clock).getCurrentDateInUK().toJavaLocalDate()
 
-            val start = from.atStartOfDay(UK_ZONE).toInstant()
+            val start = from.atStartOfDay(DateTimeHelper.UK_ZONE).toInstant()
             val end =
                 if (to == todayInUk) {
                     now

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/CostExplorerMetricsService.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/CostExplorerMetricsService.kt
@@ -1,0 +1,41 @@
+package uk.gov.communities.prsdb.webapp.services
+
+import software.amazon.awssdk.core.exception.SdkException
+import uk.gov.communities.prsdb.webapp.annotations.webAnnotations.PrsdbWebService
+import uk.gov.communities.prsdb.webapp.clients.CostExplorerMetricsClient
+import uk.gov.communities.prsdb.webapp.models.dataModels.CostMetricsDataModel
+import uk.gov.communities.prsdb.webapp.models.dataModels.ReportingPeriod
+import java.math.BigDecimal
+import java.math.RoundingMode
+
+@PrsdbWebService
+class CostExplorerMetricsService(
+    private val client: CostExplorerMetricsClient,
+) {
+    fun getMetrics(
+        period: ReportingPeriod,
+        transactionCount: Long,
+    ): CostMetricsDataModel {
+        val cost =
+            try {
+                client.getCost(period)
+            } catch (e: SdkException) {
+                println("Failed to fetch Cost Explorer metrics: ${e.message}")
+                return CostMetricsDataModel()
+            } ?: return CostMetricsDataModel()
+
+        val costPerTransaction =
+            if (transactionCount > 0) {
+                cost.amount.divide(BigDecimal.valueOf(transactionCount), 2, RoundingMode.HALF_UP)
+            } else {
+                null
+            }
+
+        return CostMetricsDataModel(
+            totalCost = cost.amount,
+            costPerTransaction = costPerTransaction,
+            currencyCode = cost.currencyCode,
+            isEstimated = cost.isEstimated,
+        )
+    }
+}

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/PlausibleMetricsService.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/PlausibleMetricsService.kt
@@ -19,6 +19,7 @@ import uk.gov.communities.prsdb.webapp.controllers.UpdateLicensingController
 import uk.gov.communities.prsdb.webapp.controllers.UpdateOccupancyController
 import uk.gov.communities.prsdb.webapp.controllers.UpdateRentFrequencyAndAmountController
 import uk.gov.communities.prsdb.webapp.controllers.UpdateRentIncludesBillsController
+import uk.gov.communities.prsdb.webapp.helpers.DateTimeHelper.Companion.UK_ZONE
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.update.electricalSafety.UpdateCheckElectricalSafetyAnswersStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.update.epc.UpdateCheckEpcAnswersStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.update.gasSafety.UpdateCheckGasSafetyAnswersStep
@@ -34,7 +35,6 @@ import java.math.BigDecimal
 import java.math.RoundingMode
 import java.time.Instant
 import java.time.LocalDate
-import java.time.ZoneId
 import java.time.format.DateTimeFormatter
 
 @PrsdbWebService
@@ -179,8 +179,6 @@ class PlausibleMetricsService(
     private fun Instant.toUkLocalDate(): LocalDate = this.atZone(UK_ZONE).toLocalDate()
 
     companion object {
-        private val UK_ZONE = ZoneId.of("Europe/London")
-
         // The name of the Plausible custom event fired on journey completion (see templates/fragments/layout.html).
         const val TRANSACTION_EVENT_NAME = "Transaction"
 

--- a/src/main/resources/messages/metrics.yml
+++ b/src/main/resources/messages/metrics.yml
@@ -30,7 +30,11 @@ rows:
   cloudFrontClientErrorRate: Client error rate (HTTP 4xx)
   cloudFrontServerErrorRate: Server error rate (HTTP 5xx)
   totalTransactions: Total number of transactions
+  totalAwsCost: Total AWS cost
+  costPerTransaction: Cost per transaction
 completionRateExplanation: Completion rates for landlord and local council user registration are based on unique visitors. Property registration completion rate is based on page views, as a single landlord may register multiple properties.
+cost:
+  estimated: '{0,,cost} (estimated)'
 saveAndReturn:
   day: '{0} day'
   days: '{0} days'

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/clients/AwsCostExplorerMetricsClientTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/clients/AwsCostExplorerMetricsClientTests.kt
@@ -1,0 +1,221 @@
+package uk.gov.communities.prsdb.webapp.clients
+
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import software.amazon.awssdk.services.costexplorer.CostExplorerClient
+import software.amazon.awssdk.services.costexplorer.model.CostExplorerException
+import software.amazon.awssdk.services.costexplorer.model.DateInterval
+import software.amazon.awssdk.services.costexplorer.model.GetCostAndUsageRequest
+import software.amazon.awssdk.services.costexplorer.model.GetCostAndUsageResponse
+import software.amazon.awssdk.services.costexplorer.model.Granularity
+import software.amazon.awssdk.services.costexplorer.model.MetricValue
+import software.amazon.awssdk.services.costexplorer.model.ResultByTime
+import uk.gov.communities.prsdb.webapp.models.dataModels.ReportingPeriod
+import java.math.BigDecimal
+import java.time.Instant
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+@ExtendWith(MockitoExtension::class)
+class AwsCostExplorerMetricsClientTests {
+    @Mock
+    private lateinit var sdkClient: CostExplorerClient
+
+    private val period =
+        ReportingPeriod(Instant.parse("2025-01-10T00:00:00Z"), Instant.parse("2025-01-20T23:59:59Z"))
+
+    private fun client() = AwsCostExplorerMetricsClient(sdkClient)
+
+    private fun metric(
+        amount: String,
+        unit: String = "USD",
+    ): MetricValue = MetricValue.builder().amount(amount).unit(unit).build()
+
+    private fun result(
+        amount: String,
+        unit: String = "USD",
+        estimated: Boolean = false,
+    ): ResultByTime =
+        ResultByTime
+            .builder()
+            .total(mapOf("UnblendedCost" to metric(amount, unit)))
+            .estimated(estimated)
+            .build()
+
+    private fun response(
+        vararg results: ResultByTime,
+        nextPageToken: String? = null,
+    ): GetCostAndUsageResponse = GetCostAndUsageResponse.builder().resultsByTime(results.toList()).nextPageToken(nextPageToken).build()
+
+    private fun stubResponse(response: GetCostAndUsageResponse) {
+        whenever(sdkClient.getCostAndUsage(any<GetCostAndUsageRequest>())).thenReturn(response)
+    }
+
+    @Test
+    fun `getCost maps reporting period to inclusive UK dates with an exclusive end date`() {
+        stubResponse(response())
+
+        client().getCost(period)
+
+        val requestCaptor = argumentCaptor<GetCostAndUsageRequest>()
+        verify(sdkClient).getCostAndUsage(requestCaptor.capture())
+        assertEquals(
+            DateInterval.builder().start("2025-01-10").end("2025-01-21").build(),
+            requestCaptor.firstValue.timePeriod(),
+        )
+    }
+
+    @Test
+    fun `getCost maps summer reporting period instants to Europe London dates`() {
+        val summerPeriod =
+            ReportingPeriod(Instant.parse("2025-07-01T23:30:00Z"), Instant.parse("2025-07-31T23:30:00Z"))
+        stubResponse(response())
+
+        client().getCost(summerPeriod)
+
+        val requestCaptor = argumentCaptor<GetCostAndUsageRequest>()
+        verify(sdkClient).getCostAndUsage(requestCaptor.capture())
+        assertEquals(
+            DateInterval.builder().start("2025-07-02").end("2025-08-02").build(),
+            requestCaptor.firstValue.timePeriod(),
+        )
+    }
+
+    @Test
+    fun `getCost requests daily unblended account costs without filters or grouping`() {
+        stubResponse(response())
+
+        client().getCost(period)
+
+        val requestCaptor = argumentCaptor<GetCostAndUsageRequest>()
+        verify(sdkClient).getCostAndUsage(requestCaptor.capture())
+        val request = requestCaptor.firstValue
+        assertEquals(Granularity.DAILY, request.granularity())
+        assertEquals(listOf("UnblendedCost"), request.metrics())
+        assertNull(request.filter())
+        assertEquals(emptyList(), request.groupBy())
+    }
+
+    @Test
+    fun `getCost sums daily values without losing decimal precision`() {
+        stubResponse(response(result("0.123456789012345678"), result("1.876543210987654322")))
+
+        val result = client().getCost(period)
+
+        assertEquals(BigDecimal("2.000000000000000000"), result?.amount)
+        assertEquals("USD", result?.currencyCode)
+    }
+
+    @Test
+    fun `getCost marks the result estimated when any daily result is estimated`() {
+        stubResponse(response(result("1.00"), result("2.00", estimated = true)))
+
+        val result = client().getCost(period)
+
+        assertTrue(result!!.isEstimated)
+    }
+
+    @Test
+    fun `getCost marks the result not estimated when no daily result is estimated`() {
+        stubResponse(response(result("1.00"), result("2.00")))
+
+        val result = client().getCost(period)
+
+        assertFalse(result!!.isEstimated)
+    }
+
+    @Test
+    fun `getCost follows pagination token and includes results from all pages`() {
+        whenever(sdkClient.getCostAndUsage(any<GetCostAndUsageRequest>())).thenReturn(
+            response(result("1.20"), nextPageToken = "next-page"),
+            response(result("2.30")),
+        )
+
+        val result = client().getCost(period)
+
+        val requestCaptor = argumentCaptor<GetCostAndUsageRequest>()
+        verify(sdkClient, times(2)).getCostAndUsage(requestCaptor.capture())
+        assertNull(requestCaptor.firstValue.nextPageToken())
+        assertEquals("next-page", requestCaptor.secondValue.nextPageToken())
+        assertEquals(BigDecimal("3.50"), result?.amount)
+    }
+
+    @Test
+    fun `getCost returns null when Cost Explorer returns no results`() {
+        stubResponse(response())
+
+        assertNull(client().getCost(period))
+    }
+
+    @Test
+    fun `getCost returns null when a result omits unblended cost`() {
+        stubResponse(
+            response(
+                ResultByTime.builder().total(mapOf("BlendedCost" to metric("1.00"))).estimated(false).build(),
+            ),
+        )
+
+        assertNull(client().getCost(period))
+    }
+
+    @Test
+    fun `getCost returns null when an amount is malformed`() {
+        stubResponse(response(result("not-a-decimal")))
+
+        assertNull(client().getCost(period))
+    }
+
+    @Test
+    fun `getCost returns null rather than a partial sum when a later page has a malformed amount`() {
+        whenever(sdkClient.getCostAndUsage(any<GetCostAndUsageRequest>())).thenReturn(
+            response(result("1.00"), nextPageToken = "next-page"),
+            response(result("not-a-decimal")),
+        )
+
+        assertNull(client().getCost(period))
+
+        verify(sdkClient, times(2)).getCostAndUsage(any<GetCostAndUsageRequest>())
+    }
+
+    @Test
+    fun `getCost returns null when a currency unit is blank`() {
+        stubResponse(response(result("1.00", unit = " ")))
+
+        assertNull(client().getCost(period))
+    }
+
+    @Test
+    fun `getCost returns null when currency units are inconsistent`() {
+        stubResponse(response(result("1.00", unit = "USD"), result("2.00", unit = "GBP")))
+
+        assertNull(client().getCost(period))
+    }
+
+    @Test
+    fun `getCost retains valid zero and negative amounts`() {
+        stubResponse(response(result("0"), result("-1.25")))
+
+        val result = client().getCost(period)
+
+        assertEquals(BigDecimal("-1.25"), result?.amount)
+    }
+
+    @Test
+    fun `getCost propagates AWS SDK exceptions`() {
+        whenever(sdkClient.getCostAndUsage(any<GetCostAndUsageRequest>())).thenThrow(
+            CostExplorerException.builder().message("AWS unavailable").build(),
+        )
+
+        assertFailsWith<CostExplorerException> { client().getCost(period) }
+    }
+}

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/clients/AwsCostExplorerMetricsClientTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/clients/AwsCostExplorerMetricsClientTests.kt
@@ -102,6 +102,7 @@ class AwsCostExplorerMetricsClientTests {
         val request = requestCaptor.firstValue
         assertEquals(Granularity.DAILY, request.granularity())
         assertEquals(listOf("UnblendedCost"), request.metrics())
+        assertNull(request.billingViewArn())
         assertNull(request.filter())
         assertEquals(emptyList(), request.groupBy())
     }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/clients/AwsCostExplorerMetricsClientTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/clients/AwsCostExplorerMetricsClientTests.kt
@@ -62,7 +62,7 @@ class AwsCostExplorerMetricsClientTests {
     }
 
     @Test
-    fun `getCost maps reporting period to inclusive UK dates with an exclusive end date`() {
+    fun `getCost requests an exclusive end date for an inclusive reporting period`() {
         stubResponse(response())
 
         client().getCost(period)

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/controllers/MetricsControllerTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/controllers/MetricsControllerTests.kt
@@ -4,7 +4,11 @@ import org.hamcrest.Matchers.containsString
 import org.hamcrest.Matchers.hasSize
 import org.hamcrest.Matchers.not
 import org.hamcrest.Matchers.stringContainsInOrder
+import org.junit.jupiter.api.BeforeEach
+import org.mockito.Mockito.verifyNoInteractions
 import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
@@ -19,11 +23,14 @@ import org.springframework.web.context.WebApplicationContext
 import uk.gov.communities.prsdb.webapp.config.MessageSourceConfig
 import uk.gov.communities.prsdb.webapp.controllers.MetricsController.Companion.METRICS_URL
 import uk.gov.communities.prsdb.webapp.models.dataModels.CloudWatchMetricsDataModel
+import uk.gov.communities.prsdb.webapp.models.dataModels.CostMetricsDataModel
 import uk.gov.communities.prsdb.webapp.models.dataModels.JourneyCompletionRatesDataModel
 import uk.gov.communities.prsdb.webapp.models.dataModels.MetricsDataModel
 import uk.gov.communities.prsdb.webapp.services.CloudWatchMetricsService
+import uk.gov.communities.prsdb.webapp.services.CostExplorerMetricsService
 import uk.gov.communities.prsdb.webapp.services.MetricsService
 import uk.gov.communities.prsdb.webapp.services.PlausibleMetricsService
+import java.math.BigDecimal
 import java.time.Duration
 import kotlin.test.Test
 
@@ -40,6 +47,14 @@ class MetricsControllerTests(
 
     @MockitoBean
     lateinit var cloudWatchMetricsService: CloudWatchMetricsService
+
+    @MockitoBean
+    lateinit var costExplorerMetricsService: CostExplorerMetricsService
+
+    @BeforeEach
+    fun setUpCostExplorerMetricsService() {
+        whenever(costExplorerMetricsService.getMetrics(any(), any())).thenReturn(CostMetricsDataModel())
+    }
 
     @Test
     fun `getMetrics returns a redirect for unauthenticated user`() {
@@ -128,6 +143,13 @@ class MetricsControllerTests(
                     attributeHasFieldErrors("formModel", "toDay")
                 }
             }
+
+        verifyNoInteractions(
+            metricsService,
+            plausibleMetricsService,
+            cloudWatchMetricsService,
+            costExplorerMetricsService,
+        )
     }
 
     @Test
@@ -172,7 +194,7 @@ class MetricsControllerTests(
 
     @Test
     @WithMockUser(roles = ["SYSTEM_OPERATOR"])
-    fun `submitMetrics populates seventeen metric rows for a valid date range`() {
+    fun `submitMetrics populates nineteen metric rows for a valid date range`() {
         whenever(metricsService.getMetrics(any())).thenReturn(
             MetricsDataModel(
                 numberOfLandlordRegistrations = 5L,
@@ -191,6 +213,14 @@ class MetricsControllerTests(
         whenever(cloudWatchMetricsService.getMetrics(any())).thenReturn(
             CloudWatchMetricsDataModel(73.4, 41.2, 62.5, 18.9, 0.82, 0.05),
         )
+        whenever(costExplorerMetricsService.getMetrics(any(), any())).thenReturn(
+            CostMetricsDataModel(
+                totalCost = BigDecimal("123.45"),
+                costPerTransaction = BigDecimal("0.17"),
+                currencyCode = "USD",
+                isEstimated = false,
+            ),
+        )
 
         mvc
             .post(METRICS_URL) {
@@ -206,7 +236,7 @@ class MetricsControllerTests(
                 status { isOk() }
                 view { name("metrics") }
                 model {
-                    attribute("metricRows", hasSize<Any>(17))
+                    attribute("metricRows", hasSize<Any>(19))
                 }
                 content {
                     string(
@@ -225,6 +255,117 @@ class MetricsControllerTests(
                             "0.05%",
                             "Total number of transactions",
                             "725",
+                            "Total AWS cost",
+                            "123.45 USD",
+                            "Cost per transaction",
+                            "0.17 USD",
+                        ),
+                    )
+                }
+            }
+
+        verify(plausibleMetricsService).getTransactionCounts(any())
+        verify(costExplorerMetricsService).getMetrics(any(), eq(725L))
+    }
+
+    @Test
+    @WithMockUser(roles = ["SYSTEM_OPERATOR"])
+    fun `submitMetrics renders estimated cost metrics`() {
+        stubNonCostMetricsServices()
+        whenever(costExplorerMetricsService.getMetrics(any(), any())).thenReturn(
+            CostMetricsDataModel(
+                totalCost = BigDecimal("123.45"),
+                costPerTransaction = BigDecimal("0.17"),
+                currencyCode = "USD",
+                isEstimated = true,
+            ),
+        )
+
+        mvc
+            .post(METRICS_URL) {
+                contentType = MediaType.APPLICATION_FORM_URLENCODED
+                param("fromDay", "10")
+                param("fromMonth", "1")
+                param("fromYear", "2025")
+                param("toDay", "20")
+                param("toMonth", "1")
+                param("toYear", "2025")
+                with(csrf())
+            }.andExpect {
+                status { isOk() }
+                content {
+                    string(
+                        stringContainsInOrder(
+                            "Total AWS cost",
+                            "123.45 USD (estimated)",
+                            "Cost per transaction",
+                            "0.17 USD (estimated)",
+                        ),
+                    )
+                }
+            }
+    }
+
+    @Test
+    @WithMockUser(roles = ["SYSTEM_OPERATOR"])
+    fun `submitMetrics renders no data for a missing cost per transaction`() {
+        stubNonCostMetricsServices()
+        whenever(costExplorerMetricsService.getMetrics(any(), any())).thenReturn(
+            CostMetricsDataModel(
+                totalCost = BigDecimal("123.45"),
+                currencyCode = "USD",
+            ),
+        )
+
+        mvc
+            .post(METRICS_URL) {
+                contentType = MediaType.APPLICATION_FORM_URLENCODED
+                param("fromDay", "10")
+                param("fromMonth", "1")
+                param("fromYear", "2025")
+                param("toDay", "20")
+                param("toMonth", "1")
+                param("toYear", "2025")
+                with(csrf())
+            }.andExpect {
+                status { isOk() }
+                content {
+                    string(
+                        stringContainsInOrder(
+                            "Total AWS cost",
+                            "123.45 USD",
+                            "Cost per transaction",
+                            "No data",
+                        ),
+                    )
+                }
+            }
+    }
+
+    @Test
+    @WithMockUser(roles = ["SYSTEM_OPERATOR"])
+    fun `submitMetrics renders no data for absent cost metrics`() {
+        stubNonCostMetricsServices()
+
+        mvc
+            .post(METRICS_URL) {
+                contentType = MediaType.APPLICATION_FORM_URLENCODED
+                param("fromDay", "10")
+                param("fromMonth", "1")
+                param("fromYear", "2025")
+                param("toDay", "20")
+                param("toMonth", "1")
+                param("toYear", "2025")
+                with(csrf())
+            }.andExpect {
+                status { isOk() }
+                content {
+                    string(
+                        stringContainsInOrder(
+                            "Total AWS cost",
+                            "No data",
+                            "Cost per transaction",
+                            "No data",
                         ),
                     )
                 }
@@ -298,5 +439,26 @@ class MetricsControllerTests(
                     attribute("metricRows", hasSize<Any>(0))
                 }
             }
+    }
+
+    private fun stubNonCostMetricsServices() {
+        whenever(metricsService.getMetrics(any())).thenReturn(
+            MetricsDataModel(
+                numberOfLandlordRegistrations = 0L,
+                numberOfVerifiedLandlords = 0L,
+                numberOfProperties = 0L,
+                numberOfLandlordsWithAProperty = 0L,
+                medianTimeToFirstProperty = null,
+                p90TimeToFirstProperty = null,
+                p95TimeToFirstProperty = null,
+            ),
+        )
+        whenever(plausibleMetricsService.getCompletionRates(any())).thenReturn(
+            JourneyCompletionRatesDataModel(null, null, null),
+        )
+        whenever(plausibleMetricsService.getTransactionCounts(any())).thenReturn(0L)
+        whenever(cloudWatchMetricsService.getMetrics(any())).thenReturn(
+            CloudWatchMetricsDataModel(null, null, null, null, null, null),
+        )
     }
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/MetricsSinglePageTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/MetricsSinglePageTests.kt
@@ -178,4 +178,15 @@ class MetricsSinglePageTests : IntegrationTestWithImmutableData("data-metrics-lo
         assertThat(reloadedPage.metricsList.rowValue(9)).containsText("33.33%")
         assertThat(reloadedPage.metricsList.rowValue(16)).containsText("753")
     }
+
+    @Test
+    fun `submitting a valid date range renders estimated cost metrics from the local stub`(page: Page) {
+        val metricsPage = navigator.goToMetricsPage()
+
+        metricsPage.submitDateRange("1", "9", "2024", "30", "6", "2025")
+
+        val reloadedPage = assertPageIs(page, MetricsPage::class)
+        assertThat(reloadedPage.metricsList.rowValue(17)).containsText("123.45 USD (estimated)")
+        assertThat(reloadedPage.metricsList.rowValue(18)).containsText("0.16 USD (estimated)")
+    }
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/CostExplorerMetricsServiceTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/CostExplorerMetricsServiceTests.kt
@@ -1,0 +1,144 @@
+package uk.gov.communities.prsdb.webapp.services
+
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import software.amazon.awssdk.core.exception.SdkClientException
+import software.amazon.awssdk.core.exception.SdkException
+import uk.gov.communities.prsdb.webapp.clients.CostExplorerMetricsClient
+import uk.gov.communities.prsdb.webapp.models.dataModels.CostExplorerCostDataModel
+import uk.gov.communities.prsdb.webapp.models.dataModels.CostMetricsDataModel
+import uk.gov.communities.prsdb.webapp.models.dataModels.ReportingPeriod
+import java.math.BigDecimal
+import java.time.Instant
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+@ExtendWith(MockitoExtension::class)
+class CostExplorerMetricsServiceTests {
+    @Mock
+    private lateinit var client: CostExplorerMetricsClient
+
+    private val period =
+        ReportingPeriod(Instant.parse("2025-01-10T00:00:00Z"), Instant.parse("2025-01-20T23:59:59Z"))
+
+    private fun service() = CostExplorerMetricsService(client)
+
+    @Test
+    fun `getMetrics returns total cost per transaction currency and final status`() {
+        whenever(client.getCost(period)).thenReturn(CostExplorerCostDataModel(BigDecimal("123.45"), "USD", false))
+
+        val result = service().getMetrics(period, 753)
+
+        assertEquals(
+            CostMetricsDataModel(
+                totalCost = BigDecimal("123.45"),
+                costPerTransaction = BigDecimal("0.16"),
+                currencyCode = "USD",
+                isEstimated = false,
+            ),
+            result,
+        )
+        verify(client).getCost(period)
+    }
+
+    @Test
+    fun `getMetrics rounds cost per transaction half up to two decimal places`() {
+        whenever(client.getCost(period)).thenReturn(CostExplorerCostDataModel(BigDecimal("1.00"), "USD", false))
+
+        val result = service().getMetrics(period, 8)
+
+        assertEquals(BigDecimal("0.13"), result.costPerTransaction)
+    }
+
+    @Test
+    fun `getMetrics preserves cost details without a cost per transaction when transaction count is zero`() {
+        whenever(client.getCost(period)).thenReturn(CostExplorerCostDataModel(BigDecimal("123.45"), "USD", true))
+
+        val result = service().getMetrics(period, 0)
+
+        assertEquals(
+            CostMetricsDataModel(totalCost = BigDecimal("123.45"), currencyCode = "USD", isEstimated = true),
+            result,
+        )
+    }
+
+    @Test
+    fun `getMetrics leaves cost per transaction null when transaction count is negative`() {
+        whenever(client.getCost(period)).thenReturn(CostExplorerCostDataModel(BigDecimal("123.45"), "USD", false))
+
+        assertEquals(null, service().getMetrics(period, -1).costPerTransaction)
+    }
+
+    @Test
+    fun `getMetrics retains zero source amounts with positive transaction counts`() {
+        whenever(client.getCost(period)).thenReturn(CostExplorerCostDataModel(BigDecimal("0.00"), "USD", false))
+
+        val result = service().getMetrics(period, 5)
+
+        assertEquals(
+            CostMetricsDataModel(
+                totalCost = BigDecimal("0.00"),
+                costPerTransaction = BigDecimal("0.00"),
+                currencyCode = "USD",
+                isEstimated = false,
+            ),
+            result,
+        )
+    }
+
+    @Test
+    fun `getMetrics retains negative source amounts and calculates negative cost per transaction`() {
+        whenever(client.getCost(period)).thenReturn(CostExplorerCostDataModel(BigDecimal("-1.00"), "USD", false))
+
+        val result = service().getMetrics(period, 8)
+
+        assertEquals(
+            CostMetricsDataModel(
+                totalCost = BigDecimal("-1.00"),
+                costPerTransaction = BigDecimal("-0.13"),
+                currencyCode = "USD",
+            ),
+            result,
+        )
+    }
+
+    @Test
+    fun `getMetrics returns no data when the client returns null`() {
+        whenever(client.getCost(period)).thenReturn(null)
+
+        assertEquals(CostMetricsDataModel(), service().getMetrics(period, 10))
+    }
+
+    @Test
+    fun `getMetrics returns no data when the client throws an SdkClientException`() {
+        whenever(client.getCost(period)).thenThrow(SdkClientException.create("AWS unavailable"))
+
+        assertEquals(CostMetricsDataModel(), service().getMetrics(period, 10))
+    }
+
+    @Test
+    fun `getMetrics returns no data when the client throws an SdkException`() {
+        whenever(client.getCost(period)).thenThrow(SdkException.builder().message("AWS unavailable").build())
+
+        assertEquals(CostMetricsDataModel(), service().getMetrics(period, 10))
+    }
+
+    @Test
+    fun `getMetrics propagates an unexpected RuntimeException from the client`() {
+        val exception = RuntimeException("Unexpected failure")
+        whenever(client.getCost(period)).thenThrow(exception)
+
+        assertEquals(exception, assertFailsWith<RuntimeException> { service().getMetrics(period, 10) })
+    }
+
+    @Test
+    fun `getMetrics copies estimated status from the cost data`() {
+        whenever(client.getCost(period)).thenReturn(CostExplorerCostDataModel(BigDecimal("1.00"), "USD", true))
+
+        assertEquals(true, service().getMetrics(period, 1).isEstimated)
+    }
+}


### PR DESCRIPTION
## Ticket number

PDJB-1036

## Goal of change

Allow system operators to see total AWS cost and cost per transaction for the selected metrics reporting period.

## Description of main change(s)

- Adds account-wide AWS Cost Explorer `UnblendedCost` for the selected inclusive reporting period.
- Adds total AWS cost and cost per transaction rows with estimated/no-data handling.
- Adds deterministic local behaviour and targeted unit, controller, and single-page integration coverage.
- Intentionally omits `BillingViewArn`; live authorization therefore requires `Resource = "*"` for the single `ce:GetCostAndUsage` action, while Cost Explorer returns the costs available to the hosting AWS account.

## Anything you'd like to highlight to the reviewer?

- Merged infra PR [communitiesuk/prsdb-infra#309](https://github.com/communitiesuk/prsdb-infra/pull/309) grants only `ce:GetCostAndUsage` with `Resource = "*"` for the live Cost Explorer query.

## Checklist

- [x] Unit tests for new logic (e.g. new service methods) have been added
- [x] Test suite has been run in full locally and is passing
- [x] Branch has been rebased onto main and run locally, with everything working as expected (both for the new feature and related functionality)
- [x] TODO comments referencing this JIRA ticket have been searched for and removed — none were found.
- [x] Any special release instructions have been added to the relevant release ticket on the Jira board, referencing this ticket number
- [x] QA instructions have been added to the ticket
- [x] This feature is not behind a feature flag. I've checked that this is appropriate and we're happy with this code becoming live as soon as we release

