### PR TITLE
PDJB-1344: Add .wiz file to ignore restrictive-license false positives

### DIFF
--- a/.wiz
+++ b/.wiz
@@ -1,0 +1,22 @@
+# Wiz Code scan exclusions for this repository.
+# Docs: https://docs.wiz.io/docs/exception-management-with-wiz-code
+# Note: the "Repository configuration file (.wiz)" setting must be enabled for this
+# repo/connector/tenant in the Wiz portal, otherwise this file has no effect.
+ignore:
+  software_management:
+    # wsscr-1 = built-in "Code library with Restrictive license" rule (false positives)
+    wsscr-1:
+      "/build.gradle.kts":
+        reason: FALSE_POSITIVE
+      "/package.json":
+        reason: FALSE_POSITIVE
+      "/package-lock.json":
+        reason: FALSE_POSITIVE
+      "/scripts/package.json":
+        reason: FALSE_POSITIVE
+      "/scripts/package-lock.json":
+        reason: FALSE_POSITIVE
+      "/scripts/plausible/package.json":
+        reason: FALSE_POSITIVE
+      "/scripts/plausible/package-lock.json":
+        reason: FALSE_POSITIVE


### PR DESCRIPTION
## Ticket number

PDJB-1344

## Goal of change

Stop Wiz Code raising false-positive restrictive-license findings against our dependencies during org-level scans.

## Description of main change(s)

Adds a root `.wiz` Wiz Code configuration file that excludes the built-in "Code library with Restrictive license" rule (`wsscr-1`) for this repository's dependency files (`build.gradle.kts` and the `package.json` / `package-lock.json` files). This is Wiz's documented repository-level exception method. The tenant-level "Enable repository configuration file (.wiz)" setting is already enabled, so the file will take effect when the (currently disabled) rule is re-enabled.

## Anything you'd like to highlight to the reviewer?

- The exclusion is scoped to dependency files only (not repo-wide) and uses `reason: FALSE_POSITIVE`.
- `wsscr-1` was confirmed from the Wiz portal (Policies > Software Management Rules) as the built-in "Code library with Restrictive license" rule.
- No `expires` is set; it can be added if we prefer to time-box the exception.

## Checklist

N/A - configuration-only change. No application code, endpoints, journeys, email templates, or database schema changes.
