### PR TITLE
PDJB-1327: Move lead trustee date of birth step between name and email steps

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/landlordRegistration/tasks/OrgLandlordRegistrationTask.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/landlordRegistration/tasks/OrgLandlordRegistrationTask.kt
@@ -119,25 +119,25 @@ class OrgLandlordRegistrationTask(
             step(journey.leadTrusteeNameStep) {
                 routeSegment(LeadTrusteeNameStep.ROUTE_SEGMENT)
                 parents { journey.orgTypeStep.isComplete() }
+                nextStep { journey.leadTrusteeDobStep }
+            }
+            step(journey.leadTrusteeDobStep) {
+                routeSegment(LeadTrusteeDobStep.ROUTE_SEGMENT)
+                parents { journey.leadTrusteeNameStep.isComplete() }
                 nextStep { journey.leadTrusteeEmailStep }
             }
             step(journey.leadTrusteeEmailStep) {
                 routeSegment(LeadTrusteeEmailStep.ROUTE_SEGMENT)
-                parents { journey.leadTrusteeNameStep.isComplete() }
+                parents { journey.leadTrusteeDobStep.isComplete() }
                 nextStep { journey.leadTrusteePhoneStep }
             }
             step(journey.leadTrusteePhoneStep) {
                 routeSegment(LeadTrusteePhoneStep.ROUTE_SEGMENT)
                 parents { journey.leadTrusteeEmailStep.isComplete() }
-                nextStep { journey.leadTrusteeDobStep }
-            }
-            step(journey.leadTrusteeDobStep) {
-                routeSegment(LeadTrusteeDobStep.ROUTE_SEGMENT)
-                parents { journey.leadTrusteePhoneStep.isComplete() }
                 nextStep { journey.trusteeAddressTask.firstStep }
             }
             duplicableTask(journey.trusteeAddressTask, TrusteeAddressTask.ROUTE_SEGMENT) {
-                parents { journey.leadTrusteeDobStep.isComplete() }
+                parents { journey.leadTrusteePhoneStep.isComplete() }
                 // TODO PDJB-1257: reroute to the exit point of the trustee section
                 nextStep { journey.orgCharityStep }
             }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/LandlordRegistrationJourneyTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/LandlordRegistrationJourneyTests.kt
@@ -293,14 +293,14 @@ class LandlordRegistrationJourneyTests : IntegrationTestWithMutableData("data-mo
         val leadTrusteeNamePage = assertPageIs(page, LeadTrusteeNameFormPageLandlordRegistration::class)
         leadTrusteeNamePage.submitName("Test Lead Trustee Name")
 
+        val leadTrusteeDobPage = assertPageIs(page, LeadTrusteeDobFormPageLandlordRegistration::class)
+        leadTrusteeDobPage.submitDate("15", "6", "1980")
+
         val leadTrusteeEmailPage = assertPageIs(page, LeadTrusteeEmailFormPageLandlordRegistration::class)
         leadTrusteeEmailPage.submitEmail("trustee@test.com")
 
         val leadTrusteePhonePage = assertPageIs(page, LeadTrusteePhoneFormPageLandlordRegistration::class)
         leadTrusteePhonePage.submitPhoneNumber("07123456789")
-
-        val leadTrusteeDobPage = assertPageIs(page, LeadTrusteeDobFormPageLandlordRegistration::class)
-        leadTrusteeDobPage.submitDate("15", "6", "1980")
 
         val leadTrusteeLookupAddressPage = assertPageIs(page, LeadTrusteeAddressFormPageLandlordRegistration::class)
         leadTrusteeLookupAddressPage.submitPostcodeAndBuildingNameOrNumber("EG1 2AA", "1")

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/OrganisationLandlordRegistrationSinglePageTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/OrganisationLandlordRegistrationSinglePageTests.kt
@@ -14,7 +14,7 @@ import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.BaseCo
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages.BasePage.Companion.assertPageIs
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.landlordRegistrationJourneyPages.LandlordTypeFormPageLandlordRegistration
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.landlordRegistrationJourneyPages.LeadTrusteeAddressFormPageLandlordRegistration
-import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.landlordRegistrationJourneyPages.LeadTrusteeDobFormPageLandlordRegistration
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.landlordRegistrationJourneyPages.LeadTrusteeEmailFormPageLandlordRegistration
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.landlordRegistrationJourneyPages.OrgEmailFormPageLandlordRegistration
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.landlordRegistrationJourneyPages.OrgGovBodyMemberLookupAddressFormPageLandlordRegistration
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.landlordRegistrationJourneyPages.OrgGovBodyMustProvideInfoFormPageLandlordRegistration
@@ -347,10 +347,10 @@ class OrganisationLandlordRegistrationSinglePageTests : IntegrationTestWithImmut
         }
 
         @Test
-        fun `submitting a valid lead trustee phone number advances to the lead trustee date of birth step`(page: Page) {
+        fun `submitting a valid lead trustee phone number advances to the lead trustee address step`(page: Page) {
             val leadTrusteePhonePage = navigator.skipToOrgLandlordRegistrationLeadTrusteePhonePage()
             leadTrusteePhonePage.submitPhoneNumber("07123456789")
-            assertPageIs(page, LeadTrusteeDobFormPageLandlordRegistration::class)
+            assertPageIs(page, LeadTrusteeAddressFormPageLandlordRegistration::class)
         }
     }
 
@@ -380,17 +380,17 @@ class OrganisationLandlordRegistrationSinglePageTests : IntegrationTestWithImmut
         }
 
         @Test
