### PR TITLE
PDJB-NONE: Keep journey redirects absolute when the journey has no stored base path

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/JourneyStateService.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/JourneyStateService.kt
@@ -198,11 +198,11 @@ class JourneyStateService(
             journeyId: String,
         ): String {
             if (path.startsWith("/")) return path
-            val basePath = journeyBasePath(journeyId)
-            // Fallback for journeys whose controller has not yet been ported to the journey dispatcher: no base
-            // path is stored, so the URL stays relative and behaves exactly as before. This fallback (and the
-            // relative-URL branch below) can be removed once every journey controller uses the dispatcher, at
-            // which point a base path is always stored and all journey URLs become absolute.
+            // Prefer the base path stored against the journey. When none is stored - for example the journey has
+            // expired from the session but its id is still in the URL - fall back to the base path the dispatcher
+            // derived for the current request. This keeps redirects absolute: a relative URL would be resolved by
+            // the browser against the current path and duplicate the task route segment.
+            val basePath = journeyBasePath(journeyId) ?: currentRequestBasePath()
             return if (!basePath.isNullOrEmpty()) "$basePath/$path" else path
         }
 

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/JourneyStateService.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/JourneyStateService.kt
@@ -200,8 +200,10 @@ class JourneyStateService(
             if (path.startsWith("/")) return path
             // Prefer the base path stored against the journey. When none is stored - for example the journey has
             // expired from the session but its id is still in the URL - fall back to the base path the dispatcher
-            // derived for the current request. This keeps redirects absolute: a relative URL would be resolved by
-            // the browser against the current path and duplicate the task route segment.
+            // derived for the current request, so the redirect stays absolute rather than relative (a relative URL
+            // would be resolved by the browser against the current path and duplicate the task route segment).
+            // If neither is available - a controller not yet ported to the journey dispatcher never sets the
+            // request base path - the URL stays relative and behaves exactly as before.
             val basePath = journeyBasePath(journeyId) ?: currentRequestBasePath()
             return if (!basePath.isNullOrEmpty()) "$basePath/$path" else path
         }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/controllers/RegisterLandlordControllerTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/controllers/RegisterLandlordControllerTests.kt
@@ -14,7 +14,6 @@ import uk.gov.communities.prsdb.webapp.controllers.LandlordController.Companion.
 import uk.gov.communities.prsdb.webapp.controllers.RegisterLandlordController.Companion.LANDLORD_REGISTRATION_CONFIRMATION_ROUTE
 import uk.gov.communities.prsdb.webapp.controllers.RegisterLandlordController.Companion.LANDLORD_REGISTRATION_ROUTE
 import uk.gov.communities.prsdb.webapp.controllers.RegisterLandlordController.Companion.LANDLORD_REGISTRATION_START_PAGE_ROUTE
-import uk.gov.communities.prsdb.webapp.journeys.JourneyStateService
 import uk.gov.communities.prsdb.webapp.journeys.NoSuchJourneyException
 import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.LandlordRegistrationJourneyFactory
 import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.PrivacyNoticeStep
@@ -86,7 +85,7 @@ class RegisterLandlordControllerTests(
             .get("$LANDLORD_REGISTRATION_ROUTE/${PrivacyNoticeStep.ROUTE_SEGMENT}")
             .andExpect {
                 status { is3xxRedirection() }
-                redirectedUrl(JourneyStateService.urlWithJourneyState(PrivacyNoticeStep.ROUTE_SEGMENT, journeyId))
+                redirectedUrl("$LANDLORD_REGISTRATION_ROUTE/${PrivacyNoticeStep.ROUTE_SEGMENT}?journeyId=$journeyId")
             }
     }
 

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/JourneyStateServiceTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/JourneyStateServiceTests.kt
@@ -15,7 +15,10 @@ import org.mockito.kotlin.never
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
+import org.springframework.mock.web.MockHttpServletRequest
 import org.springframework.mock.web.MockHttpSession
+import org.springframework.web.context.request.RequestContextHolder
+import org.springframework.web.context.request.ServletRequestAttributes
 import uk.gov.communities.prsdb.webapp.exceptions.JourneyInitialisationException
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
@@ -441,6 +444,33 @@ class JourneyStateServiceTests {
 
         // Assert
         assertEquals("$baseUrl?journeyId=$journeyId", urlWithParam)
+    }
+
+    @Test
+    fun `urlWithJourneyState falls back to the request base path when the journey has no stored base path`() {
+        // Arrange
+        val journeyId = "test-journey-id"
+        val requestBasePath = "/landlord/register-as-a-landlord"
+
+        // The journey is in the session but has no stored base path (e.g. it expired from the session but its id
+        // is still in the URL), so the base path must come from the current request.
+        val session = MockHttpSession()
+        session.setJourneyStateMetadataStore(JourneyMetadataStore(mapOf(journeyId to JourneyMetadata.createNew(journeyId))))
+
+        val request = MockHttpServletRequest()
+        request.setSession(session)
+        request.setAttribute(JourneyStateService.JOURNEY_BASE_PATH_ATTRIBUTE, requestBasePath)
+        RequestContextHolder.setRequestAttributes(ServletRequestAttributes(request))
+
+        try {
+            // Act
+            val url = JourneyStateService.urlWithJourneyState("lead-trustee-address/select-address", journeyId)
+
+            // Assert
+            assertEquals("$requestBasePath/lead-trustee-address/select-address?journeyId=$journeyId", url)
+        } finally {
+            RequestContextHolder.resetRequestAttributes()
+        }
     }
 
     @Test


### PR DESCRIPTION
## Ticket number

PDJB-NONE

## Goal of change

Fix broken journey URLs (a duplicated path segment, leading to 404s) that appeared when continuing a registration journey whose session had expired but whose id was still in the URL.

## Description of main change(s)

- Journey step URLs are built by prefixing the step path with a base path stored against the journey. When no base path was stored (e.g. the journey had expired from the session but its id was still in the URL), the URL was emitted **relative**, so the browser resolved it against the current path and duplicated the task route segment — e.g. `.../lead-trustee-address/lead-trustee-address/select-address` — which 404s.
- `resolvePathAgainstJourneyBase` now falls back to the base path the journey dispatcher already derives for the current request, so these redirects stay absolute.
- Added a unit test for the fallback, and updated one `RegisterLandlordControllerTests` assertion to expect the (now correct) absolute redirect URL.

## Anything you'd like to highlight to the reviewer?

- This is shared journey-framework code. Behaviour is unchanged for journeys that already have a stored base path, and for legacy controllers that do not set the request base-path attribute (those stay relative, exactly as before).
- This also fixes a failing integration test on the PDJB-1290 branch (the governing-body "add another" member-address flow), which hits the same root cause because the test seeds journey state into the session without a stored base path.

## Checklist

- [x] Unit tests for new logic (e.g. new service methods) have been added
- [x] Full unit test suite (`testWithoutIntegration`) and `ktlintCheck` pass locally (integration suite runs in CI)
- [x] Branch is based on the latest `main`
- [x] This feature is not behind a feature flag. I've checked that this is appropriate and we're happy with this code becoming live as soon as we release
