### PR TITLE
Chore/pdjb 896 migrate property registration without compliance

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/builders/EmbedBuilder.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/builders/EmbedBuilder.kt
@@ -5,6 +5,6 @@ import uk.gov.communities.prsdb.webapp.journeys.JourneyState
 // EmbedBuilder allows one "journey" to be embedded in another. The outer journey can be accessed as `outerState` and the embedded
 // journey can be accessed as `journey` as usual
 class EmbedBuilder<TEmbeddedState : JourneyState, TOuterState : JourneyState>(
-    journey: TEmbeddedState,
-    val outerState: TOuterState,
-) : JourneyBuilder<TEmbeddedState>(journey)
+    val task: TEmbeddedState,
+    override val journey: TOuterState,
+) : AbstractJourneyBuilder<TEmbeddedState, TOuterState>(task)

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/builders/EmbedBuilder.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/builders/EmbedBuilder.kt
@@ -1,0 +1,10 @@
+package uk.gov.communities.prsdb.webapp.journeys.builders
+
+import uk.gov.communities.prsdb.webapp.journeys.JourneyState
+
+// EmbedBuilder allows one "journey" to be embedded in another. The outer journey can be accessed as `outerState` and the embedded
+// journey can be accessed as `journey` as usual
+class EmbedBuilder<TEmbeddedState : JourneyState, TOuterState : JourneyState>(
+    journey: TEmbeddedState,
+    val outerState: TOuterState,
+) : JourneyBuilder<TEmbeddedState>(journey)

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/builders/JourneyBuilder.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/builders/JourneyBuilder.kt
@@ -37,8 +37,8 @@ interface JourneyBuilderDsl<TState : JourneyState> {
 
 open class JourneyBuilder<TState : JourneyState>(
     // The state is referred to here as the "journey" so that in the DSL steps can be referenced as `journey.stepName`
-    journey: TState,
-) : AbstractJourneyBuilder<TState>(journey) {
+    override val journey: TState,
+) : AbstractJourneyBuilder<TState, TState>(journey) {
     private val sections: MutableList<String> = mutableListOf()
 
     fun buildRoutingMap(): Map<String, StepLifecycleOrchestrator> =

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/builders/SubJourneyBuilder.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/builders/SubJourneyBuilder.kt
@@ -106,6 +106,25 @@ abstract class AbstractJourneyBuilder<TState : JourneyState>(
         journeyElements.add(taskInitialiser)
     }
 
+    // Adds a single step that is owned by a duplicable task, building it against that task's OWN state rather than the
+    // journey state. Used to check-answer one task-owned step in isolation (see duplicableCheckAnswerStep) without
+    // walking the whole task's sub-journey. The task itself provides no route here, so the step keeps its bare data
+    // key, matching how the task is composed bare in the main flow.
+    fun <TTaskState : JourneyState, TMode : Enum<TMode>, TStep : AbstractStepConfig<TMode, *, TTaskState>> duplicableStep(
+        task: DuplicableTask<TTaskState>,
+        uninitialisedStep: JourneyStep<TMode, *, TTaskState>,
+        init: StepInitialiser<TStep, TTaskState, TMode>.() -> Unit,
+    ) {
+        val stepInitialiser = StepInitialiser<TStep, TTaskState, TMode>(uninitialisedStep, task.taskState)
+        stepInitialiser.init()
+        if (journeyElements.isEmpty()) {
+            stepInitialiser.configureFirst {
+                additionalFirstElementConfiguration.forEach { it() }
+            }
+        }
+        journeyElements.add(stepInitialiser)
+    }
+
     override fun conditionallyConfigure(
         condition: ConfigurableElement<*>.() -> Boolean,
         configuration: ConfigurableElement<*>.() -> Unit,

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/builders/SubJourneyBuilder.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/builders/SubJourneyBuilder.kt
@@ -28,10 +28,12 @@ interface BuildableElement {
     )
 }
 
-abstract class AbstractJourneyBuilder<TState : JourneyState>(
-    val journey: TState,
+abstract class AbstractJourneyBuilder<TInternalState : JourneyState, TJourneyState : JourneyState>(
+    private val privateJourney: TInternalState,
 ) : BuildableElement,
-    JourneyBuilderDsl<TState> {
+    JourneyBuilderDsl<TInternalState> {
+    abstract val journey: TJourneyState
+
     private val journeyElements: MutableList<BuildableElement> = mutableListOf()
 
     private var defaultUnreachableStepDestination: (() -> Destination)? = null
@@ -72,11 +74,11 @@ abstract class AbstractJourneyBuilder<TState : JourneyState>(
         }
     }
 
-    override fun <TMode : Enum<TMode>, TStep : AbstractStepConfig<TMode, *, TState>> step(
-        uninitialisedStep: JourneyStep<TMode, *, TState>,
-        init: StepInitialiser<TStep, TState, TMode>.() -> Unit,
+    override fun <TMode : Enum<TMode>, TStep : AbstractStepConfig<TMode, *, TInternalState>> step(
+        uninitialisedStep: JourneyStep<TMode, *, TInternalState>,
+        init: StepInitialiser<TStep, TInternalState, TMode>.() -> Unit,
     ) {
-        val stepInitialiser = StepInitialiser<TStep, TState, TMode>(uninitialisedStep, journey)
+        val stepInitialiser = StepInitialiser<TStep, TInternalState, TMode>(uninitialisedStep, privateJourney)
         stepInitialiser.init()
         if (journeyElements.isEmpty()) {
             stepInitialiser.configureFirst {
@@ -87,11 +89,11 @@ abstract class AbstractJourneyBuilder<TState : JourneyState>(
     }
 
     override fun task(
-        uninitialisedTask: Task<TState>,
+        uninitialisedTask: Task<TInternalState>,
         routeSegment: String?,
-        init: TaskInitialiser<TState, Nothing>.() -> Unit,
+        init: TaskInitialiser<TInternalState, Nothing>.() -> Unit,
     ) {
-        val taskInitialiser = TaskInitialiser<TState, Nothing>(uninitialisedTask, journey)
+        val taskInitialiser = TaskInitialiser<TInternalState, Nothing>(uninitialisedTask, privateJourney)
         routeSegment?.let { taskInitialiser.routeSegment(it) }
         taskInitialiser.init()
         journeyElements.add(taskInitialiser)
@@ -109,11 +111,11 @@ abstract class AbstractJourneyBuilder<TState : JourneyState>(
         journeyElements.add(taskInitialiser)
     }
 
-    fun <TEmbeddedState : JourneyState> embed(
-        embedState: TEmbeddedState,
-        init: EmbedBuilder<TEmbeddedState, TState>.() -> Unit,
+    fun <TEmbeddedState : JourneyState> fromTask(
+        task: TEmbeddedState,
+        init: EmbedBuilder<TEmbeddedState, TInternalState>.() -> Unit,
     ) {
-        val builder = EmbedBuilder(embedState, journey)
+        val builder = EmbedBuilder(task, privateJourney)
         builder.init()
         if (journeyElements.isEmpty()) {
             builder.configureFirst { additionalFirstElementConfiguration.forEach { it() } }
@@ -171,9 +173,9 @@ abstract class AbstractJourneyBuilder<TState : JourneyState>(
 }
 
 open class SubJourneyBuilder<TState : JourneyState>(
-    journey: TState,
+    override val journey: TState,
     exitStepOverride: SubjourneyExitStep? = null,
-) : AbstractJourneyBuilder<TState>(journey) {
+) : AbstractJourneyBuilder<TState, TState>(journey) {
     var exitInits: MutableList<StepInitialiser<SubjourneyExitStepConfig, TState, SubjourneyComplete>.() -> Unit> =
         mutableListOf()
         private set

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/builders/SubJourneyBuilder.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/builders/SubJourneyBuilder.kt
@@ -5,6 +5,7 @@ import uk.gov.communities.prsdb.webapp.exceptions.JourneyInitialisationException
 import uk.gov.communities.prsdb.webapp.journeys.AbstractStepConfig
 import uk.gov.communities.prsdb.webapp.journeys.DelegateKeyRegistry
 import uk.gov.communities.prsdb.webapp.journeys.Destination
+import uk.gov.communities.prsdb.webapp.journeys.DuplicableTask
 import uk.gov.communities.prsdb.webapp.journeys.DuplicableTaskWithDependencies
 import uk.gov.communities.prsdb.webapp.journeys.JourneyState
 import uk.gov.communities.prsdb.webapp.journeys.JourneyStep

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/builders/SubJourneyBuilder.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/builders/SubJourneyBuilder.kt
@@ -5,7 +5,6 @@ import uk.gov.communities.prsdb.webapp.exceptions.JourneyInitialisationException
 import uk.gov.communities.prsdb.webapp.journeys.AbstractStepConfig
 import uk.gov.communities.prsdb.webapp.journeys.DelegateKeyRegistry
 import uk.gov.communities.prsdb.webapp.journeys.Destination
-import uk.gov.communities.prsdb.webapp.journeys.DuplicableTask
 import uk.gov.communities.prsdb.webapp.journeys.DuplicableTaskWithDependencies
 import uk.gov.communities.prsdb.webapp.journeys.JourneyState
 import uk.gov.communities.prsdb.webapp.journeys.JourneyStep
@@ -52,10 +51,13 @@ abstract class AbstractJourneyBuilder<TState : JourneyState>(
         return build(registry)
     }
 
+    private val additionalElements: MutableList<BuildableElement> = mutableListOf()
+    protected val ownedElements get() = journeyElements + additionalElements
+
     override fun configure(configuration: ConfigurableElement<*>.() -> Unit) {
         additionalConfiguration.add(
             ConditionalElementConfiguration(
-                { journeyElements.any { this === it } },
+                { ownedElements.any { this === it } },
                 configuration,
             ),
         )
@@ -107,23 +109,17 @@ abstract class AbstractJourneyBuilder<TState : JourneyState>(
         journeyElements.add(taskInitialiser)
     }
 
-    // Adds a single step that is owned by a duplicable task, building it against that task's OWN state rather than the
-    // journey state. Used to check-answer one task-owned step in isolation (see duplicableCheckAnswerStep) without
-    // walking the whole task's sub-journey. The task itself provides no route here, so the step keeps its bare data
-    // key, matching how the task is composed bare in the main flow.
-    fun <TTaskState : JourneyState, TMode : Enum<TMode>, TStep : AbstractStepConfig<TMode, *, TTaskState>> duplicableStep(
-        task: DuplicableTask<TTaskState>,
-        uninitialisedStep: JourneyStep<TMode, *, TTaskState>,
-        init: StepInitialiser<TStep, TTaskState, TMode>.() -> Unit,
+    fun <TEmbeddedState : JourneyState> embed(
+        embedState: TEmbeddedState,
+        init: EmbedBuilder<TEmbeddedState, TState>.() -> Unit,
     ) {
-        val stepInitialiser = StepInitialiser<TStep, TTaskState, TMode>(uninitialisedStep, task.taskState)
-        stepInitialiser.init()
+        val builder = EmbedBuilder(embedState, journey)
+        builder.init()
         if (journeyElements.isEmpty()) {
-            stepInitialiser.configureFirst {
-                additionalFirstElementConfiguration.forEach { it() }
-            }
+            builder.configureFirst { additionalFirstElementConfiguration.forEach { it() } }
         }
-        journeyElements.add(stepInitialiser)
+        journeyElements.add(builder)
+        additionalElements.addAll(builder.ownedElements)
     }
 
     override fun conditionallyConfigure(

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/PropertyRegistrationJourneyFactory.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/PropertyRegistrationJourneyFactory.kt
@@ -118,6 +118,7 @@ import uk.gov.communities.prsdb.webapp.journeys.shared.inviteJointLandlord.Check
 import uk.gov.communities.prsdb.webapp.journeys.shared.states.CheckYourAnswersJourneyState
 import uk.gov.communities.prsdb.webapp.journeys.shared.states.CheckYourAnswersJourneyState.Companion.checkAnswerStep
 import uk.gov.communities.prsdb.webapp.journeys.shared.states.CheckYourAnswersJourneyState.Companion.checkAnswerTask
+import uk.gov.communities.prsdb.webapp.journeys.shared.states.CheckYourAnswersJourneyState.Companion.duplicableCheckAnswerStep
 import uk.gov.communities.prsdb.webapp.journeys.shared.states.CheckYourAnswersJourneyState.Companion.duplicableCheckAnswerTask
 import uk.gov.communities.prsdb.webapp.journeys.shared.stepConfig.LookupAddressStep
 import uk.gov.communities.prsdb.webapp.journeys.shared.stepConfig.ManualAddressStep
@@ -198,11 +199,15 @@ class PropertyRegistrationJourneyFactory(
                 }
 
                 RentIncludesBillsStep.ROUTE_SEGMENT -> {
-                    checkAnswerTask(journey.rentIncludesBillsTask)
+                    duplicableCheckAnswerTask(journey.rentIncludesBillsTask)
                 }
 
                 BillsIncludedStep.ROUTE_SEGMENT -> {
-                    checkAnswerStep(journey.billsIncluded, BillsIncludedStep.ROUTE_SEGMENT)
+                    duplicableCheckAnswerStep(
+                        journey.rentIncludesBillsTask,
+                        journey.rentIncludesBillsTask.billsIncluded,
+                        BillsIncludedStep.ROUTE_SEGMENT,
+                    )
                 }
 
                 FurnishedStatusStep.ROUTE_SEGMENT -> {
@@ -614,8 +619,6 @@ class PropertyRegistrationJourney(
     override val bedrooms: BedroomsStep,
     // Nested rent includes bills task
     override val rentIncludesBillsTask: RentIncludesBillsTask,
-    override val rentIncludesBills: RentIncludesBillsStep,
-    override val billsIncluded: BillsIncludedStep,
     override val furnishedStatus: FurnishedStatusStep,
     // Nested rent frequency and amount task
     override val rentFrequencyAndAmountTask: RentFrequencyAndAmountTask,

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/PropertyRegistrationJourneyFactory.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/PropertyRegistrationJourneyFactory.kt
@@ -179,7 +179,7 @@ class PropertyRegistrationJourneyFactory(
                 HmoMandatoryLicenceStep.ROUTE_SEGMENT,
                 HmoAdditionalLicenceStep.ROUTE_SEGMENT,
                 -> {
-                    checkAnswerTask(journey.licensingTask)
+                    duplicableCheckAnswerTask(journey.licensingTask)
                 }
 
                 OccupiedStep.ROUTE_SEGMENT -> {
@@ -318,7 +318,7 @@ class PropertyRegistrationJourneyFactory(
                     nextStep { journey.licensingTask.firstStep }
                     saveProgress()
                 }
-                task(journey.licensingTask) {
+                duplicableTask(journey.licensingTask) {
                     parents { journey.ownershipTypeStep.isComplete() }
                     nextStep { journey.occupationTask.firstStep }
                     saveProgress()
@@ -470,7 +470,7 @@ class PropertyRegistrationJourneyFactory(
             }
             section {
                 withHeadingMessageKey("registerProperty.taskList.rentedOut.licensing", shouldUseNumbering = false)
-                task(journey.licensingTask) {
+                duplicableTask(journey.licensingTask) {
                     parents {
                         OrParents(
                             journey.occupied.hasOutcome(YesOrNo.YES),
@@ -606,10 +606,6 @@ class PropertyRegistrationJourney(
     override val ownershipTypeStep: OwnershipTypeStep,
     // Licensing task
     override val licensingTask: LicensingTask,
-    override val licensingTypeStep: LicensingTypeStep,
-    override val selectiveLicenceStep: SelectiveLicenceStep,
-    override val hmoMandatoryLicenceStep: HmoMandatoryLicenceStep,
-    override val hmoAdditionalLicenceStep: HmoAdditionalLicenceStep,
     // Occupation steps
     override val occupied: OccupiedStep,
     // Nested households and tenants task
@@ -768,7 +764,6 @@ class PropertyRegistrationJourney(
 
 interface PropertyRegistrationJourneyState :
     PropertyRegistrationAddressState,
-    LicensingState,
     OccupationState,
     PropertyDetailsState,
     OwnershipAndLandlordsState,

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/PropertyRegistrationJourneyFactory.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/PropertyRegistrationJourneyFactory.kt
@@ -210,7 +210,7 @@ class PropertyRegistrationJourneyFactory(
                 }
 
                 RentFrequencyStep.ROUTE_SEGMENT, RentAmountStep.ROUTE_SEGMENT -> {
-                    checkAnswerTask(journey.rentFrequencyAndAmountTask)
+                    duplicableCheckAnswerTask(journey.rentFrequencyAndAmountTask)
                 }
 
                 HasJointLandlordsStep.ROUTE_SEGMENT,
@@ -619,8 +619,6 @@ class PropertyRegistrationJourney(
     override val furnishedStatus: FurnishedStatusStep,
     // Nested rent frequency and amount task
     override val rentFrequencyAndAmountTask: RentFrequencyAndAmountTask,
-    override val rentFrequency: RentFrequencyStep,
-    override val rentAmount: RentAmountStep,
     // Joint landlords task
     override val jointLandlordsTask: JointLandlordsPropertyRegistrationTask,
     // ===== Journey-structure tasks (the two alternative flows diverge here) =====

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/PropertyRegistrationJourneyFactory.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/PropertyRegistrationJourneyFactory.kt
@@ -27,10 +27,8 @@ import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.Lice
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.OccupationState
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.OwnershipAndLandlordsState
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.PropertyDetailsState
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.PropertyRegistrationAddressState
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.TenancyDetailsState
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.AddToLandlordIncompletePropertiesStep
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.AlreadyRegisteredStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.BedroomsStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.BillsIncludedStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.CheckElectricalCertUploadsStep
@@ -121,10 +119,6 @@ import uk.gov.communities.prsdb.webapp.journeys.shared.states.CheckYourAnswersJo
 import uk.gov.communities.prsdb.webapp.journeys.shared.states.CheckYourAnswersJourneyState.Companion.duplicableCheckAnswerStep
 import uk.gov.communities.prsdb.webapp.journeys.shared.states.CheckYourAnswersJourneyState.Companion.duplicableCheckAnswerTask
 import uk.gov.communities.prsdb.webapp.journeys.shared.stepConfig.LookupAddressStep
-import uk.gov.communities.prsdb.webapp.journeys.shared.stepConfig.ManualAddressStep
-import uk.gov.communities.prsdb.webapp.journeys.shared.stepConfig.NoAddressFoundStep
-import uk.gov.communities.prsdb.webapp.journeys.shared.stepConfig.SelectAddressStep
-import uk.gov.communities.prsdb.webapp.models.dataModels.AddressDataModel
 import uk.gov.communities.prsdb.webapp.models.dataModels.EpcDataModel
 import uk.gov.communities.prsdb.webapp.models.viewModels.SectionHeaderViewModel
 import uk.gov.communities.prsdb.webapp.services.LandlordService
@@ -159,11 +153,11 @@ class PropertyRegistrationJourneyFactory(
 
             when (checkingAnswersFor) {
                 LookupAddressStep.ROUTE_SEGMENT -> {
-                    checkAnswerTask(journey.addressTask)
+                    duplicableCheckAnswerTask(journey.addressTask)
                 }
 
                 LocalCouncilStep.ROUTE_SEGMENT -> {
-                    checkAnswerStep(journey.localCouncilStep, LocalCouncilStep.ROUTE_SEGMENT)
+                    duplicableCheckAnswerStep(journey.addressTask, journey.addressTask.localCouncilStep, LocalCouncilStep.ROUTE_SEGMENT)
                 }
 
                 PropertyTypeStep.ROUTE_SEGMENT -> {
@@ -297,7 +291,7 @@ class PropertyRegistrationJourneyFactory(
                 } else {
                     withHeadingMessageKey("registerProperty.taskList.register.old.heading")
                 }
-                task(journey.addressTask) {
+                duplicableTask(journey.addressTask) {
                     parents { journey.taskListStep.always() }
                     nextStep { journey.addToLandlordIncompletePropertiesStep }
                 }
@@ -593,12 +587,6 @@ class PropertyRegistrationJourney(
     override val taskListStep: PropertyRegistrationTaskListStep,
     // Address task
     override val addressTask: PropertyRegistrationAddressTask,
-    override val lookupAddressStep: LookupAddressStep,
-    override val selectAddressStep: SelectAddressStep,
-    override val alreadyRegisteredStep: AlreadyRegisteredStep,
-    override val noAddressFoundStep: NoAddressFoundStep,
-    override val manualAddressStep: ManualAddressStep,
-    override val localCouncilStep: LocalCouncilStep,
     // Add to LandlordIncompleteProperties join table
     override val addToLandlordIncompletePropertiesStep: AddToLandlordIncompletePropertiesStep,
     // Property details steps
@@ -690,9 +678,6 @@ class PropertyRegistrationJourney(
     override val stateFactory: ObjectFactory<PropertyRegistrationJourneyState>,
 ) : AbstractJourneyState(journeyStateService),
     PropertyRegistrationJourneyState {
-    override var cachedAddresses: List<AddressDataModel>? by delegateProvider.nullableDelegate("cachedAddresses")
-    override var isAddressAlreadyRegistered: Boolean? by delegateProvider.nullableDelegate("isAddressAlreadyRegistered")
-    override var cachedSelectedAddress: String? by delegateProvider.nullableDelegate("cachedSelectedAddress")
     override var cachedOccupied: Boolean? by delegateProvider.nullableDelegate("cachedOccupied")
     override var cyaJourneys: Map<String, String> = mapOf()
     override var originalJourneyUpdated: Instant? by delegateProvider.nullableDelegate("originalJourneyUpdated")
@@ -735,9 +720,9 @@ class PropertyRegistrationJourney(
     // Cache is populated on step submission (see SelectAddressStepConfig.afterStepDataIsAdded).
     override val uprn: Long?
         get() {
-            cachedSelectedAddress?.let { return getMatchingAddress(it)?.uprn }
-            val submittedAddress = selectAddressStep.formModelOrNull?.address ?: return null
-            return getMatchingAddress(submittedAddress)?.uprn
+            addressTask.cachedSelectedAddress?.let { return addressTask.getMatchingAddress(it)?.uprn }
+            val submittedAddress = addressTask.selectAddressStep.formModelOrNull?.address ?: return null
+            return addressTask.getMatchingAddress(submittedAddress)?.uprn
         }
 
     override var backUrlKey: Int? by delegateProvider.nullableDelegate("backUrlKey")
@@ -763,7 +748,6 @@ class PropertyRegistrationJourney(
 }
 
 interface PropertyRegistrationJourneyState :
-    PropertyRegistrationAddressState,
     OccupationState,
     PropertyDetailsState,
     OwnershipAndLandlordsState,

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/PropertyRegistrationJourneyFactory.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/PropertyRegistrationJourneyFactory.kt
@@ -155,8 +155,8 @@ class PropertyRegistrationJourneyFactory(
                 }
 
                 LocalCouncilStep.ROUTE_SEGMENT -> {
-                    embed(journey.addressTask) {
-                        checkAnswerStep(journey.localCouncilStep, LocalCouncilStep.ROUTE_SEGMENT)
+                    fromTask(journey.addressTask) {
+                        checkAnswerStep(task.localCouncilStep, LocalCouncilStep.ROUTE_SEGMENT)
                     }
                 }
 
@@ -197,8 +197,8 @@ class PropertyRegistrationJourneyFactory(
                 }
 
                 BillsIncludedStep.ROUTE_SEGMENT -> {
-                    embed(journey.rentIncludesBillsTask) {
-                        checkAnswerStep(journey.billsIncluded, BillsIncludedStep.ROUTE_SEGMENT)
+                    fromTask(journey.rentIncludesBillsTask) {
+                        checkAnswerStep(task.billsIncluded, BillsIncludedStep.ROUTE_SEGMENT)
                     }
                 }
 

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/PropertyRegistrationJourneyFactory.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/PropertyRegistrationJourneyFactory.kt
@@ -100,6 +100,7 @@ import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.EpcDe
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.EpcTask
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.GasSafetyDetailsTask
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.GasSafetyTask
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.HouseHoldsAndTenantsDependencies
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.HouseholdsAndTenantsTask
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.JointLandlordsPropertyRegistrationTask
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.LicensingTask
@@ -186,7 +187,7 @@ class PropertyRegistrationJourneyFactory(
                 }
 
                 HouseholdStep.ROUTE_SEGMENT, TenantsStep.ROUTE_SEGMENT -> {
-                    duplicableCheckAnswerTask(journey.householdsAndTenantsTask)
+                    duplicableCheckAnswerTask(journey.householdsAndTenantsTask, { HouseHoldsAndTenantsDependencies(true) })
                 }
 
                 BedroomsStep.ROUTE_SEGMENT -> {

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/PropertyRegistrationJourneyFactory.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/PropertyRegistrationJourneyFactory.kt
@@ -23,7 +23,6 @@ import uk.gov.communities.prsdb.webapp.journeys.hasOutcome
 import uk.gov.communities.prsdb.webapp.journeys.isComplete
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.CertificateUpload
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.CombinedComplianceCheckState
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.LicensingState
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.OccupationState
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.OwnershipAndLandlordsState
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.PropertyDetailsState

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/PropertyRegistrationJourneyFactory.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/PropertyRegistrationJourneyFactory.kt
@@ -191,7 +191,7 @@ class PropertyRegistrationJourneyFactory(
                 }
 
                 HouseholdStep.ROUTE_SEGMENT, TenantsStep.ROUTE_SEGMENT -> {
-                    checkAnswerTask(journey.householdsAndTenantsTask)
+                    duplicableCheckAnswerTask(journey.householdsAndTenantsTask)
                 }
 
                 BedroomsStep.ROUTE_SEGMENT -> {
@@ -614,8 +614,6 @@ class PropertyRegistrationJourney(
     override val occupied: OccupiedStep,
     // Nested households and tenants task
     override val householdsAndTenantsTask: HouseholdsAndTenantsTask,
-    override val households: HouseholdStep,
-    override val tenants: TenantsStep,
     override val bedrooms: BedroomsStep,
     // Nested rent includes bills task
     override val rentIncludesBillsTask: RentIncludesBillsTask,

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/PropertyRegistrationJourneyFactory.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/PropertyRegistrationJourneyFactory.kt
@@ -116,7 +116,6 @@ import uk.gov.communities.prsdb.webapp.journeys.shared.inviteJointLandlord.Check
 import uk.gov.communities.prsdb.webapp.journeys.shared.states.CheckYourAnswersJourneyState
 import uk.gov.communities.prsdb.webapp.journeys.shared.states.CheckYourAnswersJourneyState.Companion.checkAnswerStep
 import uk.gov.communities.prsdb.webapp.journeys.shared.states.CheckYourAnswersJourneyState.Companion.checkAnswerTask
-import uk.gov.communities.prsdb.webapp.journeys.shared.states.CheckYourAnswersJourneyState.Companion.duplicableCheckAnswerStep
 import uk.gov.communities.prsdb.webapp.journeys.shared.states.CheckYourAnswersJourneyState.Companion.duplicableCheckAnswerTask
 import uk.gov.communities.prsdb.webapp.journeys.shared.stepConfig.LookupAddressStep
 import uk.gov.communities.prsdb.webapp.models.dataModels.EpcDataModel
@@ -157,7 +156,9 @@ class PropertyRegistrationJourneyFactory(
                 }
 
                 LocalCouncilStep.ROUTE_SEGMENT -> {
-                    duplicableCheckAnswerStep(journey.addressTask, journey.addressTask.localCouncilStep, LocalCouncilStep.ROUTE_SEGMENT)
+                    embed(journey.addressTask) {
+                        checkAnswerStep(journey.localCouncilStep, LocalCouncilStep.ROUTE_SEGMENT)
+                    }
                 }
 
                 PropertyTypeStep.ROUTE_SEGMENT -> {
@@ -197,11 +198,9 @@ class PropertyRegistrationJourneyFactory(
                 }
 
                 BillsIncludedStep.ROUTE_SEGMENT -> {
-                    duplicableCheckAnswerStep(
-                        journey.rentIncludesBillsTask,
-                        journey.rentIncludesBillsTask.billsIncluded,
-                        BillsIncludedStep.ROUTE_SEGMENT,
-                    )
+                    embed(journey.rentIncludesBillsTask) {
+                        checkAnswerStep(journey.billsIncluded, BillsIncludedStep.ROUTE_SEGMENT)
+                    }
                 }
 
                 FurnishedStatusStep.ROUTE_SEGMENT -> {

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/states/OccupationState.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/states/OccupationState.kt
@@ -10,7 +10,6 @@ interface OccupationState :
     JourneyState,
     HouseholdsAndTenantsState,
     BedroomsState,
-    RentIncludesBillsState,
     FurnishedStatusState {
     val occupied: OccupiedStep
     val householdsAndTenantsTask: HouseholdsAndTenantsTask

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/states/OccupationState.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/states/OccupationState.kt
@@ -11,8 +11,7 @@ interface OccupationState :
     HouseholdsAndTenantsState,
     BedroomsState,
     RentIncludesBillsState,
-    FurnishedStatusState,
-    RentFrequencyAndAmountState {
+    FurnishedStatusState {
     val occupied: OccupiedStep
     val householdsAndTenantsTask: HouseholdsAndTenantsTask
     val rentIncludesBillsTask: RentIncludesBillsTask

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/states/OccupationState.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/states/OccupationState.kt
@@ -8,7 +8,6 @@ import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.RentI
 
 interface OccupationState :
     JourneyState,
-    HouseholdsAndTenantsState,
     BedroomsState,
     FurnishedStatusState {
     val occupied: OccupiedStep

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/states/PropertyDetailsState.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/states/PropertyDetailsState.kt
@@ -7,7 +7,6 @@ import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.Prope
 
 interface PropertyDetailsState :
     JourneyState,
-    PropertyRegistrationAddressState,
     BedroomsState {
     val addressTask: PropertyRegistrationAddressTask
     val addToLandlordIncompletePropertiesStep: AddToLandlordIncompletePropertiesStep

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/states/TenancyDetailsState.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/states/TenancyDetailsState.kt
@@ -7,7 +7,6 @@ import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.RentI
 
 interface TenancyDetailsState :
     JourneyState,
-    HouseholdsAndTenantsState,
     FurnishedStatusState {
     val householdsAndTenantsTask: HouseholdsAndTenantsTask
     val rentIncludesBillsTask: RentIncludesBillsTask

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/states/TenancyDetailsState.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/states/TenancyDetailsState.kt
@@ -9,8 +9,7 @@ interface TenancyDetailsState :
     JourneyState,
     HouseholdsAndTenantsState,
     RentIncludesBillsState,
-    FurnishedStatusState,
-    RentFrequencyAndAmountState {
+    FurnishedStatusState {
     val householdsAndTenantsTask: HouseholdsAndTenantsTask
     val rentIncludesBillsTask: RentIncludesBillsTask
     val rentFrequencyAndAmountTask: RentFrequencyAndAmountTask

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/states/TenancyDetailsState.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/states/TenancyDetailsState.kt
@@ -8,7 +8,6 @@ import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.RentI
 interface TenancyDetailsState :
     JourneyState,
     HouseholdsAndTenantsState,
-    RentIncludesBillsState,
     FurnishedStatusState {
     val householdsAndTenantsTask: HouseholdsAndTenantsTask
     val rentIncludesBillsTask: RentIncludesBillsTask

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/PropertyRegistrationCyaStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/PropertyRegistrationCyaStepConfig.kt
@@ -42,7 +42,7 @@ class PropertyRegistrationCyaStepConfig(
                     } else {
                         getPropertyDetailsSummaryList(state)
                     },
-                "licensingDetails" to licensingHelper.getCheckYourAnswersSummaryList(state),
+                "licensingDetails" to licensingHelper.getCheckYourAnswersSummaryList(state, state.licensingTask),
                 "tenancyDetails" to
                     if (isRestructured) {
                         occupancyDetailsHelper.getRestructuredCheckYourAnswersSummaryList(state, messageSource)

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/PropertyRegistrationCyaStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/PropertyRegistrationCyaStepConfig.kt
@@ -35,7 +35,7 @@ class PropertyRegistrationCyaStepConfig(
                 "title" to "registerProperty.title",
                 "submitButtonText" to "forms.buttons.completeRegistration",
                 "insetText" to true,
-                "propertyName" to state.getAddress().singleLineAddress,
+                "propertyName" to state.addressTask.getAddress().singleLineAddress,
                 "propertyDetails" to
                     if (isRestructured) {
                         getRestructuredPropertyDetailsSummaryList(state)
@@ -110,17 +110,23 @@ class PropertyRegistrationCyaStepConfig(
         )
 
     private fun getAddressRows(state: PropertyRegistrationJourneyState) =
-        state.getAddress().let { address ->
+        state.addressTask.getAddress().let { address ->
             listOf(
                 SummaryListRowViewModel.forCheckYourAnswersPage(
                     "forms.checkPropertyAnswers.propertyDetails.address",
                     address.singleLineAddress,
-                    Destination.VisitableStep(state.lookupAddressStep, state.getCyaJourneyId(state.lookupAddressStep)),
+                    Destination.VisitableStep(
+                        state.addressTask.lookupAddressStep,
+                        state.getCyaJourneyId(state.addressTask.lookupAddressStep),
+                    ),
                 ),
                 SummaryListRowViewModel.forCheckYourAnswersPage(
                     "forms.checkPropertyAnswers.propertyDetails.localCouncil",
                     localCouncilService.retrieveLocalCouncilById(address.localCouncilId!!).name,
-                    Destination.VisitableStep(state.localCouncilStep, state.getCyaJourneyId(state.localCouncilStep)),
+                    Destination.VisitableStep(
+                        state.addressTask.localCouncilStep,
+                        state.getCyaJourneyId(state.addressTask.localCouncilStep),
+                    ),
                 ),
             )
         }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/SavePropertyRegistrationDataStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/SavePropertyRegistrationDataStepConfig.kt
@@ -36,7 +36,7 @@ class SavePropertyRegistrationDataStepConfig(
         try {
             registerProperty(state)
         } catch (_: EntityExistsException) {
-            state.isAddressAlreadyRegistered = true
+            state.addressTask.isAddressAlreadyRegistered = true
             return
         }
     }
@@ -45,8 +45,8 @@ class SavePropertyRegistrationDataStepConfig(
         state: PropertyRegistrationJourneyState,
         defaultDestination: Destination,
     ): Destination =
-        if (state.isAddressAlreadyRegistered == true) {
-            Destination(state.alreadyRegisteredStep)
+        if (state.addressTask.isAddressAlreadyRegistered == true) {
+            Destination(state.addressTask.alreadyRegisteredStep)
         } else {
             state.deleteJourney()
             defaultDestination
@@ -63,7 +63,7 @@ class SavePropertyRegistrationDataStepConfig(
         val markedJointLandlord = state.jointLandlordsTask.hasJointLandlordsStep.formModel.hasJointLandlords == true
 
         propertyRegistrationService.registerProperty(
-            addressModel = state.getAddress(),
+            addressModel = state.addressTask.getAddress(),
             propertyType = state.propertyTypeStep.formModel.notNullValue(PropertyTypeFormModel::propertyType),
             customPropertyType =
                 if (state.propertyTypeStep.formModel.propertyType == PropertyType.OTHER) {

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/SavePropertyRegistrationDataStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/SavePropertyRegistrationDataStepConfig.kt
@@ -77,7 +77,7 @@ class SavePropertyRegistrationDataStepConfig(
             isOccupied = isOccupied,
             numberOfHouseholds =
                 if (isOccupied) {
-                    state.households.formModel
+                    state.householdsAndTenantsTask.households.formModel
                         .notNullValue(NumberOfHouseholdsFormModel::numberOfHouseholds)
                         .toInt()
                 } else {
@@ -85,7 +85,7 @@ class SavePropertyRegistrationDataStepConfig(
                 },
             numberOfPeople =
                 if (isOccupied) {
-                    state.tenants.formModel
+                    state.householdsAndTenantsTask.tenants.formModel
                         .notNullValue(NewNumberOfPeopleFormModel::numberOfPeople)
                         .toInt()
                 } else {

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/SavePropertyRegistrationDataStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/SavePropertyRegistrationDataStepConfig.kt
@@ -55,7 +55,7 @@ class SavePropertyRegistrationDataStepConfig(
     private fun registerProperty(state: PropertyRegistrationJourneyState) {
         val isOccupied = state.occupied.formModel.notNullValue(OccupancyFormModel::occupied)
         val isRestructured = featureFlagManager.checkFeature(PROPERTY_REGISTRATION_RESTRUCTURE_AND_SKIPPING)
-        val billsIncludedDataModel = state.getBillsIncludedOrNull()
+        val billsIncludedDataModel = state.rentIncludesBillsTask.getBillsIncludedOrNull()
         val jointLandlordEmails: List<String>? =
             state.jointLandlordsTask.inviteJointLandlordsTask.invitedJointLandlordEmailsMap
                 ?.values

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/SavePropertyRegistrationDataStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/SavePropertyRegistrationDataStepConfig.kt
@@ -102,11 +102,11 @@ class SavePropertyRegistrationDataStepConfig(
             billsIncludedList = if (isOccupied) billsIncludedDataModel?.standardBillsIncludedListAsString else null,
             customBillsIncluded = if (isOccupied) billsIncludedDataModel?.customBillsIncluded else null,
             furnishedStatus = if (isOccupied) state.furnishedStatus.formModel.furnishedStatus else null,
-            rentFrequency = if (isOccupied) state.rentFrequency.formModel.rentFrequency else null,
-            customRentFrequency = if (isOccupied) state.getCustomRentFrequencyIfSelected() else null,
+            rentFrequency = if (isOccupied) state.rentFrequencyAndAmountTask.rentFrequency.formModel.rentFrequency else null,
+            customRentFrequency = if (isOccupied) state.rentFrequencyAndAmountTask.getCustomRentFrequencyIfSelected() else null,
             rentAmount =
                 if (isOccupied) {
-                    state.rentAmount.formModel.rentAmount
+                    state.rentFrequencyAndAmountTask.rentAmount.formModel.rentAmount
                         .toBigDecimal()
                 } else {
                     null

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/SavePropertyRegistrationDataStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/SavePropertyRegistrationDataStepConfig.kt
@@ -71,8 +71,8 @@ class SavePropertyRegistrationDataStepConfig(
                 } else {
                     null
                 },
-            licenseType = state.licensingTypeStep.formModel.notNullValue(LicensingTypeFormModel::licensingType),
-            licenceNumber = state.getLicenceNumberOrNull() ?: "",
+            licenseType = state.licensingTask.licensingTypeStep.formModel.notNullValue(LicensingTypeFormModel::licensingType),
+            licenceNumber = state.licensingTask.getLicenceNumberOrNull() ?: "",
             ownershipType = state.ownershipTypeStep.formModel.notNullValue(OwnershipTypeFormModel::ownershipType),
             isOccupied = isOccupied,
             numberOfHouseholds =

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/tasks/HouseholdsAndTenantsTask.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/tasks/HouseholdsAndTenantsTask.kt
@@ -1,8 +1,9 @@
 package uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks
 
 import uk.gov.communities.prsdb.webapp.annotations.webAnnotations.JourneyFrameworkComponent
+import uk.gov.communities.prsdb.webapp.journeys.DuplicableTask
+import uk.gov.communities.prsdb.webapp.journeys.JourneyStateService
 import uk.gov.communities.prsdb.webapp.journeys.OrParents
-import uk.gov.communities.prsdb.webapp.journeys.Task
 import uk.gov.communities.prsdb.webapp.journeys.hasOutcome
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.HouseholdsAndTenantsState
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.HouseholdStep
@@ -10,7 +11,14 @@ import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.Tenan
 import uk.gov.communities.prsdb.webapp.journeys.shared.Complete
 
 @JourneyFrameworkComponent
-class HouseholdsAndTenantsTask : Task<HouseholdsAndTenantsState>() {
+class HouseholdsAndTenantsTask(
+    journeyStateService: JourneyStateService,
+    override val households: HouseholdStep,
+    override val tenants: TenantsStep,
+) : DuplicableTask<HouseholdsAndTenantsState>(journeyStateService),
+    HouseholdsAndTenantsState {
+    override val taskState get() = this
+
     override fun makeSubJourney(state: HouseholdsAndTenantsState) =
         subJourney(state) {
             step(journey.households) {

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/tasks/LicensingTask.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/tasks/LicensingTask.kt
@@ -2,8 +2,9 @@ package uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks
 
 import uk.gov.communities.prsdb.webapp.annotations.webAnnotations.JourneyFrameworkComponent
 import uk.gov.communities.prsdb.webapp.config.managers.FeatureFlagManager
+import uk.gov.communities.prsdb.webapp.journeys.DuplicableTask
+import uk.gov.communities.prsdb.webapp.journeys.JourneyStateService
 import uk.gov.communities.prsdb.webapp.journeys.OrParents
-import uk.gov.communities.prsdb.webapp.journeys.Task
 import uk.gov.communities.prsdb.webapp.journeys.hasOutcome
 import uk.gov.communities.prsdb.webapp.journeys.isComplete
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.LicensingState
@@ -15,8 +16,16 @@ import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.Selec
 
 @JourneyFrameworkComponent
 class LicensingTask(
+    journeyStateService: JourneyStateService,
     private val featureFlagManager: FeatureFlagManager,
-) : Task<LicensingState>() {
+    override val licensingTypeStep: LicensingTypeStep,
+    override val selectiveLicenceStep: SelectiveLicenceStep,
+    override val hmoMandatoryLicenceStep: HmoMandatoryLicenceStep,
+    override val hmoAdditionalLicenceStep: HmoAdditionalLicenceStep,
+) : DuplicableTask<LicensingState>(journeyStateService),
+    LicensingState {
+    override val taskState get() = this
+
     override fun makeSubJourney(state: LicensingState) =
         subJourney(state) {
             // TODO(PDJB-990): route to the 'provide details about licensing later' page when 'Provide this later' is selected behind the FF: pdjb-939-property-registration-restructure-and-skipping/PROPERTY_REGISTRATION_RESTRUCTURE_AND_SKIPPING

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/tasks/OccupationTask.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/tasks/OccupationTask.kt
@@ -37,7 +37,7 @@ class OccupationTask : Task<OccupationState>() {
                 nextStep { journey.rentIncludesBillsTask.firstStep }
                 savable()
             }
-            task(journey.rentIncludesBillsTask) {
+            duplicableTask(journey.rentIncludesBillsTask) {
                 parents { journey.bedrooms.hasOutcome(Complete.COMPLETE) }
                 nextStep { journey.furnishedStatus }
             }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/tasks/OccupationTask.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/tasks/OccupationTask.kt
@@ -26,7 +26,7 @@ class OccupationTask : Task<OccupationState>() {
                 }
                 savable()
             }
-            task(journey.householdsAndTenantsTask) {
+            duplicableTask(journey.householdsAndTenantsTask) {
                 parents { journey.occupied.hasOutcome(YesOrNo.YES) }
                 nextStep { journey.bedrooms }
                 savable()

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/tasks/OccupationTask.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/tasks/OccupationTask.kt
@@ -47,7 +47,7 @@ class OccupationTask : Task<OccupationState>() {
                 nextStep { journey.rentFrequencyAndAmountTask.firstStep }
                 savable()
             }
-            task(journey.rentFrequencyAndAmountTask) {
+            duplicableTask(journey.rentFrequencyAndAmountTask) {
                 parents {
                     journey.furnishedStatus.hasOutcome(Complete.COMPLETE)
                 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/tasks/PropertyDetailsTask.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/tasks/PropertyDetailsTask.kt
@@ -11,7 +11,7 @@ import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.Prope
 class PropertyDetailsTask : Task<PropertyDetailsState>() {
     override fun makeSubJourney(state: PropertyDetailsState) =
         subJourney(state) {
-            task(journey.addressTask) {
+            duplicableTask(journey.addressTask) {
                 nextStep { journey.addToLandlordIncompletePropertiesStep }
                 savable()
             }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/tasks/PropertyRegistrationAddressTask.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/tasks/PropertyRegistrationAddressTask.kt
@@ -1,8 +1,9 @@
 package uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks
 
 import uk.gov.communities.prsdb.webapp.annotations.webAnnotations.JourneyFrameworkComponent
+import uk.gov.communities.prsdb.webapp.journeys.DuplicableTask
+import uk.gov.communities.prsdb.webapp.journeys.JourneyStateService
 import uk.gov.communities.prsdb.webapp.journeys.OrParents
-import uk.gov.communities.prsdb.webapp.journeys.Task
 import uk.gov.communities.prsdb.webapp.journeys.hasOutcome
 import uk.gov.communities.prsdb.webapp.journeys.isComplete
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.PropertyRegistrationAddressState
@@ -17,9 +18,25 @@ import uk.gov.communities.prsdb.webapp.journeys.shared.stepConfig.NoAddressFound
 import uk.gov.communities.prsdb.webapp.journeys.shared.stepConfig.NoAddressFoundStepConfig
 import uk.gov.communities.prsdb.webapp.journeys.shared.stepConfig.SelectAddressMode
 import uk.gov.communities.prsdb.webapp.journeys.shared.stepConfig.SelectAddressStep
+import uk.gov.communities.prsdb.webapp.models.dataModels.AddressDataModel
 
 @JourneyFrameworkComponent
-class PropertyRegistrationAddressTask : Task<PropertyRegistrationAddressState>() {
+class PropertyRegistrationAddressTask(
+    journeyStateService: JourneyStateService,
+    override val lookupAddressStep: LookupAddressStep,
+    override val selectAddressStep: SelectAddressStep,
+    override val noAddressFoundStep: NoAddressFoundStep,
+    override val manualAddressStep: ManualAddressStep,
+    override val alreadyRegisteredStep: AlreadyRegisteredStep,
+    override val localCouncilStep: LocalCouncilStep,
+) : DuplicableTask<PropertyRegistrationAddressState>(journeyStateService),
+    PropertyRegistrationAddressState {
+    override var cachedAddresses: List<AddressDataModel>? by delegateProvider.nullableDelegate("cachedAddresses")
+    override var cachedSelectedAddress: String? by delegateProvider.nullableDelegate("cachedSelectedAddress")
+    override var isAddressAlreadyRegistered: Boolean? by delegateProvider.nullableDelegate("isAddressAlreadyRegistered")
+
+    override val taskState get() = this
+
     override fun makeSubJourney(state: PropertyRegistrationAddressState) =
         subJourney(state) {
             step<LookupAddressMode, LookupAddressStepConfig>(journey.lookupAddressStep) {

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/tasks/RentFrequencyAndAmountTask.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/tasks/RentFrequencyAndAmountTask.kt
@@ -1,7 +1,8 @@
 package uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks
 
 import uk.gov.communities.prsdb.webapp.annotations.webAnnotations.JourneyFrameworkComponent
-import uk.gov.communities.prsdb.webapp.journeys.Task
+import uk.gov.communities.prsdb.webapp.journeys.DuplicableTask
+import uk.gov.communities.prsdb.webapp.journeys.JourneyStateService
 import uk.gov.communities.prsdb.webapp.journeys.hasOutcome
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.RentFrequencyAndAmountState
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.RentAmountStep
@@ -9,7 +10,14 @@ import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.RentF
 import uk.gov.communities.prsdb.webapp.journeys.shared.Complete
 
 @JourneyFrameworkComponent
-class RentFrequencyAndAmountTask : Task<RentFrequencyAndAmountState>() {
+class RentFrequencyAndAmountTask(
+    journeyStateService: JourneyStateService,
+    override val rentFrequency: RentFrequencyStep,
+    override val rentAmount: RentAmountStep,
+) : DuplicableTask<RentFrequencyAndAmountState>(journeyStateService),
+    RentFrequencyAndAmountState {
+    override val taskState get() = this
+
     override fun makeSubJourney(state: RentFrequencyAndAmountState) =
         subJourney(state) {
             step(journey.rentFrequency) {

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/tasks/RentIncludesBillsTask.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/tasks/RentIncludesBillsTask.kt
@@ -1,8 +1,9 @@
 package uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks
 
 import uk.gov.communities.prsdb.webapp.annotations.webAnnotations.JourneyFrameworkComponent
+import uk.gov.communities.prsdb.webapp.journeys.DuplicableTask
+import uk.gov.communities.prsdb.webapp.journeys.JourneyStateService
 import uk.gov.communities.prsdb.webapp.journeys.OrParents
-import uk.gov.communities.prsdb.webapp.journeys.Task
 import uk.gov.communities.prsdb.webapp.journeys.hasOutcome
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.RentIncludesBillsState
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.BillsIncludedStep
@@ -11,7 +12,14 @@ import uk.gov.communities.prsdb.webapp.journeys.shared.Complete
 import uk.gov.communities.prsdb.webapp.journeys.shared.YesOrNo
 
 @JourneyFrameworkComponent
-class RentIncludesBillsTask : Task<RentIncludesBillsState>() {
+class RentIncludesBillsTask(
+    journeyStateService: JourneyStateService,
+    override val rentIncludesBills: RentIncludesBillsStep,
+    override val billsIncluded: BillsIncludedStep,
+) : DuplicableTask<RentIncludesBillsState>(journeyStateService),
+    RentIncludesBillsState {
+    override val taskState get() = this
+
     override fun makeSubJourney(state: RentIncludesBillsState) =
         subJourney(state) {
             step(journey.rentIncludesBills) {

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/tasks/TenancyDetailsTask.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/tasks/TenancyDetailsTask.kt
@@ -16,7 +16,7 @@ class TenancyDetailsTask : Task<TenancyDetailsState>() {
                 nextStep { journey.rentIncludesBillsTask.firstStep }
                 savable()
             }
-            task(journey.rentIncludesBillsTask) {
+            duplicableTask(journey.rentIncludesBillsTask) {
                 parents { journey.householdsAndTenantsTask.isComplete() }
                 nextStep { journey.furnishedStatus }
                 savable()

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/tasks/TenancyDetailsTask.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/tasks/TenancyDetailsTask.kt
@@ -27,7 +27,7 @@ class TenancyDetailsTask : Task<TenancyDetailsState>() {
                 nextStep { journey.rentFrequencyAndAmountTask.firstStep }
                 savable()
             }
-            task(journey.rentFrequencyAndAmountTask) {
+            duplicableTask(journey.rentFrequencyAndAmountTask) {
                 parents { journey.furnishedStatus.hasOutcome(Complete.COMPLETE) }
                 nextStep { exitStep }
                 savable()

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/tasks/TenancyDetailsTask.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/tasks/TenancyDetailsTask.kt
@@ -13,6 +13,7 @@ class TenancyDetailsTask : Task<TenancyDetailsState>() {
     override fun makeSubJourney(state: TenancyDetailsState) =
         subJourney(state) {
             duplicableTask(journey.householdsAndTenantsTask) {
+                withDependencies { HouseHoldsAndTenantsDependencies(true) }
                 nextStep { journey.rentIncludesBillsTask.firstStep }
                 savable()
             }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/tasks/TenancyDetailsTask.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/tasks/TenancyDetailsTask.kt
@@ -12,7 +12,7 @@ import uk.gov.communities.prsdb.webapp.journeys.shared.Complete
 class TenancyDetailsTask : Task<TenancyDetailsState>() {
     override fun makeSubJourney(state: TenancyDetailsState) =
         subJourney(state) {
-            task(journey.householdsAndTenantsTask) {
+            duplicableTask(journey.householdsAndTenantsTask) {
                 nextStep { journey.rentIncludesBillsTask.firstStep }
                 savable()
             }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/update/householdsAndTenants/UpdateHouseholdsAndTenantsCyaConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/update/householdsAndTenants/UpdateHouseholdsAndTenantsCyaConfig.kt
@@ -25,7 +25,11 @@ class UpdateHouseholdsAndTenantsCyaConfig(
             "showWarning" to true,
             "submitButtonText" to "forms.buttons.confirmAndSubmitUpdate",
             "insetText" to true,
-            "summaryListData" to occupancyDetailsHelper.getCheckYourHouseHoldsAndTenantsAnswersSummaryList(state),
+            "summaryListData" to
+                occupancyDetailsHelper.getCheckYourHouseHoldsAndTenantsAnswersSummaryList(
+                    state,
+                    state.householdsAndTenantsTask,
+                ),
             "summaryName" to "forms.update.checkOccupancy.occupied.summaryName",
         )
 
@@ -34,11 +38,11 @@ class UpdateHouseholdsAndTenantsCyaConfig(
             propertyOwnershipService.updateHouseholdsAndTenants(
                 id = state.propertyId,
                 numberOfHouseholds =
-                    state.households.formModel
+                    state.householdsAndTenantsTask.households.formModel
                         .notNullValue(NumberOfHouseholdsFormModel::numberOfHouseholds)
                         .toInt(),
                 numberOfPeople =
-                    state.tenants.formModel
+                    state.householdsAndTenantsTask.tenants.formModel
                         .notNullValue(NewNumberOfPeopleFormModel::numberOfPeople)
                         .toInt(),
                 initialLastModifiedDate = Instant.parse(state.lastModifiedDate).toJavaInstant(),

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/update/householdsAndTenants/UpdateHouseholdsAndTenantsJourneyFactory.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/update/householdsAndTenants/UpdateHouseholdsAndTenantsJourneyFactory.kt
@@ -13,6 +13,7 @@ import uk.gov.communities.prsdb.webapp.journeys.StepLifecycleOrchestrator
 import uk.gov.communities.prsdb.webapp.journeys.builders.JourneyBuilder.Companion.journey
 import uk.gov.communities.prsdb.webapp.journeys.isComplete
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.FinishCyaJourneyStep
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.HouseHoldsAndTenantsDependencies
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.HouseholdsAndTenantsTask
 import uk.gov.communities.prsdb.webapp.journeys.shared.states.CheckYourAnswersJourneyState
 import uk.gov.communities.prsdb.webapp.journeys.shared.states.CheckYourAnswersJourneyState.Companion.duplicableCheckAnswerTask
@@ -56,6 +57,7 @@ class UpdateHouseholdsAndTenantsJourneyFactory(
                 initialStep()
                 backUrl { propertyDetailsRoute }
                 nextStep { journey.cyaStep }
+                withDependencies { HouseHoldsAndTenantsDependencies(false) }
                 withAdditionalContentProperty {
                     "title" to "propertyDetails.update.title"
                 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/update/householdsAndTenants/UpdateHouseholdsAndTenantsJourneyFactory.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/update/householdsAndTenants/UpdateHouseholdsAndTenantsJourneyFactory.kt
@@ -12,13 +12,10 @@ import uk.gov.communities.prsdb.webapp.journeys.JourneyStateService
 import uk.gov.communities.prsdb.webapp.journeys.StepLifecycleOrchestrator
 import uk.gov.communities.prsdb.webapp.journeys.builders.JourneyBuilder.Companion.journey
 import uk.gov.communities.prsdb.webapp.journeys.isComplete
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.HouseholdsAndTenantsState
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.FinishCyaJourneyStep
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.HouseholdStep
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.TenantsStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.HouseholdsAndTenantsTask
 import uk.gov.communities.prsdb.webapp.journeys.shared.states.CheckYourAnswersJourneyState
-import uk.gov.communities.prsdb.webapp.journeys.shared.states.CheckYourAnswersJourneyState.Companion.checkAnswerTask
+import uk.gov.communities.prsdb.webapp.journeys.shared.states.CheckYourAnswersJourneyState.Companion.duplicableCheckAnswerTask
 import uk.gov.communities.prsdb.webapp.services.PropertyOwnershipService
 import java.security.Principal
 
@@ -55,7 +52,7 @@ class UpdateHouseholdsAndTenantsJourneyFactory(
         val propertyDetailsRoute = PropertyDetailsController.getPropertyDetailsPath(propertyId)
         return journey(state) {
             unreachableStepUrl { propertyDetailsRoute }
-            task(journey.householdsAndTenantsTask) {
+            duplicableTask(journey.householdsAndTenantsTask) {
                 initialStep()
                 backUrl { propertyDetailsRoute }
                 nextStep { journey.cyaStep }
@@ -68,12 +65,12 @@ class UpdateHouseholdsAndTenantsJourneyFactory(
                 parents { journey.householdsAndTenantsTask.isComplete() }
                 nextUrl { propertyDetailsRoute }
             }
-            configureStep(journey.households) {
+            configureStep(journey.householdsAndTenantsTask.households) {
                 withAdditionalContentProperty {
                     "fieldSetHeading" to "forms.update.numberOfHouseholds.fieldSetHeading"
                 }
             }
-            configureStep(journey.tenants) {
+            configureStep(journey.householdsAndTenantsTask.tenants) {
                 withAdditionalContentProperty {
                     "fieldSetHeading" to "forms.update.numberOfPeople.fieldSetHeading"
                 }
@@ -94,17 +91,17 @@ class UpdateHouseholdsAndTenantsJourneyFactory(
                 }
             }
             configureFirst { backDestination { journey.returnToCyaPageDestination } }
-            checkAnswerTask(journey.householdsAndTenantsTask)
+            duplicableCheckAnswerTask(journey.householdsAndTenantsTask)
             step(journey.finishCyaStep) {
                 parents { journey.householdsAndTenantsTask.isComplete() }
                 nextDestination { Destination.Nowhere() }
             }
-            configureStep(journey.households) {
+            configureStep(journey.householdsAndTenantsTask.households) {
                 withAdditionalContentProperty {
                     "fieldSetHeading" to "forms.update.numberOfHouseholds.fieldSetHeading"
                 }
             }
-            configureStep(journey.tenants) {
+            configureStep(journey.householdsAndTenantsTask.tenants) {
                 withAdditionalContentProperty {
                     "fieldSetHeading" to "forms.update.numberOfPeople.fieldSetHeading"
                 }
@@ -122,8 +119,6 @@ class UpdateHouseholdsAndTenantsJourneyFactory(
 class UpdateHouseholdsAndTenantsJourney(
     // HouseholdsAndTenants task
     override val householdsAndTenantsTask: HouseholdsAndTenantsTask,
-    override val households: HouseholdStep,
-    override val tenants: TenantsStep,
     // Check your answers step
     override val cyaStep: UpdateHouseholdsAndTenantsCyaStep,
     journeyStateService: JourneyStateService,
@@ -142,7 +137,6 @@ class UpdateHouseholdsAndTenantsJourney(
 }
 
 interface UpdateHouseholdsAndTenantsJourneyState :
-    HouseholdsAndTenantsState,
     CheckYourAnswersJourneyState {
     val householdsAndTenantsTask: HouseholdsAndTenantsTask
     override val cyaStep: UpdateHouseholdsAndTenantsCyaStep

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/update/occupancy/UpdateOccupancyCyaConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/update/occupancy/UpdateOccupancyCyaConfig.kt
@@ -74,11 +74,11 @@ class UpdateOccupancyCyaConfig(
                 billsIncludedList = if (isOccupied) billsIncludedDataModel?.standardBillsIncludedListAsString else null,
                 customBillsIncluded = if (isOccupied) billsIncludedDataModel?.customBillsIncluded else null,
                 furnishedStatus = if (isOccupied) state.furnishedStatus.formModel.furnishedStatus else null,
-                rentFrequency = if (isOccupied) state.rentFrequency.formModel.rentFrequency else null,
-                customRentFrequency = if (isOccupied) state.getCustomRentFrequencyIfSelected() else null,
+                rentFrequency = if (isOccupied) state.rentFrequencyAndAmountTask.rentFrequency.formModel.rentFrequency else null,
+                customRentFrequency = if (isOccupied) state.rentFrequencyAndAmountTask.getCustomRentFrequencyIfSelected() else null,
                 rentAmount =
                     if (isOccupied) {
-                        state.rentAmount.formModel.rentAmount
+                        state.rentFrequencyAndAmountTask.rentAmount.formModel.rentAmount
                             .toBigDecimal()
                     } else {
                         null

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/update/occupancy/UpdateOccupancyCyaConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/update/occupancy/UpdateOccupancyCyaConfig.kt
@@ -49,7 +49,7 @@ class UpdateOccupancyCyaConfig(
                 //   For example, numBedrooms should no longer be set to null as that will be in the property details section
                 numberOfHouseholds =
                     if (isOccupied) {
-                        state.households.formModel
+                        state.householdsAndTenantsTask.households.formModel
                             .notNullValue(NumberOfHouseholdsFormModel::numberOfHouseholds)
                             .toInt()
                     } else {
@@ -57,7 +57,7 @@ class UpdateOccupancyCyaConfig(
                     },
                 numberOfPeople =
                     if (isOccupied) {
-                        state.tenants.formModel
+                        state.householdsAndTenantsTask.tenants.formModel
                             .notNullValue(NewNumberOfPeopleFormModel::numberOfPeople)
                             .toInt()
                     } else {

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/update/occupancy/UpdateOccupancyCyaConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/update/occupancy/UpdateOccupancyCyaConfig.kt
@@ -40,7 +40,7 @@ class UpdateOccupancyCyaConfig(
 
     override fun afterStepDataIsAdded(state: UpdateOccupancyJourneyState) {
         val isOccupied = isOccupied(state)
-        val billsIncludedDataModel = state.getBillsIncludedOrNull()
+        val billsIncludedDataModel = state.rentIncludesBillsTask.getBillsIncludedOrNull()
         try {
             propertyOwnershipService.updateOccupancy(
                 id = state.propertyId,

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/update/occupancy/UpdateOccupancyJourneyFactory.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/update/occupancy/UpdateOccupancyJourneyFactory.kt
@@ -31,7 +31,6 @@ import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.RentI
 import uk.gov.communities.prsdb.webapp.journeys.shared.states.CheckYourAnswersJourneyState
 import uk.gov.communities.prsdb.webapp.journeys.shared.states.CheckYourAnswersJourneyState.Companion.checkAnswerStep
 import uk.gov.communities.prsdb.webapp.journeys.shared.states.CheckYourAnswersJourneyState.Companion.checkAnswerTask
-import uk.gov.communities.prsdb.webapp.journeys.shared.states.CheckYourAnswersJourneyState.Companion.duplicableCheckAnswerStep
 import uk.gov.communities.prsdb.webapp.journeys.shared.states.CheckYourAnswersJourneyState.Companion.duplicableCheckAnswerTask
 import uk.gov.communities.prsdb.webapp.services.PropertyOwnershipService
 import java.security.Principal
@@ -103,20 +102,39 @@ class UpdateOccupancyJourneyFactory(
             }
             configureFirst { backDestination { journey.returnToCyaPageDestination } }
             when (checkingAnswersFor) {
-                OccupiedStep.ROUTE_SEGMENT -> checkAnswerTask(journey.occupationTask)
-                HouseholdStep.ROUTE_SEGMENT, TenantsStep.ROUTE_SEGMENT -> duplicableCheckAnswerTask(journey.householdsAndTenantsTask)
-                BedroomsStep.ROUTE_SEGMENT -> checkAnswerStep(journey.bedrooms, BedroomsStep.ROUTE_SEGMENT)
-                RentIncludesBillsStep.ROUTE_SEGMENT -> duplicableCheckAnswerTask(journey.rentIncludesBillsTask)
-                BillsIncludedStep.ROUTE_SEGMENT ->
-                    duplicableCheckAnswerStep(
-                        journey.rentIncludesBillsTask,
-                        journey.rentIncludesBillsTask.billsIncluded,
-                        BillsIncludedStep.ROUTE_SEGMENT,
-                    )
-                FurnishedStatusStep.ROUTE_SEGMENT -> checkAnswerStep(journey.furnishedStatus, FurnishedStatusStep.ROUTE_SEGMENT)
-                RentFrequencyStep.ROUTE_SEGMENT, RentAmountStep.ROUTE_SEGMENT ->
+                OccupiedStep.ROUTE_SEGMENT -> {
+                    checkAnswerTask(journey.occupationTask)
+                }
+
+                HouseholdStep.ROUTE_SEGMENT, TenantsStep.ROUTE_SEGMENT -> {
+                    duplicableCheckAnswerTask(journey.householdsAndTenantsTask)
+                }
+
+                BedroomsStep.ROUTE_SEGMENT -> {
+                    checkAnswerStep(journey.bedrooms, BedroomsStep.ROUTE_SEGMENT)
+                }
+
+                RentIncludesBillsStep.ROUTE_SEGMENT -> {
+                    duplicableCheckAnswerTask(journey.rentIncludesBillsTask)
+                }
+
+                BillsIncludedStep.ROUTE_SEGMENT -> {
+                    embed(journey.rentIncludesBillsTask) {
+                        checkAnswerStep(journey.billsIncluded, BillsIncludedStep.ROUTE_SEGMENT)
+                    }
+                }
+
+                FurnishedStatusStep.ROUTE_SEGMENT -> {
+                    checkAnswerStep(journey.furnishedStatus, FurnishedStatusStep.ROUTE_SEGMENT)
+                }
+
+                RentFrequencyStep.ROUTE_SEGMENT, RentAmountStep.ROUTE_SEGMENT -> {
                     duplicableCheckAnswerTask(journey.rentFrequencyAndAmountTask)
-                else -> throw IllegalStateException("Unknown step being checked: $checkingAnswersFor")
+                }
+
+                else -> {
+                    throw IllegalStateException("Unknown step being checked: $checkingAnswersFor")
+                }
             }
             replaceHeadings(state)
             step(journey.finishCyaStep) {

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/update/occupancy/UpdateOccupancyJourneyFactory.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/update/occupancy/UpdateOccupancyJourneyFactory.kt
@@ -119,8 +119,8 @@ class UpdateOccupancyJourneyFactory(
                 }
 
                 BillsIncludedStep.ROUTE_SEGMENT -> {
-                    embed(journey.rentIncludesBillsTask) {
-                        checkAnswerStep(journey.billsIncluded, BillsIncludedStep.ROUTE_SEGMENT)
+                    fromTask(journey.rentIncludesBillsTask) {
+                        checkAnswerStep(task.billsIncluded, BillsIncludedStep.ROUTE_SEGMENT)
                     }
                 }
 

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/update/occupancy/UpdateOccupancyJourneyFactory.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/update/occupancy/UpdateOccupancyJourneyFactory.kt
@@ -31,6 +31,7 @@ import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.RentI
 import uk.gov.communities.prsdb.webapp.journeys.shared.states.CheckYourAnswersJourneyState
 import uk.gov.communities.prsdb.webapp.journeys.shared.states.CheckYourAnswersJourneyState.Companion.checkAnswerStep
 import uk.gov.communities.prsdb.webapp.journeys.shared.states.CheckYourAnswersJourneyState.Companion.checkAnswerTask
+import uk.gov.communities.prsdb.webapp.journeys.shared.states.CheckYourAnswersJourneyState.Companion.duplicableCheckAnswerStep
 import uk.gov.communities.prsdb.webapp.journeys.shared.states.CheckYourAnswersJourneyState.Companion.duplicableCheckAnswerTask
 import uk.gov.communities.prsdb.webapp.services.PropertyOwnershipService
 import java.security.Principal
@@ -105,8 +106,13 @@ class UpdateOccupancyJourneyFactory(
                 OccupiedStep.ROUTE_SEGMENT -> checkAnswerTask(journey.occupationTask)
                 HouseholdStep.ROUTE_SEGMENT, TenantsStep.ROUTE_SEGMENT -> checkAnswerTask(journey.householdsAndTenantsTask)
                 BedroomsStep.ROUTE_SEGMENT -> checkAnswerStep(journey.bedrooms, BedroomsStep.ROUTE_SEGMENT)
-                RentIncludesBillsStep.ROUTE_SEGMENT -> checkAnswerTask(journey.rentIncludesBillsTask)
-                BillsIncludedStep.ROUTE_SEGMENT -> checkAnswerStep(journey.billsIncluded, BillsIncludedStep.ROUTE_SEGMENT)
+                RentIncludesBillsStep.ROUTE_SEGMENT -> duplicableCheckAnswerTask(journey.rentIncludesBillsTask)
+                BillsIncludedStep.ROUTE_SEGMENT ->
+                    duplicableCheckAnswerStep(
+                        journey.rentIncludesBillsTask,
+                        journey.rentIncludesBillsTask.billsIncluded,
+                        BillsIncludedStep.ROUTE_SEGMENT,
+                    )
                 FurnishedStatusStep.ROUTE_SEGMENT -> checkAnswerStep(journey.furnishedStatus, FurnishedStatusStep.ROUTE_SEGMENT)
                 RentFrequencyStep.ROUTE_SEGMENT, RentAmountStep.ROUTE_SEGMENT ->
                     duplicableCheckAnswerTask(journey.rentFrequencyAndAmountTask)
@@ -146,12 +152,12 @@ class UpdateOccupancyJourneyFactory(
                 "heading" to "forms.update.numberOfBedrooms.heading"
             }
         }
-        configureStep(journey.rentIncludesBills) {
+        configureStep(journey.rentIncludesBillsTask.rentIncludesBills) {
             withAdditionalContentProperty {
                 "fieldSetHeading" to "forms.update.rentIncludesBills.fieldSetHeading"
             }
         }
-        configureStep(journey.billsIncluded) {
+        configureStep(journey.rentIncludesBillsTask.billsIncluded) {
             withAdditionalContentProperty {
                 "fieldSetHeading" to "forms.update.billsIncluded.fieldSetHeading"
             }
@@ -186,8 +192,6 @@ class UpdateOccupancyJourney(
     override val bedrooms: BedroomsStep,
     // Nested rent includes bills task
     override val rentIncludesBillsTask: RentIncludesBillsTask,
-    override val rentIncludesBills: RentIncludesBillsStep,
-    override val billsIncluded: BillsIncludedStep,
     override val furnishedStatus: FurnishedStatusStep,
     // Nested rent frequency and amount task
     override val rentFrequencyAndAmountTask: RentFrequencyAndAmountTask,

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/update/occupancy/UpdateOccupancyJourneyFactory.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/update/occupancy/UpdateOccupancyJourneyFactory.kt
@@ -104,7 +104,7 @@ class UpdateOccupancyJourneyFactory(
             configureFirst { backDestination { journey.returnToCyaPageDestination } }
             when (checkingAnswersFor) {
                 OccupiedStep.ROUTE_SEGMENT -> checkAnswerTask(journey.occupationTask)
-                HouseholdStep.ROUTE_SEGMENT, TenantsStep.ROUTE_SEGMENT -> checkAnswerTask(journey.householdsAndTenantsTask)
+                HouseholdStep.ROUTE_SEGMENT, TenantsStep.ROUTE_SEGMENT -> duplicableCheckAnswerTask(journey.householdsAndTenantsTask)
                 BedroomsStep.ROUTE_SEGMENT -> checkAnswerStep(journey.bedrooms, BedroomsStep.ROUTE_SEGMENT)
                 RentIncludesBillsStep.ROUTE_SEGMENT -> duplicableCheckAnswerTask(journey.rentIncludesBillsTask)
                 BillsIncludedStep.ROUTE_SEGMENT ->
@@ -137,12 +137,12 @@ class UpdateOccupancyJourneyFactory(
                 "fieldSetHeading" to "forms.update.occupancy.occupied.fieldSetHeading"
             }
         }
-        configureStep(journey.households) {
+        configureStep(journey.householdsAndTenantsTask.households) {
             withAdditionalContentProperty {
                 "fieldSetHeading" to "forms.update.numberOfHouseholds.fieldSetHeading"
             }
         }
-        configureStep(journey.tenants) {
+        configureStep(journey.householdsAndTenantsTask.tenants) {
             withAdditionalContentProperty {
                 "fieldSetHeading" to "forms.update.numberOfPeople.fieldSetHeading"
             }
@@ -187,8 +187,6 @@ class UpdateOccupancyJourney(
     override val occupied: OccupiedStep,
     // Nested households and tenants task
     override val householdsAndTenantsTask: HouseholdsAndTenantsTask,
-    override val households: HouseholdStep,
-    override val tenants: TenantsStep,
     override val bedrooms: BedroomsStep,
     // Nested rent includes bills task
     override val rentIncludesBillsTask: RentIncludesBillsTask,

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/update/occupancy/UpdateOccupancyJourneyFactory.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/update/occupancy/UpdateOccupancyJourneyFactory.kt
@@ -31,6 +31,7 @@ import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.RentI
 import uk.gov.communities.prsdb.webapp.journeys.shared.states.CheckYourAnswersJourneyState
 import uk.gov.communities.prsdb.webapp.journeys.shared.states.CheckYourAnswersJourneyState.Companion.checkAnswerStep
 import uk.gov.communities.prsdb.webapp.journeys.shared.states.CheckYourAnswersJourneyState.Companion.checkAnswerTask
+import uk.gov.communities.prsdb.webapp.journeys.shared.states.CheckYourAnswersJourneyState.Companion.duplicableCheckAnswerTask
 import uk.gov.communities.prsdb.webapp.services.PropertyOwnershipService
 import java.security.Principal
 
@@ -107,7 +108,8 @@ class UpdateOccupancyJourneyFactory(
                 RentIncludesBillsStep.ROUTE_SEGMENT -> checkAnswerTask(journey.rentIncludesBillsTask)
                 BillsIncludedStep.ROUTE_SEGMENT -> checkAnswerStep(journey.billsIncluded, BillsIncludedStep.ROUTE_SEGMENT)
                 FurnishedStatusStep.ROUTE_SEGMENT -> checkAnswerStep(journey.furnishedStatus, FurnishedStatusStep.ROUTE_SEGMENT)
-                RentFrequencyStep.ROUTE_SEGMENT, RentAmountStep.ROUTE_SEGMENT -> checkAnswerTask(journey.rentFrequencyAndAmountTask)
+                RentFrequencyStep.ROUTE_SEGMENT, RentAmountStep.ROUTE_SEGMENT ->
+                    duplicableCheckAnswerTask(journey.rentFrequencyAndAmountTask)
                 else -> throw IllegalStateException("Unknown step being checked: $checkingAnswersFor")
             }
             replaceHeadings(state)
@@ -159,14 +161,14 @@ class UpdateOccupancyJourneyFactory(
                 "fieldSetHeading" to "forms.update.furnishedStatus.fieldSetHeading"
             }
         }
-        configureStep(journey.rentFrequency) {
+        configureStep(journey.rentFrequencyAndAmountTask.rentFrequency) {
             withAdditionalContentProperty {
                 "heading" to "forms.update.rentFrequency.heading"
             }
         }
-        configureStep(journey.rentAmount) {
+        configureStep(journey.rentFrequencyAndAmountTask.rentAmount) {
             withAdditionalContentProperty {
-                "heading" to state.getUpdateRentAmountHeading()
+                "heading" to state.rentFrequencyAndAmountTask.getUpdateRentAmountHeading()
             }
         }
     }
@@ -189,8 +191,6 @@ class UpdateOccupancyJourney(
     override val furnishedStatus: FurnishedStatusStep,
     // Nested rent frequency and amount task
     override val rentFrequencyAndAmountTask: RentFrequencyAndAmountTask,
-    override val rentFrequency: RentFrequencyStep,
-    override val rentAmount: RentAmountStep,
     // Check your answers step
     override val cyaStep: UpdateOccupancyCyaStep,
     override val finishCyaStep: FinishCyaJourneyStep,

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/update/rentFrequencyAndAmount/UpdateRentFrequencyAndAmountCyaConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/update/rentFrequencyAndAmount/UpdateRentFrequencyAndAmountCyaConfig.kt
@@ -24,17 +24,23 @@ class UpdateRentFrequencyAndAmountCyaConfig(
             "showWarning" to true,
             "submitButtonText" to "forms.buttons.confirmAndSubmitUpdate",
             "insetText" to true,
-            "summaryListData" to occupancyDetailsHelper.getCheckYourRentFrequencyAndAmountAnswersSummaryList(state, messageSource),
+            "summaryListData" to
+                occupancyDetailsHelper.getCheckYourRentFrequencyAndAmountAnswersSummaryList(
+                    state,
+                    state.rentFrequencyAndAmountTask,
+                    messageSource,
+                ),
             "summaryName" to "forms.update.checkOccupancy.occupied.summaryName",
         )
 
     override fun afterStepDataIsAdded(state: UpdateRentFrequencyAndAmountJourneyState) {
         try {
+            val rentTask = state.rentFrequencyAndAmountTask
             propertyOwnershipService.updateRentFrequencyAndAmount(
                 id = state.propertyId,
-                rentFrequency = state.rentFrequency.formModel.notNullValue(RentFrequencyFormModel::rentFrequency),
-                customRentFrequency = state.getCustomRentFrequencyIfSelected(),
-                rentAmount = state.rentAmount.formModel.rentAmount.toBigDecimal(),
+                rentFrequency = rentTask.rentFrequency.formModel.notNullValue(RentFrequencyFormModel::rentFrequency),
+                customRentFrequency = rentTask.getCustomRentFrequencyIfSelected(),
+                rentAmount = rentTask.rentAmount.formModel.rentAmount.toBigDecimal(),
                 initialLastModifiedDate = Instant.parse(state.lastModifiedDate).toJavaInstant(),
             )
         } catch (ex: UpdateConflictException) {

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/update/rentFrequencyAndAmount/UpdateRentFrequencyAndAmountJourneyFactory.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/update/rentFrequencyAndAmount/UpdateRentFrequencyAndAmountJourneyFactory.kt
@@ -12,13 +12,10 @@ import uk.gov.communities.prsdb.webapp.journeys.JourneyStateService
 import uk.gov.communities.prsdb.webapp.journeys.StepLifecycleOrchestrator
 import uk.gov.communities.prsdb.webapp.journeys.builders.JourneyBuilder.Companion.journey
 import uk.gov.communities.prsdb.webapp.journeys.isComplete
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.RentFrequencyAndAmountState
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.FinishCyaJourneyStep
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.RentAmountStep
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.RentFrequencyStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.RentFrequencyAndAmountTask
 import uk.gov.communities.prsdb.webapp.journeys.shared.states.CheckYourAnswersJourneyState
-import uk.gov.communities.prsdb.webapp.journeys.shared.states.CheckYourAnswersJourneyState.Companion.checkAnswerTask
+import uk.gov.communities.prsdb.webapp.journeys.shared.states.CheckYourAnswersJourneyState.Companion.duplicableCheckAnswerTask
 import uk.gov.communities.prsdb.webapp.services.PropertyOwnershipService
 import java.security.Principal
 
@@ -56,7 +53,7 @@ class UpdateRentFrequencyAndAmountJourneyFactory(
 
         return journey(state) {
             unreachableStepUrl { propertyDetailsRoute }
-            task(journey.rentFrequencyAndAmountTask) {
+            duplicableTask(journey.rentFrequencyAndAmountTask) {
                 initialStep()
                 backUrl { propertyDetailsRoute }
                 nextStep { journey.cyaStep }
@@ -69,14 +66,14 @@ class UpdateRentFrequencyAndAmountJourneyFactory(
                 parents { journey.rentFrequencyAndAmountTask.isComplete() }
                 nextUrl { propertyDetailsRoute }
             }
-            configureStep(journey.rentFrequency) {
+            configureStep(journey.rentFrequencyAndAmountTask.rentFrequency) {
                 withAdditionalContentProperty {
                     "heading" to "forms.update.rentFrequency.heading"
                 }
             }
-            configureStep(journey.rentAmount) {
+            configureStep(journey.rentFrequencyAndAmountTask.rentAmount) {
                 withAdditionalContentProperty {
-                    "heading" to state.getUpdateRentAmountHeading()
+                    "heading" to state.rentFrequencyAndAmountTask.getUpdateRentAmountHeading()
                 }
             }
         }
@@ -94,19 +91,19 @@ class UpdateRentFrequencyAndAmountJourneyFactory(
             configure {
                 withAdditionalContentProperty { "title" to "propertyDetails.update.title" }
             }
-            checkAnswerTask(journey.rentFrequencyAndAmountTask)
+            duplicableCheckAnswerTask(journey.rentFrequencyAndAmountTask)
             step(journey.finishCyaStep) {
                 parents { journey.rentFrequencyAndAmountTask.isComplete() }
                 nextDestination { Destination.Nowhere() }
             }
-            configureStep(journey.rentFrequency) {
+            configureStep(journey.rentFrequencyAndAmountTask.rentFrequency) {
                 withAdditionalContentProperty {
                     "heading" to "forms.update.rentFrequency.heading"
                 }
             }
-            configureStep(journey.rentAmount) {
+            configureStep(journey.rentFrequencyAndAmountTask.rentAmount) {
                 withAdditionalContentProperty {
-                    "heading" to state.getUpdateRentAmountHeading()
+                    "heading" to state.rentFrequencyAndAmountTask.getUpdateRentAmountHeading()
                 }
             }
         }
@@ -122,8 +119,6 @@ class UpdateRentFrequencyAndAmountJourneyFactory(
 class UpdateRentFrequencyAndAmountJourney(
     // RentFrequencyAndAmount task
     override val rentFrequencyAndAmountTask: RentFrequencyAndAmountTask,
-    override val rentFrequency: RentFrequencyStep,
-    override val rentAmount: RentAmountStep,
     // Check your answers step
     override val cyaStep: UpdateRentFrequencyAndAmountCyaStep,
     journeyStateService: JourneyStateService,
@@ -141,7 +136,6 @@ class UpdateRentFrequencyAndAmountJourney(
 }
 
 interface UpdateRentFrequencyAndAmountJourneyState :
-    RentFrequencyAndAmountState,
     CheckYourAnswersJourneyState {
     val rentFrequencyAndAmountTask: RentFrequencyAndAmountTask
     override val cyaStep: UpdateRentFrequencyAndAmountCyaStep

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/update/rentIncludesBills/UpdateRentIncludesBillsCyaConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/update/rentIncludesBills/UpdateRentIncludesBillsCyaConfig.kt
@@ -22,12 +22,13 @@ class UpdateRentIncludesBillsCyaConfig(
             "showWarning" to true,
             "submitButtonText" to "forms.buttons.confirmAndSubmitUpdate",
             "insetText" to true,
-            "summaryListData" to occupancyDetailsHelper.getCheckYourRentIncludesBillsAnswersSummaryList(state, messageSource),
+            "summaryListData" to
+                occupancyDetailsHelper.getCheckYourRentIncludesBillsAnswersSummaryList(state, state.rentIncludesBillsTask, messageSource),
             "summaryName" to "forms.update.checkOccupancy.occupied.summaryName",
         )
 
     override fun afterStepDataIsAdded(state: UpdateRentIncludesBillsJourneyState) {
-        val billsIncludedDataModel = state.getBillsIncludedOrNull()
+        val billsIncludedDataModel = state.rentIncludesBillsTask.getBillsIncludedOrNull()
         try {
             propertyOwnershipService.updateRentIncludesBills(
                 id = state.propertyId,

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/update/rentIncludesBills/UpdateRentIncludesBillsJourneyFactory.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/update/rentIncludesBills/UpdateRentIncludesBillsJourneyFactory.kt
@@ -99,8 +99,8 @@ class UpdateRentIncludesBillsJourneyFactory(
                 }
 
                 BillsIncludedStep.ROUTE_SEGMENT -> {
-                    embed(journey.rentIncludesBillsTask) {
-                        checkAnswerStep(journey.billsIncluded, BillsIncludedStep.ROUTE_SEGMENT)
+                    fromTask(journey.rentIncludesBillsTask) {
+                        checkAnswerStep(task.billsIncluded, BillsIncludedStep.ROUTE_SEGMENT)
                     }
                 }
 

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/update/rentIncludesBills/UpdateRentIncludesBillsJourneyFactory.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/update/rentIncludesBills/UpdateRentIncludesBillsJourneyFactory.kt
@@ -12,14 +12,13 @@ import uk.gov.communities.prsdb.webapp.journeys.JourneyStateService
 import uk.gov.communities.prsdb.webapp.journeys.StepLifecycleOrchestrator
 import uk.gov.communities.prsdb.webapp.journeys.builders.JourneyBuilder.Companion.journey
 import uk.gov.communities.prsdb.webapp.journeys.isComplete
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.RentIncludesBillsState
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.BillsIncludedStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.FinishCyaJourneyStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.RentIncludesBillsStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.RentIncludesBillsTask
 import uk.gov.communities.prsdb.webapp.journeys.shared.states.CheckYourAnswersJourneyState
-import uk.gov.communities.prsdb.webapp.journeys.shared.states.CheckYourAnswersJourneyState.Companion.checkAnswerStep
-import uk.gov.communities.prsdb.webapp.journeys.shared.states.CheckYourAnswersJourneyState.Companion.checkAnswerTask
+import uk.gov.communities.prsdb.webapp.journeys.shared.states.CheckYourAnswersJourneyState.Companion.duplicableCheckAnswerStep
+import uk.gov.communities.prsdb.webapp.journeys.shared.states.CheckYourAnswersJourneyState.Companion.duplicableCheckAnswerTask
 import uk.gov.communities.prsdb.webapp.services.PropertyOwnershipService
 import java.security.Principal
 
@@ -57,7 +56,7 @@ class UpdateRentIncludesBillsJourneyFactory(
 
         return journey(state) {
             unreachableStepUrl { propertyDetailsRoute }
-            task(journey.rentIncludesBillsTask) {
+            duplicableTask(journey.rentIncludesBillsTask) {
                 initialStep()
                 backUrl { propertyDetailsRoute }
                 nextStep { journey.cyaStep }
@@ -70,12 +69,12 @@ class UpdateRentIncludesBillsJourneyFactory(
                 parents { journey.rentIncludesBillsTask.isComplete() }
                 nextUrl { propertyDetailsRoute }
             }
-            configureStep(journey.rentIncludesBills) {
+            configureStep(journey.rentIncludesBillsTask.rentIncludesBills) {
                 withAdditionalContentProperty {
                     "fieldSetHeading" to "forms.update.rentIncludesBills.fieldSetHeading"
                 }
             }
-            configureStep(journey.billsIncluded) {
+            configureStep(journey.rentIncludesBillsTask.billsIncluded) {
                 withAdditionalContentProperty {
                     "fieldSetHeading" to "forms.update.billsIncluded.fieldSetHeading"
                 }
@@ -95,20 +94,25 @@ class UpdateRentIncludesBillsJourneyFactory(
 
             configureFirst { backDestination { journey.returnToCyaPageDestination } }
             when (checkingAnswersFor) {
-                RentIncludesBillsStep.ROUTE_SEGMENT -> checkAnswerTask(journey.rentIncludesBillsTask)
-                BillsIncludedStep.ROUTE_SEGMENT -> checkAnswerStep(journey.billsIncluded, BillsIncludedStep.ROUTE_SEGMENT)
+                RentIncludesBillsStep.ROUTE_SEGMENT -> duplicableCheckAnswerTask(journey.rentIncludesBillsTask)
+                BillsIncludedStep.ROUTE_SEGMENT ->
+                    duplicableCheckAnswerStep(
+                        journey.rentIncludesBillsTask,
+                        journey.rentIncludesBillsTask.billsIncluded,
+                        BillsIncludedStep.ROUTE_SEGMENT,
+                    )
                 else -> throw IllegalStateException("Unknown step being checked: $checkingAnswersFor")
             }
             step(journey.finishCyaStep) {
                 initialStep()
                 nextDestination { Destination.Nowhere() }
             }
-            configureStep(journey.rentIncludesBills) {
+            configureStep(journey.rentIncludesBillsTask.rentIncludesBills) {
                 withAdditionalContentProperty {
                     "fieldSetHeading" to "forms.update.rentIncludesBills.fieldSetHeading"
                 }
             }
-            configureStep(journey.billsIncluded) {
+            configureStep(journey.rentIncludesBillsTask.billsIncluded) {
                 withAdditionalContentProperty {
                     "fieldSetHeading" to "forms.update.billsIncluded.fieldSetHeading"
                 }
@@ -131,8 +135,6 @@ class UpdateRentIncludesBillsJourneyFactory(
 class UpdateRentIncludesBillsJourney(
     // RentIncludesBills task
     override val rentIncludesBillsTask: RentIncludesBillsTask,
-    override val rentIncludesBills: RentIncludesBillsStep,
-    override val billsIncluded: BillsIncludedStep,
     // Check your answers step
     override val cyaStep: UpdateRentIncludesBillsCyaStep,
     journeyStateService: JourneyStateService,
@@ -151,7 +153,6 @@ class UpdateRentIncludesBillsJourney(
 }
 
 interface UpdateRentIncludesBillsJourneyState :
-    RentIncludesBillsState,
     CheckYourAnswersJourneyState {
     val rentIncludesBillsTask: RentIncludesBillsTask
     override val cyaStep: UpdateRentIncludesBillsCyaStep

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/update/rentIncludesBills/UpdateRentIncludesBillsJourneyFactory.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/update/rentIncludesBills/UpdateRentIncludesBillsJourneyFactory.kt
@@ -17,7 +17,7 @@ import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.Finis
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.RentIncludesBillsStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.RentIncludesBillsTask
 import uk.gov.communities.prsdb.webapp.journeys.shared.states.CheckYourAnswersJourneyState
-import uk.gov.communities.prsdb.webapp.journeys.shared.states.CheckYourAnswersJourneyState.Companion.duplicableCheckAnswerStep
+import uk.gov.communities.prsdb.webapp.journeys.shared.states.CheckYourAnswersJourneyState.Companion.checkAnswerStep
 import uk.gov.communities.prsdb.webapp.journeys.shared.states.CheckYourAnswersJourneyState.Companion.duplicableCheckAnswerTask
 import uk.gov.communities.prsdb.webapp.services.PropertyOwnershipService
 import java.security.Principal
@@ -94,14 +94,19 @@ class UpdateRentIncludesBillsJourneyFactory(
 
             configureFirst { backDestination { journey.returnToCyaPageDestination } }
             when (checkingAnswersFor) {
-                RentIncludesBillsStep.ROUTE_SEGMENT -> duplicableCheckAnswerTask(journey.rentIncludesBillsTask)
-                BillsIncludedStep.ROUTE_SEGMENT ->
-                    duplicableCheckAnswerStep(
-                        journey.rentIncludesBillsTask,
-                        journey.rentIncludesBillsTask.billsIncluded,
-                        BillsIncludedStep.ROUTE_SEGMENT,
-                    )
-                else -> throw IllegalStateException("Unknown step being checked: $checkingAnswersFor")
+                RentIncludesBillsStep.ROUTE_SEGMENT -> {
+                    duplicableCheckAnswerTask(journey.rentIncludesBillsTask)
+                }
+
+                BillsIncludedStep.ROUTE_SEGMENT -> {
+                    embed(journey.rentIncludesBillsTask) {
+                        checkAnswerStep(journey.billsIncluded, BillsIncludedStep.ROUTE_SEGMENT)
+                    }
+                }
+
+                else -> {
+                    throw IllegalStateException("Unknown step being checked: $checkingAnswersFor")
+                }
             }
             step(journey.finishCyaStep) {
                 initialStep()
@@ -152,8 +157,7 @@ class UpdateRentIncludesBillsJourney(
     override var cyaUrlPath: String? by delegateProvider.nullableDelegate("cyaRouteSegment")
 }
 
-interface UpdateRentIncludesBillsJourneyState :
-    CheckYourAnswersJourneyState {
+interface UpdateRentIncludesBillsJourneyState : CheckYourAnswersJourneyState {
     val rentIncludesBillsTask: RentIncludesBillsTask
     override val cyaStep: UpdateRentIncludesBillsCyaStep
     val propertyId: Long

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/update/updateLicensing/UpdateLicensingCyaConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/update/updateLicensing/UpdateLicensingCyaConfig.kt
@@ -28,6 +28,7 @@ class UpdateLicensingCyaConfig(
             "summaryListData" to
                 licensingDetailsHelper.getCheckYourAnswersSummaryList(
                     state,
+                    state.licensingTask,
                 ),
             "summaryName" to
                 if (isRemovingLicensing(state)) {
@@ -41,8 +42,8 @@ class UpdateLicensingCyaConfig(
         try {
             propertyOwnershipService.updateLicensing(
                 state.propertyId,
-                state.licensingTypeStep.formModel.notNullValue(LicensingTypeFormModel::licensingType),
-                state.getLicenceNumberOrNull(),
+                state.licensingTask.licensingTypeStep.formModel.notNullValue(LicensingTypeFormModel::licensingType),
+                state.licensingTask.getLicenceNumberOrNull(),
                 Instant.parse(state.lastModifiedDate).toJavaInstant(),
             )
         } catch (ex: UpdateConflictException) {
@@ -57,7 +58,7 @@ class UpdateLicensingCyaConfig(
     }
 
     private fun isRemovingLicensing(state: UpdateLicensingJourneyState): Boolean {
-        val newLicensingType = state.licensingTypeStep.formModel.notNullValue(LicensingTypeFormModel::licensingType)
+        val newLicensingType = state.licensingTask.licensingTypeStep.formModel.notNullValue(LicensingTypeFormModel::licensingType)
         return state.hasOriginalLicense && newLicensingType == LicensingType.NO_LICENSING
     }
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/update/updateLicensing/UpdatePropertyLicensingJourneyFactory.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/update/updateLicensing/UpdatePropertyLicensingJourneyFactory.kt
@@ -12,15 +12,10 @@ import uk.gov.communities.prsdb.webapp.journeys.JourneyStateService
 import uk.gov.communities.prsdb.webapp.journeys.StepLifecycleOrchestrator
 import uk.gov.communities.prsdb.webapp.journeys.builders.JourneyBuilder.Companion.journey
 import uk.gov.communities.prsdb.webapp.journeys.isComplete
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.LicensingState
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.FinishCyaJourneyStep
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.HmoAdditionalLicenceStep
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.HmoMandatoryLicenceStep
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.LicensingTypeStep
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.SelectiveLicenceStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.LicensingTask
 import uk.gov.communities.prsdb.webapp.journeys.shared.states.CheckYourAnswersJourneyState
-import uk.gov.communities.prsdb.webapp.journeys.shared.states.CheckYourAnswersJourneyState.Companion.checkAnswerTask
+import uk.gov.communities.prsdb.webapp.journeys.shared.states.CheckYourAnswersJourneyState.Companion.duplicableCheckAnswerTask
 import uk.gov.communities.prsdb.webapp.services.PropertyOwnershipService
 import java.security.Principal
 
@@ -60,8 +55,8 @@ class UpdateLicensingJourneyFactory(
             configureFirst { backDestination { journey.returnToCyaPageDestination } }
             unreachableStepDestination { journey.returnToCyaPageDestination }
             configureFirst { backDestination { journey.returnToCyaPageDestination } }
-            checkAnswerTask(journey.licensingTask)
-            configureStep(journey.licensingTypeStep) {
+            duplicableCheckAnswerTask(journey.licensingTask)
+            configureStep(journey.licensingTask.licensingTypeStep) {
                 withAdditionalContentProperty {
                     "fieldSetHeading" to "forms.update.licensingType.fieldSetHeading"
                 }
@@ -76,7 +71,7 @@ class UpdateLicensingJourneyFactory(
         journey(state) {
             val propertyDetailsRoute = PropertyDetailsController.getPropertyDetailsPath(journey.propertyId)
             unreachableStepUrl { propertyDetailsRoute }
-            task(journey.licensingTask) {
+            duplicableTask(journey.licensingTask) {
                 initialStep()
                 backUrl { propertyDetailsRoute }
                 nextStep { journey.cyaStep }
@@ -89,7 +84,7 @@ class UpdateLicensingJourneyFactory(
                 parents { journey.licensingTask.isComplete() }
                 nextUrl { propertyDetailsRoute }
             }
-            configureStep(journey.licensingTypeStep) {
+            configureStep(journey.licensingTask.licensingTypeStep) {
                 withAdditionalContentProperty {
                     "fieldSetHeading" to "forms.update.licensingType.fieldSetHeading"
                 }
@@ -106,10 +101,6 @@ class UpdateLicensingJourneyFactory(
 class UpdateLicensingJourney(
     // Licensing task
     override val licensingTask: LicensingTask,
-    override val licensingTypeStep: LicensingTypeStep,
-    override val selectiveLicenceStep: SelectiveLicenceStep,
-    override val hmoMandatoryLicenceStep: HmoMandatoryLicenceStep,
-    override val hmoAdditionalLicenceStep: HmoAdditionalLicenceStep,
     // Check your answers step
     override val cyaStep: UpdateLicensingCyaStep,
     override val finishCyaStep: FinishCyaJourneyStep,
@@ -129,7 +120,6 @@ class UpdateLicensingJourney(
 }
 
 interface UpdateLicensingJourneyState :
-    LicensingState,
     CheckYourAnswersJourneyState {
     val licensingTask: LicensingTask
     override val finishCyaStep: FinishCyaJourneyStep

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/shared/helpers/LicensingDetailsHelper.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/shared/helpers/LicensingDetailsHelper.kt
@@ -14,8 +14,8 @@ import uk.gov.communities.prsdb.webapp.models.viewModels.summaryModels.SummaryLi
 class LicensingDetailsHelper(
     private val featureFlagManager: FeatureFlagManager,
 ) {
-    fun <T : CheckYourAnswersJourneyState> getCheckYourAnswersSummaryList(
-        state: T,
+    fun getCheckYourAnswersSummaryList(
+        state: CheckYourAnswersJourneyState,
         licensingState: LicensingState,
     ): List<SummaryListRowViewModel> {
         // TODO(PDJB-990): show 'Provide this later' in the licensing CYA row (property registration only) behind the FF: pdjb-939-property-registration-restructure-and-skipping/PROPERTY_REGISTRATION_RESTRUCTURE_AND_SKIPPING

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/shared/helpers/LicensingDetailsHelper.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/shared/helpers/LicensingDetailsHelper.kt
@@ -14,21 +14,22 @@ import uk.gov.communities.prsdb.webapp.models.viewModels.summaryModels.SummaryLi
 class LicensingDetailsHelper(
     private val featureFlagManager: FeatureFlagManager,
 ) {
-    fun <T> getCheckYourAnswersSummaryList(
+    fun <T : CheckYourAnswersJourneyState> getCheckYourAnswersSummaryList(
         state: T,
-    ): List<SummaryListRowViewModel> where T : LicensingState, T : CheckYourAnswersJourneyState {
+        licensingState: LicensingState,
+    ): List<SummaryListRowViewModel> {
         // TODO(PDJB-990): show 'Provide this later' in the licensing CYA row (property registration only) behind the FF: pdjb-939-property-registration-restructure-and-skipping/PROPERTY_REGISTRATION_RESTRUCTURE_AND_SKIPPING
-        return state.licensingTypeStep.formModel.notNullValue(LicensingTypeFormModel::licensingType).let { licensingType ->
+        return licensingState.licensingTypeStep.formModel.notNullValue(LicensingTypeFormModel::licensingType).let { licensingType ->
             listOfNotNull(
                 SummaryListRowViewModel.forCheckYourAnswersPage(
                     "forms.checkPropertyAnswers.propertyDetails.licensingType",
                     licensingType,
-                    Destination.VisitableStep(state.licensingTypeStep, state.getCyaJourneyId(state.licensingTypeStep)),
+                    Destination.VisitableStep(licensingState.licensingTypeStep, state.getCyaJourneyId(licensingState.licensingTypeStep)),
                 ),
                 when (licensingType) {
-                    LicensingType.HMO_MANDATORY_LICENCE -> (state.getLicenceNumber() to state.hmoMandatoryLicenceStep)
-                    LicensingType.HMO_ADDITIONAL_LICENCE -> (state.getLicenceNumber() to state.hmoAdditionalLicenceStep)
-                    LicensingType.SELECTIVE_LICENCE -> (state.getLicenceNumber() to state.selectiveLicenceStep)
+                    LicensingType.HMO_MANDATORY_LICENCE -> (licensingState.getLicenceNumber() to licensingState.hmoMandatoryLicenceStep)
+                    LicensingType.HMO_ADDITIONAL_LICENCE -> (licensingState.getLicenceNumber() to licensingState.hmoAdditionalLicenceStep)
+                    LicensingType.SELECTIVE_LICENCE -> (licensingState.getLicenceNumber() to licensingState.selectiveLicenceStep)
                     else -> null
                 }?.let { (licenceNumber, step) ->
                     SummaryListRowViewModel.forCheckYourAnswersPage(

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/shared/helpers/OccupancyDetailsHelper.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/shared/helpers/OccupancyDetailsHelper.kt
@@ -38,13 +38,14 @@ class OccupancyDetailsHelper {
                 if (isOccupied) addAll(getRestructuredOccupiedTenancyDetailsSummaryList(state, messageSource))
             }
 
-    fun <T> getCheckYourHouseHoldsAndTenantsAnswersSummaryList(
+    fun <T : CheckYourAnswersJourneyState> getCheckYourHouseHoldsAndTenantsAnswersSummaryList(
         state: T,
-    ): List<SummaryListRowViewModel> where T : HouseholdsAndTenantsState, T : CheckYourAnswersJourneyState =
+        householdsAndTenantsState: HouseholdsAndTenantsState,
+    ): List<SummaryListRowViewModel> =
         mutableListOf<SummaryListRowViewModel>()
             .apply {
-                val householdsStep = state.households
-                val tenantsStep = state.tenants
+                val householdsStep = householdsAndTenantsState.households
+                val tenantsStep = householdsAndTenantsState.tenants
                 add(
                     SummaryListRowViewModel.forCheckYourAnswersPage(
                         "forms.checkPropertyAnswers.tenancyDetails.households",
@@ -130,7 +131,7 @@ class OccupancyDetailsHelper {
         state: T,
         messageSource: MessageSource,
     ): List<SummaryListRowViewModel> where T : OccupationState, T : CheckYourAnswersJourneyState =
-        getCheckYourHouseHoldsAndTenantsAnswersSummaryList(state) +
+        getCheckYourHouseHoldsAndTenantsAnswersSummaryList(state, state.householdsAndTenantsTask) +
             getBedroomsRow(state) +
             getRentBillsAndFurnishingsSummaryList(state, messageSource)
 
@@ -138,7 +139,7 @@ class OccupancyDetailsHelper {
         state: T,
         messageSource: MessageSource,
     ): List<SummaryListRowViewModel> where T : OccupationState, T : CheckYourAnswersJourneyState =
-        getCheckYourHouseHoldsAndTenantsAnswersSummaryList(state) +
+        getCheckYourHouseHoldsAndTenantsAnswersSummaryList(state, state.householdsAndTenantsTask) +
             getRentBillsAndFurnishingsSummaryList(state, messageSource)
 
     private fun <T> getBedroomsRow(state: T): SummaryListRowViewModel where T : OccupationState, T : CheckYourAnswersJourneyState {

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/shared/helpers/OccupancyDetailsHelper.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/shared/helpers/OccupancyDetailsHelper.kt
@@ -38,8 +38,8 @@ class OccupancyDetailsHelper {
                 if (isOccupied) addAll(getRestructuredOccupiedTenancyDetailsSummaryList(state, messageSource))
             }
 
-    fun <T : CheckYourAnswersJourneyState> getCheckYourHouseHoldsAndTenantsAnswersSummaryList(
-        state: T,
+    fun getCheckYourHouseHoldsAndTenantsAnswersSummaryList(
+        state: CheckYourAnswersJourneyState,
         householdsAndTenantsState: HouseholdsAndTenantsState,
     ): List<SummaryListRowViewModel> =
         mutableListOf<SummaryListRowViewModel>()
@@ -62,8 +62,8 @@ class OccupancyDetailsHelper {
                 )
             }
 
-    fun <T : CheckYourAnswersJourneyState> getCheckYourRentIncludesBillsAnswersSummaryList(
-        state: T,
+    fun getCheckYourRentIncludesBillsAnswersSummaryList(
+        state: CheckYourAnswersJourneyState,
         rentIncludesBillsState: RentIncludesBillsState,
         messageSource: MessageSource,
     ): List<SummaryListRowViewModel> =
@@ -90,8 +90,8 @@ class OccupancyDetailsHelper {
                 }
             }
 
-    fun <T : CheckYourAnswersJourneyState> getCheckYourRentFrequencyAndAmountAnswersSummaryList(
-        state: T,
+    fun getCheckYourRentFrequencyAndAmountAnswersSummaryList(
+        state: CheckYourAnswersJourneyState,
         rentFrequencyAndAmountState: RentFrequencyAndAmountState,
         messageSource: MessageSource,
     ): List<SummaryListRowViewModel> =

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/shared/helpers/OccupancyDetailsHelper.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/shared/helpers/OccupancyDetailsHelper.kt
@@ -61,15 +61,16 @@ class OccupancyDetailsHelper {
                 )
             }
 
-    fun <T> getCheckYourRentIncludesBillsAnswersSummaryList(
+    fun <T : CheckYourAnswersJourneyState> getCheckYourRentIncludesBillsAnswersSummaryList(
         state: T,
+        rentIncludesBillsState: RentIncludesBillsState,
         messageSource: MessageSource,
-    ): List<SummaryListRowViewModel> where T : RentIncludesBillsState, T : CheckYourAnswersJourneyState =
+    ): List<SummaryListRowViewModel> =
         mutableListOf<SummaryListRowViewModel>()
             .apply {
-                val rentIncludesBillsStep = state.rentIncludesBills
-                val billsIncludedStep = state.billsIncluded
-                val rentIncludesBills = state.doesRentIncludeBills()
+                val rentIncludesBillsStep = rentIncludesBillsState.rentIncludesBills
+                val billsIncludedStep = rentIncludesBillsState.billsIncluded
+                val rentIncludesBills = rentIncludesBillsState.doesRentIncludeBills()
                 add(
                     SummaryListRowViewModel.forCheckYourAnswersPage(
                         "forms.checkPropertyAnswers.tenancyDetails.rentIncludesBills",
@@ -81,7 +82,7 @@ class OccupancyDetailsHelper {
                     add(
                         SummaryListRowViewModel.forCheckYourAnswersPage(
                             "forms.checkPropertyAnswers.tenancyDetails.billsIncluded",
-                            state.getBillsIncluded(messageSource),
+                            rentIncludesBillsState.getBillsIncluded(messageSource),
                             Destination.VisitableStep(billsIncludedStep, state.getCyaJourneyId(billsIncludedStep)),
                         ),
                     )
@@ -156,7 +157,7 @@ class OccupancyDetailsHelper {
         mutableListOf<SummaryListRowViewModel>()
             .apply {
                 val furnishedStatusStep = state.furnishedStatus
-                addAll(getCheckYourRentIncludesBillsAnswersSummaryList(state, messageSource))
+                addAll(getCheckYourRentIncludesBillsAnswersSummaryList(state, state.rentIncludesBillsTask, messageSource))
                 add(
                     SummaryListRowViewModel.forCheckYourAnswersPage(
                         "forms.checkPropertyAnswers.tenancyDetails.furnishedStatus",

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/shared/helpers/OccupancyDetailsHelper.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/shared/helpers/OccupancyDetailsHelper.kt
@@ -88,14 +88,15 @@ class OccupancyDetailsHelper {
                 }
             }
 
-    fun <T> getCheckYourRentFrequencyAndAmountAnswersSummaryList(
+    fun <T : CheckYourAnswersJourneyState> getCheckYourRentFrequencyAndAmountAnswersSummaryList(
         state: T,
+        rentFrequencyAndAmountState: RentFrequencyAndAmountState,
         messageSource: MessageSource,
-    ): List<SummaryListRowViewModel> where T : RentFrequencyAndAmountState, T : CheckYourAnswersJourneyState =
+    ): List<SummaryListRowViewModel> =
         mutableListOf<SummaryListRowViewModel>()
             .apply {
-                val rentFrequencyStep = state.rentFrequency
-                val rentAmountStep = state.rentAmount
+                val rentFrequencyStep = rentFrequencyAndAmountState.rentFrequency
+                val rentAmountStep = rentFrequencyAndAmountState.rentAmount
                 val rentFrequency = rentFrequencyStep.formModel.notNullValue(RentFrequencyFormModel::rentFrequency)
                 add(
                     SummaryListRowViewModel.forCheckYourAnswersPage(
@@ -107,7 +108,7 @@ class OccupancyDetailsHelper {
                 add(
                     SummaryListRowViewModel.forCheckYourAnswersPage(
                         "forms.checkPropertyAnswers.tenancyDetails.rentAmount",
-                        state.getRentAmount(messageSource),
+                        rentFrequencyAndAmountState.getRentAmount(messageSource),
                         Destination.VisitableStep(rentAmountStep, state.getCyaJourneyId(rentAmountStep)),
                     ),
                 )
@@ -163,6 +164,6 @@ class OccupancyDetailsHelper {
                         Destination.VisitableStep(furnishedStatusStep, state.getCyaJourneyId(furnishedStatusStep)),
                     ),
                 )
-                addAll(getCheckYourRentFrequencyAndAmountAnswersSummaryList(state, messageSource))
+                addAll(getCheckYourRentFrequencyAndAmountAnswersSummaryList(state, state.rentFrequencyAndAmountTask, messageSource))
             }
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/shared/states/CheckYourAnswersJourneyState.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/shared/states/CheckYourAnswersJourneyState.kt
@@ -8,6 +8,7 @@ import uk.gov.communities.prsdb.webapp.journeys.DuplicableTaskWithDependencies
 import uk.gov.communities.prsdb.webapp.journeys.JourneyState
 import uk.gov.communities.prsdb.webapp.journeys.JourneyStep
 import uk.gov.communities.prsdb.webapp.journeys.Task
+import uk.gov.communities.prsdb.webapp.journeys.builders.EmbedBuilder
 import uk.gov.communities.prsdb.webapp.journeys.builders.JourneyBuilder
 import uk.gov.communities.prsdb.webapp.journeys.builders.StepInitialiser
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.FinishCyaJourneyStep
@@ -132,15 +133,13 @@ interface CheckYourAnswersJourneyState : JourneyState {
         }
 
         @Suppress("ktlint:standard:max-line-length")
-        fun <TJourneyState : CheckYourAnswersJourneyState, TTaskState : JourneyState, TMode : Enum<TMode>> JourneyBuilder<TJourneyState>.duplicableCheckAnswerStep(
-            task: DuplicableTask<TTaskState>,
-            step: JourneyStep<TMode, *, TTaskState>,
+        fun <TEmbeddedState : JourneyState, TOuterState : CheckYourAnswersJourneyState, TMode : Enum<TMode>> EmbedBuilder<TEmbeddedState, TOuterState>.checkAnswerStep(
+            step: JourneyStep<TMode, *, TEmbeddedState>,
             route: String,
         ) {
-            val cyaJourney = journey
-            duplicableStep(task, step) {
+            step(step) {
                 initialStep()
-                nextStep { cyaJourney.finishCyaStep }
+                nextStep { outerState.finishCyaStep }
                 routeSegment(route)
             }
         }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/shared/states/CheckYourAnswersJourneyState.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/shared/states/CheckYourAnswersJourneyState.kt
@@ -131,6 +131,20 @@ interface CheckYourAnswersJourneyState : JourneyState {
             }
         }
 
+        @Suppress("ktlint:standard:max-line-length")
+        fun <TJourneyState : CheckYourAnswersJourneyState, TTaskState : JourneyState, TMode : Enum<TMode>> JourneyBuilder<TJourneyState>.duplicableCheckAnswerStep(
+            task: DuplicableTask<TTaskState>,
+            step: JourneyStep<TMode, *, TTaskState>,
+            route: String,
+        ) {
+            val cyaJourney = journey
+            duplicableStep(task, step) {
+                initialStep()
+                nextStep { cyaJourney.finishCyaStep }
+                routeSegment(route)
+            }
+        }
+
         fun <T : CheckYourAnswersJourneyState, TMode : Enum<TMode>> JourneyBuilder<T>.checkAnswerStep(
             step: JourneyStep<TMode, *, T>,
             route: String,

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/shared/states/CheckYourAnswersJourneyState.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/shared/states/CheckYourAnswersJourneyState.kt
@@ -139,7 +139,7 @@ interface CheckYourAnswersJourneyState : JourneyState {
         ) {
             step(step) {
                 initialStep()
-                nextStep { outerState.finishCyaStep }
+                nextStep { journey.finishCyaStep }
                 routeSegment(route)
             }
         }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/UpdateHouseholdsAndTenantsCyaConfigTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/UpdateHouseholdsAndTenantsCyaConfigTests.kt
@@ -14,6 +14,7 @@ import org.mockito.kotlin.whenever
 import uk.gov.communities.prsdb.webapp.exceptions.UpdateConflictException
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.HouseholdStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.TenantsStep
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.HouseholdsAndTenantsTask
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.update.householdsAndTenants.UpdateHouseholdsAndTenantsCyaConfig
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.update.householdsAndTenants.UpdateHouseholdsAndTenantsJourneyState
 import uk.gov.communities.prsdb.webapp.journeys.shared.helpers.OccupancyDetailsHelper
@@ -40,6 +41,9 @@ class UpdateHouseholdsAndTenantsCyaConfigTests {
     private lateinit var mockTenantsStep: TenantsStep
 
     @Mock
+    private lateinit var mockHouseholdsAndTenantsTask: HouseholdsAndTenantsTask
+
+    @Mock
     private lateinit var stepConfig: UpdateHouseholdsAndTenantsCyaConfig
 
     @Mock
@@ -64,8 +68,9 @@ class UpdateHouseholdsAndTenantsCyaConfigTests {
             )
         stepConfig.afterStepIsReached(mockState) // This initializes the childJourneyId
         whenever(mockState.propertyId).thenReturn(propertyId)
-        whenever(mockState.households).thenReturn(mockHouseholdStep)
-        whenever(mockState.tenants).thenReturn(mockTenantsStep)
+        whenever(mockState.householdsAndTenantsTask).thenReturn(mockHouseholdsAndTenantsTask)
+        whenever(mockHouseholdsAndTenantsTask.households).thenReturn(mockHouseholdStep)
+        whenever(mockHouseholdsAndTenantsTask.tenants).thenReturn(mockTenantsStep)
         whenever(mockState.lastModifiedDate).thenReturn(initialLastModifiedDate.toString())
         whenever(mockHouseholdStep.formModel).thenReturn(mockNumberOfHouseholdsFormModel)
         whenever(mockTenantsStep.formModel).thenReturn(mockNumberOfTenantsFormModel)

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/UpdateLicensingCyaConfigTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/UpdateLicensingCyaConfigTests.kt
@@ -14,6 +14,7 @@ import org.mockito.kotlin.whenever
 import uk.gov.communities.prsdb.webapp.constants.enums.LicensingType
 import uk.gov.communities.prsdb.webapp.exceptions.UpdateConflictException
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.LicensingTypeStep
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.LicensingTask
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.update.updateLicensing.UpdateLicensingCyaConfig
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.update.updateLicensing.UpdateLicensingCyaStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.update.updateLicensing.UpdateLicensingJourneyState
@@ -41,6 +42,9 @@ class UpdateLicensingCyaConfigTests {
     private lateinit var mockLicensingTypeStep: LicensingTypeStep
 
     @Mock
+    private lateinit var mockLicensingTask: LicensingTask
+
+    @Mock
     private lateinit var mockLicensingTypeFormModel: LicensingTypeFormModel
 
     private val propertyId = 123L
@@ -61,10 +65,11 @@ class UpdateLicensingCyaConfigTests {
         stepConfig.afterStepIsReached(mockState)
         whenever(mockState.propertyId).thenReturn(propertyId)
         whenever(mockState.lastModifiedDate).thenReturn("2024-01-01T00:00:00Z")
-        whenever(mockState.licensingTypeStep).thenReturn(mockLicensingTypeStep)
+        whenever(mockState.licensingTask).thenReturn(mockLicensingTask)
+        whenever(mockLicensingTask.licensingTypeStep).thenReturn(mockLicensingTypeStep)
         whenever(mockLicensingTypeStep.formModel).thenReturn(mockLicensingTypeFormModel)
         whenever(mockLicensingTypeFormModel.licensingType).thenReturn(LicensingType.NO_LICENSING)
-        whenever(mockState.getLicenceNumberOrNull()).thenReturn(null)
+        whenever(mockLicensingTask.getLicenceNumberOrNull()).thenReturn(null)
     }
 
     @Test

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/UpdateOccupancyCyaConfigTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/UpdateOccupancyCyaConfigTests.kt
@@ -22,6 +22,7 @@ import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.Occup
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.RentAmountStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.RentFrequencyStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.TenantsStep
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.HouseholdsAndTenantsTask
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.RentFrequencyAndAmountTask
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.RentIncludesBillsTask
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.update.occupancy.UpdateOccupancyCyaConfig
@@ -105,6 +106,9 @@ class UpdateOccupancyCyaConfigTests {
     private lateinit var mockBillsIncludedStep: BillsIncludedStep
 
     @Mock
+    private lateinit var mockHouseholdsAndTenantsTask: HouseholdsAndTenantsTask
+
+    @Mock
     private lateinit var mockRentIncludesBillsTask: RentIncludesBillsTask
 
     private val propertyId = 123L
@@ -131,10 +135,11 @@ class UpdateOccupancyCyaConfigTests {
         whenever(mockOccupiedStep.formModel).thenReturn(mockOccupancyFormModel)
         whenever(mockOccupancyFormModel.occupied).thenReturn(true)
         lenient().`when`(mockState.wasOccupied).thenReturn(false)
-        lenient().`when`(mockState.households).thenReturn(mockHouseholdStep)
+        lenient().`when`(mockState.householdsAndTenantsTask).thenReturn(mockHouseholdsAndTenantsTask)
+        lenient().`when`(mockHouseholdsAndTenantsTask.households).thenReturn(mockHouseholdStep)
         lenient().`when`(mockHouseholdStep.formModel).thenReturn(mockNumberOfHouseholdsFormModel)
         lenient().`when`(mockNumberOfHouseholdsFormModel.numberOfHouseholds).thenReturn("2")
-        lenient().`when`(mockState.tenants).thenReturn(mockTenantsStep)
+        lenient().`when`(mockHouseholdsAndTenantsTask.tenants).thenReturn(mockTenantsStep)
         lenient().`when`(mockTenantsStep.formModel).thenReturn(mockNumberOfTenantsFormModel)
         lenient().`when`(mockNumberOfTenantsFormModel.numberOfPeople).thenReturn("5")
         lenient().`when`(mockState.bedrooms).thenReturn(mockBedroomsStep)

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/UpdateOccupancyCyaConfigTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/UpdateOccupancyCyaConfigTests.kt
@@ -23,6 +23,7 @@ import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.RentA
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.RentFrequencyStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.TenantsStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.RentFrequencyAndAmountTask
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.RentIncludesBillsTask
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.update.occupancy.UpdateOccupancyCyaConfig
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.update.occupancy.UpdateOccupancyCyaStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.update.occupancy.UpdateOccupancyJourneyState
@@ -103,6 +104,9 @@ class UpdateOccupancyCyaConfigTests {
     @Mock
     private lateinit var mockBillsIncludedStep: BillsIncludedStep
 
+    @Mock
+    private lateinit var mockRentIncludesBillsTask: RentIncludesBillsTask
+
     private val propertyId = 123L
     private val initialLastModifiedDate = Clock.System.now().toJavaInstant()
 
@@ -136,7 +140,8 @@ class UpdateOccupancyCyaConfigTests {
         lenient().`when`(mockState.bedrooms).thenReturn(mockBedroomsStep)
         lenient().`when`(mockBedroomsStep.formModel).thenReturn(mockNumberOfBedroomsFormModel)
         lenient().`when`(mockNumberOfBedroomsFormModel.numberOfBedrooms).thenReturn("3")
-        lenient().`when`(mockState.getBillsIncludedOrNull()).thenReturn(null)
+        lenient().`when`(mockState.rentIncludesBillsTask).thenReturn(mockRentIncludesBillsTask)
+        lenient().`when`(mockRentIncludesBillsTask.getBillsIncludedOrNull()).thenReturn(null)
         lenient().`when`(mockState.furnishedStatus).thenReturn(mockFurnishedStatusStep)
         lenient().`when`(mockFurnishedStatusStep.formModel).thenReturn(mockFurnishedStatusFormModel)
         lenient().`when`(mockFurnishedStatusFormModel.furnishedStatus).thenReturn(null)

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/UpdateOccupancyCyaConfigTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/UpdateOccupancyCyaConfigTests.kt
@@ -22,6 +22,7 @@ import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.Occup
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.RentAmountStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.RentFrequencyStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.TenantsStep
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.RentFrequencyAndAmountTask
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.update.occupancy.UpdateOccupancyCyaConfig
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.update.occupancy.UpdateOccupancyCyaStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.update.occupancy.UpdateOccupancyJourneyState
@@ -88,6 +89,9 @@ class UpdateOccupancyCyaConfigTests {
     private lateinit var mockRentFrequencyStep: RentFrequencyStep
 
     @Mock
+    private lateinit var mockRentFrequencyAndAmountTask: RentFrequencyAndAmountTask
+
+    @Mock
     private lateinit var mockRentFrequencyFormModel: RentFrequencyFormModel
 
     @Mock
@@ -136,11 +140,12 @@ class UpdateOccupancyCyaConfigTests {
         lenient().`when`(mockState.furnishedStatus).thenReturn(mockFurnishedStatusStep)
         lenient().`when`(mockFurnishedStatusStep.formModel).thenReturn(mockFurnishedStatusFormModel)
         lenient().`when`(mockFurnishedStatusFormModel.furnishedStatus).thenReturn(null)
-        lenient().`when`(mockState.rentFrequency).thenReturn(mockRentFrequencyStep)
+        lenient().`when`(mockState.rentFrequencyAndAmountTask).thenReturn(mockRentFrequencyAndAmountTask)
+        lenient().`when`(mockRentFrequencyAndAmountTask.rentFrequency).thenReturn(mockRentFrequencyStep)
         lenient().`when`(mockRentFrequencyStep.formModel).thenReturn(mockRentFrequencyFormModel)
         lenient().`when`(mockRentFrequencyFormModel.rentFrequency).thenReturn(null)
-        lenient().`when`(mockState.getCustomRentFrequencyIfSelected()).thenReturn(null)
-        lenient().`when`(mockState.rentAmount).thenReturn(mockRentAmountStep)
+        lenient().`when`(mockRentFrequencyAndAmountTask.getCustomRentFrequencyIfSelected()).thenReturn(null)
+        lenient().`when`(mockRentFrequencyAndAmountTask.rentAmount).thenReturn(mockRentAmountStep)
         lenient().`when`(mockRentAmountStep.formModel).thenReturn(mockRentAmountFormModel)
         lenient().`when`(mockRentAmountFormModel.rentAmount).thenReturn("500")
     }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/UpdateRentFrequencyAndAmountCyaConfigTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/UpdateRentFrequencyAndAmountCyaConfigTests.kt
@@ -14,6 +14,7 @@ import uk.gov.communities.prsdb.webapp.constants.enums.RentFrequency
 import uk.gov.communities.prsdb.webapp.exceptions.UpdateConflictException
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.RentAmountStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.RentFrequencyStep
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.RentFrequencyAndAmountTask
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.update.rentFrequencyAndAmount.UpdateRentFrequencyAndAmountCyaConfig
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.update.rentFrequencyAndAmount.UpdateRentFrequencyAndAmountJourneyState
 import uk.gov.communities.prsdb.webapp.journeys.shared.helpers.OccupancyDetailsHelper
@@ -30,6 +31,9 @@ class UpdateRentFrequencyAndAmountCyaConfigTests {
 
     @Mock
     private lateinit var mockState: UpdateRentFrequencyAndAmountJourneyState
+
+    @Mock
+    private lateinit var mockRentFrequencyAndAmountTask: RentFrequencyAndAmountTask
 
     @Mock
     private lateinit var stepConfig: UpdateRentFrequencyAndAmountCyaConfig
@@ -63,13 +67,14 @@ class UpdateRentFrequencyAndAmountCyaConfigTests {
                 messageSource = mockMessageSource,
             )
         whenever(mockState.propertyId).thenReturn(propertyId)
-        whenever(mockState.rentFrequency).thenReturn(mockRentFrequencyStep)
-        whenever(mockState.rentAmount).thenReturn(mockRentAmountStep)
+        whenever(mockState.rentFrequencyAndAmountTask).thenReturn(mockRentFrequencyAndAmountTask)
+        whenever(mockRentFrequencyAndAmountTask.rentFrequency).thenReturn(mockRentFrequencyStep)
+        whenever(mockRentFrequencyAndAmountTask.rentAmount).thenReturn(mockRentAmountStep)
         whenever(mockState.lastModifiedDate).thenReturn(initialLastModifiedDate.toString())
         whenever(mockRentFrequencyStep.formModel).thenReturn(mockRentFrequencyFormModel)
         whenever(mockRentAmountStep.formModel).thenReturn(mockRentAMountFormModel)
         whenever(mockRentFrequencyFormModel.rentFrequency).thenReturn(rentFrequency)
-        whenever(mockState.getCustomRentFrequencyIfSelected()).thenReturn(customRentFrequency)
+        whenever(mockRentFrequencyAndAmountTask.getCustomRentFrequencyIfSelected()).thenReturn(customRentFrequency)
         whenever(mockRentAMountFormModel.rentAmount).thenReturn(rentAmount.toString())
     }
 

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/UpdateRentIncludesBillsCyaConfigTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/UpdateRentIncludesBillsCyaConfigTests.kt
@@ -12,6 +12,7 @@ import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import uk.gov.communities.prsdb.webapp.constants.enums.BillsIncluded
 import uk.gov.communities.prsdb.webapp.exceptions.UpdateConflictException
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.RentIncludesBillsTask
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.update.rentIncludesBills.UpdateRentIncludesBillsCyaConfig
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.update.rentIncludesBills.UpdateRentIncludesBillsJourneyState
 import uk.gov.communities.prsdb.webapp.journeys.shared.helpers.OccupancyDetailsHelper
@@ -26,6 +27,9 @@ class UpdateRentIncludesBillsCyaConfigTests {
 
     @Mock
     private lateinit var mockState: UpdateRentIncludesBillsJourneyState
+
+    @Mock
+    private lateinit var mockRentIncludesBillsTask: RentIncludesBillsTask
 
     @Mock
     private lateinit var stepConfig: UpdateRentIncludesBillsCyaConfig
@@ -53,7 +57,8 @@ class UpdateRentIncludesBillsCyaConfigTests {
             )
         whenever(mockState.propertyId).thenReturn(propertyId)
         whenever(mockState.lastModifiedDate).thenReturn(initialLastModifiedDate.toString())
-        whenever(mockState.getBillsIncludedOrNull()).thenReturn(billsIncludedDataModel)
+        whenever(mockState.rentIncludesBillsTask).thenReturn(mockRentIncludesBillsTask)
+        whenever(mockRentIncludesBillsTask.getBillsIncludedOrNull()).thenReturn(billsIncludedDataModel)
     }
 
     @Test

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/HouseholdStepConfigTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/HouseholdStepConfigTests.kt
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.Mock
+import org.mockito.Mockito.mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.whenever
 import uk.gov.communities.prsdb.webapp.config.managers.FeatureFlagManager
@@ -23,6 +24,7 @@ class HouseholdStepConfigTests {
         // Arrange
         val stepConfig = HouseholdStepConfig(mockFeatureFlagManager)
         whenever(mockFeatureFlagManager.checkFeature(PROPERTY_REGISTRATION_RESTRUCTURE_AND_SKIPPING)).thenReturn(true)
+        whenever(mockHouseholdsAndTenantsState.dependencies).thenReturn(mock())
 
         // Act
         val content = stepConfig.getStepSpecificContent(mockHouseholdsAndTenantsState)

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/HouseholdStepConfigTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/HouseholdStepConfigTests.kt
@@ -8,7 +8,7 @@ import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.whenever
 import uk.gov.communities.prsdb.webapp.config.managers.FeatureFlagManager
 import uk.gov.communities.prsdb.webapp.constants.PROPERTY_REGISTRATION_RESTRUCTURE_AND_SKIPPING
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.update.householdsAndTenants.UpdateHouseholdsAndTenantsJourneyState
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.HouseholdsAndTenantsState
 
 @ExtendWith(MockitoExtension::class)
 class HouseholdStepConfigTests {
@@ -16,7 +16,7 @@ class HouseholdStepConfigTests {
     private lateinit var mockFeatureFlagManager: FeatureFlagManager
 
     @Mock
-    private lateinit var mockUpdateHouseholdsJourneyState: UpdateHouseholdsAndTenantsJourneyState
+    private lateinit var mockHouseholdsAndTenantsState: HouseholdsAndTenantsState
 
     @Test
     fun `Content shows the restructure and skipping households content when feature flag is enabled`() {
@@ -25,11 +25,11 @@ class HouseholdStepConfigTests {
         whenever(mockFeatureFlagManager.checkFeature(PROPERTY_REGISTRATION_RESTRUCTURE_AND_SKIPPING)).thenReturn(true)
 
         // Act
-        val content = stepConfig.getStepSpecificContent(mockUpdateHouseholdsJourneyState)
+        val content = stepConfig.getStepSpecificContent(mockHouseholdsAndTenantsState)
 
         // Assert
         assertEquals("forms.numberOfHouseholdsRestructureAndSkipping.heading", content["fieldSetHeading"])
-        assertEquals("forms/numberOfHouseholdsFormRestructureAndSkipping", stepConfig.chooseTemplate(mockUpdateHouseholdsJourneyState))
+        assertEquals("forms/numberOfHouseholdsFormRestructureAndSkipping", stepConfig.chooseTemplate(mockHouseholdsAndTenantsState))
     }
 
     @Test
@@ -39,11 +39,11 @@ class HouseholdStepConfigTests {
         whenever(mockFeatureFlagManager.checkFeature(PROPERTY_REGISTRATION_RESTRUCTURE_AND_SKIPPING)).thenReturn(false)
 
         // Act
-        val content = stepConfig.getStepSpecificContent(mockUpdateHouseholdsJourneyState)
+        val content = stepConfig.getStepSpecificContent(mockHouseholdsAndTenantsState)
 
         // Assert
         assertEquals("forms.numberOfHouseholdsRestructureAndSkipping.heading", content["fieldSetHeading"])
         assertEquals("forms.numberOfHouseholdsRestructureAndSkipping.label", content["label"])
-        assertEquals("forms/numberOfHouseholdsFormOld", stepConfig.chooseTemplate(mockUpdateHouseholdsJourneyState))
+        assertEquals("forms/numberOfHouseholdsFormOld", stepConfig.chooseTemplate(mockHouseholdsAndTenantsState))
     }
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/SavePropertyRegistrationDataStepConfigTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/SavePropertyRegistrationDataStepConfigTests.kt
@@ -29,6 +29,7 @@ import uk.gov.communities.prsdb.webapp.constants.enums.PropertyType
 import uk.gov.communities.prsdb.webapp.journeys.Destination
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.PropertyRegistrationJourneyState
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.JointLandlordsPropertyRegistrationTask
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.RentIncludesBillsTask
 import uk.gov.communities.prsdb.webapp.journeys.shared.Complete
 import uk.gov.communities.prsdb.webapp.journeys.shared.YesOrNo
 import uk.gov.communities.prsdb.webapp.models.dataModels.AddressDataModel
@@ -306,7 +307,9 @@ class SavePropertyRegistrationDataStepConfigTests {
         whenever(mockState.occupied).thenReturn(mockOccupiedStep)
         whenever(mockOccupiedStep.formModel).thenReturn(occupancyFormModel)
 
-        whenever(mockState.getBillsIncludedOrNull()).thenReturn(null)
+        val mockRentIncludesBillsTask = mock<RentIncludesBillsTask>()
+        whenever(mockState.rentIncludesBillsTask).thenReturn(mockRentIncludesBillsTask)
+        whenever(mockRentIncludesBillsTask.getBillsIncludedOrNull()).thenReturn(null)
 
         whenever(mockState.getAddress()).thenReturn(
             AddressDataModel(singleLineAddress = "1 Test St", uprn = 12345L, localCouncilId = 1),

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/SavePropertyRegistrationDataStepConfigTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/SavePropertyRegistrationDataStepConfigTests.kt
@@ -30,6 +30,7 @@ import uk.gov.communities.prsdb.webapp.journeys.Destination
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.PropertyRegistrationJourneyState
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.JointLandlordsPropertyRegistrationTask
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.LicensingTask
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.PropertyRegistrationAddressTask
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.RentIncludesBillsTask
 import uk.gov.communities.prsdb.webapp.journeys.shared.Complete
 import uk.gov.communities.prsdb.webapp.journeys.shared.YesOrNo
@@ -61,6 +62,9 @@ class SavePropertyRegistrationDataStepConfigTests {
 
     @Mock
     private lateinit var mockState: PropertyRegistrationJourneyState
+
+    @Mock
+    private lateinit var mockAddressTask: PropertyRegistrationAddressTask
 
     private lateinit var stepConfig: SavePropertyRegistrationDataStepConfig
 
@@ -216,7 +220,7 @@ class SavePropertyRegistrationDataStepConfigTests {
         stepConfig.afterStepIsReached(mockState)
 
         // Assert
-        verify(mockState).isAddressAlreadyRegistered = true
+        verify(mockAddressTask).isAddressAlreadyRegistered = true
     }
 
     @Test
@@ -273,7 +277,8 @@ class SavePropertyRegistrationDataStepConfigTests {
     fun `resolveNextDestination deletes journey and returns default destination when address is not already registered`() {
         // Arrange
         val defaultDestination = Destination.ExternalUrl("redirect")
-        whenever(mockState.isAddressAlreadyRegistered).thenReturn(false)
+        whenever(mockState.addressTask).thenReturn(mockAddressTask)
+        whenever(mockAddressTask.isAddressAlreadyRegistered).thenReturn(false)
 
         // Act
         val result = stepConfig.resolveNextDestination(mockState, defaultDestination)
@@ -289,8 +294,9 @@ class SavePropertyRegistrationDataStepConfigTests {
         val defaultDestination = Destination.ExternalUrl("redirect")
         val mockAlreadyRegisteredStep = mock<AlreadyRegisteredStep>()
         whenever(mockAlreadyRegisteredStep.currentJourneyId).thenReturn("test-journey-id")
-        whenever(mockState.isAddressAlreadyRegistered).thenReturn(true)
-        whenever(mockState.alreadyRegisteredStep).thenReturn(mockAlreadyRegisteredStep)
+        whenever(mockState.addressTask).thenReturn(mockAddressTask)
+        whenever(mockAddressTask.isAddressAlreadyRegistered).thenReturn(true)
+        whenever(mockAddressTask.alreadyRegisteredStep).thenReturn(mockAlreadyRegisteredStep)
 
         // Act
         val result = stepConfig.resolveNextDestination(mockState, defaultDestination)
@@ -312,7 +318,8 @@ class SavePropertyRegistrationDataStepConfigTests {
         whenever(mockState.rentIncludesBillsTask).thenReturn(mockRentIncludesBillsTask)
         whenever(mockRentIncludesBillsTask.getBillsIncludedOrNull()).thenReturn(null)
 
-        whenever(mockState.getAddress()).thenReturn(
+        whenever(mockState.addressTask).thenReturn(mockAddressTask)
+        whenever(mockAddressTask.getAddress()).thenReturn(
             AddressDataModel(singleLineAddress = "1 Test St", uprn = 12345L, localCouncilId = 1),
         )
 

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/SavePropertyRegistrationDataStepConfigTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/SavePropertyRegistrationDataStepConfigTests.kt
@@ -29,6 +29,7 @@ import uk.gov.communities.prsdb.webapp.constants.enums.PropertyType
 import uk.gov.communities.prsdb.webapp.journeys.Destination
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.PropertyRegistrationJourneyState
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.JointLandlordsPropertyRegistrationTask
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.LicensingTask
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.RentIncludesBillsTask
 import uk.gov.communities.prsdb.webapp.journeys.shared.Complete
 import uk.gov.communities.prsdb.webapp.journeys.shared.YesOrNo
@@ -322,10 +323,12 @@ class SavePropertyRegistrationDataStepConfigTests {
 
         val mockLicensingTypeStep = mock<LicensingTypeStep>()
         val licensingTypeFormModel = LicensingTypeFormModel().apply { licensingType = LicensingType.SELECTIVE_LICENCE }
-        whenever(mockState.licensingTypeStep).thenReturn(mockLicensingTypeStep)
+        val mockLicensingTask = mock<LicensingTask>()
+        whenever(mockState.licensingTask).thenReturn(mockLicensingTask)
+        whenever(mockLicensingTask.licensingTypeStep).thenReturn(mockLicensingTypeStep)
         whenever(mockLicensingTypeStep.formModel).thenReturn(licensingTypeFormModel)
 
-        whenever(mockState.getLicenceNumberOrNull()).thenReturn(null)
+        whenever(mockLicensingTask.getLicenceNumberOrNull()).thenReturn(null)
 
         val mockOwnershipTypeStep = mock<OwnershipTypeStep>()
         val ownershipTypeFormModel = OwnershipTypeFormModel().apply { ownershipType = OwnershipType.FREEHOLD }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/shared/helpers/LicensingDetailsHelperTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/shared/helpers/LicensingDetailsHelperTests.kt
@@ -30,7 +30,7 @@ class LicensingDetailsHelperTests {
         val state = createMockLicensingState(LicensingType.NO_LICENSING, null)
 
         // Act
-        val summaryList = licensingDetailsHelper.getCheckYourAnswersSummaryList(state)
+        val summaryList = licensingDetailsHelper.getCheckYourAnswersSummaryList(state, state)
 
         // Assert
         summaryList.single().let { row ->
@@ -50,7 +50,7 @@ class LicensingDetailsHelperTests {
         val state = createMockLicensingState(LicensingType.HMO_MANDATORY_LICENCE, licenceNumber)
 
         // Act
-        val summaryList = licensingDetailsHelper.getCheckYourAnswersSummaryList(state)
+        val summaryList = licensingDetailsHelper.getCheckYourAnswersSummaryList(state, state)
 
         // Assert
         assertEquals(2, summaryList.size)

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/testHelpers/builders/AddressStateBuilder.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/testHelpers/builders/AddressStateBuilder.kt
@@ -69,6 +69,7 @@ interface AddressStateBuilder<out SelfType : AddressStateBuilder<SelfType>> {
                 address = MANUAL_ADDRESS_CHOSEN
             }
         withSubmittedValue(selectAddressKey, selectAddressFormModel)
+        additionalDataMap["cachedSelectedAddress"] = Json.encodeToString(serializer(), MANUAL_ADDRESS_CHOSEN)
 
         return self()
     }
@@ -101,6 +102,7 @@ interface AddressStateBuilder<out SelfType : AddressStateBuilder<SelfType>> {
                 address = singleLineAddress
             }
         withSubmittedValue(selectAddressKey, selectAddressFormModel)
+        additionalDataMap["cachedSelectedAddress"] = Json.encodeToString(serializer(), singleLineAddress)
 
         return self()
     }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/testHelpers/builders/OccupancyStateBuilder.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/testHelpers/builders/OccupancyStateBuilder.kt
@@ -1,5 +1,7 @@
 package uk.gov.communities.prsdb.webapp.testHelpers.builders
 
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.serializer
 import uk.gov.communities.prsdb.webapp.constants.enums.BillsIncluded
 import uk.gov.communities.prsdb.webapp.constants.enums.FurnishedStatus
 import uk.gov.communities.prsdb.webapp.constants.enums.RentFrequency
@@ -25,6 +27,7 @@ import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.RentInclu
 
 interface OccupancyStateBuilder<SelfType : OccupancyStateBuilder<SelfType>> {
     val submittedValueMap: MutableMap<String, FormModel>
+    val additionalDataMap: MutableMap<String, String>
 
     fun withSubmittedValue(
         key: String,
@@ -51,6 +54,7 @@ interface OccupancyStateBuilder<SelfType : OccupancyStateBuilder<SelfType>> {
                 occupied = false
             }
         withSubmittedValue("occupancy", occupancyFormModel)
+        additionalDataMap["cachedOccupied"] = Json.encodeToString(serializer(), false)
         return self()
     }
 
@@ -60,6 +64,7 @@ interface OccupancyStateBuilder<SelfType : OccupancyStateBuilder<SelfType>> {
                 this.occupied = occupied
             }
         withSubmittedValue(OccupiedStep.ROUTE_SEGMENT, occupancyFormModel)
+        additionalDataMap["cachedOccupied"] = Json.encodeToString(serializer(), occupied)
         return self()
     }
 


### PR DESCRIPTION
## Ticket number

PDJB-896

## Goal of change

Migrate the remaining property registration leaf-tasks (not counting compliance) to the self-stated duplicable-task composition model so the aggregate journey-state inheritance can be dismantled.

## Description of main change(s)

Pure refactor - no user-facing behaviour change in either journey variant.

- Migrates the property registration leaf tasks (rent frequency and amount, rent includes bills, households and tenants, licensing, address, occupancy) to self-stated `DuplicableTask`s.
- Updates both the property registration and update-occupancy journey factories to the `duplicableTask` / `duplicableCheckAnswerTask` mount DSL.

## Anything you''d like to highlight to the reviewer?
- The addition of the `EmbedBuilder` and `embed` function. This essentially allows a step within a task to be added directly to the journey map without the default configuration provided by the task. This is used here to add "checkYourAnswerSteps" where a single step is added to CYA journeys rather than a whole task. This wasn't needed before because all steps also existed on the top level journey.

## Checklist

- [x] Unit tests for new logic (e.g. new service methods) have been added
- [x] Test suite has been run in full locally and is passing
- [x] Branch has been rebased onto main and run locally, with everything working as expected (both for your new feature and any related functionality)