### PR TITLE
PDJB-1169: Fix landlord model error

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/database/entity/AuditableEntity.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/database/entity/AuditableEntity.kt
@@ -16,6 +16,6 @@ abstract class AuditableEntity : Serializable {
     @CreatedDate
     @Temporal(TemporalType.TIMESTAMP)
     @Column(nullable = false, updatable = false)
-    lateinit var createdDate: Instant
-        private set
+    open lateinit var createdDate: Instant
+        protected set
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/database/entity/IndividualLandlord.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/database/entity/IndividualLandlord.kt
@@ -7,12 +7,18 @@ import jakarta.persistence.JoinColumn
 import jakarta.persistence.ManyToOne
 import jakarta.persistence.OneToMany
 import jakarta.persistence.OneToOne
+import jakarta.persistence.Transient
 import uk.gov.communities.prsdb.webapp.constants.ENGLAND_OR_WALES
+import uk.gov.communities.prsdb.webapp.constants.enums.LandlordType
 import java.time.LocalDate
 
 @Entity
 @DiscriminatorValue("0")
 class IndividualLandlord() : Landlord() {
+    @get:Transient
+    override val landlordType: LandlordType
+        get() = LandlordType.INDIVIDUAL
+
     @OneToOne
     @JoinColumn(name = "individual_subject_identifier", unique = true)
     lateinit var baseUser: PrsdbUser

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/database/entity/Landlord.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/database/entity/Landlord.kt
@@ -15,14 +15,15 @@ import jakarta.persistence.OneToOne
 @Entity
 @Inheritance(strategy = InheritanceType.SINGLE_TABLE)
 @DiscriminatorColumn(name = "landlord_type", discriminatorType = DiscriminatorType.INTEGER)
-sealed class Landlord : ModifiableAuditableEntity() {
+// Hibernate creates subclass proxies for this inheritance root, so it and its persistent getters must remain open.
+abstract class Landlord : ModifiableAuditableEntity() {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    val id: Long = 0
+    open val id: Long = 0
 
     @OneToOne(optional = false)
     @JoinColumn(name = "registration_number_id", nullable = false, unique = true)
-    lateinit var registrationNumber: RegistrationNumber
+    open lateinit var registrationNumber: RegistrationNumber
         protected set
 
     @OneToMany(mappedBy = "landlord", orphanRemoval = true)

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/database/entity/Landlord.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/database/entity/Landlord.kt
@@ -11,12 +11,17 @@ import jakarta.persistence.InheritanceType
 import jakarta.persistence.JoinColumn
 import jakarta.persistence.OneToMany
 import jakarta.persistence.OneToOne
+import jakarta.persistence.Transient
+import uk.gov.communities.prsdb.webapp.constants.enums.LandlordType
 
 @Entity
 @Inheritance(strategy = InheritanceType.SINGLE_TABLE)
 @DiscriminatorColumn(name = "landlord_type", discriminatorType = DiscriminatorType.INTEGER)
 // Hibernate creates subclass proxies for this inheritance root, so it and its persistent getters must remain open.
 abstract class Landlord : ModifiableAuditableEntity() {
+    @get:Transient
+    abstract val landlordType: LandlordType
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     open val id: Long = 0

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/database/entity/ModifiableAuditableEntity.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/database/entity/ModifiableAuditableEntity.kt
@@ -15,8 +15,8 @@ abstract class ModifiableAuditableEntity :
     @LastModifiedDate
     @Temporal(TemporalType.TIMESTAMP)
     @Column(insertable = false)
-    var lastModifiedDate: Instant? = null
-        private set
+    open var lastModifiedDate: Instant? = null
+        protected set
 
     fun getMostRecentlyUpdated(): Instant = lastModifiedDate ?: createdDate
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/database/entity/OrganisationLandlord.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/database/entity/OrganisationLandlord.kt
@@ -5,12 +5,18 @@ import jakarta.persistence.DiscriminatorValue
 import jakarta.persistence.Entity
 import jakarta.persistence.JoinColumn
 import jakarta.persistence.ManyToOne
+import jakarta.persistence.Transient
 import uk.gov.communities.prsdb.webapp.constants.enums.CharityRegulator
+import uk.gov.communities.prsdb.webapp.constants.enums.LandlordType
 import java.time.LocalDate
 
 @Entity
 @DiscriminatorValue("1")
 class OrganisationLandlord() : Landlord() {
+    @get:Transient
+    override val landlordType: LandlordType
+        get() = LandlordType.ORGANISATION
+
     @Column(name = "organisation_landlord_name")
     var name: String? = null
 


### PR DESCRIPTION
## Ticket number

[PDJB-1169](https://mhclgdigital.atlassian.net/browse/PDJB-1169)

## Goal of change

resolves the following warning on app boot

```
Getter methods of lazy classes cannot be final: uk.gov.communities.prsdb.webapp.database.entity.AuditableEntity#getCreatedDate
```

## Description of main change(s)

the issue is that hibernate wants to make a proxy object for landlord to allow for lazy loading for a generic landlord reference. it cannot do this if:
- there are final methods
- the class is sealed

this PR removes the following from the landlord objects

since this removes the sealed annotation, I've added a getter to a landlord type to return an enum, this means you can still discriminate on landlord types exhaustively

## Checklist

Delete any that are not applicable, and add explanation below for any that are applicable but haven't been done

- [x] Test suite has been run in full locally and is passing
- [x] Branch has been rebased onto main and run locally, with everything working as expected (both for your new feature
  and any related functionality)
- [x] This feature is not behind a feature flag. I've checked that this is appropriate and we're happy with this code becoming live as soon as we release