-        fun `submitting a valid date of birth advances to the lead trustee address step`(page: Page) {
+        fun `submitting a valid date of birth advances to the lead trustee email step`(page: Page) {
             val leadTrusteeDobPage = navigator.skipToOrgLandlordRegistrationLeadTrusteeDobPage()
             leadTrusteeDobPage.submitDate("15", "6", "1980")
-            assertPageIs(page, LeadTrusteeAddressFormPageLandlordRegistration::class)
+            assertPageIs(page, LeadTrusteeEmailFormPageLandlordRegistration::class)
         }
 
         @Test
-        fun `submitting a valid date of birth with leading zeros advances to the lead trustee address step`(page: Page) {
+        fun `submitting a valid date of birth with leading zeros advances to the lead trustee email step`(page: Page) {
             val leadTrusteeDobPage = navigator.skipToOrgLandlordRegistrationLeadTrusteeDobPage()
             leadTrusteeDobPage.submitDate("05", "06", "1980")
-            assertPageIs(page, LeadTrusteeAddressFormPageLandlordRegistration::class)
+            assertPageIs(page, LeadTrusteeEmailFormPageLandlordRegistration::class)
         }
     }
 

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/testHelpers/builders/LandlordStateSessionBuilder.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/testHelpers/builders/LandlordStateSessionBuilder.kt
@@ -326,13 +326,13 @@ class LandlordStateSessionBuilder(
 
         fun beforeLeadTrusteeName() = beforeOrgType().withOrgType()
 
-        fun beforeLeadTrusteeEmail() = beforeLeadTrusteeName().withLeadTrusteeName()
+        fun beforeLeadTrusteeDob() = beforeLeadTrusteeName().withLeadTrusteeName()
+
+        fun beforeLeadTrusteeEmail() = beforeLeadTrusteeDob().withLeadTrusteeDob()
 
         fun beforeLeadTrusteePhone() = beforeLeadTrusteeEmail().withLeadTrusteeEmail()
 
-        fun beforeLeadTrusteeDob() = beforeLeadTrusteePhone().withLeadTrusteePhone()
-
-        fun beforeLeadTrusteeAddress() = beforeLeadTrusteeDob().withLeadTrusteeDob()
+        fun beforeLeadTrusteeAddress() = beforeLeadTrusteePhone().withLeadTrusteePhone()
 
         fun beforeOrgCharity() = beforeLeadTrusteeAddress().withLeadTrusteeAddress()
 


### PR DESCRIPTION
## Ticket number

PDJB-1327

## Goal of change

Reorder the organisation landlord registration journey so the lead trustee's date of birth is captured immediately after their name, rather than after their phone number.

## Description of main change(s)

- Moves the Lead Trustee Date of Birth step so it sits between the Lead Trustee Name and Lead Trustee Email steps. New order: Name → Date of Birth → Email → Phone → Address.
- Updates the journey integration test and single-page step tests to reflect the new step order.

## Anything you'd like to highlight to the reviewer?

Pure reordering — no new fields, entities, migrations, or feature flags. The whole journey is still gated behind the (unreleased) `ORGANISATION_LANDLORD_REGISTRATION` flag. The two existing `// TODO PDJB-1257` comments in `OrgLandlordRegistrationTask.kt` belong to a different ticket and are intentionally left in place.

## Checklist

- [x] Test suite has been run in full locally and is passing 
- [x] Branch has been rebased onto main and run locally, with everything working as expected — branch was cut from freshly pulled `main`.
- [x] TODO comments referencing this JIRA ticket have been searched for and removed 
- [x] QA instructions have been added to the ticket (particularly if this is the last PR required to complete the ticket)
- [x] This feature is behind a feature flag. I've checked that there will be no change in function if the feature flag is disabled
