### PR TITLE
PDJB-NONE: Fix ownership-link audit timestamps

### DIFF
--- a/src/main/resources/db/migrations/V1_41_0__use_timezone_aware_ownership_link_timestamps.sql
+++ b/src/main/resources/db/migrations/V1_41_0__use_timezone_aware_ownership_link_timestamps.sql
@@ -1,0 +1,5 @@
+ALTER TABLE ownership_link
+    ALTER COLUMN created_date TYPE TIMESTAMPTZ(6)
+        USING created_date AT TIME ZONE 'UTC',
+    ALTER COLUMN last_modified_date TYPE TIMESTAMPTZ(6)
+        USING last_modified_date AT TIME ZONE 'UTC';

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/MetricsSinglePageTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/MetricsSinglePageTests.kt
@@ -124,9 +124,9 @@ class MetricsSinglePageTests : IntegrationTestWithImmutableData("data-metrics-lo
         assertThat(reloadedPage.metricsList.rowValue(1)).containsText("72")
         assertThat(reloadedPage.metricsList.rowValue(2)).containsText("100")
         assertThat(reloadedPage.metricsList.rowValue(3)).containsText("100")
-        assertThat(reloadedPage.metricsList.rowValue(4)).containsText("22 minutes")
-        assertThat(reloadedPage.metricsList.rowValue(5)).containsText("1 day, 6 hours, 21 minutes")
-        assertThat(reloadedPage.metricsList.rowValue(6)).containsText("2 days, 43 minutes")
+        assertThat(reloadedPage.metricsList.rowValue(4)).hasText("22 minutes")
+        assertThat(reloadedPage.metricsList.rowValue(5)).hasText("1 day, 6 hours, 21 minutes")
+        assertThat(reloadedPage.metricsList.rowValue(6)).hasText("2 days, 43 minutes")
     }
 
     @Test


### PR DESCRIPTION
## Ticket number

PDJB-NONE

## Goal of change

Fixes environment-dependent metrics durations by aligning ownership-link audit timestamps with their `Instant` mappings.

## Description of main change(s)

- Makes both ownership-link audit timestamps timezone-aware while preserving existing values as UTC.
- Tightens the 2028 duration assertions so extra timezone-derived text cannot pass.

## Anything you'd like to highlight to the reviewer?

The dedicated historical migration regression test is intentionally not included; targeted metrics tests pass in both UTC and Europe/London.

## Checklist

- [x] Branch has been rebased onto main and run locally, with everything working as expected (both for your new feature and any related functionality)
- [x] TODO comments referencing this JIRA ticket have been searched for and removed - if a future PR will address them, mention that here
- [x] This feature is not behind a feature flag. I've checked that this is appropriate and we're happy with this code becoming live as soon as we release