### PR TITLE
PDJB-1353: Decouple bedrooms from occupancy updates

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/PropertyDetailsController.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/PropertyDetailsController.kt
@@ -12,11 +12,13 @@ import org.springframework.web.servlet.mvc.support.RedirectAttributes
 import org.springframework.web.util.UriTemplate
 import uk.gov.communities.prsdb.webapp.annotations.webAnnotations.PrsdbController
 import uk.gov.communities.prsdb.webapp.config.interceptors.BackLinkInterceptor.Companion.overrideBackLinkForUrl
+import uk.gov.communities.prsdb.webapp.config.managers.FeatureFlagManager
 import uk.gov.communities.prsdb.webapp.constants.COMPLIANCE_INFO_FRAGMENT
 import uk.gov.communities.prsdb.webapp.constants.LANDLORD_DETAILS_FRAGMENT
 import uk.gov.communities.prsdb.webapp.constants.LANDLORD_PATH_SEGMENT
 import uk.gov.communities.prsdb.webapp.constants.LOCAL_COUNCIL_PATH_SEGMENT
 import uk.gov.communities.prsdb.webapp.constants.PROPERTY_DETAILS_SEGMENT
+import uk.gov.communities.prsdb.webapp.constants.PROPERTY_REGISTRATION_RESTRUCTURE_AND_SKIPPING
 import uk.gov.communities.prsdb.webapp.constants.REMOVE_EXPIRED_INVITE_PATH_SEGMENT
 import uk.gov.communities.prsdb.webapp.controllers.LandlordController.Companion.LANDLORD_DASHBOARD_URL
 import uk.gov.communities.prsdb.webapp.controllers.LocalCouncilDashboardController.Companion.LOCAL_COUNCIL_DASHBOARD_URL
