### PR TITLE
PDJB-1257: Move lead trustee questions

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/landlordRegistration/stepConfig/OrgTypeStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/landlordRegistration/stepConfig/OrgTypeStepConfig.kt
@@ -5,13 +5,12 @@ import uk.gov.communities.prsdb.webapp.constants.enums.OrgType
 import uk.gov.communities.prsdb.webapp.journeys.AbstractRequestableStepConfig
 import uk.gov.communities.prsdb.webapp.journeys.JourneyState
 import uk.gov.communities.prsdb.webapp.journeys.JourneyStep.RequestableStep
-import uk.gov.communities.prsdb.webapp.journeys.shared.Complete
 import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.OrgTypeFormModel
 import uk.gov.communities.prsdb.webapp.models.viewModels.formModels.CheckboxButtonViewModel
 import uk.gov.communities.prsdb.webapp.models.viewModels.formModels.CheckboxDividerViewModel
 
 @JourneyFrameworkComponent
-class OrgTypeStepConfig : AbstractRequestableStepConfig<Complete, OrgTypeFormModel, JourneyState>() {
+class OrgTypeStepConfig : AbstractRequestableStepConfig<OrgTypeMode, OrgTypeFormModel, JourneyState>() {
     override val formModelClass = OrgTypeFormModel::class
 
     override fun getStepSpecificContent(state: JourneyState) =
@@ -42,13 +41,25 @@ class OrgTypeStepConfig : AbstractRequestableStepConfig<Complete, OrgTypeFormMod
 
     override fun chooseTemplate(state: JourneyState) = "forms/orgTypeForm"
 
-    override fun mode(state: JourneyState) = getFormModelFromStateOrNull(state)?.let { Complete.COMPLETE }
+    override fun mode(state: JourneyState) =
+        getFormModelFromStateOrNull(state)?.let {
+            if (OrgType.TRUST in it.getSelectedOrgTypes()) {
+                OrgTypeMode.INCLUDES_TRUST
+            } else {
+                OrgTypeMode.EXCLUDES_TRUST
+            }
+        }
+}
+
+enum class OrgTypeMode {
+    INCLUDES_TRUST,
+    EXCLUDES_TRUST,
 }
 
 @JourneyFrameworkComponent
 final class OrgTypeStep(
     stepConfig: OrgTypeStepConfig,
-) : RequestableStep<Complete, OrgTypeFormModel, JourneyState>(stepConfig) {
+) : RequestableStep<OrgTypeMode, OrgTypeFormModel, JourneyState>(stepConfig) {
     companion object {
         const val ROUTE_SEGMENT = "organisation-type"
     }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/landlordRegistration/tasks/OrgLandlordRegistrationTask.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/landlordRegistration/tasks/OrgLandlordRegistrationTask.kt
@@ -33,6 +33,7 @@ import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.
 import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.OrgMainContactStep
 import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.OrgNameStep
 import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.OrgPhoneNumberStep
+import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.OrgTypeMode
 import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.OrgTypeStep
 import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.SaveGovBodyMemberStep
 import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.YourDetailsStep
@@ -113,12 +114,16 @@ class OrgLandlordRegistrationTask(
             step(journey.orgTypeStep) {
                 routeSegment(OrgTypeStep.ROUTE_SEGMENT)
                 parents { journey.orgPhoneNumberStep.isComplete() }
-                nextStep { journey.leadTrusteeNameStep }
+                nextDestination { mode ->
+                    when (mode) {
+                        OrgTypeMode.INCLUDES_TRUST -> Destination(journey.leadTrusteeNameStep)
+                        OrgTypeMode.EXCLUDES_TRUST -> Destination(journey.orgCharityStep)
+                    }
+                }
             }
-            // TODO: PDJB-1257: branch to here conditionally based on orgTypeStep outcome
             step(journey.leadTrusteeNameStep) {
                 routeSegment(LeadTrusteeNameStep.ROUTE_SEGMENT)
-                parents { journey.orgTypeStep.isComplete() }
+                parents { journey.orgTypeStep.hasOutcome(OrgTypeMode.INCLUDES_TRUST) }
                 nextStep { journey.leadTrusteeDobStep }
             }
             step(journey.leadTrusteeDobStep) {
@@ -137,13 +142,17 @@ class OrgLandlordRegistrationTask(
                 nextStep { journey.trusteeAddressTask.firstStep }
             }
             duplicableTask(journey.trusteeAddressTask, TrusteeAddressTask.ROUTE_SEGMENT) {
-                parents { journey.leadTrusteePhoneStep.isComplete() }
-                // TODO PDJB-1257: reroute to the exit point of the trustee section
+                parents { journey.leadTrusteeDobStep.isComplete() }
                 nextStep { journey.orgCharityStep }
             }
             step(journey.orgCharityStep) {
                 routeSegment(OrgCharityStep.ROUTE_SEGMENT)
-                parents { journey.trusteeAddressTask.isComplete() }
+                parents {
+                    OrParents(
+                        journey.trusteeAddressTask.isComplete(),
+                        journey.orgTypeStep.hasOutcome(OrgTypeMode.EXCLUDES_TRUST),
+                    )
+                }
                 nextDestination { mode ->
                     when (mode) {
                         YesOrNo.YES -> Destination(journey.orgCharityRegisteredWithStep)

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/requestModels/formModels/OrgTypeFormModel.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/requestModels/formModels/OrgTypeFormModel.kt
@@ -24,4 +24,6 @@ class OrgTypeFormModel : FormModel {
         if (selected.isEmpty()) return false
         return !(selected.contains(OrgType.NONE.name) && selected.size > 1)
     }
+
+    fun getSelectedOrgTypes(): List<OrgType> = orgTypes.filterNotNull().filter { it.isNotBlank() }.map { OrgType.valueOf(it) }
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/LandlordRegistrationJourneyTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/LandlordRegistrationJourneyTests.kt
@@ -290,24 +290,6 @@ class LandlordRegistrationJourneyTests : IntegrationTestWithMutableData("data-mo
         orgTypePage.selectCompany()
         orgTypePage.form.submit()
 
-        val leadTrusteeNamePage = assertPageIs(page, LeadTrusteeNameFormPageLandlordRegistration::class)
-        leadTrusteeNamePage.submitName("Test Lead Trustee Name")
-
-        val leadTrusteeDobPage = assertPageIs(page, LeadTrusteeDobFormPageLandlordRegistration::class)
-        leadTrusteeDobPage.submitDate("15", "6", "1980")
-
-        val leadTrusteeEmailPage = assertPageIs(page, LeadTrusteeEmailFormPageLandlordRegistration::class)
-        leadTrusteeEmailPage.submitEmail("trustee@test.com")
-
-        val leadTrusteePhonePage = assertPageIs(page, LeadTrusteePhoneFormPageLandlordRegistration::class)
-        leadTrusteePhonePage.submitPhoneNumber("07123456789")
-
-        val leadTrusteeLookupAddressPage = assertPageIs(page, LeadTrusteeAddressFormPageLandlordRegistration::class)
-        leadTrusteeLookupAddressPage.submitPostcodeAndBuildingNameOrNumber("EG1 2AA", "1")
-
-        val leadTrusteeSelectAddressPage = assertPageIs(page, LeadTrusteeSelectAddressFormPageLandlordRegistration::class)
-        leadTrusteeSelectAddressPage.selectAddressAndSubmit("1 PRSDB Square, EG1 2AA")
-
         val orgCharityPage = assertPageIs(page, OrgCharityFormPageLandlordRegistration::class)
         orgCharityPage.submitYes()
 
@@ -330,6 +312,36 @@ class LandlordRegistrationJourneyTests : IntegrationTestWithMutableData("data-mo
         assertPageIs(page, OrgLandlordCyaPageLandlordRegistration::class)
 
         // TODO: PDJB-1180: Once we can save OL to the database make sure that the confirmation page shows correctly here upon submitting
+    }
+
+    @Test
+    fun `Selecting trust on org type shows lead trustee questions before proceeding to charity`(page: Page) {
+        featureFlagManager.enable(ORGANISATION_LANDLORD_REGISTRATION)
+
+        val orgTypePage = navigator.skipToLandlordRegistrationOrganisationTypePage()
+        orgTypePage.selectTrust()
+        orgTypePage.form.submit()
+
+        val leadTrusteeNamePage = assertPageIs(page, LeadTrusteeNameFormPageLandlordRegistration::class)
+        leadTrusteeNamePage.submitName("Test Lead Trustee Name")
+
+        val leadTrusteeDobPage = assertPageIs(page, LeadTrusteeDobFormPageLandlordRegistration::class)
+        leadTrusteeDobPage.submitDate("15", "6", "1980")
+
+        val leadTrusteeEmailPage = assertPageIs(page, LeadTrusteeEmailFormPageLandlordRegistration::class)
+        leadTrusteeEmailPage.submitEmail("trustee@test.com")
+
+        val leadTrusteePhonePage = assertPageIs(page, LeadTrusteePhoneFormPageLandlordRegistration::class)
+        leadTrusteePhonePage.submitPhoneNumber("07123456789")
+
+        val leadTrusteeLookupAddressPage = assertPageIs(page, LeadTrusteeAddressFormPageLandlordRegistration::class)
+        leadTrusteeLookupAddressPage.submitPostcodeAndBuildingNameOrNumber("EG1 2AA", "1")
+
+        val leadTrusteeSelectAddressPage =
+            assertPageIs(page, LeadTrusteeSelectAddressFormPageLandlordRegistration::class)
+        leadTrusteeSelectAddressPage.selectAddressAndSubmit("1 PRSDB Square, EG1 2AA")
+
+        assertPageIs(page, OrgCharityFormPageLandlordRegistration::class)
     }
 
     @Test

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/landlordRegistrationJourneyPages/OrgTypeFormPageLandlordRegistration.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/landlordRegistrationJourneyPages/OrgTypeFormPageLandlordRegistration.kt
@@ -15,6 +15,8 @@ class OrgTypeFormPageLandlordRegistration(
 
     fun selectCompany() = form.orgTypeCheckboxes.checkCheckbox(OrgType.COMPANY.toString())
 
+    fun selectTrust() = form.orgTypeCheckboxes.checkCheckbox(OrgType.TRUST.toString())
+
     fun selectNoneOfThese() = form.orgTypeCheckboxes.checkCheckbox(OrgType.NONE.toString())
 
     class OrgTypeForm(

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/testHelpers/JourneyStateDeserializer.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/testHelpers/JourneyStateDeserializer.kt
@@ -29,10 +29,29 @@ class JourneyStateDeserializer : StdDeserializer<FormData>(Map::class.java) {
                     this.asText()
                 }
             }
-            this.isNumber -> this.numberValue()
-            this.isBoolean -> this.booleanValue()
-            this.isNull -> null
-            this.isObject -> deserialize(this.traverse(parser.codec), context)
-            else -> this
+
+            this.isNumber -> {
+                this.numberValue()
+            }
+
+            this.isBoolean -> {
+                this.booleanValue()
+            }
+
+            this.isNull -> {
+                null
+            }
+
+            this.isArray -> {
+                this.map { it.deserializeValue(parser, context) }
+            }
+
+            this.isObject -> {
+                deserialize(this.traverse(parser.codec), context)
+            }
+
+            else -> {
+                this
+            }
         }
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/testHelpers/builders/LandlordStateSessionBuilder.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/testHelpers/builders/LandlordStateSessionBuilder.kt
@@ -7,6 +7,7 @@ import org.mockito.Mockito.mock
 import uk.gov.communities.prsdb.webapp.constants.enums.CharityRegulator
 import uk.gov.communities.prsdb.webapp.constants.enums.GoverningBodyMemberType
 import uk.gov.communities.prsdb.webapp.constants.enums.LandlordType
+import uk.gov.communities.prsdb.webapp.constants.enums.OrgType
 import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.EmailStep
 import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.LandlordTypeStep
 import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.LeadTrusteeDobStep
@@ -54,6 +55,7 @@ import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.OrgGovBod
 import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.OrgGovBodyMemberDobFormModel
 import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.OrgGovBodyWhoToProvideFormModel
 import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.OrgMainContactFormModel
+import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.OrgTypeFormModel
 import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.PhoneNumberFormModel
 import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.SelectAddressFormModel
 import uk.gov.communities.prsdb.webapp.services.LocalCouncilService
@@ -122,8 +124,9 @@ class LandlordStateSessionBuilder(
         return self()
     }
 
-    fun withOrgType(): LandlordStateSessionBuilder {
-        withSubmittedValue(OrgTypeStep.ROUTE_SEGMENT, NoInputFormModel())
+    fun withOrgType(orgTypes: List<OrgType> = listOf(OrgType.COMPANY)): LandlordStateSessionBuilder {
+        val formModel = OrgTypeFormModel().apply { this.orgTypes = orgTypes.map { it.name }.toMutableList() }
+        withSubmittedValue(OrgTypeStep.ROUTE_SEGMENT, formModel)
         return self()
     }
 
@@ -324,7 +327,7 @@ class LandlordStateSessionBuilder(
 
         fun beforeOrgType() = beforeOrgPhoneNumber().withOrgPhoneNumber()
 
-        fun beforeLeadTrusteeName() = beforeOrgType().withOrgType()
+        fun beforeLeadTrusteeName() = beforeOrgType().withOrgType(listOf(OrgType.TRUST))
 
         fun beforeLeadTrusteeDob() = beforeLeadTrusteeName().withLeadTrusteeName()
 


### PR DESCRIPTION
## Ticket number

[PDJB-1257](https://mhclgdigital.atlassian.net/browse/PDJB-1257)

## Goal of change

move lead trustee questions to appear after the company type question and only if the selection contains 'trust'

## Anything you'd like to highlight to the reviewer?

added a getter to the org type form model to let us query with the enum type directly, since it appears at a glance we can't bind this directly. there may be a neater way to do this?

had to make a change to the test json deserializer as it looks like it's been silently failing for array JSON objects this whole time? indeed when attempting to add a test that depended on an array of tickboxes the form model mysteriously didn't have the changes it was expecting to have bound

## Checklist

Delete any that are not applicable, and add explanation below for any that are applicable but haven't been done

- [x] New journey steps have been added to the appropriate journey integration test(s)
- [x] Test suite has been run in full locally and is passing
- [x] Branch has been rebased onto main and run locally, with everything working as expected (both for your new feature
  and any related functionality)
- [x] TODO comments referencing this JIRA ticket have been searched for and removed - if a future PR will address them,
  mention that here
- [x] QA instructions have been added to the ticket (particularly if this is the last PR required to complete the ticket)
- [x] This feature is behind a feature flag. I've checked that there will be no change in function if the feature flag is disabled
