### PR TITLE
PDJB-1353: Show bedrooms in restructured property details

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/PropertyDetailsController.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/PropertyDetailsController.kt
@@ -12,11 +12,13 @@ import org.springframework.web.servlet.mvc.support.RedirectAttributes
 import org.springframework.web.util.UriTemplate
 import uk.gov.communities.prsdb.webapp.annotations.webAnnotations.PrsdbController
 import uk.gov.communities.prsdb.webapp.config.interceptors.BackLinkInterceptor.Companion.overrideBackLinkForUrl
+import uk.gov.communities.prsdb.webapp.config.managers.FeatureFlagManager
 import uk.gov.communities.prsdb.webapp.constants.COMPLIANCE_INFO_FRAGMENT
 import uk.gov.communities.prsdb.webapp.constants.LANDLORD_DETAILS_FRAGMENT
 import uk.gov.communities.prsdb.webapp.constants.LANDLORD_PATH_SEGMENT
 import uk.gov.communities.prsdb.webapp.constants.LOCAL_COUNCIL_PATH_SEGMENT
 import uk.gov.communities.prsdb.webapp.constants.PROPERTY_DETAILS_SEGMENT
+import uk.gov.communities.prsdb.webapp.constants.PROPERTY_REGISTRATION_RESTRUCTURE_AND_SKIPPING
 import uk.gov.communities.prsdb.webapp.constants.REMOVE_EXPIRED_INVITE_PATH_SEGMENT
 import uk.gov.communities.prsdb.webapp.controllers.LandlordController.Companion.LANDLORD_DASHBOARD_URL
 import uk.gov.communities.prsdb.webapp.controllers.LocalCouncilDashboardController.Companion.LOCAL_COUNCIL_DASHBOARD_URL
