### PR TITLE
PDJB-1312: fix healthcheck failure issue

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/controllerAdvice/GlobalModelAttributes.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/controllerAdvice/GlobalModelAttributes.kt
@@ -23,6 +23,7 @@ import uk.gov.communities.prsdb.webapp.constants.RENTERS_RIGHTS_BILL_URL
 import uk.gov.communities.prsdb.webapp.constants.SYSTEM_OPERATOR_PATH_SEGMENT
 import uk.gov.communities.prsdb.webapp.controllers.BetaFeedbackController.Companion.FEEDBACK_URL
 import uk.gov.communities.prsdb.webapp.controllers.CookiesController.Companion.COOKIES_ROUTE
+import uk.gov.communities.prsdb.webapp.controllers.HealthCheckController.Companion.HEALTHCHECK_ROUTE
 import uk.gov.communities.prsdb.webapp.models.viewModels.NavigationLinkViewModel
 import uk.gov.communities.prsdb.webapp.services.BackUrlStorageService
 import uk.gov.communities.prsdb.webapp.services.DashboardUrlProvider
@@ -42,6 +43,10 @@ class GlobalModelAttributes(
         model: Model,
         request: HttpServletRequest,
     ) {
+        if (request.requestURI == HEALTHCHECK_ROUTE) {
+            return
+        }
+
         model.addAttribute("cookiesUrl", COOKIES_ROUTE.overrideBackLinkForUrl(backUrlStorageService.storeCurrentUrlReturningKey()))
         model.addAttribute("plausibleUrl", "$PLAUSIBLE_URL/js/pa-$plausibleSiteId.js")
         model.addAttribute("serverGeneratedNonce", getCurrentNonce())

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/DashboardUrlProvider.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/DashboardUrlProvider.kt
@@ -1,9 +1,8 @@
 package uk.gov.communities.prsdb.webapp.services
 
-import org.springframework.context.annotation.Primary
 import org.springframework.security.core.context.SecurityContextHolder
-import uk.gov.communities.prsdb.webapp.annotations.webAnnotations.PrsdbFlip
 import uk.gov.communities.prsdb.webapp.annotations.webAnnotations.PrsdbWebService
+import uk.gov.communities.prsdb.webapp.config.managers.FeatureFlagManager
 import uk.gov.communities.prsdb.webapp.constants.DASHBOARD_NAV_LINK
 import uk.gov.communities.prsdb.webapp.constants.ROLE_LANDLORD
 import uk.gov.communities.prsdb.webapp.constants.ROLE_LOCAL_COUNCIL_ADMIN
@@ -13,21 +12,15 @@ import uk.gov.communities.prsdb.webapp.controllers.LandlordController.Companion.
 import uk.gov.communities.prsdb.webapp.controllers.LocalCouncilDashboardController.Companion.LOCAL_COUNCIL_DASHBOARD_URL
 import uk.gov.communities.prsdb.webapp.controllers.SystemOperatorDashboardController.Companion.SYSTEM_OPERATOR_DASHBOARD_URL
 
-@PrsdbFlip(name = DASHBOARD_NAV_LINK, alterBean = "dashboard-url-provider-flag-on")
-interface DashboardUrlProvider {
-    fun getDashboardUrlForCurrentUser(): String?
-}
+@PrsdbWebService
+class DashboardUrlProvider(
+    private val featureFlagManager: FeatureFlagManager,
+) {
+    fun getDashboardUrlForCurrentUser(): String? {
+        if (!featureFlagManager.checkFeature(DASHBOARD_NAV_LINK)) {
+            return null
+        }
 
-@Primary
-@PrsdbWebService("dashboard-url-provider-flag-off")
-class DashboardUrlProviderImplFlagOff : DashboardUrlProvider {
-    // The dashboard nav link feature is disabled, so no dashboard URL is provided.
-    override fun getDashboardUrlForCurrentUser(): String? = null
-}
-
-@PrsdbWebService("dashboard-url-provider-flag-on")
-class DashboardUrlProviderImplFlagOn : DashboardUrlProvider {
-    override fun getDashboardUrlForCurrentUser(): String? {
         val authorities =
             SecurityContextHolder.getContext().authentication
                 ?.authorities

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/controllers/controllerAdvice/GlobalModelAttributesTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/controllers/controllerAdvice/GlobalModelAttributesTests.kt
@@ -3,10 +3,13 @@ package uk.gov.communities.prsdb.webapp.controllers.controllerAdvice
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.Mock
+import org.mockito.Mockito.verifyNoInteractions
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.any
 import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.eq
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.springframework.context.MessageSource
 import org.springframework.mock.web.MockHttpServletRequest
@@ -17,6 +20,7 @@ import org.springframework.test.util.ReflectionTestUtils
 import org.springframework.ui.ExtendedModelMap
 import uk.gov.communities.prsdb.webapp.constants.LOCAL_COUNCIL_PATH_SEGMENT
 import uk.gov.communities.prsdb.webapp.constants.SYSTEM_OPERATOR_PATH_SEGMENT
+import uk.gov.communities.prsdb.webapp.controllers.HealthCheckController
 import uk.gov.communities.prsdb.webapp.models.viewModels.NavigationLinkViewModel
 import uk.gov.communities.prsdb.webapp.services.BackUrlStorageService
 import uk.gov.communities.prsdb.webapp.services.DashboardUrlProvider
@@ -261,6 +265,21 @@ class GlobalModelAttributesTests {
         globalModelAttributes.addGlobalModelAttributes(model, request)
 
         assertNull(model["navLinks"])
+    }
+
+    @Test
+    fun `addGlobalModelAttributes does no page setup work for the healthcheck route`() {
+        val globalModelAttributes = createGlobalModelAttributes()
+        val model = ExtendedModelMap()
+        val request = MockHttpServletRequest()
+        request.requestURI = HealthCheckController.HEALTHCHECK_ROUTE
+
+        globalModelAttributes.addGlobalModelAttributes(model, request)
+
+        verify(backUrlStorageService, never()).storeCurrentUrlReturningKey()
+        verify(dashboardUrlProvider, never()).getDashboardUrlForCurrentUser()
+        verifyNoInteractions(messageSource)
+        assertTrue(model.asMap().isEmpty())
     }
 
     private fun createOAuth2AuthenticationToken(registrationId: String): OAuth2AuthenticationToken {


### PR DESCRIPTION
## Ticket number

PDJB-1312

## Goal of change

Fixes the healthcheck failure issue

## Description of main change(s)

Does this by early returning for healthcheck instead of trying to render the dashboard.
Also replaces PRSDB flip with flag manager.

## Checklist

Delete any that are not applicable, and add explanation below for any that are applicable but haven't been done

- [x] Unit tests for new logic (e.g. new service methods) have been added
- [x] Test suite has been run in full locally and is passing
- [ ] Branch has been rebased onto main and run locally, with everything working as expected (both for your new feature
  and any related functionality)
- [ ] QA instructions have been added to the ticket (particularly if this is the last PR required to complete the ticket)