### PR TITLE
Chore/pdjb 896 migrate property registration containers

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/builders/JourneyBuilder.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/builders/JourneyBuilder.kt
@@ -64,70 +64,59 @@ open class JourneyBuilder<TState : JourneyState>(
             }
         }
 
-    fun section(init: SectionBuilder<TState>.() -> Unit) {
-        val sectionBuilder = SectionBuilder<TState>(this)
+    open fun section(init: SectionBuilder<TState>.() -> Unit) {
+        val sectionBuilder = SectionBuilder(journey, this)
         sectionBuilder.init()
         sectionBuilder.validateHeadingSet()
+        sectionBuilder.applySectionHeader()
+        registerTransparentBuilder(sectionBuilder)
     }
 
+    private fun getSectionHeaderViewModel(
+        headingMessageKey: String,
+        useNumbering: Boolean,
+    ): SectionHeaderViewModel {
+        val sectionIndex = sections.indexOf(headingMessageKey) + 1
+        val totalSections = sections.size
+        return SectionHeaderViewModel(headingMessageKey, sectionIndex, totalSections, useNumbering)
+    }
+
+    // A section groups steps and tasks under a shared numbered heading. It owns its elements (like an embedded
+    // sub-journey) and splices them transparently into the parent journey, so the parent's configuration still
+    // applies to them and additional element types (e.g. embed) become available inside a section. The section
+    // header is applied to every owned element via a single lazy content provider, so numbering reflects the
+    // final total once all sections have been declared.
     class SectionBuilder<TState : JourneyState>(
-        private val journeyBuilder: JourneyBuilder<TState>,
-    ) : JourneyBuilderDsl<TState> {
+        journey: TState,
+        private val parent: JourneyBuilder<TState>,
+    ) : JourneyBuilder<TState>(journey) {
         private lateinit var headingMessageKey: String
         private var useNumbering: Boolean = true
+
+        // Sections are flat, top-level groupings on the journey's task list; nesting them would register the inner
+        // heading against the wrong `sections` list (breaking numbering) and mask the inner header with the outer's.
+        override fun section(init: SectionBuilder<TState>.() -> Unit): Unit =
+            throw JourneyInitialisationException("Sections cannot be nested")
 
         fun withHeadingMessageKey(
             key: String,
             shouldUseNumbering: Boolean = true,
         ) {
-            journeyBuilder.sections.add(key)
+            parent.sections.add(key)
             headingMessageKey = key
             useNumbering = shouldUseNumbering
         }
 
-        override fun <TMode : Enum<TMode>, TStep : AbstractStepConfig<TMode, *, TState>> step(
-            uninitialisedStep: JourneyStep<TMode, *, TState>,
-            init: StepInitialiser<TStep, TState, TMode>.() -> Unit,
-        ) = journeyBuilder.step<TMode, TStep>(uninitialisedStep) {
-            init()
-            withAdditionalContentProperty {
-                "sectionHeaderInfo" to journeyBuilder.getSectionHeaderViewModel(headingMessageKey, useNumbering)
+        internal fun applySectionHeader() {
+            configure {
+                withAdditionalContentProperty {
+                    "sectionHeaderInfo" to parent.getSectionHeaderViewModel(headingMessageKey, useNumbering)
+                }
             }
-        }
-
-        override fun task(
-            uninitialisedTask: Task<TState>,
-            routeSegment: String?,
-            init: TaskInitialiser<TState, Nothing>.() -> Unit,
-        ) = journeyBuilder.task(uninitialisedTask, routeSegment) {
-            init()
-            withAdditionalContentProperty {
-                "sectionHeaderInfo" to journeyBuilder.getSectionHeaderViewModel(headingMessageKey, useNumbering)
-            }
-        }
-
-        override fun <TTaskState : JourneyState, TDependencies : Any> duplicableTask(
-            uninitialisedTask: DuplicableTaskWithDependencies<TTaskState, TDependencies>,
-            routeSegment: String?,
-            init: TaskInitialiser<TTaskState, TDependencies>.() -> Unit,
-        ) = journeyBuilder.duplicableTask(uninitialisedTask, routeSegment) {
-            init()
-            withAdditionalContentProperty {
-                "sectionHeaderInfo" to journeyBuilder.getSectionHeaderViewModel(headingMessageKey, useNumbering)
-            }
-        }
-
-        private fun JourneyBuilder<*>.getSectionHeaderViewModel(
-            headingMessageKey: String,
-            useNumbering: Boolean,
-        ): SectionHeaderViewModel {
-            val sectionIndex = sections.indexOf(headingMessageKey) + 1
-            val totalSections = sections.size
-            return SectionHeaderViewModel(headingMessageKey, sectionIndex, totalSections, useNumbering)
         }
 
         fun validateHeadingSet() {
-            if (!::headingMessageKey.isInitialized || !journeyBuilder.sections.contains(headingMessageKey)) {
+            if (!::headingMessageKey.isInitialized || !parent.sections.contains(headingMessageKey)) {
                 throw JourneyInitialisationException("Section heading message key must be set using withHeadingMessageKey")
             }
         }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/builders/SubJourneyBuilder.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/builders/SubJourneyBuilder.kt
@@ -117,6 +117,13 @@ abstract class AbstractJourneyBuilder<TInternalState : JourneyState, TJourneySta
     ) {
         val builder = EmbedBuilder(task, privateJourney)
         builder.init()
+        registerTransparentBuilder(builder)
+    }
+
+    // Splices a sub-builder's elements into this journey so that its steps are built inline while remaining
+    // reachable, by declared identity, to this builder's configuration (via additionalElements). Used by both
+    // embed and section so outer configuration is applied transparently to the sub-builder's owned elements.
+    protected fun registerTransparentBuilder(builder: AbstractJourneyBuilder<*>) {
         if (journeyElements.isEmpty()) {
             builder.configureFirst { additionalFirstElementConfiguration.forEach { it() } }
         }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/builders/SubJourneyBuilder.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/builders/SubJourneyBuilder.kt
@@ -123,7 +123,7 @@ abstract class AbstractJourneyBuilder<TInternalState : JourneyState, TJourneySta
     // Splices a sub-builder's elements into this journey so that its steps are built inline while remaining
     // reachable, by declared identity, to this builder's configuration (via additionalElements). Used by both
     // embed and section so outer configuration is applied transparently to the sub-builder's owned elements.
-    protected fun registerTransparentBuilder(builder: AbstractJourneyBuilder<*>) {
+    protected fun registerTransparentBuilder(builder: AbstractJourneyBuilder<*, *>) {
         if (journeyElements.isEmpty()) {
             builder.configureFirst { additionalFirstElementConfiguration.forEach { it() } }
         }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/PropertyRegistrationJourneyFactory.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/PropertyRegistrationJourneyFactory.kt
@@ -24,7 +24,6 @@ import uk.gov.communities.prsdb.webapp.journeys.isComplete
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.CertificateUpload
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.CombinedComplianceCheckState
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.OccupationState
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.TenancyDetailsState
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.BedroomsStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.BillsIncludedStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.CheckElectricalCertUploadsStep
@@ -98,14 +97,11 @@ import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.EpcTa
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.GasSafetyDetailsTask
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.GasSafetyTask
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.HouseHoldsAndTenantsDependencies
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.HouseholdsAndTenantsTask
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.LicensingTask
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.OccupationTask
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.OccupationTaskWithProvideLaterAllowed
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.OwnershipAndLandlordsTask
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.PropertyDetailsTask
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.RentFrequencyAndAmountTask
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.RentIncludesBillsTask
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.TenancyDetailsTask
 import uk.gov.communities.prsdb.webapp.journeys.shared.YesOrNo
 import uk.gov.communities.prsdb.webapp.journeys.shared.inviteJointLandlord.CheckJointLandlordsStep
@@ -508,7 +504,7 @@ class PropertyRegistrationJourneyFactory(
             }
             section {
                 withHeadingMessageKey("registerProperty.taskList.rentedOut.tenancyDetails", shouldUseNumbering = false)
-                task(journey.tenancyDetailsTask) {
+                duplicableTask(journey.tenancyDetailsTask) {
                     parents {
                         AndParents(
                             journey.epcTask.isComplete(),
@@ -594,13 +590,6 @@ class PropertyRegistrationJourney(
     override val licensingTask: LicensingTask,
     // Occupation steps
     override val occupied: OccupiedStep,
-    // Nested households and tenants task
-    override val householdsAndTenantsTask: HouseholdsAndTenantsTask,
-    // Nested rent includes bills task
-    override val rentIncludesBillsTask: RentIncludesBillsTask,
-    override val furnishedStatus: FurnishedStatusStep,
-    // Nested rent frequency and amount task
-    override val rentFrequencyAndAmountTask: RentFrequencyAndAmountTask,
     // ===== Journey-structure tasks (the two alternative flows diverge here) =====
     // Legacy journey only (flag-off) — delete this (and OccupationTask, legacyMainJourneyMap,
     // legacySectionViewModels, bedrooms override) when the old journey is removed.
@@ -702,7 +691,12 @@ class PropertyRegistrationJourney(
                 ?: throw PrsdbWebException("Cannot use isOccupied until after the occupation step")
         }
 
-    override val bedrooms: BedroomsStep = propertyDetailsTask.bedrooms
+    // Legacy steps and tasks that should be removed when the legacy structure is retired
+    override val bedrooms = propertyDetailsTask.bedrooms
+    override val householdsAndTenantsTask = tenancyDetailsTask.householdsAndTenantsTask
+    override val rentIncludesBillsTask = tenancyDetailsTask.rentIncludesBillsTask
+    override val rentFrequencyAndAmountTask = tenancyDetailsTask.rentFrequencyAndAmountTask
+    override val furnishedStatus = tenancyDetailsTask.furnishedStatus
 
     override var gasUploadMap: Map<Int, CertificateUpload> by delegateProvider.requiredDelegate("gasUploadMap", mapOf())
     override var highestAssignedGasMemberId: Int? by delegateProvider.nullableDelegate("highestGasUploadMemberId")
@@ -748,7 +742,6 @@ class PropertyRegistrationJourney(
 interface PropertyRegistrationJourneyState :
     OccupationState,
     InviteJointLandlordsTaskDependencies,
-    TenancyDetailsState,
     CombinedComplianceCheckState,
     CheckYourAnswersJourneyState {
     val taskListStep: PropertyRegistrationTaskListStep

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/PropertyRegistrationJourneyFactory.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/PropertyRegistrationJourneyFactory.kt
@@ -25,9 +25,7 @@ import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.Cert
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.CombinedComplianceCheckState
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.OccupationState
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.OwnershipAndLandlordsState
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.PropertyDetailsState
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.TenancyDetailsState
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.AddToLandlordIncompletePropertiesStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.BedroomsStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.BillsIncludedStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.CheckElectricalCertUploadsStep
@@ -108,7 +106,6 @@ import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.Occup
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.OccupationTaskWithProvideLaterAllowed
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.OwnershipAndLandlordsTask
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.PropertyDetailsTask
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.PropertyRegistrationAddressTask
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.RentFrequencyAndAmountTask
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.RentIncludesBillsTask
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.TenancyDetailsTask
@@ -153,17 +150,19 @@ class PropertyRegistrationJourneyFactory(
 
             when (checkingAnswersFor) {
                 LookupAddressStep.ROUTE_SEGMENT -> {
-                    duplicableCheckAnswerTask(journey.addressTask)
+                    duplicableCheckAnswerTask(journey.propertyDetailsTask.addressTask)
                 }
 
                 LocalCouncilStep.ROUTE_SEGMENT -> {
-                    fromTask(journey.addressTask) {
+                    fromTask(journey.propertyDetailsTask.addressTask) {
                         checkAnswerStep(task.localCouncilStep, LocalCouncilStep.ROUTE_SEGMENT)
                     }
                 }
 
                 PropertyTypeStep.ROUTE_SEGMENT -> {
-                    checkAnswerStep(journey.propertyTypeStep, PropertyTypeStep.ROUTE_SEGMENT)
+                    fromTask(journey.propertyDetailsTask) {
+                        checkAnswerStep(task.propertyTypeStep, PropertyTypeStep.ROUTE_SEGMENT)
+                    }
                 }
 
                 OwnershipTypeStep.ROUTE_SEGMENT -> {
@@ -291,24 +290,26 @@ class PropertyRegistrationJourneyFactory(
                 } else {
                     withHeadingMessageKey("registerProperty.taskList.register.old.heading")
                 }
-                duplicableTask(journey.addressTask) {
-                    parents { journey.taskListStep.always() }
-                    nextStep { journey.addToLandlordIncompletePropertiesStep }
-                }
-                step(journey.addToLandlordIncompletePropertiesStep) {
-                    parents { journey.addressTask.isComplete() }
-                    nextStep { journey.propertyTypeStep }
-                    saveProgress()
-                }
-                step(journey.propertyTypeStep) {
-                    routeSegment(PropertyTypeStep.ROUTE_SEGMENT)
-                    parents { journey.addressTask.isComplete() }
-                    nextStep { journey.ownershipTypeStep }
-                    saveProgress()
+                fromTask(journey.propertyDetailsTask) {
+                    duplicableTask(task.addressTask) {
+                        parents { journey.taskListStep.always() }
+                        nextStep { task.addToLandlordIncompletePropertiesStep }
+                    }
+                    step(task.addToLandlordIncompletePropertiesStep) {
+                        parents { task.addressTask.isComplete() }
+                        nextStep { task.propertyTypeStep }
+                        saveProgress()
+                    }
+                    step(task.propertyTypeStep) {
+                        routeSegment(PropertyTypeStep.ROUTE_SEGMENT)
+                        parents { task.addressTask.isComplete() }
+                        nextStep { journey.ownershipTypeStep }
+                        saveProgress()
+                    }
                 }
                 step(journey.ownershipTypeStep) {
                     routeSegment(OwnershipTypeStep.ROUTE_SEGMENT)
-                    parents { journey.propertyTypeStep.isComplete() }
+                    parents { journey.propertyDetailsTask.propertyTypeStep.isComplete() }
                     nextStep { journey.licensingTask.firstStep }
                     saveProgress()
                 }
@@ -439,7 +440,7 @@ class PropertyRegistrationJourneyFactory(
             }
             section {
                 withHeadingMessageKey("registerProperty.taskList.aboutYourProperty.propertyDetails", shouldUseNumbering = false)
-                task(journey.propertyDetailsTask) {
+                duplicableTask(journey.propertyDetailsTask) {
                     parents { journey.taskListStep.always() }
                     nextStep { journey.ownershipAndLandlordsTask.firstStep }
                     saveProgress()
@@ -585,12 +586,7 @@ class PropertyRegistrationJourneyFactory(
 class PropertyRegistrationJourney(
     // Task list step
     override val taskListStep: PropertyRegistrationTaskListStep,
-    // Address task
-    override val addressTask: PropertyRegistrationAddressTask,
-    // Add to LandlordIncompleteProperties join table
-    override val addToLandlordIncompletePropertiesStep: AddToLandlordIncompletePropertiesStep,
     // Property details steps
-    override val propertyTypeStep: PropertyTypeStep,
     override val ownershipTypeStep: OwnershipTypeStep,
     // Licensing task
     override val licensingTask: LicensingTask,
@@ -598,7 +594,6 @@ class PropertyRegistrationJourney(
     override val occupied: OccupiedStep,
     // Nested households and tenants task
     override val householdsAndTenantsTask: HouseholdsAndTenantsTask,
-    override val bedrooms: BedroomsStep,
     // Nested rent includes bills task
     override val rentIncludesBillsTask: RentIncludesBillsTask,
     override val furnishedStatus: FurnishedStatusStep,
@@ -608,7 +603,7 @@ class PropertyRegistrationJourney(
     override val jointLandlordsTask: JointLandlordsPropertyRegistrationTask,
     // ===== Journey-structure tasks (the two alternative flows diverge here) =====
     // Legacy journey only (flag-off) — delete this (and OccupationTask, legacyMainJourneyMap,
-    // legacySectionViewModels) when the old journey is removed.
+    // legacySectionViewModels, bedrooms override) when the old journey is removed.
     override val occupationTask: OccupationTaskWithProvideLaterAllowed,
     // Restructured journey only (flag-on) — grouping tasks for the new task-list structure.
     override val propertyDetailsTask: PropertyDetailsTask,
@@ -707,6 +702,8 @@ class PropertyRegistrationJourney(
                 ?: throw PrsdbWebException("Cannot use isOccupied until after the occupation step")
         }
 
+    override val bedrooms: BedroomsStep = propertyDetailsTask.bedrooms
+
     override var gasUploadMap: Map<Int, CertificateUpload> by delegateProvider.requiredDelegate("gasUploadMap", mapOf())
     override var highestAssignedGasMemberId: Int? by delegateProvider.nullableDelegate("highestGasUploadMemberId")
 
@@ -720,6 +717,7 @@ class PropertyRegistrationJourney(
     // Cache is populated on step submission (see SelectAddressStepConfig.afterStepDataIsAdded).
     override val uprn: Long?
         get() {
+            val addressTask = propertyDetailsTask.addressTask
             addressTask.cachedSelectedAddress?.let { return addressTask.getMatchingAddress(it)?.uprn }
             val submittedAddress = addressTask.selectAddressStep.formModelOrNull?.address ?: return null
             return addressTask.getMatchingAddress(submittedAddress)?.uprn
@@ -749,7 +747,6 @@ class PropertyRegistrationJourney(
 
 interface PropertyRegistrationJourneyState :
     OccupationState,
-    PropertyDetailsState,
     OwnershipAndLandlordsState,
     TenancyDetailsState,
     CombinedComplianceCheckState,

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/PropertyRegistrationJourneyFactory.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/PropertyRegistrationJourneyFactory.kt
@@ -24,7 +24,6 @@ import uk.gov.communities.prsdb.webapp.journeys.isComplete
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.CertificateUpload
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.CombinedComplianceCheckState
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.OccupationState
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.OwnershipAndLandlordsState
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.TenancyDetailsState
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.BedroomsStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.BillsIncludedStep
@@ -100,7 +99,6 @@ import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.GasSa
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.GasSafetyTask
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.HouseHoldsAndTenantsDependencies
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.HouseholdsAndTenantsTask
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.JointLandlordsPropertyRegistrationTask
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.LicensingTask
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.OccupationTask
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.OccupationTaskWithProvideLaterAllowed
@@ -111,6 +109,7 @@ import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.RentI
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.TenancyDetailsTask
 import uk.gov.communities.prsdb.webapp.journeys.shared.YesOrNo
 import uk.gov.communities.prsdb.webapp.journeys.shared.inviteJointLandlord.CheckJointLandlordsStep
+import uk.gov.communities.prsdb.webapp.journeys.shared.inviteJointLandlord.InviteJointLandlordsTaskDependencies
 import uk.gov.communities.prsdb.webapp.journeys.shared.states.CheckYourAnswersJourneyState
 import uk.gov.communities.prsdb.webapp.journeys.shared.states.CheckYourAnswersJourneyState.Companion.checkAnswerStep
 import uk.gov.communities.prsdb.webapp.journeys.shared.states.CheckYourAnswersJourneyState.Companion.checkAnswerTask
@@ -166,7 +165,9 @@ class PropertyRegistrationJourneyFactory(
                 }
 
                 OwnershipTypeStep.ROUTE_SEGMENT -> {
-                    checkAnswerStep(journey.ownershipTypeStep, OwnershipTypeStep.ROUTE_SEGMENT)
+                    fromTask(journey.ownershipAndLandlordsTask) {
+                        checkAnswerStep(task.ownershipTypeStep, OwnershipTypeStep.ROUTE_SEGMENT)
+                    }
                 }
 
                 LicensingTypeStep.ROUTE_SEGMENT,
@@ -214,7 +215,7 @@ class PropertyRegistrationJourneyFactory(
                 HasJointLandlordsStep.ROUTE_SEGMENT,
                 CheckJointLandlordsStep.ROUTE_SEGMENT,
                 -> {
-                    duplicableCheckAnswerTask(journey.jointLandlordsTask, { journey })
+                    duplicableCheckAnswerTask(journey.ownershipAndLandlordsTask.jointLandlordsTask, { journey })
                 }
 
                 HasGasSupplyStep.ROUTE_SEGMENT,
@@ -303,35 +304,37 @@ class PropertyRegistrationJourneyFactory(
                     step(task.propertyTypeStep) {
                         routeSegment(PropertyTypeStep.ROUTE_SEGMENT)
                         parents { task.addressTask.isComplete() }
-                        nextStep { journey.ownershipTypeStep }
+                        nextStep { journey.ownershipAndLandlordsTask.ownershipTypeStep }
                         saveProgress()
                     }
                 }
-                step(journey.ownershipTypeStep) {
-                    routeSegment(OwnershipTypeStep.ROUTE_SEGMENT)
-                    parents { journey.propertyDetailsTask.propertyTypeStep.isComplete() }
-                    nextStep { journey.licensingTask.firstStep }
-                    saveProgress()
+                fromTask(journey.ownershipAndLandlordsTask) {
+                    step(task.ownershipTypeStep) {
+                        routeSegment(OwnershipTypeStep.ROUTE_SEGMENT)
+                        parents { journey.propertyDetailsTask.propertyTypeStep.isComplete() }
+                        nextStep { journey.licensingTask.firstStep }
+                        saveProgress()
+                    }
                 }
                 duplicableTask(journey.licensingTask) {
-                    parents { journey.ownershipTypeStep.isComplete() }
+                    parents { journey.ownershipAndLandlordsTask.ownershipTypeStep.isComplete() }
                     nextStep { journey.occupationTask.firstStep }
                     saveProgress()
                 }
 
                 task(journey.occupationTask) {
                     parents { journey.licensingTask.isComplete() }
-                    nextStep { journey.jointLandlordsTask.firstStep }
+                    nextStep { journey.ownershipAndLandlordsTask.jointLandlordsTask.firstStep }
                     saveProgress()
                 }
-                duplicableTask(journey.jointLandlordsTask) {
+                duplicableTask(journey.ownershipAndLandlordsTask.jointLandlordsTask) {
                     withDependencies { journey }
                     parents { journey.occupationTask.isComplete() }
                     nextStep { journey.gasSafetyTask.firstStep }
                     saveProgress()
                 }
                 task(journey.gasSafetyTask) {
-                    parents { journey.jointLandlordsTask.isComplete() }
+                    parents { journey.ownershipAndLandlordsTask.jointLandlordsTask.isComplete() }
                     nextStep { journey.taskListStep }
                     saveProgress()
                 }
@@ -448,7 +451,8 @@ class PropertyRegistrationJourneyFactory(
             }
             section {
                 withHeadingMessageKey("registerProperty.taskList.aboutYourProperty.ownershipAndLandlords", shouldUseNumbering = false)
-                task(journey.ownershipAndLandlordsTask) {
+                duplicableTask(journey.ownershipAndLandlordsTask) {
+                    withDependencies { journey }
                     parents { journey.propertyDetailsTask.isComplete() }
                     nextStep { journey.occupied }
                     saveProgress()
@@ -586,8 +590,6 @@ class PropertyRegistrationJourneyFactory(
 class PropertyRegistrationJourney(
     // Task list step
     override val taskListStep: PropertyRegistrationTaskListStep,
-    // Property details steps
-    override val ownershipTypeStep: OwnershipTypeStep,
     // Licensing task
     override val licensingTask: LicensingTask,
     // Occupation steps
@@ -599,8 +601,6 @@ class PropertyRegistrationJourney(
     override val furnishedStatus: FurnishedStatusStep,
     // Nested rent frequency and amount task
     override val rentFrequencyAndAmountTask: RentFrequencyAndAmountTask,
-    // Joint landlords task
-    override val jointLandlordsTask: JointLandlordsPropertyRegistrationTask,
     // ===== Journey-structure tasks (the two alternative flows diverge here) =====
     // Legacy journey only (flag-off) — delete this (and OccupationTask, legacyMainJourneyMap,
     // legacySectionViewModels, bedrooms override) when the old journey is removed.
@@ -747,7 +747,7 @@ class PropertyRegistrationJourney(
 
 interface PropertyRegistrationJourneyState :
     OccupationState,
-    OwnershipAndLandlordsState,
+    InviteJointLandlordsTaskDependencies,
     TenancyDetailsState,
     CombinedComplianceCheckState,
     CheckYourAnswersJourneyState {

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/states/OwnershipAndLandlordsState.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/states/OwnershipAndLandlordsState.kt
@@ -3,11 +3,8 @@ package uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states
 import uk.gov.communities.prsdb.webapp.journeys.JourneyState
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.OwnershipTypeStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.JointLandlordsPropertyRegistrationTask
-import uk.gov.communities.prsdb.webapp.journeys.shared.inviteJointLandlord.InviteJointLandlordsTaskDependencies
 
-interface OwnershipAndLandlordsState :
-    JourneyState,
-    InviteJointLandlordsTaskDependencies {
+interface OwnershipAndLandlordsState : JourneyState {
     val ownershipTypeStep: OwnershipTypeStep
     val jointLandlordsTask: JointLandlordsPropertyRegistrationTask
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/PropertyRegistrationCyaStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/PropertyRegistrationCyaStepConfig.kt
@@ -35,7 +35,7 @@ class PropertyRegistrationCyaStepConfig(
                 "title" to "registerProperty.title",
                 "submitButtonText" to "forms.buttons.completeRegistration",
                 "insetText" to true,
-                "propertyName" to state.addressTask.getAddress().singleLineAddress,
+                "propertyName" to state.propertyDetailsTask.addressTask.getAddress().singleLineAddress,
                 "propertyDetails" to
                     if (isRestructured) {
                         getRestructuredPropertyDetailsSummaryList(state)
@@ -110,34 +110,35 @@ class PropertyRegistrationCyaStepConfig(
         )
 
     private fun getAddressRows(state: PropertyRegistrationJourneyState) =
-        state.addressTask.getAddress().let { address ->
+        state.propertyDetailsTask.addressTask.getAddress().let { address ->
             listOf(
                 SummaryListRowViewModel.forCheckYourAnswersPage(
                     "forms.checkPropertyAnswers.propertyDetails.address",
                     address.singleLineAddress,
                     Destination.VisitableStep(
-                        state.addressTask.lookupAddressStep,
-                        state.getCyaJourneyId(state.addressTask.lookupAddressStep),
+                        state.propertyDetailsTask.addressTask.lookupAddressStep,
+                        state.getCyaJourneyId(state.propertyDetailsTask.addressTask.lookupAddressStep),
                     ),
                 ),
                 SummaryListRowViewModel.forCheckYourAnswersPage(
                     "forms.checkPropertyAnswers.propertyDetails.localCouncil",
                     localCouncilService.retrieveLocalCouncilById(address.localCouncilId!!).name,
                     Destination.VisitableStep(
-                        state.addressTask.localCouncilStep,
-                        state.getCyaJourneyId(state.addressTask.localCouncilStep),
+                        state.propertyDetailsTask.addressTask.localCouncilStep,
+                        state.getCyaJourneyId(state.propertyDetailsTask.addressTask.localCouncilStep),
                     ),
                 ),
             )
         }
 
     private fun getPropertyTypeRow(state: PropertyRegistrationJourneyState): SummaryListRowViewModel {
-        val propertyType = state.propertyTypeStep.formModel.propertyType
-        val customType = state.propertyTypeStep.formModel.customPropertyType
+        val propertyTypeStep = state.propertyDetailsTask.propertyTypeStep
+        val propertyType = propertyTypeStep.formModel.propertyType
+        val customType = propertyTypeStep.formModel.customPropertyType
         return SummaryListRowViewModel.forCheckYourAnswersPage(
             "forms.checkPropertyAnswers.propertyDetails.type",
             if (propertyType == PropertyType.OTHER) listOf(propertyType, customType) else propertyType,
-            Destination.VisitableStep(state.propertyTypeStep, state.getCyaJourneyId(state.propertyTypeStep)),
+            Destination.VisitableStep(propertyTypeStep, state.getCyaJourneyId(propertyTypeStep)),
         )
     }
 

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/PropertyRegistrationCyaStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/PropertyRegistrationCyaStepConfig.kt
@@ -66,17 +66,18 @@ class PropertyRegistrationCyaStepConfig(
     ): Destination = defaultDestination
 
     private fun getJointLandLordsSummaryRow(state: PropertyRegistrationJourneyState): SummaryListRowViewModel {
+        val jointLandlordsTask = state.ownershipAndLandlordsTask.jointLandlordsTask
         val hasJointLandlords =
-            state.jointLandlordsTask.hasJointLandlordsStep.formModel.notNullValue(
+            jointLandlordsTask.hasJointLandlordsStep.formModel.notNullValue(
                 HasJointLandlordsFormModel::hasJointLandlords,
             )
         return if (hasJointLandlords) {
             SummaryListRowViewModel.forCheckYourAnswersPage(
                 "forms.checkPropertyAnswers.jointLandlordsDetails.invitations",
-                state.jointLandlordsTask.inviteJointLandlordsTask.invitedJointLandlords,
+                jointLandlordsTask.inviteJointLandlordsTask.invitedJointLandlords,
                 Destination.VisitableStep(
-                    state.jointLandlordsTask.inviteJointLandlordsTask.checkJointLandlordsStep,
-                    state.getCyaJourneyId(state.jointLandlordsTask.inviteJointLandlordsTask.checkJointLandlordsStep),
+                    jointLandlordsTask.inviteJointLandlordsTask.checkJointLandlordsStep,
+                    state.getCyaJourneyId(jointLandlordsTask.inviteJointLandlordsTask.checkJointLandlordsStep),
                 ),
             )
         } else {
@@ -84,8 +85,8 @@ class PropertyRegistrationCyaStepConfig(
                 "forms.checkPropertyAnswers.jointLandlordsDetails.areThereJointLandlords",
                 "forms.checkPropertyAnswers.jointLandlordsDetails.noJointLandlords",
                 Destination.VisitableStep(
-                    state.jointLandlordsTask.hasJointLandlordsStep,
-                    state.getCyaJourneyId(state.jointLandlordsTask.hasJointLandlordsStep),
+                    jointLandlordsTask.hasJointLandlordsStep,
+                    state.getCyaJourneyId(jointLandlordsTask.hasJointLandlordsStep),
                 ),
             )
         }
@@ -142,12 +143,14 @@ class PropertyRegistrationCyaStepConfig(
         )
     }
 
-    private fun getOwnershipTypeRow(state: PropertyRegistrationJourneyState) =
-        SummaryListRowViewModel.forCheckYourAnswersPage(
+    private fun getOwnershipTypeRow(state: PropertyRegistrationJourneyState): SummaryListRowViewModel {
+        val ownershipTypeStep = state.ownershipAndLandlordsTask.ownershipTypeStep
+        return SummaryListRowViewModel.forCheckYourAnswersPage(
             "forms.checkPropertyAnswers.propertyDetails.ownership",
-            state.ownershipTypeStep.formModel.ownershipType,
-            Destination.VisitableStep(state.ownershipTypeStep, state.getCyaJourneyId(state.ownershipTypeStep)),
+            ownershipTypeStep.formModel.ownershipType,
+            Destination.VisitableStep(ownershipTypeStep, state.getCyaJourneyId(ownershipTypeStep)),
         )
+    }
 }
 
 @JourneyFrameworkComponent

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/PropertyRegistrationTaskListStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/PropertyRegistrationTaskListStepConfig.kt
@@ -59,18 +59,19 @@ class PropertyRegistrationTaskListStepConfig(
     }
 
     private fun legacySectionViewModels(state: PropertyRegistrationJourneyState): List<TaskSectionViewModel> {
+        val ownershipTypeStep = state.ownershipAndLandlordsTask.ownershipTypeStep
         val registerTaskItems =
             listOf(
                 TaskListItemViewModel.fromTask("registerProperty.taskList.register.addAddress", state.propertyDetailsTask.addressTask),
                 TaskListItemViewModel.fromStep("registerProperty.taskList.register.selectType", state.propertyDetailsTask.propertyTypeStep),
-                TaskListItemViewModel.fromStep("registerProperty.taskList.register.selectOwnership", state.ownershipTypeStep),
+                TaskListItemViewModel.fromStep("registerProperty.taskList.register.selectOwnership", ownershipTypeStep),
                 TaskListItemViewModel.fromTask("registerProperty.taskList.register.addLicensing", state.licensingTask),
                 TaskListItemViewModel.fromTask("registerProperty.taskList.register.addTenancyInfo", state.occupationTask),
             ) +
                 listOf(
                     TaskListItemViewModel.fromTask(
                         "registerProperty.taskList.register.inviteJointLandlords",
-                        state.jointLandlordsTask,
+                        state.ownershipAndLandlordsTask.jointLandlordsTask,
                     ),
                 ) +
                 listOf(

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/PropertyRegistrationTaskListStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/PropertyRegistrationTaskListStepConfig.kt
@@ -61,8 +61,8 @@ class PropertyRegistrationTaskListStepConfig(
     private fun legacySectionViewModels(state: PropertyRegistrationJourneyState): List<TaskSectionViewModel> {
         val registerTaskItems =
             listOf(
-                TaskListItemViewModel.fromTask("registerProperty.taskList.register.addAddress", state.addressTask),
-                TaskListItemViewModel.fromStep("registerProperty.taskList.register.selectType", state.propertyTypeStep),
+                TaskListItemViewModel.fromTask("registerProperty.taskList.register.addAddress", state.propertyDetailsTask.addressTask),
+                TaskListItemViewModel.fromStep("registerProperty.taskList.register.selectType", state.propertyDetailsTask.propertyTypeStep),
                 TaskListItemViewModel.fromStep("registerProperty.taskList.register.selectOwnership", state.ownershipTypeStep),
                 TaskListItemViewModel.fromTask("registerProperty.taskList.register.addLicensing", state.licensingTask),
                 TaskListItemViewModel.fromTask("registerProperty.taskList.register.addTenancyInfo", state.occupationTask),

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/SavePropertyRegistrationDataStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/SavePropertyRegistrationDataStepConfig.kt
@@ -56,11 +56,12 @@ class SavePropertyRegistrationDataStepConfig(
         val isOccupied = state.occupied.formModel.notNullValue(OccupancyFormModel::occupied)
         val isRestructured = featureFlagManager.checkFeature(PROPERTY_REGISTRATION_RESTRUCTURE_AND_SKIPPING)
         val billsIncludedDataModel = state.rentIncludesBillsTask.getBillsIncludedOrNull()
+        val jointLandlordsTask = state.ownershipAndLandlordsTask.jointLandlordsTask
         val jointLandlordEmails: List<String>? =
-            state.jointLandlordsTask.inviteJointLandlordsTask.invitedJointLandlordEmailsMap
+            jointLandlordsTask.inviteJointLandlordsTask.invitedJointLandlordEmailsMap
                 ?.values
                 ?.toList()
-        val markedJointLandlord = state.jointLandlordsTask.hasJointLandlordsStep.formModel.hasJointLandlords == true
+        val markedJointLandlord = jointLandlordsTask.hasJointLandlordsStep.formModel.hasJointLandlords == true
 
         propertyRegistrationService.registerProperty(
             addressModel = state.propertyDetailsTask.addressTask.getAddress(),
@@ -73,7 +74,7 @@ class SavePropertyRegistrationDataStepConfig(
                 },
             licenseType = state.licensingTask.licensingTypeStep.formModel.notNullValue(LicensingTypeFormModel::licensingType),
             licenceNumber = state.licensingTask.getLicenceNumberOrNull() ?: "",
-            ownershipType = state.ownershipTypeStep.formModel.notNullValue(OwnershipTypeFormModel::ownershipType),
+            ownershipType = state.ownershipAndLandlordsTask.ownershipTypeStep.formModel.notNullValue(OwnershipTypeFormModel::ownershipType),
             isOccupied = isOccupied,
             numberOfHouseholds =
                 if (isOccupied) {

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/SavePropertyRegistrationDataStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/SavePropertyRegistrationDataStepConfig.kt
@@ -36,7 +36,7 @@ class SavePropertyRegistrationDataStepConfig(
         try {
             registerProperty(state)
         } catch (_: EntityExistsException) {
-            state.addressTask.isAddressAlreadyRegistered = true
+            state.propertyDetailsTask.addressTask.isAddressAlreadyRegistered = true
             return
         }
     }
@@ -45,8 +45,8 @@ class SavePropertyRegistrationDataStepConfig(
         state: PropertyRegistrationJourneyState,
         defaultDestination: Destination,
     ): Destination =
-        if (state.addressTask.isAddressAlreadyRegistered == true) {
-            Destination(state.addressTask.alreadyRegisteredStep)
+        if (state.propertyDetailsTask.addressTask.isAddressAlreadyRegistered == true) {
+            Destination(state.propertyDetailsTask.addressTask.alreadyRegisteredStep)
         } else {
             state.deleteJourney()
             defaultDestination
@@ -63,11 +63,11 @@ class SavePropertyRegistrationDataStepConfig(
         val markedJointLandlord = state.jointLandlordsTask.hasJointLandlordsStep.formModel.hasJointLandlords == true
 
         propertyRegistrationService.registerProperty(
-            addressModel = state.addressTask.getAddress(),
-            propertyType = state.propertyTypeStep.formModel.notNullValue(PropertyTypeFormModel::propertyType),
+            addressModel = state.propertyDetailsTask.addressTask.getAddress(),
+            propertyType = state.propertyDetailsTask.propertyTypeStep.formModel.notNullValue(PropertyTypeFormModel::propertyType),
             customPropertyType =
-                if (state.propertyTypeStep.formModel.propertyType == PropertyType.OTHER) {
-                    state.propertyTypeStep.formModel.customPropertyType
+                if (state.propertyDetailsTask.propertyTypeStep.formModel.propertyType == PropertyType.OTHER) {
+                    state.propertyDetailsTask.propertyTypeStep.formModel.customPropertyType
                 } else {
                     null
                 },

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/tasks/OwnershipAndLandlordsTask.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/tasks/OwnershipAndLandlordsTask.kt
@@ -1,13 +1,24 @@
 package uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks
 
 import uk.gov.communities.prsdb.webapp.annotations.webAnnotations.JourneyFrameworkComponent
-import uk.gov.communities.prsdb.webapp.journeys.Task
+import uk.gov.communities.prsdb.webapp.journeys.DuplicableTaskWithDependencies
+import uk.gov.communities.prsdb.webapp.journeys.JourneyStateService
 import uk.gov.communities.prsdb.webapp.journeys.isComplete
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.OwnershipAndLandlordsState
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.OwnershipTypeStep
+import uk.gov.communities.prsdb.webapp.journeys.shared.inviteJointLandlord.InviteJointLandlordsTaskDependencies
 
 @JourneyFrameworkComponent
-class OwnershipAndLandlordsTask : Task<OwnershipAndLandlordsState>() {
+class OwnershipAndLandlordsTask(
+    journeyStateService: JourneyStateService,
+    override val ownershipTypeStep: OwnershipTypeStep,
+    override val jointLandlordsTask: JointLandlordsPropertyRegistrationTask,
+) : DuplicableTaskWithDependencies<OwnershipAndLandlordsState, InviteJointLandlordsTaskDependencies>(
+        journeyStateService,
+    ),
+    OwnershipAndLandlordsState {
+    override val taskState get() = this
+
     override fun makeSubJourney(state: OwnershipAndLandlordsState) =
         subJourney(state) {
             step(journey.ownershipTypeStep) {
@@ -16,7 +27,7 @@ class OwnershipAndLandlordsTask : Task<OwnershipAndLandlordsState>() {
                 savable()
             }
             duplicableTask(journey.jointLandlordsTask) {
-                withDependencies { journey }
+                withDependencies { this@OwnershipAndLandlordsTask.dependencies }
                 parents { journey.ownershipTypeStep.isComplete() }
                 nextStep { exitStep }
                 savable()

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/tasks/PropertyDetailsTask.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/tasks/PropertyDetailsTask.kt
@@ -1,14 +1,25 @@
 package uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks
 
 import uk.gov.communities.prsdb.webapp.annotations.webAnnotations.JourneyFrameworkComponent
-import uk.gov.communities.prsdb.webapp.journeys.Task
+import uk.gov.communities.prsdb.webapp.journeys.DuplicableTask
+import uk.gov.communities.prsdb.webapp.journeys.JourneyStateService
 import uk.gov.communities.prsdb.webapp.journeys.isComplete
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.PropertyDetailsState
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.AddToLandlordIncompletePropertiesStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.BedroomsStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.PropertyTypeStep
 
 @JourneyFrameworkComponent
-class PropertyDetailsTask : Task<PropertyDetailsState>() {
+class PropertyDetailsTask(
+    journeyStateService: JourneyStateService,
+    override val addressTask: PropertyRegistrationAddressTask,
+    override val addToLandlordIncompletePropertiesStep: AddToLandlordIncompletePropertiesStep,
+    override val propertyTypeStep: PropertyTypeStep,
+    override val bedrooms: BedroomsStep,
+) : DuplicableTask<PropertyDetailsState>(journeyStateService),
+    PropertyDetailsState {
+    override val taskState get() = this
+
     override fun makeSubJourney(state: PropertyDetailsState) =
         subJourney(state) {
             duplicableTask(journey.addressTask) {

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/tasks/TenancyDetailsTask.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/tasks/TenancyDetailsTask.kt
@@ -1,7 +1,8 @@
 package uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks
 
 import uk.gov.communities.prsdb.webapp.annotations.webAnnotations.JourneyFrameworkComponent
-import uk.gov.communities.prsdb.webapp.journeys.Task
+import uk.gov.communities.prsdb.webapp.journeys.DuplicableTask
+import uk.gov.communities.prsdb.webapp.journeys.JourneyStateService
 import uk.gov.communities.prsdb.webapp.journeys.hasOutcome
 import uk.gov.communities.prsdb.webapp.journeys.isComplete
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.TenancyDetailsState
@@ -9,7 +10,16 @@ import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.Furni
 import uk.gov.communities.prsdb.webapp.journeys.shared.Complete
 
 @JourneyFrameworkComponent
-class TenancyDetailsTask : Task<TenancyDetailsState>() {
+class TenancyDetailsTask(
+    journeyStateService: JourneyStateService,
+    override val householdsAndTenantsTask: HouseholdsAndTenantsTask,
+    override val rentIncludesBillsTask: RentIncludesBillsTask,
+    override val furnishedStatus: FurnishedStatusStep,
+    override val rentFrequencyAndAmountTask: RentFrequencyAndAmountTask,
+) : DuplicableTask<TenancyDetailsState>(journeyStateService),
+    TenancyDetailsState {
+    override val taskState get() = this
+
     override fun makeSubJourney(state: TenancyDetailsState) =
         subJourney(state) {
             duplicableTask(journey.householdsAndTenantsTask) {

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/builders/JourneyBuilderTest.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/builders/JourneyBuilderTest.kt
@@ -766,6 +766,22 @@ class JourneyBuilderTest {
         }
 
         @Test
+        fun `nested sections throw JourneyInitialisationException`() {
+            // Arrange
+            val jb = JourneyBuilder(mock<JourneyState>())
+
+            // Act & Assert
+            assertThrows<JourneyInitialisationException> {
+                jb.section {
+                    withHeadingMessageKey("section.outer")
+                    section {
+                        withHeadingMessageKey("section.inner")
+                    }
+                }
+            }
+        }
+
+        @Test
         fun `a step inside a section has sectionHeaderInfo added to its content properties`() {
             // Arrange
             val jb = JourneyBuilder(mock())

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/builders/JourneyBuilderTest.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/builders/JourneyBuilderTest.kt
@@ -898,6 +898,57 @@ class JourneyBuilderTest {
             assertFalse(sectionHeaderInfo.useNumbering)
         }
 
+        @Test
+        fun `a step inside a section added from fromTask has sectionHeaderInfo added to its content properties`() {
+            // Arrange
+            val jb = JourneyBuilder(mock<JourneyState>())
+            val embeddedState = mock<JourneyState>()
+            val embeddedStep = StepInitialiserTests.mockInitialisableStep()
+
+            // Act
+            jb.section {
+                withHeadingMessageKey("section.heading")
+                fromTask(embeddedState) {
+                    step(embeddedStep) {
+                        initialStep()
+                        nextUrl { "url1" }
+                        unreachableStepUrl { "unreachable" }
+                    }
+                }
+            }
+            jb.buildRoutingMap()
+
+            // Assert
+            val expectedSectionHeaderInfo = SectionHeaderViewModel("section.heading", 1, 1)
+            val sectionHeaderInfo = capturedSectionHeader(embeddedStep)
+            assertEquals(expectedSectionHeaderInfo, sectionHeaderInfo)
+        }
+
+        @Test
+        fun `withAdditionalContentProperty configured on a step inside a section is applied alongside the section header`() {
+            // Arrange
+            val jb = JourneyBuilder(mock<JourneyState>())
+            val step = StepInitialiserTests.mockInitialisableStep()
+
+            // Act
+            jb.section {
+                withHeadingMessageKey("section.heading")
+                step(step) {
+                    initialStep()
+                    nextUrl { "url1" }
+                    unreachableStepUrl { "unreachable" }
+                    withAdditionalContentProperty { "extra" to "value" }
+                }
+            }
+            jb.buildRoutingMap()
+
+            // Assert
+            val capturedContent = capturedContentProperties(step)
+            val expectedSectionHeaderInfo = SectionHeaderViewModel("section.heading", 1, 1)
+            assertEquals(expectedSectionHeaderInfo, capturedContent["sectionHeaderInfo"])
+            assertEquals("value", capturedContent["extra"])
+        }
+
         private fun testTaskWithSteps(vararg steps: JourneyStep.RequestableStep<TestEnum, *, JourneyState>): Task<JourneyState> =
             object : Task<JourneyState>() {
                 override fun makeSubJourney(state: JourneyState) =
@@ -916,7 +967,7 @@ class JourneyBuilderTest {
             }
     }
 
-    private fun capturedSectionHeader(step: JourneyStep.RequestableStep<TestEnum, *, JourneyState>): SectionHeaderViewModel {
+    private fun capturedContentProperties(step: JourneyStep.RequestableStep<TestEnum, *, JourneyState>): Map<String, Any> {
         val captor = argumentCaptor<() -> Map<String, Any>>()
         verify(step).initialize(
             anyOrNull(),
@@ -928,8 +979,11 @@ class JourneyBuilderTest {
             anyOrNull(),
             captor.capture(),
         )
-        return captor.firstValue()["sectionHeaderInfo"] as SectionHeaderViewModel
+        return captor.firstValue()
     }
+
+    private fun capturedSectionHeader(step: JourneyStep.RequestableStep<TestEnum, *, JourneyState>): SectionHeaderViewModel =
+        capturedContentProperties(step)["sectionHeaderInfo"] as SectionHeaderViewModel
 
     @Nested
     inner class RoutableTaskTests {

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/SavePropertyRegistrationDataStepConfigTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/SavePropertyRegistrationDataStepConfigTests.kt
@@ -30,6 +30,7 @@ import uk.gov.communities.prsdb.webapp.journeys.Destination
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.PropertyRegistrationJourneyState
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.JointLandlordsPropertyRegistrationTask
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.LicensingTask
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.OwnershipAndLandlordsTask
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.PropertyDetailsTask
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.PropertyRegistrationAddressTask
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.RentIncludesBillsTask
@@ -69,6 +70,9 @@ class SavePropertyRegistrationDataStepConfigTests {
 
     @Mock
     private lateinit var mockPropertyDetailsTask: PropertyDetailsTask
+
+    @Mock
+    private lateinit var mockOwnershipAndLandlordsTask: OwnershipAndLandlordsTask
 
     private lateinit var stepConfig: SavePropertyRegistrationDataStepConfig
 
@@ -346,11 +350,12 @@ class SavePropertyRegistrationDataStepConfigTests {
 
         val mockOwnershipTypeStep = mock<OwnershipTypeStep>()
         val ownershipTypeFormModel = OwnershipTypeFormModel().apply { ownershipType = OwnershipType.FREEHOLD }
-        whenever(mockState.ownershipTypeStep).thenReturn(mockOwnershipTypeStep)
+        whenever(mockState.ownershipAndLandlordsTask).thenReturn(mockOwnershipAndLandlordsTask)
+        whenever(mockOwnershipAndLandlordsTask.ownershipTypeStep).thenReturn(mockOwnershipTypeStep)
         whenever(mockOwnershipTypeStep.formModel).thenReturn(ownershipTypeFormModel)
 
         val mockJointLandlordsTask = mock<JointLandlordsPropertyRegistrationTask>()
-        whenever(mockState.jointLandlordsTask).thenReturn(mockJointLandlordsTask)
+        whenever(mockOwnershipAndLandlordsTask.jointLandlordsTask).thenReturn(mockJointLandlordsTask)
 
         val mockHasJointLandlordsStep = mock<HasJointLandlordsStep>()
         val hasJointLandlordsFormModel = HasJointLandlordsFormModel().apply { hasJointLandlords = false }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/SavePropertyRegistrationDataStepConfigTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/SavePropertyRegistrationDataStepConfigTests.kt
@@ -30,6 +30,7 @@ import uk.gov.communities.prsdb.webapp.journeys.Destination
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.PropertyRegistrationJourneyState
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.JointLandlordsPropertyRegistrationTask
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.LicensingTask
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.PropertyDetailsTask
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.PropertyRegistrationAddressTask
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.RentIncludesBillsTask
 import uk.gov.communities.prsdb.webapp.journeys.shared.Complete
@@ -65,6 +66,9 @@ class SavePropertyRegistrationDataStepConfigTests {
 
     @Mock
     private lateinit var mockAddressTask: PropertyRegistrationAddressTask
+
+    @Mock
+    private lateinit var mockPropertyDetailsTask: PropertyDetailsTask
 
     private lateinit var stepConfig: SavePropertyRegistrationDataStepConfig
 
@@ -277,7 +281,8 @@ class SavePropertyRegistrationDataStepConfigTests {
     fun `resolveNextDestination deletes journey and returns default destination when address is not already registered`() {
         // Arrange
         val defaultDestination = Destination.ExternalUrl("redirect")
-        whenever(mockState.addressTask).thenReturn(mockAddressTask)
+        whenever(mockState.propertyDetailsTask).thenReturn(mockPropertyDetailsTask)
+        whenever(mockPropertyDetailsTask.addressTask).thenReturn(mockAddressTask)
         whenever(mockAddressTask.isAddressAlreadyRegistered).thenReturn(false)
 
         // Act
@@ -294,7 +299,8 @@ class SavePropertyRegistrationDataStepConfigTests {
         val defaultDestination = Destination.ExternalUrl("redirect")
         val mockAlreadyRegisteredStep = mock<AlreadyRegisteredStep>()
         whenever(mockAlreadyRegisteredStep.currentJourneyId).thenReturn("test-journey-id")
-        whenever(mockState.addressTask).thenReturn(mockAddressTask)
+        whenever(mockState.propertyDetailsTask).thenReturn(mockPropertyDetailsTask)
+        whenever(mockPropertyDetailsTask.addressTask).thenReturn(mockAddressTask)
         whenever(mockAddressTask.isAddressAlreadyRegistered).thenReturn(true)
         whenever(mockAddressTask.alreadyRegisteredStep).thenReturn(mockAlreadyRegisteredStep)
 
@@ -318,14 +324,15 @@ class SavePropertyRegistrationDataStepConfigTests {
         whenever(mockState.rentIncludesBillsTask).thenReturn(mockRentIncludesBillsTask)
         whenever(mockRentIncludesBillsTask.getBillsIncludedOrNull()).thenReturn(null)
 
-        whenever(mockState.addressTask).thenReturn(mockAddressTask)
+        whenever(mockState.propertyDetailsTask).thenReturn(mockPropertyDetailsTask)
+        whenever(mockPropertyDetailsTask.addressTask).thenReturn(mockAddressTask)
         whenever(mockAddressTask.getAddress()).thenReturn(
             AddressDataModel(singleLineAddress = "1 Test St", uprn = 12345L, localCouncilId = 1),
         )
 
         val mockPropertyTypeStep = mock<PropertyTypeStep>()
         val propertyTypeFormModel = PropertyTypeFormModel().apply { propertyType = PropertyType.DETACHED_HOUSE }
-        whenever(mockState.propertyTypeStep).thenReturn(mockPropertyTypeStep)
+        whenever(mockPropertyDetailsTask.propertyTypeStep).thenReturn(mockPropertyTypeStep)
         whenever(mockPropertyTypeStep.formModel).thenReturn(propertyTypeFormModel)
 
         val mockLicensingTypeStep = mock<LicensingTypeStep>()


### PR DESCRIPTION
## Ticket number
PDJB-896 

## Goal of change
Migrates the tasks (not compliance) in the new restructured journey to duplicable tasks.


## Anything you'd like to highlight to the reviewer?
* Sections have been refactored to use the same structure as embedded journeys - this means they play nicely together

## Checklist

Delete any that are not applicable, and add explanation below for any that are applicable but haven't been done

- [X] Unit tests for new logic (e.g. new service methods) have been added
- [X] Single page integration tests have been added for any unhappy-flow UI features, e.g. validation errors
- [X] New journey steps have been added to the appropriate journey integration test(s)
- [X] Test suite has been run in full locally and is passing
- [X] Branch has been rebased onto main and run locally, with everything working as expected (both for your new feature
  and any related functionality)
- [X] Migration ongoing