@@ -41,6 +43,7 @@ class PropertyDetailsController(
     private val messageSource: MessageSource,
     private val jointLandlordInvitationService: JointLandlordInvitationService,
     private val absoluteUrlProvider: AbsoluteUrlProvider,
+    private val featureFlagManager: FeatureFlagManager,
 ) {
     @PreAuthorize("hasRole('LANDLORD')")
     @GetMapping(LANDLORD_PROPERTY_DETAILS_ROUTE)
@@ -57,6 +60,8 @@ class PropertyDetailsController(
                 propertyOwnership = propertyOwnership,
                 withChangeLinks = true,
                 hideNullUprn = true,
+                isRestructureAndSkippingEnabled =
+                    featureFlagManager.checkFeature(PROPERTY_REGISTRATION_RESTRUCTURE_AND_SKIPPING),
                 messageSource = messageSource,
             )
 
@@ -148,6 +153,8 @@ class PropertyDetailsController(
                 propertyOwnership = propertyOwnership,
                 withChangeLinks = false,
                 hideNullUprn = false,
+                isRestructureAndSkippingEnabled =
+                    featureFlagManager.checkFeature(PROPERTY_REGISTRATION_RESTRUCTURE_AND_SKIPPING),
                 messageSource = messageSource,
             )
 

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/summaryModels/PropertyDetailsViewModel.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/summaryModels/PropertyDetailsViewModel.kt
@@ -31,6 +31,7 @@ class PropertyDetailsViewModel(
     private val propertyOwnership: PropertyOwnership,
     private val withChangeLinks: Boolean = true,
     private val hideNullUprn: Boolean = true,
+    private val isRestructureAndSkippingEnabled: Boolean = false,
     private val messageSource: MessageSource,
 ) {
     val address: String = propertyOwnership.address.singleLineAddress
@@ -70,8 +71,12 @@ class PropertyDetailsViewModel(
                 )
                 addRow(
                     "propertyDetails.propertyRecord.propertyType",
-                    propertyOwnership.customPropertyType ?: MessageKeyConverter.convert(propertyOwnership.propertyBuildType),
+                    propertyOwnership.customPropertyType
+                        ?: MessageKeyConverter.convert(propertyOwnership.propertyBuildType),
                 )
+                if (isRestructureAndSkippingEnabled) {
+                    addBedroomsRow()
+                }
                 addRow(
                     "propertyDetails.propertyRecord.ownershipType",
                     MessageKeyConverter.convert(propertyOwnership.ownershipType),
@@ -130,14 +135,9 @@ class PropertyDetailsViewModel(
                         "propertyDetails.propertyRecord.tenancyAndRentalInformation.numberOfPeople",
                         propertyOwnership.currentNumTenants,
                     )
-                    addRow(
-                        "propertyDetails.propertyRecord.tenancyAndRentalInformation.numberOfBedrooms",
-                        propertyOwnership.numBedrooms,
-                        changeLinkMessageKey,
-                        UpdateBedroomsController.getUpdateBedroomsRoute(propertyOwnership.id) +
-                            "/${BedroomsStep.ROUTE_SEGMENT}",
-                        withChangeLinks,
-                    )
+                    if (!isRestructureAndSkippingEnabled) {
+                        addBedroomsRow()
+                    }
                     addRow(
                         "propertyDetails.propertyRecord.tenancyAndRentalInformation.rentIncludesBills.rowName",
                         MessageKeyConverter.convert(propertyOwnership.rentIncludesBills),
@@ -167,7 +167,10 @@ class PropertyDetailsViewModel(
                     addRow(
                         "propertyDetails.propertyRecord.tenancyAndRentalInformation.rentFrequency.rowName",
                         // TODO PDJB-548 remove not-null assertion !! once occupancy is embedded in PropertyOwnership
-                        RentDataHelper.getRentFrequency(propertyOwnership.rentFrequency!!, propertyOwnership.customRentFrequency),
+                        RentDataHelper.getRentFrequency(
+                            propertyOwnership.rentFrequency!!,
+                            propertyOwnership.customRentFrequency,
+                        ),
                         changeLinkMessageKey,
                         UpdateRentFrequencyAndAmountController.getUpdateRentFrequencyAndAmountRoute(propertyOwnership.id) +
                             "/${RentFrequencyStep.ROUTE_SEGMENT}",
@@ -187,6 +190,17 @@ class PropertyDetailsViewModel(
                     )
                 }
             }.toList()
+
+    private fun MutableList<SummaryListRowViewModel>.addBedroomsRow() {
+        addRow(
+            "propertyDetails.propertyRecord.tenancyAndRentalInformation.numberOfBedrooms",
+            propertyOwnership.numBedrooms,
+            changeLinkMessageKey,
+            UpdateBedroomsController.getUpdateBedroomsRoute(propertyOwnership.id) +
+                "/${BedroomsStep.ROUTE_SEGMENT}",
+            withChangeLinks,
+        )
+    }
 
     private fun getIsTenantedKey(isOccupied: Boolean): String =
         when (isOccupied) {

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/controllers/PropertyDetailsControllerTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/controllers/PropertyDetailsControllerTests.kt
@@ -1,5 +1,6 @@
 package uk.gov.communities.prsdb.webapp.controllers
 
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.mockito.kotlin.any
 import org.mockito.kotlin.eq
@@ -11,6 +12,10 @@ import org.springframework.security.test.context.support.WithMockUser
 import org.springframework.test.context.bean.override.mockito.MockitoBean
 import org.springframework.test.web.servlet.get
 import org.springframework.web.context.WebApplicationContext
+import uk.gov.communities.prsdb.webapp.config.managers.FeatureFlagManager
+import uk.gov.communities.prsdb.webapp.constants.PROPERTY_REGISTRATION_RESTRUCTURE_AND_SKIPPING
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.BedroomsStep
+import uk.gov.communities.prsdb.webapp.models.viewModels.summaryModels.PropertyDetailsViewModel
 import uk.gov.communities.prsdb.webapp.models.viewModels.summaryModels.propertyComplianceViewModels.PropertyComplianceViewModelFactory
 import uk.gov.communities.prsdb.webapp.services.AbsoluteUrlProvider
 import uk.gov.communities.prsdb.webapp.services.JointLandlordInvitationService
@@ -20,6 +25,8 @@ import uk.gov.communities.prsdb.webapp.testHelpers.mockObjects.MockLandlordData
 import uk.gov.communities.prsdb.webapp.testHelpers.mockObjects.MockLandlordData.Companion.createIndividualLandlord
 import uk.gov.communities.prsdb.webapp.testHelpers.mockObjects.MockLandlordData.Companion.createPropertyOwnership
 import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 
 @WebMvcTest(PropertyDetailsController::class)
 class PropertyDetailsControllerTests(
@@ -39,6 +46,14 @@ class PropertyDetailsControllerTests(
 
     @MockitoBean
     private lateinit var absoluteUrlProvider: AbsoluteUrlProvider
+
+    @MockitoBean
+    private lateinit var featureFlagManager: FeatureFlagManager
+
+    @BeforeEach
+    fun setUpFeatureFlag() {
+        whenever(featureFlagManager.checkFeature(PROPERTY_REGISTRATION_RESTRUCTURE_AND_SKIPPING)).thenReturn(false)
+    }
 
     @Nested
     inner class GetPropertyDetailsLandlordViewTests {
@@ -248,6 +263,38 @@ class PropertyDetailsControllerTests(
                 model { attribute("landlordCount", 2) }
             }
         }
+
+        @Test
+        @WithMockUser(roles = ["LANDLORD"])
+        fun `getPropertyDetails places bedrooms in property record with update action when restructure flag is enabled`() {
+            val propertyOwnership = createPropertyOwnership(numberOfBedrooms = 3)
+            val bedroomsHeading = "propertyDetails.propertyRecord.tenancyAndRentalInformation.numberOfBedrooms"
+
+            whenever(featureFlagManager.checkFeature(PROPERTY_REGISTRATION_RESTRUCTURE_AND_SKIPPING)).thenReturn(true)
+            whenever(propertyOwnershipService.getPropertyOwnershipIfAuthorizedUser(eq(propertyOwnership.id), any()))
+                .thenReturn(propertyOwnership)
+            whenever(jointLandlordInvitationService.getPendingAndExpiredInvitations(propertyOwnership))
+                .thenReturn(Pair(emptyList(), emptyList()))
+
+            val result =
+                mvc.get(PropertyDetailsController.getPropertyDetailsPath(propertyOwnership.id, isLocalCouncilView = false))
+                    .andExpect { status { isOk() } }
+                    .andReturn()
+            val viewModel = result.modelAndView!!.model["propertyDetails"] as PropertyDetailsViewModel
+            val propertyRecordHeadings = viewModel.propertyRecord.map { it.fieldHeading }
+            val bedroomsIndex = propertyRecordHeadings.indexOf(bedroomsHeading)
+
+            assertEquals(propertyRecordHeadings.indexOf("propertyDetails.propertyRecord.propertyType") + 1, bedroomsIndex)
+            assertEquals(
+                bedroomsIndex + 1,
+                propertyRecordHeadings.indexOf("propertyDetails.propertyRecord.ownershipType"),
+            )
+            assertFalse(viewModel.tenancyAndRentalInformation.any { it.fieldHeading == bedroomsHeading })
+            assertEquals(
+                UpdateBedroomsController.getUpdateBedroomsRoute(propertyOwnership.id) + "/${BedroomsStep.ROUTE_SEGMENT}",
+                viewModel.propertyRecord.single { it.fieldHeading == bedroomsHeading }.actions.single().url,
+            )
+        }
     }
 
     @Nested
@@ -303,6 +350,33 @@ class PropertyDetailsControllerTests(
             mvc.get(PropertyDetailsController.getPropertyDetailsPath(1L, isLocalCouncilView = true)).andExpect {
                 status { status { isOk() } }
             }
+        }
+
+        @Test
+        @WithMockUser(roles = ["LOCAL_COUNCIL_USER"])
+        fun `getPropertyDetailsLocalCouncilView places bedrooms in property record without actions when restructure flag is enabled`() {
+            val propertyOwnership = createPropertyOwnership(numberOfBedrooms = 3)
+            val bedroomsHeading = "propertyDetails.propertyRecord.tenancyAndRentalInformation.numberOfBedrooms"
+
+            whenever(featureFlagManager.checkFeature(PROPERTY_REGISTRATION_RESTRUCTURE_AND_SKIPPING)).thenReturn(true)
+            whenever(propertyOwnershipService.getPropertyOwnershipIfAuthorizedUser(eq(propertyOwnership.id), any()))
+                .thenReturn(propertyOwnership)
+
+            val result =
+                mvc.get(PropertyDetailsController.getPropertyDetailsPath(propertyOwnership.id, isLocalCouncilView = true))
+                    .andExpect { status { isOk() } }
+                    .andReturn()
+            val viewModel = result.modelAndView!!.model["propertyDetails"] as PropertyDetailsViewModel
+            val propertyRecordHeadings = viewModel.propertyRecord.map { it.fieldHeading }
+            val bedroomsIndex = propertyRecordHeadings.indexOf(bedroomsHeading)
+
+            assertEquals(propertyRecordHeadings.indexOf("propertyDetails.propertyRecord.propertyType") + 1, bedroomsIndex)
+            assertEquals(
+                bedroomsIndex + 1,
+                propertyRecordHeadings.indexOf("propertyDetails.propertyRecord.ownershipType"),
+            )
+            assertFalse(viewModel.tenancyAndRentalInformation.any { it.fieldHeading == bedroomsHeading })
+            assertEquals(0, viewModel.propertyRecord.single { it.fieldHeading == bedroomsHeading }.actions.size)
         }
     }
 

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/PropertyDetailsUpdateJourneyTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/PropertyDetailsUpdateJourneyTests.kt
@@ -455,6 +455,28 @@ class PropertyDetailsUpdateJourneyTests : IntegrationTestWithMutableData("data-l
                     assertThat(propertyDetailsPage.propertyDetailsSummaryList.numberOfBedroomsRow.value)
                         .containsText(newNumberOfBedrooms.toString())
                 }
+
+                @Test
+                fun `An unoccupied property can have its number of bedrooms updated on the standalone page`(page: Page) {
+                    val newNumberOfBedrooms = 4
+
+                    // Details page
+                    var propertyDetailsPage = navigator.goToPropertyDetailsLandlordView(vacantPropertyOwnershipId)
+                    assertThat(propertyDetailsPage.propertyDetailsSummaryList.numberOfBedroomsRow).isVisible()
+                    propertyDetailsPage.propertyDetailsSummaryList.numberOfBedroomsRow.clickFirstActionLinkAndWait()
+                    val updateNumberOfBedroomsPage =
+                        assertPageIs(page, NumberOfBedroomsFormPagePropertyDetailsUpdate::class, vacantPropertyUrlArguments)
+
+                    // Update number of bedrooms
+                    assertThat(updateNumberOfBedroomsPage.header).containsText("Update how many bedrooms are in your property")
+                    updateNumberOfBedroomsPage.submitNumOfBedrooms(newNumberOfBedrooms)
+                    propertyDetailsPage =
+                        assertPageIs(page, PropertyDetailsPageLandlordView::class, vacantPropertyUrlArguments)
+
+                    // Check change has occurred
+                    assertThat(propertyDetailsPage.propertyDetailsSummaryList.numberOfBedroomsRow.value)
+                        .containsText(newNumberOfBedrooms.toString())
+                }
             }
 
             @Nested

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/summaryModels/PropertyDetailsViewModelTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/summaryModels/PropertyDetailsViewModelTests.kt
@@ -7,7 +7,9 @@ import uk.gov.communities.prsdb.webapp.constants.enums.FurnishedStatus
 import uk.gov.communities.prsdb.webapp.constants.enums.LicensingType
 import uk.gov.communities.prsdb.webapp.constants.enums.PropertyType
 import uk.gov.communities.prsdb.webapp.constants.enums.RentFrequency
+import uk.gov.communities.prsdb.webapp.controllers.UpdateBedroomsController
 import uk.gov.communities.prsdb.webapp.database.entity.License
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.BedroomsStep
 import uk.gov.communities.prsdb.webapp.testHelpers.mockObjects.MockLandlordData.Companion.createAddress
 import uk.gov.communities.prsdb.webapp.testHelpers.mockObjects.MockLandlordData.Companion.createOccupiedPropertyOwnership
 import uk.gov.communities.prsdb.webapp.testHelpers.mockObjects.MockLandlordData.Companion.createPropertyOwnership
@@ -43,6 +45,155 @@ class PropertyDetailsViewModelTests {
 
         // Assert
         assertEquals(expectedHeaderList, headerList)
+    }
+
+    @Test
+    fun `Bedrooms are placed after property type and before ownership type when restructure is enabled for an unoccupied property`() {
+        val propertyOwnership = createPropertyOwnership(numberOfBedrooms = 3)
+
+        val viewModel =
+            PropertyDetailsViewModel(
+                propertyOwnership,
+                isRestructureAndSkippingEnabled = true,
+                messageSource = mockMessageSource,
+            )
+
+        assertEquals(
+            listOf(
+                "propertyDetails.propertyRecord.registrationDate",
+                "propertyDetails.propertyRecord.registrationNumber",
+                "propertyDetails.propertyRecord.address",
+                "propertyDetails.propertyRecord.localCouncil",
+                "propertyDetails.propertyRecord.propertyType",
+                "propertyDetails.propertyRecord.tenancyAndRentalInformation.numberOfBedrooms",
+                "propertyDetails.propertyRecord.ownershipType",
+            ),
+            viewModel.propertyRecord.map { it.fieldHeading },
+        )
+        assertNull(
+            viewModel.tenancyAndRentalInformation.firstOrNull {
+                it.fieldHeading == "propertyDetails.propertyRecord.tenancyAndRentalInformation.numberOfBedrooms"
+            },
+        )
+    }
+
+    @Test
+    fun `Bedrooms are placed between property and ownership type exactly once when restructure is enabled for an occupied property`() {
+        val propertyOwnership = createOccupiedPropertyOwnership()
+        val bedroomsHeading = "propertyDetails.propertyRecord.tenancyAndRentalInformation.numberOfBedrooms"
+
+        val viewModel =
+            PropertyDetailsViewModel(
+                propertyOwnership,
+                isRestructureAndSkippingEnabled = true,
+                messageSource = mockMessageSource,
+            )
+        val propertyRecordHeadings = viewModel.propertyRecord.map { it.fieldHeading }
+        val bedroomsIndex = propertyRecordHeadings.indexOf(bedroomsHeading)
+
+        assertEquals(
+            listOf(
+                "propertyDetails.propertyRecord.propertyType",
+                bedroomsHeading,
+                "propertyDetails.propertyRecord.ownershipType",
+            ),
+            propertyRecordHeadings.subList(bedroomsIndex - 1, bedroomsIndex + 2),
+        )
+        assertEquals(
+            1,
+            (viewModel.propertyRecord + viewModel.tenancyAndRentalInformation).count {
+                it.fieldHeading == bedroomsHeading
+            },
+        )
+    }
+
+    @Test
+    fun `Bedrooms row has the update bedrooms action when restructure and change links are enabled`() {
+        val propertyOwnership = createPropertyOwnership(id = 123, numberOfBedrooms = 3)
+
+        val viewModel =
+            PropertyDetailsViewModel(
+                propertyOwnership,
+                withChangeLinks = true,
+                isRestructureAndSkippingEnabled = true,
+                messageSource = mockMessageSource,
+            )
+
+        val bedroomsRow =
+            viewModel.propertyRecord.single {
+                it.fieldHeading == "propertyDetails.propertyRecord.tenancyAndRentalInformation.numberOfBedrooms"
+            }
+
+        assertEquals(
+            UpdateBedroomsController.getUpdateBedroomsRoute(propertyOwnership.id) + "/${BedroomsStep.ROUTE_SEGMENT}",
+            bedroomsRow.actions.single().url,
+        )
+    }
+
+    @Test
+    fun `Bedrooms row remains without actions when restructure is enabled and change links are disabled`() {
+        val propertyOwnership = createPropertyOwnership(numberOfBedrooms = 3)
+
+        val viewModel =
+            PropertyDetailsViewModel(
+                propertyOwnership,
+                withChangeLinks = false,
+                isRestructureAndSkippingEnabled = true,
+                messageSource = mockMessageSource,
+            )
+
+        val bedroomsRow =
+            viewModel.propertyRecord.single {
+                it.fieldHeading == "propertyDetails.propertyRecord.tenancyAndRentalInformation.numberOfBedrooms"
+            }
+
+        assertEquals(3, bedroomsRow.fieldValue)
+        assertEquals(emptyList<SummaryListRowActionsViewModel>(), bedroomsRow.actions)
+    }
+
+    @Test
+    fun `Bedrooms retain occupied tenancy placement and ordering when restructure is disabled`() {
+        val occupiedViewModel =
+            PropertyDetailsViewModel(
+                createOccupiedPropertyOwnership(),
+                isRestructureAndSkippingEnabled = false,
+                messageSource = mockMessageSource,
+            )
+        val unoccupiedViewModel =
+            PropertyDetailsViewModel(
+                createUnoccupiedPropertyOwnership(),
+                isRestructureAndSkippingEnabled = false,
+                messageSource = mockMessageSource,
+            )
+
+        assertEquals(
+            listOf(
+                "propertyDetails.propertyRecord.tenancyAndRentalInformation.occupied",
+                "propertyDetails.propertyRecord.tenancyAndRentalInformation.numberOfHouseholds.rowName",
+                "propertyDetails.propertyRecord.tenancyAndRentalInformation.numberOfPeople",
+                "propertyDetails.propertyRecord.tenancyAndRentalInformation.numberOfBedrooms",
+                "propertyDetails.propertyRecord.tenancyAndRentalInformation.rentIncludesBills.rowName",
+                "propertyDetails.propertyRecord.tenancyAndRentalInformation.billsIncluded",
+                "propertyDetails.propertyRecord.tenancyAndRentalInformation.furnishedStatus",
+                "propertyDetails.propertyRecord.tenancyAndRentalInformation.rentFrequency.rowName",
+                "propertyDetails.propertyRecord.tenancyAndRentalInformation.rentAmount",
+            ),
+            occupiedViewModel.tenancyAndRentalInformation.map { it.fieldHeading },
+        )
+        assertEquals(
+            listOf("propertyDetails.propertyRecord.tenancyAndRentalInformation.occupied"),
+            unoccupiedViewModel.tenancyAndRentalInformation.map { it.fieldHeading },
+        )
+        assertNull(
+            occupiedViewModel.propertyRecord.firstOrNull {
+                it.fieldHeading == "propertyDetails.propertyRecord.tenancyAndRentalInformation.numberOfBedrooms"
+            },
+        )
+        assertNull(
+            unoccupiedViewModel.propertyRecord.firstOrNull {
+                it.fieldHeading == "propertyDetails.propertyRecord.tenancyAndRentalInformation.numberOfBedrooms"
+            },
+        )
     }
 
     @Test
@@ -203,7 +354,8 @@ class PropertyDetailsViewModelTests {
     @Test
     fun `the correct message key are returned for occupancy tab and occupancy row value when property is unoccupied`() {
         val unoccupiedPropertyOwnership = createUnoccupiedPropertyOwnership()
-        val unoccupiedViewModel = PropertyDetailsViewModel(unoccupiedPropertyOwnership, messageSource = mockMessageSource)
+        val unoccupiedViewModel =
+            PropertyDetailsViewModel(unoccupiedPropertyOwnership, messageSource = mockMessageSource)
         val unoccupiedPropertyDetailsRow =
             unoccupiedViewModel.tenancyAndRentalInformation
                 .single { it.fieldHeading == "propertyDetails.propertyRecord.tenancyAndRentalInformation.occupied" }
@@ -274,7 +426,8 @@ class PropertyDetailsViewModelTests {
         val rentFrequency = RentFrequency.OTHER
         val customRentFrequency = "fortnightly"
         val rentAmount = BigDecimal(200)
-        val expectedRentAmount = "£$rentAmount Message for forms.checkPropertyAnswers.tenancyDetails.customFrequencyRentAmountSuffix"
+        val expectedRentAmount =
+            "£$rentAmount Message for forms.checkPropertyAnswers.tenancyDetails.customFrequencyRentAmountSuffix"
         val expectedBillsIncluded =
             "Message for forms.billsIncluded.checkbox.electricity, Message for forms.billsIncluded.checkbox.water, Cat sitting"
 
@@ -340,7 +493,8 @@ class PropertyDetailsViewModelTests {
             createPropertyOwnership(
                 license = License(LicensingType.NO_LICENSING, ""),
             )
-        val viewModelDeclaredNoLicense = PropertyDetailsViewModel(propertyOwnershipDeclaredNoLicense, messageSource = mockMessageSource)
+        val viewModelDeclaredNoLicense =
+            PropertyDetailsViewModel(propertyOwnershipDeclaredNoLicense, messageSource = mockMessageSource)
         val propertyRecordDeclaredNoLicense =
             viewModelDeclaredNoLicense.licensingInformation
                 .single { it.fieldHeading == "propertyDetails.propertyRecord.licensingInformation.licensingType" }
@@ -352,7 +506,8 @@ class PropertyDetailsViewModelTests {
 
         val propertyOwnershipNullLicense =
             createPropertyOwnership()
-        val viewModelNullLicense = PropertyDetailsViewModel(propertyOwnershipNullLicense, messageSource = mockMessageSource)
+        val viewModelNullLicense =
+            PropertyDetailsViewModel(propertyOwnershipNullLicense, messageSource = mockMessageSource)
         val propertyRecordNullLicense =
             viewModelNullLicense.licensingInformation
                 .single { it.fieldHeading == "propertyDetails.propertyRecord.licensingInformation.licensingType" }
@@ -419,7 +574,8 @@ class PropertyDetailsViewModelTests {
     fun `Property details hides null uprn if hideNullUprn is true`() {
         val propertyOwnership = createPropertyOwnership()
 
-        val viewModel = PropertyDetailsViewModel(propertyOwnership, hideNullUprn = true, messageSource = mockMessageSource)
+        val viewModel =
+            PropertyDetailsViewModel(propertyOwnership, hideNullUprn = true, messageSource = mockMessageSource)
 
         assertNull(viewModel.propertyRecord.firstOrNull { it.fieldHeading == "propertyDetails.propertyRecord.uprn" })
     }
@@ -428,7 +584,8 @@ class PropertyDetailsViewModelTests {
     fun `Property details declares null uprn unavailable if hideNullUprn is false`() {
         val propertyOwnership = createPropertyOwnership()
 
-        val viewModel = PropertyDetailsViewModel(propertyOwnership, hideNullUprn = false, messageSource = mockMessageSource)
+        val viewModel =
+            PropertyDetailsViewModel(propertyOwnership, hideNullUprn = false, messageSource = mockMessageSource)
 
         val uprnKey =
             viewModel.propertyRecord
@@ -446,7 +603,8 @@ class PropertyDetailsViewModelTests {
                 address = createAddress(uprn = 1234.toLong()),
             )
 
-        val viewModel = PropertyDetailsViewModel(propertyOwnership, withChangeLinks = true, messageSource = mockMessageSource)
+        val viewModel =
+            PropertyDetailsViewModel(propertyOwnership, withChangeLinks = true, messageSource = mockMessageSource)
 
         val propertyRecordChangeLinkCount = viewModel.propertyRecord.count { it.actions.isNotEmpty() }
 
@@ -454,7 +612,8 @@ class PropertyDetailsViewModelTests {
 
         val tenancyInformationChangeLinkCount = viewModel.tenancyAndRentalInformation.count { it.actions.isNotEmpty() }
 
-        val totalChangeLinkCount = propertyRecordChangeLinkCount + licensingInformationChangeLinkCount + tenancyInformationChangeLinkCount
+        val totalChangeLinkCount =
+            propertyRecordChangeLinkCount + licensingInformationChangeLinkCount + tenancyInformationChangeLinkCount
 
         assertEquals(8, totalChangeLinkCount)
     }
@@ -467,7 +626,8 @@ class PropertyDetailsViewModelTests {
                 address = createAddress(uprn = 1234.toLong()),
             )
 
-        val viewModel = PropertyDetailsViewModel(propertyOwnership, withChangeLinks = false, messageSource = mockMessageSource)
+        val viewModel =
+            PropertyDetailsViewModel(propertyOwnership, withChangeLinks = false, messageSource = mockMessageSource)
 
         val propertyRecordChangeLinkCount = viewModel.propertyRecord.count { it.actions.isNotEmpty() }
 
@@ -475,7 +635,8 @@ class PropertyDetailsViewModelTests {
 
         val tenancyInformationChangeLinkCount = viewModel.tenancyAndRentalInformation.count { it.actions.isNotEmpty() }
 
-        val totalChangeLinkCount = propertyRecordChangeLinkCount + licensingInformationChangeLinkCount + tenancyInformationChangeLinkCount
+        val totalChangeLinkCount =
+            propertyRecordChangeLinkCount + licensingInformationChangeLinkCount + tenancyInformationChangeLinkCount
 
         assertEquals(0, totalChangeLinkCount)
     }


### PR DESCRIPTION
## Ticket number

PDJB-1353

## Goal of change

Make bedroom updates independent of occupancy in the restructured property record.

## Description of main change(s)

- Shows Number of bedrooms in Property details for occupied and unoccupied properties when the restructure flag is enabled.
- Keeps landlord updates on the existing one-page bedroom journey while local-council records remain read-only.
- Preserves the existing occupied tenancy placement when the flag is disabled.
- Adds view-model, controller, and journey coverage for the new placement and navigation.

## Anything you'd like to highlight to the reviewer?

This is PR 1 of 2. Occupancy journey, check-answers, and bedroom-preservation changes are intentionally deferred to PR 2.

## Checklist

- [x] Unit tests for new logic (e.g. new service methods) have been added
- [x] Test suite has been run in full locally and is passing
- [x] Branch has been rebased onto main and run locally, with everything working as expected (both for your new feature and any related functionality)
- [x] TODO comments referencing this JIRA ticket have been searched for and removed - if a future PR will address them, mention that here
- [x] This feature is behind a feature flag. I've checked that there will be no change in function if the feature flag is disabled

The full integration suite was not run. Post-rebase verification passed `testWithoutIntegration --rerun-tasks`, the targeted `PropertyDetailsUpdateJourneyTests --rerun-tasks`, `ktlintCheck`, the IntelliJ build, and focused landlord/local-council smoke tests.
