### PR TITLE
PDJB-NONE: remove uneccesary prefix from some route segments

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/landlordRegistration/tasks/OrgLandlordRegistrationTask.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/landlordRegistration/tasks/OrgLandlordRegistrationTask.kt
@@ -190,7 +190,7 @@ class OrgLandlordRegistrationTask(
                 parents { journey.leadTrusteePhoneStep.isComplete() }
                 nextStep { journey.trusteeAddressTask.firstStep }
             }
-            duplicableTask(journey.trusteeAddressTask, TrusteeAddressTask.LEAD_TRUSTEE_ADDRESS_ROUTE_SEGMENT) {
+            duplicableTask(journey.trusteeAddressTask, TrusteeAddressTask.ROUTE_SEGMENT) {
                 parents { journey.leadTrusteeDobStep.isComplete() }
                 nextStep { journey.orgGovBodyDetailsStep }
             }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/shared/tasks/TrusteeAddressTask.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/shared/tasks/TrusteeAddressTask.kt
@@ -36,6 +36,6 @@ class TrusteeAddressTask(
         )
 
     companion object {
-        const val LEAD_TRUSTEE_ADDRESS_ROUTE_SEGMENT = "lead-trustee-address"
+        const val ROUTE_SEGMENT = "lead-trustee-address"
     }
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/Navigator.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/Navigator.kt
@@ -392,7 +392,7 @@ class Navigator(
 
     fun skipToOrgLandlordRegistrationLeadTrusteeAddressTaskRoute(): LeadTrusteeAddressFormPageLandlordRegistration {
         setJourneyStateInSession(LandlordStateSessionBuilder.beforeLeadTrusteeAddress().build())
-        navigateToLandlordRegistrationJourneyStep(TrusteeAddressTask.LEAD_TRUSTEE_ADDRESS_ROUTE_SEGMENT)
+        navigateToLandlordRegistrationJourneyStep(TrusteeAddressTask.ROUTE_SEGMENT)
         return createValidPage(page, LeadTrusteeAddressFormPageLandlordRegistration::class)
     }
 

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/landlordRegistrationJourneyPages/LeadTrusteeAddressFormPageLandlordRegistration.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/landlordRegistrationJourneyPages/LeadTrusteeAddressFormPageLandlordRegistration.kt
@@ -10,5 +10,5 @@ class LeadTrusteeAddressFormPageLandlordRegistration(
     page: Page,
 ) : LookupAddressFormPage(
         page,
-        "$LANDLORD_REGISTRATION_ROUTE/${TrusteeAddressTask.LEAD_TRUSTEE_ADDRESS_ROUTE_SEGMENT}/${LookupAddressStep.ROUTE_SEGMENT}",
+        "$LANDLORD_REGISTRATION_ROUTE/${TrusteeAddressTask.ROUTE_SEGMENT}/${LookupAddressStep.ROUTE_SEGMENT}",
     )

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/landlordRegistrationJourneyPages/LeadTrusteeSelectAddressFormPageLandlordRegistration.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/landlordRegistrationJourneyPages/LeadTrusteeSelectAddressFormPageLandlordRegistration.kt
@@ -10,5 +10,5 @@ class LeadTrusteeSelectAddressFormPageLandlordRegistration(
     page: Page,
 ) : SelectAddressFormPage(
         page,
-        "$LANDLORD_REGISTRATION_ROUTE/${TrusteeAddressTask.LEAD_TRUSTEE_ADDRESS_ROUTE_SEGMENT}/${SelectAddressStep.ROUTE_SEGMENT}",
+        "$LANDLORD_REGISTRATION_ROUTE/${TrusteeAddressTask.ROUTE_SEGMENT}/${SelectAddressStep.ROUTE_SEGMENT}",
     )

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/testHelpers/builders/LandlordStateSessionBuilder.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/testHelpers/builders/LandlordStateSessionBuilder.kt
@@ -176,7 +176,7 @@ class LandlordStateSessionBuilder(
         // The lead trustee address is a routed instance of the shared address task, so its data is stored under
         // keys prefixed with the task route. Provide a full "found and selected an address" path so the task is
         // complete and the journey can proceed past it.
-        val routePrefix = TrusteeAddressTask.LEAD_TRUSTEE_ADDRESS_ROUTE_SEGMENT
+        val routePrefix = TrusteeAddressTask.ROUTE_SEGMENT
         val singleLineAddress = "1 Example Street, Exampleton, EG1 2AB"
         withAdditionalData(
             "$routePrefix/cachedAddresses",


### PR DESCRIPTION
## Ticket number

PDJB-NONE

## Goal of change

Cleans up some route segments as per @Travis-Softwire's [comment on this PR](https://github.com/communitiesuk/prsdb-webapp/pull/1590#discussion_r3594356343)

## Description of main change(s)

Renames the other slug that isn't called a ROUTE_SEGMENT

## Checklist

Delete any that are not applicable, and add explanation below for any that are applicable but haven't been done

- [x] Test suite has been run in full locally and is passing
- [x] Branch has been rebased onto main and run locally, with everything working as expected (both for your new feature
  and any related functionality)