@@ -41,6 +43,7 @@ class PropertyDetailsController(
     private val messageSource: MessageSource,
     private val jointLandlordInvitationService: JointLandlordInvitationService,
     private val absoluteUrlProvider: AbsoluteUrlProvider,
+    private val featureFlagManager: FeatureFlagManager,
 ) {
     @PreAuthorize("hasRole('LANDLORD')")
     @GetMapping(LANDLORD_PROPERTY_DETAILS_ROUTE)
@@ -57,6 +60,8 @@ class PropertyDetailsController(
                 propertyOwnership = propertyOwnership,
                 withChangeLinks = true,
                 hideNullUprn = true,
+                isRestructureAndSkippingEnabled =
+                    featureFlagManager.checkFeature(PROPERTY_REGISTRATION_RESTRUCTURE_AND_SKIPPING),
                 messageSource = messageSource,
             )
 
@@ -148,6 +153,8 @@ class PropertyDetailsController(
                 propertyOwnership = propertyOwnership,
                 withChangeLinks = false,
                 hideNullUprn = false,
+                isRestructureAndSkippingEnabled =
+                    featureFlagManager.checkFeature(PROPERTY_REGISTRATION_RESTRUCTURE_AND_SKIPPING),
                 messageSource = messageSource,
             )
 

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/tasks/OccupationTask.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/tasks/OccupationTask.kt
@@ -1,6 +1,8 @@
 package uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks
 
 import uk.gov.communities.prsdb.webapp.annotations.webAnnotations.JourneyFrameworkComponent
+import uk.gov.communities.prsdb.webapp.config.managers.FeatureFlagManager
+import uk.gov.communities.prsdb.webapp.constants.PROPERTY_REGISTRATION_RESTRUCTURE_AND_SKIPPING
 import uk.gov.communities.prsdb.webapp.journeys.OrParents
 import uk.gov.communities.prsdb.webapp.journeys.Task
 import uk.gov.communities.prsdb.webapp.journeys.hasOutcome
@@ -13,21 +15,30 @@ import uk.gov.communities.prsdb.webapp.journeys.shared.Complete
 import uk.gov.communities.prsdb.webapp.journeys.shared.YesOrNo
 
 @JourneyFrameworkComponent
-class OccupationTaskWithProvideLaterAllowed : OccupationTask() {
+class OccupationTaskWithProvideLaterAllowed(
+    featureFlagManager: FeatureFlagManager,
+) : OccupationTask(featureFlagManager) {
     override val householdsAndTenantsDependencies = HouseHoldsAndTenantsDependencies(true)
 }
 
 @JourneyFrameworkComponent
-class OccupationTaskWithOccupationRequired : OccupationTask() {
+class OccupationTaskWithOccupationRequired(
+    featureFlagManager: FeatureFlagManager,
+) : OccupationTask(featureFlagManager) {
     override val householdsAndTenantsDependencies = HouseHoldsAndTenantsDependencies(false)
 }
 
-abstract class OccupationTask : Task<OccupationState>() {
+abstract class OccupationTask(
+    private val featureFlagManager: FeatureFlagManager,
+) : Task<OccupationState>() {
     // TODO PDJB-896: Remerge the three versions of occupation task when this class uses DuplicableTaskWithDependencies
     abstract val householdsAndTenantsDependencies: HouseHoldsAndTenantsDependencies
 
     override fun makeSubJourney(state: OccupationState) =
         subJourney(state) {
+            val isRestructureAndSkippingEnabled =
+                featureFlagManager.checkFeature(PROPERTY_REGISTRATION_RESTRUCTURE_AND_SKIPPING)
+
             step(journey.occupied) {
                 routeSegment(OccupiedStep.ROUTE_SEGMENT)
                 nextStep { mode ->
@@ -41,17 +52,31 @@ abstract class OccupationTask : Task<OccupationState>() {
             duplicableTask(journey.householdsAndTenantsTask) {
                 parents { journey.occupied.hasOutcome(YesOrNo.YES) }
                 withDependencies { householdsAndTenantsDependencies }
-                nextStep { journey.bedrooms }
+                nextStep {
+                    if (isRestructureAndSkippingEnabled) {
+                        journey.rentIncludesBillsTask.firstStep
+                    } else {
+                        journey.bedrooms
+                    }
+                }
                 savable()
             }
-            step(journey.bedrooms) {
-                routeSegment(BedroomsStep.ROUTE_SEGMENT)
-                parents { journey.householdsAndTenantsTask.isComplete() }
-                nextStep { journey.rentIncludesBillsTask.firstStep }
-                savable()
+            if (!isRestructureAndSkippingEnabled) {
+                step(journey.bedrooms) {
+                    routeSegment(BedroomsStep.ROUTE_SEGMENT)
+                    parents { journey.householdsAndTenantsTask.isComplete() }
+                    nextStep { journey.rentIncludesBillsTask.firstStep }
+                    savable()
+                }
             }
             duplicableTask(journey.rentIncludesBillsTask) {
-                parents { journey.bedrooms.hasOutcome(Complete.COMPLETE) }
+                parents {
+                    if (isRestructureAndSkippingEnabled) {
+                        journey.householdsAndTenantsTask.isComplete()
+                    } else {
+                        journey.bedrooms.hasOutcome(Complete.COMPLETE)
+                    }
+                }
                 nextStep { journey.furnishedStatus }
             }
             step(journey.furnishedStatus) {

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/update/occupancy/UpdateOccupancyCyaConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/update/occupancy/UpdateOccupancyCyaConfig.kt
@@ -4,6 +4,8 @@ import kotlinx.datetime.Instant
 import kotlinx.datetime.toJavaInstant
 import org.springframework.context.MessageSource
 import uk.gov.communities.prsdb.webapp.annotations.webAnnotations.JourneyFrameworkComponent
+import uk.gov.communities.prsdb.webapp.config.managers.FeatureFlagManager
+import uk.gov.communities.prsdb.webapp.constants.PROPERTY_REGISTRATION_RESTRUCTURE_AND_SKIPPING
 import uk.gov.communities.prsdb.webapp.exceptions.NotNullFormModelValueIsNullException.Companion.notNullValue
 import uk.gov.communities.prsdb.webapp.exceptions.UpdateConflictException
 import uk.gov.communities.prsdb.webapp.journeys.shared.helpers.OccupancyDetailsHelper
@@ -22,14 +24,23 @@ class UpdateOccupancyCyaConfig(
     private val propertyOwnershipService: PropertyOwnershipService,
     private val messageSource: MessageSource,
     private val propertyUpdateEmailService: PropertyUpdateEmailService,
+    private val featureFlagManager: FeatureFlagManager,
 ) : AbstractCheckYourAnswersStepConfig<UpdateOccupancyJourneyState>() {
-    override fun getStepSpecificContent(state: UpdateOccupancyJourneyState): Map<String, Any?> =
-        mapOf(
+    override fun getStepSpecificContent(state: UpdateOccupancyJourneyState): Map<String, Any?> {
+        val isRestructureAndSkippingEnabled =
+            featureFlagManager.checkFeature(PROPERTY_REGISTRATION_RESTRUCTURE_AND_SKIPPING)
+
+        return mapOf(
             "title" to "propertyDetails.update.title",
             "showWarning" to true,
             "submitButtonText" to "forms.buttons.confirmAndSubmitUpdate",
             "insetText" to true,
-            "summaryListData" to occupancyDetailsHelper.getCheckYourAnswersSummaryList(state, messageSource),
+            "summaryListData" to
+                if (isRestructureAndSkippingEnabled) {
+                    occupancyDetailsHelper.getRestructuredCheckYourAnswersSummaryList(state, messageSource)
+                } else {
+                    occupancyDetailsHelper.getCheckYourAnswersSummaryList(state, messageSource)
+                },
             "summaryName" to
                 if (isOccupied(state)) {
                     "forms.update.checkOccupancy.occupied.summaryName"
@@ -37,16 +48,17 @@ class UpdateOccupancyCyaConfig(
                     "forms.update.checkOccupancy.notOccupied.summaryName"
                 },
         )
+    }
 
     override fun afterStepDataIsAdded(state: UpdateOccupancyJourneyState) {
+        val isRestructureAndSkippingEnabled =
+            featureFlagManager.checkFeature(PROPERTY_REGISTRATION_RESTRUCTURE_AND_SKIPPING)
         val isOccupied = isOccupied(state)
         val billsIncludedDataModel = state.rentIncludesBillsTask.getBillsIncludedOrNull()
         try {
             propertyOwnershipService.updateOccupancy(
                 id = state.propertyId,
                 isOccupied = isOccupied,
-                // TODO PDJB-1304 - check which of these fields should still be updated when occupancy is updated.
-                //   For example, numBedrooms should no longer be set to null as that will be in the property details section
                 numberOfHouseholds =
                     if (isOccupied) {
                         state.householdsAndTenantsTask.households.formModel
@@ -64,7 +76,9 @@ class UpdateOccupancyCyaConfig(
                         0
                     },
                 numBedrooms =
-                    if (isOccupied) {
+                    if (isRestructureAndSkippingEnabled) {
+                        state.initialNumberOfBedrooms
+                    } else if (isOccupied) {
                         state.bedrooms.formModel
                             .notNullValue(NumberOfBedroomsFormModel::numberOfBedrooms)
                             .toInt()

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/update/occupancy/UpdateOccupancyJourneyFactory.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/update/occupancy/UpdateOccupancyJourneyFactory.kt
@@ -49,6 +49,7 @@ class UpdateOccupancyJourneyFactory(
             state.propertyId = propertyId
             state.lastModifiedDate = propertyOwnership.getMostRecentlyUpdated().toString()
             state.wasOccupied = propertyOwnership.isOccupied
+            state.initialNumberOfBedrooms = propertyOwnership.numBedrooms
             state.isStateInitialized = true
         }
 
@@ -232,6 +233,8 @@ class UpdateOccupancyJourney(
 
     override var wasOccupied: Boolean by delegateProvider.requiredImmutableDelegate("wasOccupied")
 
+    override var initialNumberOfBedrooms: Int? by delegateProvider.nullableDelegate("initialNumberOfBedrooms")
+
     override var cachedOccupied: Boolean? by delegateProvider.nullableDelegate("cachedOccupied")
 }
 
@@ -243,4 +246,5 @@ interface UpdateOccupancyJourneyState :
     val propertyId: Long
     val lastModifiedDate: String
     val wasOccupied: Boolean
+    val initialNumberOfBedrooms: Int?
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/summaryModels/PropertyDetailsViewModel.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/summaryModels/PropertyDetailsViewModel.kt
@@ -31,6 +31,7 @@ class PropertyDetailsViewModel(
     private val propertyOwnership: PropertyOwnership,
     private val withChangeLinks: Boolean = true,
     private val hideNullUprn: Boolean = true,
+    private val isRestructureAndSkippingEnabled: Boolean = false,
     private val messageSource: MessageSource,
 ) {
     val address: String = propertyOwnership.address.singleLineAddress
@@ -70,8 +71,12 @@ class PropertyDetailsViewModel(
                 )
                 addRow(
                     "propertyDetails.propertyRecord.propertyType",
-                    propertyOwnership.customPropertyType ?: MessageKeyConverter.convert(propertyOwnership.propertyBuildType),
+                    propertyOwnership.customPropertyType
+                        ?: MessageKeyConverter.convert(propertyOwnership.propertyBuildType),
                 )
+                if (isRestructureAndSkippingEnabled) {
+                    addBedroomsRow()
+                }
                 addRow(
                     "propertyDetails.propertyRecord.ownershipType",
                     MessageKeyConverter.convert(propertyOwnership.ownershipType),
@@ -130,14 +135,9 @@ class PropertyDetailsViewModel(
                         "propertyDetails.propertyRecord.tenancyAndRentalInformation.numberOfPeople",
                         propertyOwnership.currentNumTenants,
                     )
-                    addRow(
-                        "propertyDetails.propertyRecord.tenancyAndRentalInformation.numberOfBedrooms",
-                        propertyOwnership.numBedrooms,
-                        changeLinkMessageKey,
-                        UpdateBedroomsController.getUpdateBedroomsRoute(propertyOwnership.id) +
-                            "/${BedroomsStep.ROUTE_SEGMENT}",
-                        withChangeLinks,
-                    )
+                    if (!isRestructureAndSkippingEnabled) {
+                        addBedroomsRow()
+                    }
                     addRow(
                         "propertyDetails.propertyRecord.tenancyAndRentalInformation.rentIncludesBills.rowName",
                         MessageKeyConverter.convert(propertyOwnership.rentIncludesBills),
@@ -167,7 +167,10 @@ class PropertyDetailsViewModel(
                     addRow(
                         "propertyDetails.propertyRecord.tenancyAndRentalInformation.rentFrequency.rowName",
                         // TODO PDJB-548 remove not-null assertion !! once occupancy is embedded in PropertyOwnership
-                        RentDataHelper.getRentFrequency(propertyOwnership.rentFrequency!!, propertyOwnership.customRentFrequency),
+                        RentDataHelper.getRentFrequency(
+                            propertyOwnership.rentFrequency!!,
+                            propertyOwnership.customRentFrequency,
+                        ),
                         changeLinkMessageKey,
                         UpdateRentFrequencyAndAmountController.getUpdateRentFrequencyAndAmountRoute(propertyOwnership.id) +
                             "/${RentFrequencyStep.ROUTE_SEGMENT}",
@@ -187,6 +190,17 @@ class PropertyDetailsViewModel(
                     )
                 }
             }.toList()
+
+    private fun MutableList<SummaryListRowViewModel>.addBedroomsRow() {
+        addRow(
+            "propertyDetails.propertyRecord.tenancyAndRentalInformation.numberOfBedrooms",
+            propertyOwnership.numBedrooms,
+            changeLinkMessageKey,
+            UpdateBedroomsController.getUpdateBedroomsRoute(propertyOwnership.id) +
+                "/${BedroomsStep.ROUTE_SEGMENT}",
+            withChangeLinks,
+        )
+    }
 
     private fun getIsTenantedKey(isOccupied: Boolean): String =
         when (isOccupied) {

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/controllers/PropertyDetailsControllerTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/controllers/PropertyDetailsControllerTests.kt
@@ -1,5 +1,6 @@
 package uk.gov.communities.prsdb.webapp.controllers
 
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.mockito.kotlin.any
 import org.mockito.kotlin.eq
@@ -11,6 +12,10 @@ import org.springframework.security.test.context.support.WithMockUser
 import org.springframework.test.context.bean.override.mockito.MockitoBean
 import org.springframework.test.web.servlet.get
 import org.springframework.web.context.WebApplicationContext
+import uk.gov.communities.prsdb.webapp.config.managers.FeatureFlagManager
+import uk.gov.communities.prsdb.webapp.constants.PROPERTY_REGISTRATION_RESTRUCTURE_AND_SKIPPING
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.BedroomsStep
+import uk.gov.communities.prsdb.webapp.models.viewModels.summaryModels.PropertyDetailsViewModel
 import uk.gov.communities.prsdb.webapp.models.viewModels.summaryModels.propertyComplianceViewModels.PropertyComplianceViewModelFactory
 import uk.gov.communities.prsdb.webapp.services.AbsoluteUrlProvider
 import uk.gov.communities.prsdb.webapp.services.JointLandlordInvitationService
@@ -20,6 +25,8 @@ import uk.gov.communities.prsdb.webapp.testHelpers.mockObjects.MockLandlordData
 import uk.gov.communities.prsdb.webapp.testHelpers.mockObjects.MockLandlordData.Companion.createIndividualLandlord
 import uk.gov.communities.prsdb.webapp.testHelpers.mockObjects.MockLandlordData.Companion.createPropertyOwnership
 import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 
 @WebMvcTest(PropertyDetailsController::class)
 class PropertyDetailsControllerTests(
@@ -39,6 +46,14 @@ class PropertyDetailsControllerTests(
 
     @MockitoBean
     private lateinit var absoluteUrlProvider: AbsoluteUrlProvider
+
+    @MockitoBean
+    private lateinit var featureFlagManager: FeatureFlagManager
+
+    @BeforeEach
+    fun setUpFeatureFlag() {
+        whenever(featureFlagManager.checkFeature(PROPERTY_REGISTRATION_RESTRUCTURE_AND_SKIPPING)).thenReturn(false)
+    }
 
     @Nested
     inner class GetPropertyDetailsLandlordViewTests {
@@ -248,6 +263,38 @@ class PropertyDetailsControllerTests(
                 model { attribute("landlordCount", 2) }
             }
         }
+
+        @Test
+        @WithMockUser(roles = ["LANDLORD"])
+        fun `getPropertyDetails places bedrooms in property record with update action when restructure flag is enabled`() {
+            val propertyOwnership = createPropertyOwnership(numberOfBedrooms = 3)
+            val bedroomsHeading = "propertyDetails.propertyRecord.tenancyAndRentalInformation.numberOfBedrooms"
+
+            whenever(featureFlagManager.checkFeature(PROPERTY_REGISTRATION_RESTRUCTURE_AND_SKIPPING)).thenReturn(true)
+            whenever(propertyOwnershipService.getPropertyOwnershipIfAuthorizedUser(eq(propertyOwnership.id), any()))
+                .thenReturn(propertyOwnership)
+            whenever(jointLandlordInvitationService.getPendingAndExpiredInvitations(propertyOwnership))
+                .thenReturn(Pair(emptyList(), emptyList()))
+
+            val result =
+                mvc.get(PropertyDetailsController.getPropertyDetailsPath(propertyOwnership.id, isLocalCouncilView = false))
+                    .andExpect { status { isOk() } }
+                    .andReturn()
+            val viewModel = result.modelAndView!!.model["propertyDetails"] as PropertyDetailsViewModel
+            val propertyRecordHeadings = viewModel.propertyRecord.map { it.fieldHeading }
+            val bedroomsIndex = propertyRecordHeadings.indexOf(bedroomsHeading)
+
+            assertEquals(propertyRecordHeadings.indexOf("propertyDetails.propertyRecord.propertyType") + 1, bedroomsIndex)
+            assertEquals(
+                bedroomsIndex + 1,
+                propertyRecordHeadings.indexOf("propertyDetails.propertyRecord.ownershipType"),
+            )
+            assertFalse(viewModel.tenancyAndRentalInformation.any { it.fieldHeading == bedroomsHeading })
+            assertEquals(
+                UpdateBedroomsController.getUpdateBedroomsRoute(propertyOwnership.id) + "/${BedroomsStep.ROUTE_SEGMENT}",
+                viewModel.propertyRecord.single { it.fieldHeading == bedroomsHeading }.actions.single().url,
+            )
+        }
     }
 
     @Nested
@@ -303,6 +350,33 @@ class PropertyDetailsControllerTests(
             mvc.get(PropertyDetailsController.getPropertyDetailsPath(1L, isLocalCouncilView = true)).andExpect {
                 status { status { isOk() } }
             }
+        }
+
+        @Test
+        @WithMockUser(roles = ["LOCAL_COUNCIL_USER"])
+        fun `getPropertyDetailsLocalCouncilView places bedrooms in property record without actions when restructure flag is enabled`() {
+            val propertyOwnership = createPropertyOwnership(numberOfBedrooms = 3)
+            val bedroomsHeading = "propertyDetails.propertyRecord.tenancyAndRentalInformation.numberOfBedrooms"
+
+            whenever(featureFlagManager.checkFeature(PROPERTY_REGISTRATION_RESTRUCTURE_AND_SKIPPING)).thenReturn(true)
+            whenever(propertyOwnershipService.getPropertyOwnershipIfAuthorizedUser(eq(propertyOwnership.id), any()))
+                .thenReturn(propertyOwnership)
+
+            val result =
+                mvc.get(PropertyDetailsController.getPropertyDetailsPath(propertyOwnership.id, isLocalCouncilView = true))
+                    .andExpect { status { isOk() } }
+                    .andReturn()
+            val viewModel = result.modelAndView!!.model["propertyDetails"] as PropertyDetailsViewModel
+            val propertyRecordHeadings = viewModel.propertyRecord.map { it.fieldHeading }
+            val bedroomsIndex = propertyRecordHeadings.indexOf(bedroomsHeading)
+
+            assertEquals(propertyRecordHeadings.indexOf("propertyDetails.propertyRecord.propertyType") + 1, bedroomsIndex)
+            assertEquals(
+                bedroomsIndex + 1,
+                propertyRecordHeadings.indexOf("propertyDetails.propertyRecord.ownershipType"),
+            )
+            assertFalse(viewModel.tenancyAndRentalInformation.any { it.fieldHeading == bedroomsHeading })
+            assertEquals(0, viewModel.propertyRecord.single { it.fieldHeading == bedroomsHeading }.actions.size)
         }
     }
 

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/PropertyDetailsUpdateJourneyTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/PropertyDetailsUpdateJourneyTests.kt
@@ -455,6 +455,28 @@ class PropertyDetailsUpdateJourneyTests : IntegrationTestWithMutableData("data-l
                     assertThat(propertyDetailsPage.propertyDetailsSummaryList.numberOfBedroomsRow.value)
                         .containsText(newNumberOfBedrooms.toString())
                 }
+
+                @Test
+                fun `An unoccupied property can have its number of bedrooms updated on the standalone page`(page: Page) {
+                    val newNumberOfBedrooms = 4
+
+                    // Details page
+                    var propertyDetailsPage = navigator.goToPropertyDetailsLandlordView(vacantPropertyOwnershipId)
+                    assertThat(propertyDetailsPage.propertyDetailsSummaryList.numberOfBedroomsRow).isVisible()
+                    propertyDetailsPage.propertyDetailsSummaryList.numberOfBedroomsRow.clickFirstActionLinkAndWait()
+                    val updateNumberOfBedroomsPage =
+                        assertPageIs(page, NumberOfBedroomsFormPagePropertyDetailsUpdate::class, vacantPropertyUrlArguments)
+
+                    // Update number of bedrooms
+                    assertThat(updateNumberOfBedroomsPage.header).containsText("Update how many bedrooms are in your property")
+                    updateNumberOfBedroomsPage.submitNumOfBedrooms(newNumberOfBedrooms)
+                    propertyDetailsPage =
+                        assertPageIs(page, PropertyDetailsPageLandlordView::class, vacantPropertyUrlArguments)
+
+                    // Check change has occurred
+                    assertThat(propertyDetailsPage.propertyDetailsSummaryList.numberOfBedroomsRow.value)
+                        .containsText(newNumberOfBedrooms.toString())
+                }
             }
 
             @Nested

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/PropertyDetailsUpdateJourneyTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/PropertyDetailsUpdateJourneyTests.kt
@@ -247,6 +247,10 @@ class PropertyDetailsUpdateJourneyTests : IntegrationTestWithMutableData("data-l
                 fun `A property can have its occupancy updated from occupied to vacant`(page: Page) {
                     // Details page
                     var propertyDetailsPage = navigator.goToPropertyDetailsLandlordView(occupiedPropertyOwnershipId)
+                    assertThat(propertyDetailsPage.propertyDetailsSummaryList.numberOfBedroomsRow).isVisible()
+                    val originalNumberOfBedrooms =
+                        propertyDetailsPage.propertyDetailsSummaryList.numberOfBedroomsRow.value.textContent()
+                    assertThat(propertyDetailsPage.propertyDetailsSummaryList.numberOfBedroomsRow.value).containsText("1")
                     propertyDetailsPage.propertyDetailsSummaryList.occupancyRow.clickFirstActionLinkAndWait()
                     val updateOccupancyPage =
                         assertPageIs(page, OccupancyFormPagePropertyDetailsUpdate::class, occupiedPropertyUrlArguments)
@@ -266,47 +270,58 @@ class PropertyDetailsUpdateJourneyTests : IntegrationTestWithMutableData("data-l
 
                     // Check changes have occurred
                     assertThat(propertyDetailsPage.propertyDetailsSummaryList.occupancyRow.value).containsText("No")
+                    assertThat(propertyDetailsPage.propertyDetailsSummaryList.numberOfBedroomsRow).isVisible()
+                    assertThat(propertyDetailsPage.propertyDetailsSummaryList.numberOfBedroomsRow.value)
+                        .containsText(originalNumberOfBedrooms)
                 }
 
                 @Test
                 fun `A property can have its occupancy updated from vacant to occupied`(page: Page) {
-                    // Details page
-                    var propertyDetailsPage = navigator.goToPropertyDetailsLandlordView(vacantPropertyOwnershipId)
+                    var propertyDetailsPage = navigator.goToPropertyDetailsLandlordView(occupiedPropertyOwnershipId)
                     propertyDetailsPage.propertyDetailsSummaryList.occupancyRow.clickFirstActionLinkAndWait()
-                    val updateOccupancyPage = assertPageIs(page, OccupancyFormPagePropertyDetailsUpdate::class, vacantPropertyUrlArguments)
+                    val updateOccupancyToVacantPage =
+                        assertPageIs(page, OccupancyFormPagePropertyDetailsUpdate::class, occupiedPropertyUrlArguments)
+                    updateOccupancyToVacantPage.submitIsVacant()
+                    val checkVacantOccupancyAnswersPage =
+                        assertPageIs(page, CheckOccupancyAnswersPagePropertyDetailsUpdate::class, occupiedPropertyUrlArguments)
+                    checkVacantOccupancyAnswersPage.confirm()
+
+                    // Details page
+                    propertyDetailsPage = assertPageIs(page, PropertyDetailsPageLandlordView::class, occupiedPropertyUrlArguments)
+                    assertThat(propertyDetailsPage.propertyDetailsSummaryList.occupancyRow.value).containsText("No")
+                    assertThat(propertyDetailsPage.propertyDetailsSummaryList.numberOfBedroomsRow).isVisible()
+                    val originalNumberOfBedrooms =
+                        propertyDetailsPage.propertyDetailsSummaryList.numberOfBedroomsRow.value.textContent()
+                    assertThat(propertyDetailsPage.propertyDetailsSummaryList.numberOfBedroomsRow.value).containsText("1")
+                    propertyDetailsPage.propertyDetailsSummaryList.occupancyRow.clickFirstActionLinkAndWait()
+                    val updateOccupancyPage =
+                        assertPageIs(page, OccupancyFormPagePropertyDetailsUpdate::class, occupiedPropertyUrlArguments)
 
                     // Update occupancy to occupied
                     assertThat(updateOccupancyPage.form.fieldsetHeading).containsText("Update whether your property is occupied by tenants")
                     updateOccupancyPage.submitIsOccupied()
                     val updateNumberOfHouseholdsPage =
-                        assertPageIs(page, OccupancyNumberOfHouseholdsFormPagePropertyDetailsUpdate::class, vacantPropertyUrlArguments)
+                        assertPageIs(page, OccupancyNumberOfHouseholdsFormPagePropertyDetailsUpdate::class, occupiedPropertyUrlArguments)
 
                     // Update number of households
                     val newNumberOfHouseholds = 1
                     assertThat(updateNumberOfHouseholdsPage.header).containsText("Households in your property")
                     updateNumberOfHouseholdsPage.submitNumberOfHouseholds(newNumberOfHouseholds)
                     val updateNumberOfPeoplePage =
-                        assertPageIs(page, OccupancyNumberOfPeopleFormPagePropertyDetailsUpdate::class, vacantPropertyUrlArguments)
+                        assertPageIs(page, OccupancyNumberOfPeopleFormPagePropertyDetailsUpdate::class, occupiedPropertyUrlArguments)
 
                     // Update number of people
                     val newNumberOfPeople = 3
                     assertThat(updateNumberOfPeoplePage.header).containsText("Update how many people live in your property")
                     updateNumberOfPeoplePage.submitNumOfPeople(newNumberOfPeople)
-                    val bedroomsPage =
-                        assertPageIs(page, OccupancyNumberOfBedroomsFormPagePropertyDetailsUpdate::class, vacantPropertyUrlArguments)
-
-                    // Update number of bedrooms
-                    val newNumberOfBedrooms = 3
-                    assertThat(bedroomsPage.header).containsText("Update how many bedrooms are in your property")
-                    bedroomsPage.submitNumOfBedrooms(newNumberOfBedrooms)
                     val rentIncludesBillsPage =
-                        assertPageIs(page, OccupancyRentIncludesBillsFormPagePropertyDetailsUpdate::class, vacantPropertyUrlArguments)
+                        assertPageIs(page, OccupancyRentIncludesBillsFormPagePropertyDetailsUpdate::class, occupiedPropertyUrlArguments)
 
                     // Update rent include bills
                     assertThat(rentIncludesBillsPage.form.fieldsetHeading).containsText("Update whether the rent includes bills")
                     rentIncludesBillsPage.submitIsIncluded()
                     val billsIncludedPage =
-                        assertPageIs(page, OccupancyBillsIncludedFormPagePropertyDetailsUpdate::class, vacantPropertyUrlArguments)
+                        assertPageIs(page, OccupancyBillsIncludedFormPagePropertyDetailsUpdate::class, occupiedPropertyUrlArguments)
 
                     // Update bills included
                     val expectedBillsIncluded = "Gas, Electricity, Water"
@@ -314,7 +329,7 @@ class PropertyDetailsUpdateJourneyTests : IntegrationTestWithMutableData("data-l
                     billsIncludedPage.selectGasElectricityWater()
                     billsIncludedPage.form.submit()
                     val furnishedPage =
-                        assertPageIs(page, OccupancyFurnishedStatusFormPagePropertyDetailsUpdate::class, vacantPropertyUrlArguments)
+                        assertPageIs(page, OccupancyFurnishedStatusFormPagePropertyDetailsUpdate::class, occupiedPropertyUrlArguments)
 
                     // Update furnished status
                     val expectedFurnishedStatus = "Furnished"
@@ -323,7 +338,7 @@ class PropertyDetailsUpdateJourneyTests : IntegrationTestWithMutableData("data-l
                     ).containsText("Update is the property furnished")
                     furnishedPage.submitFurnishedStatus(FurnishedStatus.FURNISHED)
                     val rentFrequencyPage =
-                        assertPageIs(page, OccupancyRentFrequencyFormPagePropertyDetailsUpdate::class, vacantPropertyUrlArguments)
+                        assertPageIs(page, OccupancyRentFrequencyFormPagePropertyDetailsUpdate::class, occupiedPropertyUrlArguments)
 
                     // Update rent frequency
                     val expectedRentFrequency = "Weekly"
@@ -331,26 +346,26 @@ class PropertyDetailsUpdateJourneyTests : IntegrationTestWithMutableData("data-l
                     rentFrequencyPage.selectRentFrequency(RentFrequency.WEEKLY)
                     rentFrequencyPage.form.submit()
                     val rentAmountPage =
-                        assertPageIs(page, OccupancyRentAmountFormPagePropertyDetailsUpdate::class, vacantPropertyUrlArguments)
+                        assertPageIs(page, OccupancyRentAmountFormPagePropertyDetailsUpdate::class, occupiedPropertyUrlArguments)
 
                     // Update rent amount
                     val expectedRentAmount = "£400"
                     assertThat(rentAmountPage.header).containsText("Update your weekly rent")
                     rentAmountPage.submitRentAmount("400")
                     val checkOccupancyAnswersPage =
-                        assertPageIs(page, CheckOccupancyAnswersPagePropertyDetailsUpdate::class, vacantPropertyUrlArguments)
+                        assertPageIs(page, CheckOccupancyAnswersPagePropertyDetailsUpdate::class, occupiedPropertyUrlArguments)
                     // Check occupancy answers
                     assertThat(checkOccupancyAnswersPage.summaryList.occupancyRow).containsText("Yes")
                     assertThat(checkOccupancyAnswersPage.summaryList.numberOfHouseholdsRow).containsText(newNumberOfHouseholds.toString())
                     assertThat(checkOccupancyAnswersPage.summaryList.numberOfPeopleRow).containsText(newNumberOfPeople.toString())
-                    assertThat(checkOccupancyAnswersPage.summaryList.numberOfBedroomsRow).containsText(newNumberOfBedrooms.toString())
+                    assertThat(checkOccupancyAnswersPage.summaryList.numberOfBedroomsRow).isHidden()
                     assertThat(checkOccupancyAnswersPage.summaryList.rentIncludesBillsRow).containsText("Yes")
                     assertThat(checkOccupancyAnswersPage.summaryList.billsIncludedRow).containsText(expectedBillsIncluded)
                     assertThat(checkOccupancyAnswersPage.summaryList.furnishedStatusRow).containsText(expectedFurnishedStatus)
                     assertThat(checkOccupancyAnswersPage.summaryList.rentFrequencyRow).containsText(expectedRentFrequency)
                     assertThat(checkOccupancyAnswersPage.summaryList.rentAmountRow).containsText(expectedRentAmount)
                     checkOccupancyAnswersPage.confirm()
-                    propertyDetailsPage = assertPageIs(page, PropertyDetailsPageLandlordView::class, vacantPropertyUrlArguments)
+                    propertyDetailsPage = assertPageIs(page, PropertyDetailsPageLandlordView::class, occupiedPropertyUrlArguments)
 
                     // Check changes have occurred
                     assertThat(propertyDetailsPage.propertyDetailsSummaryList.occupancyRow.value).containsText("Yes")
@@ -358,8 +373,9 @@ class PropertyDetailsUpdateJourneyTests : IntegrationTestWithMutableData("data-l
                         .containsText(newNumberOfHouseholds.toString())
                     assertThat(propertyDetailsPage.propertyDetailsSummaryList.numberOfPeopleRow.value)
                         .containsText(newNumberOfPeople.toString())
+                    assertThat(propertyDetailsPage.propertyDetailsSummaryList.numberOfBedroomsRow).isVisible()
                     assertThat(propertyDetailsPage.propertyDetailsSummaryList.numberOfBedroomsRow.value)
-                        .containsText(newNumberOfBedrooms.toString())
+                        .containsText(originalNumberOfBedrooms)
                     assertThat(propertyDetailsPage.propertyDetailsSummaryList.rentIncludesBillsRow.value).containsText("Yes")
                     assertThat(propertyDetailsPage.propertyDetailsSummaryList.billsIncludedRow.value).containsText(expectedBillsIncluded)
                     assertThat(
@@ -908,6 +924,7 @@ class PropertyDetailsUpdateJourneyTests : IntegrationTestWithMutableData("data-l
 
                     // Check changes have occurred
                     assertThat(propertyDetailsPage.propertyDetailsSummaryList.occupancyRow.value).containsText("No")
+                    assertThat(propertyDetailsPage.propertyDetailsSummaryList.numberOfBedroomsRow).isHidden()
                 }
 
                 @Test

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/UpdateOccupancyCyaConfigTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/UpdateOccupancyCyaConfigTests.kt
@@ -10,9 +10,12 @@ import org.mockito.Mock
 import org.mockito.Mockito.lenient
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.eq
+import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.springframework.context.MessageSource
+import uk.gov.communities.prsdb.webapp.config.managers.FeatureFlagManager
+import uk.gov.communities.prsdb.webapp.constants.PROPERTY_REGISTRATION_RESTRUCTURE_AND_SKIPPING
 import uk.gov.communities.prsdb.webapp.exceptions.UpdateConflictException
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.BedroomsStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.BillsIncludedStep
@@ -50,6 +53,9 @@ class UpdateOccupancyCyaConfigTests {
 
     @Mock
     private lateinit var mockMessageSource: MessageSource
+
+    @Mock
+    private lateinit var mockFeatureFlagManager: FeatureFlagManager
 
     @Mock
     private lateinit var mockPropertyUpdateEmailService: PropertyUpdateEmailService
@@ -113,6 +119,7 @@ class UpdateOccupancyCyaConfigTests {
 
     private val propertyId = 123L
     private val initialLastModifiedDate = Clock.System.now().toJavaInstant()
+    private val initialNumberOfBedrooms = 4
 
     @Mock
     private lateinit var stepConfig: UpdateOccupancyCyaConfig
@@ -125,12 +132,13 @@ class UpdateOccupancyCyaConfigTests {
                 propertyOwnershipService = mockPropertyOwnershipService,
                 messageSource = mockMessageSource,
                 propertyUpdateEmailService = mockPropertyUpdateEmailService,
+                featureFlagManager = mockFeatureFlagManager,
             )
         stepConfig.routeSegment = UpdateOccupancyCyaStep.ROUTE_SEGMENT
         stepConfig.validator = AlwaysTrueValidator()
         stepConfig.afterStepIsReached(mockState)
-        whenever(mockState.propertyId).thenReturn(propertyId)
-        whenever(mockState.lastModifiedDate).thenReturn(initialLastModifiedDate.toString())
+        lenient().`when`(mockState.propertyId).thenReturn(propertyId)
+        lenient().`when`(mockState.lastModifiedDate).thenReturn(initialLastModifiedDate.toString())
         whenever(mockState.occupied).thenReturn(mockOccupiedStep)
         whenever(mockOccupiedStep.formModel).thenReturn(mockOccupancyFormModel)
         whenever(mockOccupancyFormModel.occupied).thenReturn(true)
@@ -158,6 +166,132 @@ class UpdateOccupancyCyaConfigTests {
         lenient().`when`(mockRentFrequencyAndAmountTask.rentAmount).thenReturn(mockRentAmountStep)
         lenient().`when`(mockRentAmountStep.formModel).thenReturn(mockRentAmountFormModel)
         lenient().`when`(mockRentAmountFormModel.rentAmount).thenReturn("500")
+    }
+
+    @Test
+    fun `getStepSpecificContent uses the restructured summary when restructure and skipping is enabled`() {
+        whenever(
+            mockFeatureFlagManager.checkFeature(PROPERTY_REGISTRATION_RESTRUCTURE_AND_SKIPPING),
+        ).thenReturn(true)
+
+        stepConfig.getStepSpecificContent(mockState)
+
+        verify(mockOccupancyDetailsHelper)
+            .getRestructuredCheckYourAnswersSummaryList(mockState, mockMessageSource)
+        verify(mockOccupancyDetailsHelper, never())
+            .getCheckYourAnswersSummaryList(mockState, mockMessageSource)
+    }
+
+    @Test
+    fun `getStepSpecificContent uses the existing summary when restructure and skipping is disabled`() {
+        whenever(
+            mockFeatureFlagManager.checkFeature(PROPERTY_REGISTRATION_RESTRUCTURE_AND_SKIPPING),
+        ).thenReturn(false)
+
+        stepConfig.getStepSpecificContent(mockState)
+
+        verify(mockOccupancyDetailsHelper)
+            .getCheckYourAnswersSummaryList(mockState, mockMessageSource)
+        verify(mockOccupancyDetailsHelper, never())
+            .getRestructuredCheckYourAnswersSummaryList(mockState, mockMessageSource)
+    }
+
+    @Test
+    fun `afterStepDataIsAdded preserves bedrooms when restructure is enabled and occupancy changes from occupied to unoccupied`() {
+        whenever(
+            mockFeatureFlagManager.checkFeature(PROPERTY_REGISTRATION_RESTRUCTURE_AND_SKIPPING),
+        ).thenReturn(true)
+        whenever(mockState.wasOccupied).thenReturn(true)
+        whenever(mockOccupancyFormModel.occupied).thenReturn(false)
+        whenever(mockState.initialNumberOfBedrooms).thenReturn(initialNumberOfBedrooms)
+
+        stepConfig.afterStepDataIsAdded(mockState)
+
+        verifyOccupancyUpdate(
+            isOccupied = false,
+            numBedrooms = initialNumberOfBedrooms,
+        )
+    }
+
+    @Test
+    fun `afterStepDataIsAdded preserves bedrooms when restructure is enabled and occupancy changes from unoccupied to occupied`() {
+        whenever(
+            mockFeatureFlagManager.checkFeature(PROPERTY_REGISTRATION_RESTRUCTURE_AND_SKIPPING),
+        ).thenReturn(true)
+        whenever(mockState.wasOccupied).thenReturn(false)
+        whenever(mockOccupancyFormModel.occupied).thenReturn(true)
+        whenever(mockState.initialNumberOfBedrooms).thenReturn(initialNumberOfBedrooms)
+
+        stepConfig.afterStepDataIsAdded(mockState)
+
+        verifyOccupancyUpdate(
+            isOccupied = true,
+            numBedrooms = initialNumberOfBedrooms,
+        )
+    }
+
+    @Test
+    fun `afterStepDataIsAdded preserves bedrooms when restructure is enabled and property remains occupied`() {
+        whenever(
+            mockFeatureFlagManager.checkFeature(PROPERTY_REGISTRATION_RESTRUCTURE_AND_SKIPPING),
+        ).thenReturn(true)
+        whenever(mockState.wasOccupied).thenReturn(true)
+        whenever(mockOccupancyFormModel.occupied).thenReturn(true)
+        whenever(mockState.initialNumberOfBedrooms).thenReturn(initialNumberOfBedrooms)
+
+        stepConfig.afterStepDataIsAdded(mockState)
+
+        verifyOccupancyUpdate(
+            isOccupied = true,
+            numBedrooms = initialNumberOfBedrooms,
+        )
+    }
+
+    @Test
+    fun `afterStepDataIsAdded preserves bedrooms when restructure is enabled and property remains unoccupied`() {
+        whenever(
+            mockFeatureFlagManager.checkFeature(PROPERTY_REGISTRATION_RESTRUCTURE_AND_SKIPPING),
+        ).thenReturn(true)
+        whenever(mockState.wasOccupied).thenReturn(false)
+        whenever(mockOccupancyFormModel.occupied).thenReturn(false)
+        whenever(mockState.initialNumberOfBedrooms).thenReturn(initialNumberOfBedrooms)
+
+        stepConfig.afterStepDataIsAdded(mockState)
+
+        verifyOccupancyUpdate(
+            isOccupied = false,
+            numBedrooms = initialNumberOfBedrooms,
+        )
+    }
+
+    @Test
+    fun `afterStepDataIsAdded uses submitted bedrooms when restructure is disabled and property is occupied`() {
+        whenever(
+            mockFeatureFlagManager.checkFeature(PROPERTY_REGISTRATION_RESTRUCTURE_AND_SKIPPING),
+        ).thenReturn(false)
+        whenever(mockOccupancyFormModel.occupied).thenReturn(true)
+
+        stepConfig.afterStepDataIsAdded(mockState)
+
+        verifyOccupancyUpdate(
+            isOccupied = true,
+            numBedrooms = 3,
+        )
+    }
+
+    @Test
+    fun `afterStepDataIsAdded clears bedrooms when restructure is disabled and property is unoccupied`() {
+        whenever(
+            mockFeatureFlagManager.checkFeature(PROPERTY_REGISTRATION_RESTRUCTURE_AND_SKIPPING),
+        ).thenReturn(false)
+        whenever(mockOccupancyFormModel.occupied).thenReturn(false)
+
+        stepConfig.afterStepDataIsAdded(mockState)
+
+        verifyOccupancyUpdate(
+            isOccupied = false,
+            numBedrooms = null,
+        )
     }
 
     @Test
@@ -242,5 +376,25 @@ class UpdateOccupancyCyaConfigTests {
         assertThrows<UpdateConflictException> { stepConfig.afterStepDataIsAdded(mockState) }
 
         verify(mockState).deleteJourney()
+    }
+
+    private fun verifyOccupancyUpdate(
+        isOccupied: Boolean,
+        numBedrooms: Int?,
+    ) {
+        verify(mockPropertyOwnershipService).updateOccupancy(
+            id = propertyId,
+            isOccupied = isOccupied,
+            numberOfHouseholds = if (isOccupied) 2 else 0,
+            numberOfPeople = if (isOccupied) 5 else 0,
+            numBedrooms = numBedrooms,
+            billsIncludedList = null,
+            customBillsIncluded = null,
+            furnishedStatus = null,
+            rentFrequency = null,
+            customRentFrequency = null,
+            rentAmount = if (isOccupied) "500".toBigDecimal() else null,
+            initialLastModifiedDate = initialLastModifiedDate,
+        )
     }
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/summaryModels/PropertyDetailsViewModelTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/summaryModels/PropertyDetailsViewModelTests.kt
@@ -7,7 +7,9 @@ import uk.gov.communities.prsdb.webapp.constants.enums.FurnishedStatus
 import uk.gov.communities.prsdb.webapp.constants.enums.LicensingType
 import uk.gov.communities.prsdb.webapp.constants.enums.PropertyType
 import uk.gov.communities.prsdb.webapp.constants.enums.RentFrequency
+import uk.gov.communities.prsdb.webapp.controllers.UpdateBedroomsController
 import uk.gov.communities.prsdb.webapp.database.entity.License
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.BedroomsStep
 import uk.gov.communities.prsdb.webapp.testHelpers.mockObjects.MockLandlordData.Companion.createAddress
 import uk.gov.communities.prsdb.webapp.testHelpers.mockObjects.MockLandlordData.Companion.createOccupiedPropertyOwnership
 import uk.gov.communities.prsdb.webapp.testHelpers.mockObjects.MockLandlordData.Companion.createPropertyOwnership
@@ -43,6 +45,155 @@ class PropertyDetailsViewModelTests {
 
         // Assert
         assertEquals(expectedHeaderList, headerList)
+    }
+
+    @Test
+    fun `Bedrooms are placed after property type and before ownership type when restructure is enabled for an unoccupied property`() {
+        val propertyOwnership = createPropertyOwnership(numberOfBedrooms = 3)
+
+        val viewModel =
+            PropertyDetailsViewModel(
+                propertyOwnership,
+                isRestructureAndSkippingEnabled = true,
+                messageSource = mockMessageSource,
+            )
+
+        assertEquals(
+            listOf(
+                "propertyDetails.propertyRecord.registrationDate",
+                "propertyDetails.propertyRecord.registrationNumber",
+                "propertyDetails.propertyRecord.address",
+                "propertyDetails.propertyRecord.localCouncil",
+                "propertyDetails.propertyRecord.propertyType",
+                "propertyDetails.propertyRecord.tenancyAndRentalInformation.numberOfBedrooms",
+                "propertyDetails.propertyRecord.ownershipType",
+            ),
+            viewModel.propertyRecord.map { it.fieldHeading },
+        )
+        assertNull(
+            viewModel.tenancyAndRentalInformation.firstOrNull {
+                it.fieldHeading == "propertyDetails.propertyRecord.tenancyAndRentalInformation.numberOfBedrooms"
+            },
+        )
+    }
+
+    @Test
+    fun `Bedrooms are placed between property and ownership type exactly once when restructure is enabled for an occupied property`() {
+        val propertyOwnership = createOccupiedPropertyOwnership()
+        val bedroomsHeading = "propertyDetails.propertyRecord.tenancyAndRentalInformation.numberOfBedrooms"
+
+        val viewModel =
+            PropertyDetailsViewModel(
+                propertyOwnership,
+                isRestructureAndSkippingEnabled = true,
+                messageSource = mockMessageSource,
+            )
+        val propertyRecordHeadings = viewModel.propertyRecord.map { it.fieldHeading }
+        val bedroomsIndex = propertyRecordHeadings.indexOf(bedroomsHeading)
+
+        assertEquals(
+            listOf(
+                "propertyDetails.propertyRecord.propertyType",
+                bedroomsHeading,
+                "propertyDetails.propertyRecord.ownershipType",
+            ),
+            propertyRecordHeadings.subList(bedroomsIndex - 1, bedroomsIndex + 2),
+        )
+        assertEquals(
+            1,
+            (viewModel.propertyRecord + viewModel.tenancyAndRentalInformation).count {
+                it.fieldHeading == bedroomsHeading
+            },
+        )
+    }
+
+    @Test
+    fun `Bedrooms row has the update bedrooms action when restructure and change links are enabled`() {
+        val propertyOwnership = createPropertyOwnership(id = 123, numberOfBedrooms = 3)
+
+        val viewModel =
+            PropertyDetailsViewModel(
+                propertyOwnership,
+                withChangeLinks = true,
+                isRestructureAndSkippingEnabled = true,
+                messageSource = mockMessageSource,
+            )
+
+        val bedroomsRow =
+            viewModel.propertyRecord.single {
+                it.fieldHeading == "propertyDetails.propertyRecord.tenancyAndRentalInformation.numberOfBedrooms"
+            }
+
+        assertEquals(
+            UpdateBedroomsController.getUpdateBedroomsRoute(propertyOwnership.id) + "/${BedroomsStep.ROUTE_SEGMENT}",
+            bedroomsRow.actions.single().url,
+        )
+    }
+
+    @Test
+    fun `Bedrooms row remains without actions when restructure is enabled and change links are disabled`() {
+        val propertyOwnership = createPropertyOwnership(numberOfBedrooms = 3)
+
+        val viewModel =
+            PropertyDetailsViewModel(
+                propertyOwnership,
+                withChangeLinks = false,
+                isRestructureAndSkippingEnabled = true,
+                messageSource = mockMessageSource,
+            )
+
+        val bedroomsRow =
+            viewModel.propertyRecord.single {
+                it.fieldHeading == "propertyDetails.propertyRecord.tenancyAndRentalInformation.numberOfBedrooms"
+            }
+
+        assertEquals(3, bedroomsRow.fieldValue)
+        assertEquals(emptyList<SummaryListRowActionsViewModel>(), bedroomsRow.actions)
+    }
+
+    @Test
+    fun `Bedrooms retain occupied tenancy placement and ordering when restructure is disabled`() {
+        val occupiedViewModel =
+            PropertyDetailsViewModel(
+                createOccupiedPropertyOwnership(),
+                isRestructureAndSkippingEnabled = false,
+                messageSource = mockMessageSource,
+            )
+        val unoccupiedViewModel =
+            PropertyDetailsViewModel(
+                createUnoccupiedPropertyOwnership(),
+                isRestructureAndSkippingEnabled = false,
+                messageSource = mockMessageSource,
+            )
+
+        assertEquals(
+            listOf(
+                "propertyDetails.propertyRecord.tenancyAndRentalInformation.occupied",
+                "propertyDetails.propertyRecord.tenancyAndRentalInformation.numberOfHouseholds.rowName",
+                "propertyDetails.propertyRecord.tenancyAndRentalInformation.numberOfPeople",
+                "propertyDetails.propertyRecord.tenancyAndRentalInformation.numberOfBedrooms",
+                "propertyDetails.propertyRecord.tenancyAndRentalInformation.rentIncludesBills.rowName",
+                "propertyDetails.propertyRecord.tenancyAndRentalInformation.billsIncluded",
+                "propertyDetails.propertyRecord.tenancyAndRentalInformation.furnishedStatus",
+                "propertyDetails.propertyRecord.tenancyAndRentalInformation.rentFrequency.rowName",
+                "propertyDetails.propertyRecord.tenancyAndRentalInformation.rentAmount",
+            ),
+            occupiedViewModel.tenancyAndRentalInformation.map { it.fieldHeading },
+        )
+        assertEquals(
+            listOf("propertyDetails.propertyRecord.tenancyAndRentalInformation.occupied"),
+            unoccupiedViewModel.tenancyAndRentalInformation.map { it.fieldHeading },
+        )
+        assertNull(
+            occupiedViewModel.propertyRecord.firstOrNull {
+                it.fieldHeading == "propertyDetails.propertyRecord.tenancyAndRentalInformation.numberOfBedrooms"
+            },
+        )
+        assertNull(
+            unoccupiedViewModel.propertyRecord.firstOrNull {
+                it.fieldHeading == "propertyDetails.propertyRecord.tenancyAndRentalInformation.numberOfBedrooms"
+            },
+        )
     }
 
     @Test
@@ -203,7 +354,8 @@ class PropertyDetailsViewModelTests {
     @Test
     fun `the correct message key are returned for occupancy tab and occupancy row value when property is unoccupied`() {
         val unoccupiedPropertyOwnership = createUnoccupiedPropertyOwnership()
-        val unoccupiedViewModel = PropertyDetailsViewModel(unoccupiedPropertyOwnership, messageSource = mockMessageSource)
+        val unoccupiedViewModel =
+            PropertyDetailsViewModel(unoccupiedPropertyOwnership, messageSource = mockMessageSource)
         val unoccupiedPropertyDetailsRow =
             unoccupiedViewModel.tenancyAndRentalInformation
                 .single { it.fieldHeading == "propertyDetails.propertyRecord.tenancyAndRentalInformation.occupied" }
@@ -274,7 +426,8 @@ class PropertyDetailsViewModelTests {
         val rentFrequency = RentFrequency.OTHER
         val customRentFrequency = "fortnightly"
         val rentAmount = BigDecimal(200)
-        val expectedRentAmount = "£$rentAmount Message for forms.checkPropertyAnswers.tenancyDetails.customFrequencyRentAmountSuffix"
+        val expectedRentAmount =
+            "£$rentAmount Message for forms.checkPropertyAnswers.tenancyDetails.customFrequencyRentAmountSuffix"
         val expectedBillsIncluded =
             "Message for forms.billsIncluded.checkbox.electricity, Message for forms.billsIncluded.checkbox.water, Cat sitting"
 
@@ -340,7 +493,8 @@ class PropertyDetailsViewModelTests {
             createPropertyOwnership(
                 license = License(LicensingType.NO_LICENSING, ""),
             )
-        val viewModelDeclaredNoLicense = PropertyDetailsViewModel(propertyOwnershipDeclaredNoLicense, messageSource = mockMessageSource)
+        val viewModelDeclaredNoLicense =
+            PropertyDetailsViewModel(propertyOwnershipDeclaredNoLicense, messageSource = mockMessageSource)
         val propertyRecordDeclaredNoLicense =
             viewModelDeclaredNoLicense.licensingInformation
                 .single { it.fieldHeading == "propertyDetails.propertyRecord.licensingInformation.licensingType" }
@@ -352,7 +506,8 @@ class PropertyDetailsViewModelTests {
 
         val propertyOwnershipNullLicense =
             createPropertyOwnership()
-        val viewModelNullLicense = PropertyDetailsViewModel(propertyOwnershipNullLicense, messageSource = mockMessageSource)
+        val viewModelNullLicense =
+            PropertyDetailsViewModel(propertyOwnershipNullLicense, messageSource = mockMessageSource)
         val propertyRecordNullLicense =
             viewModelNullLicense.licensingInformation
                 .single { it.fieldHeading == "propertyDetails.propertyRecord.licensingInformation.licensingType" }
@@ -419,7 +574,8 @@ class PropertyDetailsViewModelTests {
     fun `Property details hides null uprn if hideNullUprn is true`() {
         val propertyOwnership = createPropertyOwnership()
 
-        val viewModel = PropertyDetailsViewModel(propertyOwnership, hideNullUprn = true, messageSource = mockMessageSource)
+        val viewModel =
+            PropertyDetailsViewModel(propertyOwnership, hideNullUprn = true, messageSource = mockMessageSource)
 
         assertNull(viewModel.propertyRecord.firstOrNull { it.fieldHeading == "propertyDetails.propertyRecord.uprn" })
     }
@@ -428,7 +584,8 @@ class PropertyDetailsViewModelTests {
     fun `Property details declares null uprn unavailable if hideNullUprn is false`() {
         val propertyOwnership = createPropertyOwnership()
 
-        val viewModel = PropertyDetailsViewModel(propertyOwnership, hideNullUprn = false, messageSource = mockMessageSource)
+        val viewModel =
+            PropertyDetailsViewModel(propertyOwnership, hideNullUprn = false, messageSource = mockMessageSource)
 
         val uprnKey =
             viewModel.propertyRecord
@@ -446,7 +603,8 @@ class PropertyDetailsViewModelTests {
                 address = createAddress(uprn = 1234.toLong()),
             )
 
-        val viewModel = PropertyDetailsViewModel(propertyOwnership, withChangeLinks = true, messageSource = mockMessageSource)
+        val viewModel =
+            PropertyDetailsViewModel(propertyOwnership, withChangeLinks = true, messageSource = mockMessageSource)
 
         val propertyRecordChangeLinkCount = viewModel.propertyRecord.count { it.actions.isNotEmpty() }
 
@@ -454,7 +612,8 @@ class PropertyDetailsViewModelTests {
 
         val tenancyInformationChangeLinkCount = viewModel.tenancyAndRentalInformation.count { it.actions.isNotEmpty() }
 
-        val totalChangeLinkCount = propertyRecordChangeLinkCount + licensingInformationChangeLinkCount + tenancyInformationChangeLinkCount
+        val totalChangeLinkCount =
+            propertyRecordChangeLinkCount + licensingInformationChangeLinkCount + tenancyInformationChangeLinkCount
 
         assertEquals(8, totalChangeLinkCount)
     }
@@ -467,7 +626,8 @@ class PropertyDetailsViewModelTests {
                 address = createAddress(uprn = 1234.toLong()),
             )
 
-        val viewModel = PropertyDetailsViewModel(propertyOwnership, withChangeLinks = false, messageSource = mockMessageSource)
+        val viewModel =
+            PropertyDetailsViewModel(propertyOwnership, withChangeLinks = false, messageSource = mockMessageSource)
 
         val propertyRecordChangeLinkCount = viewModel.propertyRecord.count { it.actions.isNotEmpty() }
 
@@ -475,7 +635,8 @@ class PropertyDetailsViewModelTests {
 
         val tenancyInformationChangeLinkCount = viewModel.tenancyAndRentalInformation.count { it.actions.isNotEmpty() }
 
-        val totalChangeLinkCount = propertyRecordChangeLinkCount + licensingInformationChangeLinkCount + tenancyInformationChangeLinkCount
+        val totalChangeLinkCount =
+            propertyRecordChangeLinkCount + licensingInformationChangeLinkCount + tenancyInformationChangeLinkCount
 
         assertEquals(0, totalChangeLinkCount)
     }


### PR DESCRIPTION
## Ticket number

PDJB-1353

## Goal of change

Keep bedroom data independent from occupancy updates in the restructured property journey.

## Description of main change(s)

- Removes the bedroom step and bedroom row from flag-on occupancy updates
- Preserves the stored bedroom count when occupancy changes
- Retains legacy flag-off behaviour, with unit and journey integration coverage for both paths

## Anything you'd like to highlight to the reviewer?

This is stacked on #1645 and should be reviewed against `fix/PDJB-1353-single-step-bedroom-update`; after #1645 merges, this branch will be rebased onto `main` and retargeted.

## Checklist

- [x] Unit tests for new logic (e.g. new service methods) have been added
- [ ] Test suite has been run in full locally and is passing

  The full non-integration suite, targeted journey integration tests, forced Kotlin compilation, and ktlint passed; the full integration suite was not run.

- [ ] Branch has been rebased onto main and run locally, with everything working as expected (both for your new feature and any related functionality)

  This stacked branch is based on #1645 and passed local smoke testing; it will be rebased onto `main` after #1645 merges.

- [x] TODO comments referencing this JIRA ticket have been searched for and removed - if a future PR will address them, mention that here
- [ ] QA instructions have been added to the ticket (particularly if this is the last PR required to complete the ticket)
- [x] This feature is behind a feature flag. I've checked that there will be no change in function if the feature flag is disabled