### PR TITLE
PDJB-1346: Hide compliance notification banner from local council users

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/summaryModels/propertyComplianceViewModels/PropertyComplianceViewModelFactory.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/summaryModels/propertyComplianceViewModels/PropertyComplianceViewModelFactory.kt
@@ -101,7 +101,12 @@ class PropertyComplianceViewModelFactory(
 
         val epcExpiredInsetViewModel = epcViewModelFactory.getEpcExpiredInsetViewModel(propertyCompliance)
 
-        val notificationMessages = notificationBannerViewModelFactory.getNotificationMessageKeys(propertyCompliance)
+        val notificationMessages =
+            if (landlordView) {
+                notificationBannerViewModelFactory.getNotificationMessageKeys(propertyCompliance)
+            } else {
+                emptyList()
+            }
 
         val isAllValid = notificationBannerViewModelFactory.getIsAllValid(propertyCompliance)
 

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/PropertyDetailsTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/PropertyDetailsTests.kt
@@ -330,30 +330,27 @@ class PropertyDetailsTests : IntegrationTestWithImmutableData("data-local.sql") 
         @Nested
         inner class NotificationBanner {
             @Test
-            fun `is visible and includes correct messages when all certs are missing`(page: Page) {
+            fun `is not visible when certs are missing`(page: Page) {
                 val propertyOwnershipId = 8
                 val detailsPage = navigator.goToPropertyDetailsLocalCouncilView(propertyOwnershipId.toLong())
 
-                assertThat(detailsPage.notificationBanner).isVisible()
-                assertThat(detailsPage.notificationBanner).containsText("You must add compliance certificates for this property")
+                assertThat(detailsPage.notificationBanner).isHidden()
             }
 
             @Test
-            fun `is visible and includes correct messages when all certs are expired`(page: Page) {
+            fun `is not visible when certs are expired`(page: Page) {
                 val propertyOwnershipId = 9
                 val detailsPage = navigator.goToPropertyDetailsLocalCouncilView(propertyOwnershipId.toLong())
 
-                assertThat(detailsPage.notificationBanner).isVisible()
-                assertThat(detailsPage.notificationBanner).containsText("Multiple compliance certificates for this property have expired")
+                assertThat(detailsPage.notificationBanner).isHidden()
             }
 
             @Test
-            fun `is visible and includes correct message when epc has a low rating and mees exemption is missing`(page: Page) {
+            fun `is not visible when epc has a low rating and mees exemption is missing`(page: Page) {
                 val propertyOwnershipId = 10
                 val detailsPage = navigator.goToPropertyDetailsLocalCouncilView(propertyOwnershipId.toLong())
 
-                assertThat(detailsPage.notificationBanner).isVisible()
-                assertThat(detailsPage.notificationBanner).containsText("You must add compliance certificates for this property")
+                assertThat(detailsPage.notificationBanner).isHidden()
             }
 
             @Test

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/summaryModels/propertyComplianceViewModels/PropertyComplianceViewModelFactoryTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/summaryModels/propertyComplianceViewModels/PropertyComplianceViewModelFactoryTests.kt
@@ -522,7 +522,67 @@ class PropertyComplianceViewModelFactoryTests {
     }
 
     @Nested
-    inner class NonLandlordViewNotifications : NotificationTests() {
-        override val landlordView = false
+    inner class LocalCouncilViewNotifications {
+        @Test
+        fun `notificationMessages is empty when occupied property has all certs missing`() {
+            val propertyCompliance = PropertyComplianceBuilder.createWithMissingCerts(propertyIsOccupied = true)
+
+            val result =
+                propertyComplianceViewModelFactory.create(
+                    propertyCompliance,
+                    landlordView = false,
+                    propertyOwnershipId = propertyOwnershipId,
+                )
+
+            assertEquals(emptyList(), result.notificationMessages)
+        }
+
+        @Test
+        fun `notificationMessages is empty when all certs are expired`() {
+            val propertyCompliance = PropertyComplianceBuilder.createWithExpiredCerts()
+
+            val result =
+                propertyComplianceViewModelFactory.create(
+                    propertyCompliance,
+                    landlordView = false,
+                    propertyOwnershipId = propertyOwnershipId,
+                )
+
+            assertEquals(emptyList(), result.notificationMessages)
+        }
+
+        @Test
+        fun `notificationMessages is empty when occupied property has missing and expired certs`() {
+            val propertyCompliance =
+                PropertyComplianceBuilder()
+                    .withOccupiedPropertyOwnership()
+                    .withExpiredGasSafetyCert()
+                    .withElectricalCertType()
+                    .withEpc()
+                    .build()
+
+            val result =
+                propertyComplianceViewModelFactory.create(
+                    propertyCompliance,
+                    landlordView = false,
+                    propertyOwnershipId = propertyOwnershipId,
+                )
+
+            assertEquals(emptyList(), result.notificationMessages)
+        }
+
+        @Test
+        fun `notificationMessages is empty when epc rating is low`() {
+            val propertyCompliance = PropertyComplianceBuilder.createWithInDateCertsAndLowEpcRating(propertyIsOccupied = true)
+
+            val result =
+                propertyComplianceViewModelFactory.create(
+                    propertyCompliance,
+                    landlordView = false,
+                    propertyOwnershipId = propertyOwnershipId,
+                )
+
+            assertEquals(emptyList(), result.notificationMessages)
+        }
     }
 }


### PR DESCRIPTION
## Ticket number

PDJB-1346

## Goal of change

Stop the "Important" compliance notification banner (e.g. "You must add compliance certificates for this property") from being shown to local council users on the property record page — it is a landlord-directed call to action.

## Description of main change(s)

- `PropertyComplianceViewModelFactory` now returns no compliance notification messages for the local council view, so the property record no longer shows the "Important" compliance banner to LC users. This mirrors the factory's existing `landlordView` gating of the landlord-only "change" actions; landlord behaviour is unchanged.
- Updated the affected tests: new `LocalCouncilViewNotifications` unit cases (assert no messages for LC) and the LC property-record integration tests (assert the banner is hidden).

## Anything you'd like to highlight to the reviewer?

- The separate "no compliance information" banner (shown when a property has no compliance record at all) was already role-aware and is intentionally left unchanged.

## Checklist

- [x] Unit tests for new logic (e.g. new service methods) have been added
- [x] Branch has been rebased onto main and run locally, with everything working as expected (both for your new feature and any related functionality)
- [x] TODO comments referencing this JIRA ticket have been searched for and removed - if a future PR will address them, mention that here
- [x] This feature is not behind a feature flag. I've checked that this is appropriate and we're happy with this code becoming live as soon as we release
- [x] Screenshots of any UI changes have been added
- [x] Test suite has been run in full locally and is passing
- [x] QA instructions have been added to the ticket (particularly if this is the last PR required to complete the ticket)

<img width="992" height="698" alt="image" src="https://github.com/user-attachments/assets/751e2bb5-4066-4885-a01e-a8a5f17047a4" />

