### PR TITLE
PDJB-896: Migrate remaining journey controllers to JourneyStepDispatcher

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/CancelJointLandlordInvitationController.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/CancelJointLandlordInvitationController.kt
@@ -1,13 +1,11 @@
 package uk.gov.communities.prsdb.webapp.controllers
 
-import org.springframework.http.HttpStatus
 import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
-import org.springframework.web.server.ResponseStatusException
 import org.springframework.web.servlet.ModelAndView
 import uk.gov.communities.prsdb.webapp.annotations.webAnnotations.PrsdbController
 import uk.gov.communities.prsdb.webapp.constants.CANCEL_JOINT_LANDLORD_INVITATION_JOURNEY_URL
@@ -17,8 +15,8 @@ import uk.gov.communities.prsdb.webapp.constants.LANDLORD_PATH_SEGMENT
 import uk.gov.communities.prsdb.webapp.controllers.CancelJointLandlordInvitationController.Companion.CANCEL_JOINT_LANDLORD_INVITATION_ROUTE
 import uk.gov.communities.prsdb.webapp.exceptions.PrsdbWebException
 import uk.gov.communities.prsdb.webapp.journeys.FormData
-import uk.gov.communities.prsdb.webapp.journeys.JourneyStateService
-import uk.gov.communities.prsdb.webapp.journeys.NoSuchJourneyException
+import uk.gov.communities.prsdb.webapp.journeys.JourneyStepDispatcher
+import uk.gov.communities.prsdb.webapp.journeys.StepLifecycleOrchestrator
 import uk.gov.communities.prsdb.webapp.journeys.cancelJointLandlordInvitation.CancelJointLandlordInvitationJourneyFactory
 import uk.gov.communities.prsdb.webapp.journeys.cancelJointLandlordInvitation.stepConfig.AreYouSureStep
 import uk.gov.communities.prsdb.webapp.services.JointLandlordInvitationService
@@ -31,41 +29,33 @@ class CancelJointLandlordInvitationController(
     private val journeyFactory: CancelJointLandlordInvitationJourneyFactory,
     private val jointLandlordInvitationService: JointLandlordInvitationService,
 ) {
-    @GetMapping("/{invitationId}/{stepName}")
+    @GetMapping("/{invitationId}/{*stepPath}")
     fun getJourneyStep(
         @PathVariable invitationId: Long,
-        @PathVariable stepName: String,
+        @PathVariable stepPath: String,
         principal: Principal,
-    ): ModelAndView =
-        try {
-            journeyFactory.createJourneySteps(invitationId, principal.name)[stepName]?.getStepModelAndView()
-                ?: throw ResponseStatusException(HttpStatus.NOT_FOUND, "Step not found")
-        } catch (_: NoSuchJourneyException) {
-            initializeAndRedirect(invitationId, stepName)
-        }
+    ): ModelAndView = dispatchJourneyStep(stepPath, invitationId, principal) { getStepModelAndView() }
 
-    @PostMapping("/{invitationId}/{stepName}")
+    @PostMapping("/{invitationId}/{*stepPath}")
     fun postJourneyData(
         @PathVariable invitationId: Long,
-        @PathVariable stepName: String,
+        @PathVariable stepPath: String,
         @RequestParam formData: FormData,
         principal: Principal,
-    ): ModelAndView =
-        try {
-            journeyFactory.createJourneySteps(invitationId, principal.name)[stepName]?.postStepModelAndView(formData)
-                ?: throw ResponseStatusException(HttpStatus.NOT_FOUND, "Step not found")
-        } catch (_: NoSuchJourneyException) {
-            initializeAndRedirect(invitationId, stepName)
-        }
+    ): ModelAndView = dispatchJourneyStep(stepPath, invitationId, principal) { postStepModelAndView(formData) }
 
-    private fun initializeAndRedirect(
+    private fun dispatchJourneyStep(
+        stepPath: String,
         invitationId: Long,
-        stepName: String,
-    ): ModelAndView {
-        val journeyId = journeyFactory.initializeJourneyState()
-        val redirectUrl = JourneyStateService.urlWithJourneyState(stepName, journeyId)
-        return ModelAndView("redirect:$CANCEL_JOINT_LANDLORD_INVITATION_ROUTE/$invitationId/$redirectUrl")
-    }
+        principal: Principal,
+        dispatch: StepLifecycleOrchestrator.() -> ModelAndView,
+    ): ModelAndView =
+        JourneyStepDispatcher.handleInitialisableRequest(
+            rawStepPath = stepPath,
+            createRoutingMap = { journeyFactory.createJourneySteps(invitationId, principal.name) },
+            initialiseJourney = { journeyFactory.initializeJourneyState() },
+            dispatch = dispatch,
+        )
 
     @GetMapping("/$CONFIRMATION_PATH_SEGMENT")
     fun getConfirmation(

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/DeregisterLandlordController.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/DeregisterLandlordController.kt
@@ -15,8 +15,8 @@ import uk.gov.communities.prsdb.webapp.constants.DEREGISTER_LANDLORD_JOURNEY_URL
 import uk.gov.communities.prsdb.webapp.constants.LANDLORD_PATH_SEGMENT
 import uk.gov.communities.prsdb.webapp.controllers.DeregisterLandlordController.Companion.LANDLORD_DEREGISTRATION_ROUTE
 import uk.gov.communities.prsdb.webapp.journeys.FormData
-import uk.gov.communities.prsdb.webapp.journeys.JourneyStateService
-import uk.gov.communities.prsdb.webapp.journeys.NoSuchJourneyException
+import uk.gov.communities.prsdb.webapp.journeys.JourneyStepDispatcher
+import uk.gov.communities.prsdb.webapp.journeys.StepLifecycleOrchestrator
 import uk.gov.communities.prsdb.webapp.journeys.landlordDeregistration.LandlordDeregistrationJourneyFactory
 import uk.gov.communities.prsdb.webapp.journeys.landlordDeregistration.stepConfig.AreYouSureStep
 import uk.gov.communities.prsdb.webapp.services.LandlordDeregistrationService
@@ -31,37 +31,31 @@ class DeregisterLandlordController(
     private val landlordDeregistrationService: LandlordDeregistrationService,
 ) {
     @PreAuthorize("hasRole('LANDLORD')")
-    @GetMapping("/{stepName}")
+    @GetMapping("/{*stepPath}")
     fun getJourneyStep(
-        @PathVariable("stepName") stepName: String,
+        @PathVariable stepPath: String,
         principal: Principal,
-    ): ModelAndView =
-        try {
-            landlordDeregistrationJourneyFactory.createJourneySteps(principal.name)[stepName]?.getStepModelAndView()
-                ?: throw ResponseStatusException(HttpStatus.NOT_FOUND, "Step not found")
-        } catch (_: NoSuchJourneyException) {
-            initializeAndRedirect(stepName)
-        }
+    ): ModelAndView = dispatchJourneyStep(stepPath, principal) { getStepModelAndView() }
 
     @PreAuthorize("hasRole('LANDLORD')")
-    @PostMapping("/{stepName}")
+    @PostMapping("/{*stepPath}")
     fun postJourneyData(
-        @PathVariable("stepName") stepName: String,
+        @PathVariable stepPath: String,
         @RequestParam formData: FormData,
         principal: Principal,
-    ): ModelAndView =
-        try {
-            landlordDeregistrationJourneyFactory.createJourneySteps(principal.name)[stepName]?.postStepModelAndView(formData)
-                ?: throw ResponseStatusException(HttpStatus.NOT_FOUND, "Step not found")
-        } catch (_: NoSuchJourneyException) {
-            initializeAndRedirect(stepName)
-        }
+    ): ModelAndView = dispatchJourneyStep(stepPath, principal) { postStepModelAndView(formData) }
 
-    private fun initializeAndRedirect(stepName: String): ModelAndView {
-        val journeyId = landlordDeregistrationJourneyFactory.initializeJourneyState()
-        val redirectUrl = JourneyStateService.urlWithJourneyState(stepName, journeyId)
-        return ModelAndView("redirect:$redirectUrl")
-    }
+    private fun dispatchJourneyStep(
+        stepPath: String,
+        principal: Principal,
+        dispatch: StepLifecycleOrchestrator.() -> ModelAndView,
+    ): ModelAndView =
+        JourneyStepDispatcher.handleInitialisableRequest(
+            rawStepPath = stepPath,
+            createRoutingMap = { landlordDeregistrationJourneyFactory.createJourneySteps(principal.name) },
+            initialiseJourney = { landlordDeregistrationJourneyFactory.initializeJourneyState() },
+            dispatch = dispatch,
+        )
 
     @GetMapping("/$CONFIRMATION_PATH_SEGMENT")
     fun getConfirmation(principal: Principal): String {

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/DeregisterPropertyController.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/DeregisterPropertyController.kt
@@ -19,8 +19,7 @@ import uk.gov.communities.prsdb.webapp.controllers.DeregisterPropertyController.
 import uk.gov.communities.prsdb.webapp.controllers.LandlordController.Companion.LANDLORD_DASHBOARD_URL
 import uk.gov.communities.prsdb.webapp.exceptions.PropertyOwnershipMismatchException
 import uk.gov.communities.prsdb.webapp.journeys.FormData
-import uk.gov.communities.prsdb.webapp.journeys.JourneyStateService
-import uk.gov.communities.prsdb.webapp.journeys.NoSuchJourneyException
+import uk.gov.communities.prsdb.webapp.journeys.JourneyStepDispatcher
 import uk.gov.communities.prsdb.webapp.journeys.StepLifecycleOrchestrator
 import uk.gov.communities.prsdb.webapp.journeys.propertyDeregistration.PropertyDeregistrationJourneyFactory
 import uk.gov.communities.prsdb.webapp.journeys.propertyDeregistration.stepConfig.CheckCanDeregisterStep
@@ -36,56 +35,39 @@ class DeregisterPropertyController(
     private val propertyOwnershipService: PropertyOwnershipService,
     private val propertyDeregistrationService: PropertyDeregistrationService,
 ) {
-    @GetMapping("/{stepName}")
+    @GetMapping("/{*stepPath}")
     fun getJourneyStep(
-        @PathVariable("stepName") stepName: String,
+        @PathVariable stepPath: String,
         @PathVariable("propertyOwnershipId") propertyOwnershipId: Long,
         principal: Principal,
     ): ModelAndView {
         throwExceptionIfCurrentUserIsUnauthorizedToDeregisterProperty(propertyOwnershipId, principal)
-
-        return try {
-            val journeyMap = getJourneySteps(propertyOwnershipId)
-            journeyMap[stepName]?.getStepModelAndView()
-                ?: throw ResponseStatusException(HttpStatus.NOT_FOUND, "Step not found")
-        } catch (_: NoSuchJourneyException) {
-            initializeAndRedirect(propertyOwnershipId, stepName)
-        } catch (_: PropertyOwnershipMismatchException) {
-            initializeAndRedirect(propertyOwnershipId, stepName)
-        }
+        return dispatchJourneyStep(stepPath, propertyOwnershipId) { getStepModelAndView() }
     }
 
-    @PostMapping("/{stepName}")
+    @PostMapping("/{*stepPath}")
     fun postJourneyData(
-        @PathVariable("stepName") stepName: String,
+        @PathVariable stepPath: String,
         @PathVariable("propertyOwnershipId") propertyOwnershipId: Long,
         @RequestParam formData: FormData,
         principal: Principal,
     ): ModelAndView {
         throwExceptionIfCurrentUserIsUnauthorizedToDeregisterProperty(propertyOwnershipId, principal)
-
-        return try {
-            val journeyMap = getJourneySteps(propertyOwnershipId)
-            journeyMap[stepName]?.postStepModelAndView(formData)
-                ?: throw ResponseStatusException(HttpStatus.NOT_FOUND, "Step not found")
-        } catch (_: NoSuchJourneyException) {
-            initializeAndRedirect(propertyOwnershipId, stepName)
-        } catch (_: PropertyOwnershipMismatchException) {
-            initializeAndRedirect(propertyOwnershipId, stepName)
-        }
+        return dispatchJourneyStep(stepPath, propertyOwnershipId) { postStepModelAndView(formData) }
     }
 
-    private fun initializeAndRedirect(
+    private fun dispatchJourneyStep(
+        stepPath: String,
         propertyOwnershipId: Long,
-        stepName: String,
-    ): ModelAndView {
-        val journeyId = propertyDeregistrationJourneyFactory.initializeJourneyState(propertyOwnershipId)
-        val redirectUrl = JourneyStateService.urlWithJourneyState(stepName, journeyId)
-        return ModelAndView("redirect:$redirectUrl")
-    }
-
-    private fun getJourneySteps(propertyOwnershipId: Long): Map<String, StepLifecycleOrchestrator> =
-        propertyDeregistrationJourneyFactory.createJourneySteps(propertyOwnershipId)
+        dispatch: StepLifecycleOrchestrator.() -> ModelAndView,
+    ): ModelAndView =
+        JourneyStepDispatcher.handleInitialisableRequest(
+            rawStepPath = stepPath,
+            createRoutingMap = { propertyDeregistrationJourneyFactory.createJourneySteps(propertyOwnershipId) },
+            initialiseJourney = { propertyDeregistrationJourneyFactory.initializeJourneyState(propertyOwnershipId) },
+            dispatch = dispatch,
+            startNewJourneyOn = { it is PropertyOwnershipMismatchException },
+        )
 
     @GetMapping("/$CONFIRMATION_PATH_SEGMENT")
     fun getConfirmation(

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/InviteJointLandlordController.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/InviteJointLandlordController.kt
@@ -19,8 +19,8 @@ import uk.gov.communities.prsdb.webapp.constants.PROPERTY_DETAILS_SEGMENT
 import uk.gov.communities.prsdb.webapp.constants.RESEND_PATH_SEGMENT
 import uk.gov.communities.prsdb.webapp.controllers.InviteJointLandlordController.Companion.INVITE_JOINT_LANDLORD_ROUTE
 import uk.gov.communities.prsdb.webapp.journeys.FormData
-import uk.gov.communities.prsdb.webapp.journeys.JourneyStateService
-import uk.gov.communities.prsdb.webapp.journeys.NoSuchJourneyException
+import uk.gov.communities.prsdb.webapp.journeys.JourneyStepDispatcher
+import uk.gov.communities.prsdb.webapp.journeys.StepLifecycleOrchestrator
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.update.inviteJointLandlord.InviteJointLandlordJourneyFactory
 import uk.gov.communities.prsdb.webapp.journeys.shared.inviteJointLandlord.StartInviteJointLandlordStep
 import uk.gov.communities.prsdb.webapp.services.JointLandlordInvitationService
@@ -37,43 +37,40 @@ class InviteJointLandlordController(
     private val jointLandlordInvitationService: JointLandlordInvitationService,
     private val landlordService: LandlordService,
 ) {
-    @GetMapping("{stepName}")
+    @GetMapping("/{*stepPath}")
     fun getUpdateStep(
         principal: Principal,
         @PathVariable propertyOwnershipId: Long,
-        @PathVariable("stepName") stepName: String,
+        @PathVariable stepPath: String,
     ): ModelAndView {
         throwErrorIfUserIsNotAuthorized(principal.name, propertyOwnershipId)
-        return try {
-            val journeyMap = journeyFactory.createJourneySteps(propertyOwnershipId)
-            journeyMap[stepName]?.getStepModelAndView()
-                ?: throw ResponseStatusException(HttpStatus.NOT_FOUND, "Step not found")
-        } catch (_: NoSuchJourneyException) {
-            val journeyId = journeyFactory.initializeJourneyState(propertyOwnershipId, principal)
-            val redirectUrl = JourneyStateService.urlWithJourneyState(stepName, journeyId)
-            ModelAndView("redirect:$redirectUrl")
-        }
+        return dispatchJourneyStep(stepPath, propertyOwnershipId, principal) { getStepModelAndView() }
     }
 
-    @PostMapping("{stepName}")
+    @PostMapping("/{*stepPath}")
     fun postUpdateStep(
         model: Model,
         principal: Principal,
         @PathVariable propertyOwnershipId: Long,
-        @PathVariable("stepName") stepName: String,
+        @PathVariable stepPath: String,
         @RequestParam formData: FormData,
     ): ModelAndView {
         throwErrorIfUserIsNotAuthorized(principal.name, propertyOwnershipId)
-        return try {
-            val journeyMap = journeyFactory.createJourneySteps(propertyOwnershipId)
-            journeyMap[stepName]?.postStepModelAndView(formData)
-                ?: throw ResponseStatusException(HttpStatus.NOT_FOUND, "Step not found")
-        } catch (_: NoSuchJourneyException) {
-            val journeyId = journeyFactory.initializeJourneyState(propertyOwnershipId, principal)
-            val redirectUrl = JourneyStateService.urlWithJourneyState(stepName, journeyId)
-            ModelAndView("redirect:$redirectUrl")
-        }
+        return dispatchJourneyStep(stepPath, propertyOwnershipId, principal) { postStepModelAndView(formData) }
     }
+
+    private fun dispatchJourneyStep(
+        stepPath: String,
+        propertyOwnershipId: Long,
+        principal: Principal,
+        dispatch: StepLifecycleOrchestrator.() -> ModelAndView,
+    ): ModelAndView =
+        JourneyStepDispatcher.handleInitialisableRequest(
+            rawStepPath = stepPath,
+            createRoutingMap = { journeyFactory.createJourneySteps(propertyOwnershipId) },
+            initialiseJourney = { journeyFactory.initializeJourneyState(propertyOwnershipId, principal) },
+            dispatch = dispatch,
+        )
 
     // TODO: PDJB-1060: We should not be using a GET for editing actions. Replace with a confirmation page.
     @GetMapping("$RESEND_PATH_SEGMENT/{invitationId}")

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/LeavePropertyController.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/LeavePropertyController.kt
@@ -19,8 +19,7 @@ import uk.gov.communities.prsdb.webapp.controllers.LandlordController.Companion.
 import uk.gov.communities.prsdb.webapp.controllers.LeavePropertyController.Companion.LEAVE_PROPERTY_ROUTE
 import uk.gov.communities.prsdb.webapp.exceptions.PropertyOwnershipMismatchException
 import uk.gov.communities.prsdb.webapp.journeys.FormData
-import uk.gov.communities.prsdb.webapp.journeys.JourneyStateService
-import uk.gov.communities.prsdb.webapp.journeys.NoSuchJourneyException
+import uk.gov.communities.prsdb.webapp.journeys.JourneyStepDispatcher
 import uk.gov.communities.prsdb.webapp.journeys.StepLifecycleOrchestrator
 import uk.gov.communities.prsdb.webapp.journeys.leaveProperty.LeavePropertyJourneyFactory
 import uk.gov.communities.prsdb.webapp.journeys.leaveProperty.stepConfig.ConfirmStep
@@ -34,44 +33,40 @@ class LeavePropertyController(
     private val leavePropertyJourneyFactory: LeavePropertyJourneyFactory,
     private val leavePropertyService: LeavePropertyService,
 ) {
-    @GetMapping("/{stepName}")
+    @GetMapping("/{*stepPath}")
     fun getJourneyStep(
-        @PathVariable("stepName") stepName: String,
+        @PathVariable stepPath: String,
         @PathVariable("propertyOwnershipId") propertyOwnershipId: Long,
         principal: Principal,
     ): ModelAndView {
         leavePropertyService.getPropertyOwnershipIfUserCanLeave(propertyOwnershipId, principal.name)
-
-        return try {
-            val journeyMap = getJourneySteps(propertyOwnershipId, principal.name)
-            journeyMap[stepName]?.getStepModelAndView()
-                ?: throw ResponseStatusException(HttpStatus.NOT_FOUND, "Step not found")
-        } catch (_: NoSuchJourneyException) {
-            initializeAndRedirect(propertyOwnershipId, stepName)
-        } catch (_: PropertyOwnershipMismatchException) {
-            initializeAndRedirect(propertyOwnershipId, stepName)
-        }
+        return dispatchJourneyStep(stepPath, propertyOwnershipId, principal) { getStepModelAndView() }
     }
 
-    @PostMapping("/{stepName}")
+    @PostMapping("/{*stepPath}")
     fun postJourneyData(
-        @PathVariable("stepName") stepName: String,
+        @PathVariable stepPath: String,
         @PathVariable("propertyOwnershipId") propertyOwnershipId: Long,
         @RequestParam formData: FormData,
         principal: Principal,
     ): ModelAndView {
         leavePropertyService.getPropertyOwnershipIfUserCanLeave(propertyOwnershipId, principal.name)
-
-        return try {
-            val journeyMap = getJourneySteps(propertyOwnershipId, principal.name)
-            journeyMap[stepName]?.postStepModelAndView(formData)
-                ?: throw ResponseStatusException(HttpStatus.NOT_FOUND, "Step not found")
-        } catch (_: NoSuchJourneyException) {
-            initializeAndRedirect(propertyOwnershipId, stepName)
-        } catch (_: PropertyOwnershipMismatchException) {
-            initializeAndRedirect(propertyOwnershipId, stepName)
-        }
+        return dispatchJourneyStep(stepPath, propertyOwnershipId, principal) { postStepModelAndView(formData) }
     }
+
+    private fun dispatchJourneyStep(
+        stepPath: String,
+        propertyOwnershipId: Long,
+        principal: Principal,
+        dispatch: StepLifecycleOrchestrator.() -> ModelAndView,
+    ): ModelAndView =
+        JourneyStepDispatcher.handleInitialisableRequest(
+            rawStepPath = stepPath,
+            createRoutingMap = { leavePropertyJourneyFactory.createJourneySteps(propertyOwnershipId, principal.name) },
+            initialiseJourney = { leavePropertyJourneyFactory.initializeJourneyState(propertyOwnershipId) },
+            dispatch = dispatch,
+            startNewJourneyOn = { it is PropertyOwnershipMismatchException },
+        )
 
     @GetMapping("/$CONFIRMATION_PATH_SEGMENT")
     fun getConfirmation(
@@ -93,20 +88,6 @@ class LeavePropertyController(
         )
 
         return "leavePropertyConfirmation"
-    }
-
-    private fun getJourneySteps(
-        propertyOwnershipId: Long,
-        baseUserId: String,
-    ): Map<String, StepLifecycleOrchestrator> = leavePropertyJourneyFactory.createJourneySteps(propertyOwnershipId, baseUserId)
-
-    private fun initializeAndRedirect(
-        propertyOwnershipId: Long,
-        stepName: String,
-    ): ModelAndView {
-        val journeyId = leavePropertyJourneyFactory.initializeJourneyState(propertyOwnershipId)
-        val redirectUrl = JourneyStateService.urlWithJourneyState(stepName, journeyId)
-        return ModelAndView("redirect:$redirectUrl")
     }
 
     companion object {

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/RegisterLocalCouncilUserController.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/RegisterLocalCouncilUserController.kt
@@ -21,8 +21,8 @@ import uk.gov.communities.prsdb.webapp.controllers.LocalCouncilDashboardControll
 import uk.gov.communities.prsdb.webapp.controllers.RegisterLocalCouncilUserController.Companion.LOCAL_COUNCIL_USER_REGISTRATION_ROUTE
 import uk.gov.communities.prsdb.webapp.exceptions.InvalidInvitationException
 import uk.gov.communities.prsdb.webapp.journeys.FormData
-import uk.gov.communities.prsdb.webapp.journeys.JourneyStateService
-import uk.gov.communities.prsdb.webapp.journeys.NoSuchJourneyException
+import uk.gov.communities.prsdb.webapp.journeys.JourneyStepDispatcher
+import uk.gov.communities.prsdb.webapp.journeys.StepLifecycleOrchestrator
 import uk.gov.communities.prsdb.webapp.journeys.localCouncilUserRegistration.LocalCouncilUserRegistrationJourneyFactory
 import uk.gov.communities.prsdb.webapp.services.LocalCouncilDataService
 import uk.gov.communities.prsdb.webapp.services.LocalCouncilInvitationService
@@ -60,60 +60,42 @@ class RegisterLocalCouncilUserController(
         }
     }
 
-    @GetMapping("/{stepName}")
+    @GetMapping("/{*stepPath}")
     fun getJourneyStep(
-        @PathVariable("stepName") stepName: String,
+        @PathVariable stepPath: String,
     ): ModelAndView {
         val token =
             getValidTokenFromSessionOrNull()
                 ?: return redirectToInvalidLink()
-
-        return try {
-            try {
-                val journeyMap = localCouncilUserRegistrationJourneyFactory.createJourneySteps(token)
-                journeyMap[stepName]?.getStepModelAndView()
-                    ?: throw ResponseStatusException(HttpStatus.NOT_FOUND, "Step not found")
-            } catch (_: NoSuchJourneyException) {
-                val journeyId = localCouncilUserRegistrationJourneyFactory.initializeJourneyState(token)
-                val redirectUrl =
-                    JourneyStateService.urlWithJourneyState(
-                        stepName,
-                        journeyId,
-                    )
-                ModelAndView("redirect:$redirectUrl")
-            }
-        } catch (_: InvalidInvitationException) {
-            redirectToInvalidLink()
-        }
+        return dispatchJourneyStep(stepPath, token) { getStepModelAndView() }
     }
 
-    @PostMapping("/{stepName}")
+    @PostMapping("/{*stepPath}")
     fun postJourneyData(
-        @PathVariable("stepName") stepName: String,
+        @PathVariable stepPath: String,
         @RequestParam formData: FormData,
     ): ModelAndView {
         val token =
             getValidTokenFromSessionOrNull()
                 ?: return redirectToInvalidLink()
+        return dispatchJourneyStep(stepPath, token) { postStepModelAndView(formData) }
+    }
 
-        return try {
-            try {
-                val journeyMap = localCouncilUserRegistrationJourneyFactory.createJourneySteps(token)
-                journeyMap[stepName]?.postStepModelAndView(formData)
-                    ?: throw ResponseStatusException(HttpStatus.NOT_FOUND, "Step not found")
-            } catch (_: NoSuchJourneyException) {
-                val journeyId = localCouncilUserRegistrationJourneyFactory.initializeJourneyState(token)
-                val redirectUrl =
-                    JourneyStateService.urlWithJourneyState(
-                        stepName,
-                        journeyId,
-                    )
-                ModelAndView("redirect:$redirectUrl")
-            }
+    private fun dispatchJourneyStep(
+        stepPath: String,
+        token: String,
+        dispatch: StepLifecycleOrchestrator.() -> ModelAndView,
+    ): ModelAndView =
+        try {
+            JourneyStepDispatcher.handleInitialisableRequest(
+                rawStepPath = stepPath,
+                createRoutingMap = { localCouncilUserRegistrationJourneyFactory.createJourneySteps(token) },
+                initialiseJourney = { localCouncilUserRegistrationJourneyFactory.initializeJourneyState(token) },
+                dispatch = dispatch,
+            )
         } catch (_: InvalidInvitationException) {
             redirectToInvalidLink()
         }
-    }
 
     @GetMapping("/$CONFIRMATION_PATH_SEGMENT")
     fun getConfirmation(model: Model): String {

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/RegisterPropertyController.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/RegisterPropertyController.kt
@@ -35,7 +35,8 @@ import uk.gov.communities.prsdb.webapp.helpers.CompleteByDateHelper
 import uk.gov.communities.prsdb.webapp.journeys.FormData
 import uk.gov.communities.prsdb.webapp.journeys.JourneyIdProvider
 import uk.gov.communities.prsdb.webapp.journeys.JourneyStateService
-import uk.gov.communities.prsdb.webapp.journeys.NoSuchJourneyException
+import uk.gov.communities.prsdb.webapp.journeys.JourneyStepDispatcher
+import uk.gov.communities.prsdb.webapp.journeys.StepLifecycleOrchestrator
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.PropertyRegistrationJourneyFactory
 import uk.gov.communities.prsdb.webapp.models.dataModels.RegistrationNumberDataModel
 import uk.gov.communities.prsdb.webapp.services.BackUrlStorageService
@@ -131,35 +132,26 @@ class RegisterPropertyController(
         return "registerPropertyConfirmation"
     }
 
-    @GetMapping("/{stepName}")
+    @GetMapping("/{*stepPath}")
     fun getJourneyStep(
-        @PathVariable("stepName") stepName: String,
+        @PathVariable stepPath: String,
         principal: Principal,
-    ): ModelAndView =
-        try {
-            val journeyMap = propertyRegistrationJourneyFactory.createJourneySteps()
-            journeyMap[stepName]?.getStepModelAndView()
-                ?: throw ResponseStatusException(HttpStatus.NOT_FOUND, "Step not found")
-        } catch (_: NoSuchJourneyException) {
-            val journeyId = propertyRegistrationJourneyFactory.initializeJourneyState(principal)
-            val redirectUrl = JourneyStateService.urlWithJourneyState(stepName, journeyId)
-            ModelAndView("redirect:$redirectUrl")
-        }
+    ): ModelAndView = dispatchJourneyStep(stepPath, principal) { getStepModelAndView() }
 
-    @PostMapping("/{stepName}")
+    @PostMapping("/{*stepPath}")
     fun postJourneyData(
-        @PathVariable("stepName") stepName: String,
+        @PathVariable stepPath: String,
         @RequestParam formData: FormData,
         principal: Principal,
     ): ModelAndView {
         val annotatedFormData = CertificateUploadHelper.annotateFormDataForMetadataOnlyFileUpload(formData)
 
-        return postProcessedJourneyData(stepName, annotatedFormData, principal)
+        return dispatchJourneyStep(stepPath, principal) { postStepModelAndView(annotatedFormData) }
     }
 
-    @PostMapping("/{stepName}", consumes = [MediaType.MULTIPART_FORM_DATA_VALUE])
+    @PostMapping("/{*stepPath}", consumes = [MediaType.MULTIPART_FORM_DATA_VALUE])
     fun postFileUploadJourneyData(
-        @PathVariable("stepName") stepName: String,
+        @PathVariable stepPath: String,
         @RequestParam(JourneyIdProvider.PARAMETER_NAME) journeyId: String,
         @RequestParam(CollectionKeyParameterService.PARAMETER_NAME) memberId: String?,
         @RequestAttribute(MultipartFormDataFilter.ITERATOR_ATTRIBUTE) fileInputIterator: FileItemInputIterator,
@@ -167,6 +159,7 @@ class RegisterPropertyController(
         principal: Principal,
         request: HttpServletRequest,
     ): ModelAndView {
+        val stepName = stepPath.trimStart('/')
         val formData =
             certificateUploadHelper.uploadFileAndReturnFormModel(
                 CertificateFilenameHelper.getCertFilename(journeyId, stepName, memberId),
@@ -175,23 +168,20 @@ class RegisterPropertyController(
                 request,
             )
 
-        return postProcessedJourneyData(stepName, formData, principal)
+        return dispatchJourneyStep(stepPath, principal) { postStepModelAndView(formData) }
     }
 
-    private fun postProcessedJourneyData(
-        stepName: String,
-        formData: FormData,
+    private fun dispatchJourneyStep(
+        stepPath: String,
         principal: Principal,
+        dispatch: StepLifecycleOrchestrator.() -> ModelAndView,
     ): ModelAndView =
-        try {
-            val journeyMap = propertyRegistrationJourneyFactory.createJourneySteps()
-            journeyMap[stepName]?.postStepModelAndView(formData)
-                ?: throw ResponseStatusException(HttpStatus.NOT_FOUND, "Step not found")
-        } catch (_: NoSuchJourneyException) {
-            val journeyId = propertyRegistrationJourneyFactory.initializeJourneyState(principal)
-            val redirectUrl = JourneyStateService.urlWithJourneyState(stepName, journeyId)
-            ModelAndView("redirect:$redirectUrl")
-        }
+        JourneyStepDispatcher.handleInitialisableRequest(
+            rawStepPath = stepPath,
+            createRoutingMap = { propertyRegistrationJourneyFactory.createJourneySteps() },
+            initialiseJourney = { propertyRegistrationJourneyFactory.initializeJourneyState(principal) },
+            dispatch = dispatch,
+        )
 
     companion object {
         const val PROPERTY_REGISTRATION_ROUTE = "/$LANDLORD_PATH_SEGMENT/$REGISTER_PROPERTY_JOURNEY_URL"

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/SwitchToIndividualController.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/SwitchToIndividualController.kt
@@ -21,8 +21,8 @@ import uk.gov.communities.prsdb.webapp.constants.SWITCH_TO_INDIVIDUAL_JOURNEY_UR
 import uk.gov.communities.prsdb.webapp.controllers.SwitchToIndividualController.Companion.SWITCH_TO_INDIVIDUAL_ROUTE
 import uk.gov.communities.prsdb.webapp.exceptions.PropertyOwnershipMismatchException
 import uk.gov.communities.prsdb.webapp.journeys.FormData
-import uk.gov.communities.prsdb.webapp.journeys.JourneyStateService
-import uk.gov.communities.prsdb.webapp.journeys.NoSuchJourneyException
+import uk.gov.communities.prsdb.webapp.journeys.JourneyStepDispatcher
+import uk.gov.communities.prsdb.webapp.journeys.StepLifecycleOrchestrator
 import uk.gov.communities.prsdb.webapp.journeys.shared.stepConfig.HasPendingInvitationsStep
 import uk.gov.communities.prsdb.webapp.journeys.switchToIndividual.SwitchToIndividualJourneyFactory
 import uk.gov.communities.prsdb.webapp.services.PropertyOwnershipService
@@ -35,44 +35,39 @@ class SwitchToIndividualController(
     private val switchToIndividualJourneyFactory: SwitchToIndividualJourneyFactory,
     private val propertyOwnershipService: PropertyOwnershipService,
 ) {
-    @GetMapping("/{stepName}")
+    @GetMapping("/{*stepPath}")
     fun getJourneyStep(
-        @PathVariable stepName: String,
+        @PathVariable stepPath: String,
         @PathVariable propertyOwnershipId: Long,
         principal: Principal,
     ): ModelAndView {
         throwExceptionIfUnauthorized(propertyOwnershipId, principal)
-
-        return try {
-            val journeyMap = switchToIndividualJourneyFactory.createJourneySteps(propertyOwnershipId)
-            journeyMap[stepName]?.getStepModelAndView()
-                ?: throw ResponseStatusException(HttpStatus.NOT_FOUND, "Step not found")
-        } catch (_: NoSuchJourneyException) {
-            initializeAndRedirect(propertyOwnershipId, stepName)
-        } catch (_: PropertyOwnershipMismatchException) {
-            initializeAndRedirect(propertyOwnershipId, stepName)
-        }
+        return dispatchJourneyStep(stepPath, propertyOwnershipId) { getStepModelAndView() }
     }
 
-    @PostMapping("/{stepName}")
+    @PostMapping("/{*stepPath}")
     fun postJourneyData(
-        @PathVariable stepName: String,
+        @PathVariable stepPath: String,
         @PathVariable propertyOwnershipId: Long,
         @RequestParam formData: FormData,
         principal: Principal,
     ): ModelAndView {
         throwExceptionIfUnauthorized(propertyOwnershipId, principal)
-
-        return try {
-            val journeyMap = switchToIndividualJourneyFactory.createJourneySteps(propertyOwnershipId)
-            journeyMap[stepName]?.postStepModelAndView(formData)
-                ?: throw ResponseStatusException(HttpStatus.NOT_FOUND, "Step not found")
-        } catch (_: NoSuchJourneyException) {
-            initializeAndRedirect(propertyOwnershipId, stepName)
-        } catch (_: PropertyOwnershipMismatchException) {
-            initializeAndRedirect(propertyOwnershipId, stepName)
-        }
+        return dispatchJourneyStep(stepPath, propertyOwnershipId) { postStepModelAndView(formData) }
     }
+
+    private fun dispatchJourneyStep(
+        stepPath: String,
+        propertyOwnershipId: Long,
+        dispatch: StepLifecycleOrchestrator.() -> ModelAndView,
+    ): ModelAndView =
+        JourneyStepDispatcher.handleInitialisableRequest(
+            rawStepPath = stepPath,
+            createRoutingMap = { switchToIndividualJourneyFactory.createJourneySteps(propertyOwnershipId) },
+            initialiseJourney = { switchToIndividualJourneyFactory.initializeJourneyState(propertyOwnershipId) },
+            dispatch = dispatch,
+            startNewJourneyOn = { it is PropertyOwnershipMismatchException },
+        )
 
     @GetMapping("/$CONFIRMATION_PATH_SEGMENT")
     fun getSuccess(
@@ -93,15 +88,6 @@ class SwitchToIndividualController(
         model.addAttribute("propertyDetailsUrl", PropertyDetailsController.getPropertyDetailsPath(propertyOwnershipId))
 
         return "switchToIndividualSuccess"
-    }
-
-    private fun initializeAndRedirect(
-        propertyOwnershipId: Long,
-        stepName: String,
-    ): ModelAndView {
-        val journeyId = switchToIndividualJourneyFactory.initializeJourneyState(propertyOwnershipId)
-        val redirectUrl = JourneyStateService.urlWithJourneyState(stepName, journeyId)
-        return ModelAndView("redirect:$redirectUrl")
     }
 
     private fun throwExceptionIfUnauthorized(

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/UpdateBedroomsController.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/UpdateBedroomsController.kt
@@ -15,8 +15,8 @@ import uk.gov.communities.prsdb.webapp.constants.LANDLORD_PATH_SEGMENT
 import uk.gov.communities.prsdb.webapp.constants.PROPERTY_DETAILS_SEGMENT
 import uk.gov.communities.prsdb.webapp.controllers.UpdateBedroomsController.Companion.UPDATE_BEDROOMS_ROUTE
 import uk.gov.communities.prsdb.webapp.journeys.FormData
-import uk.gov.communities.prsdb.webapp.journeys.JourneyStateService
-import uk.gov.communities.prsdb.webapp.journeys.NoSuchJourneyException
+import uk.gov.communities.prsdb.webapp.journeys.JourneyStepDispatcher
+import uk.gov.communities.prsdb.webapp.journeys.StepLifecycleOrchestrator
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.update.bedrooms.UpdateBedroomsJourneyFactory
 import uk.gov.communities.prsdb.webapp.services.PropertyOwnershipService
 import java.security.Principal
@@ -28,43 +28,40 @@ class UpdateBedroomsController(
     private val journeyFactory: UpdateBedroomsJourneyFactory,
     private val propertyOwnershipService: PropertyOwnershipService,
 ) {
-    @GetMapping("{stepName}")
+    @GetMapping("/{*stepPath}")
     fun getUpdateStep(
         principal: Principal,
         @PathVariable propertyOwnershipId: Long,
-        @PathVariable("stepName") stepName: String,
+        @PathVariable stepPath: String,
     ): ModelAndView {
         throwErrorIfUserIsNotAuthorized(principal.name, propertyOwnershipId)
-        return try {
-            val journeyMap = journeyFactory.createJourneySteps(propertyOwnershipId)
-            journeyMap[stepName]?.getStepModelAndView()
-                ?: throw ResponseStatusException(HttpStatus.NOT_FOUND, "Step not found")
-        } catch (_: NoSuchJourneyException) {
-            val journeyId = journeyFactory.initializeJourneyState(propertyOwnershipId, principal)
-            val redirectUrl = JourneyStateService.urlWithJourneyState(stepName, journeyId)
-            ModelAndView("redirect:$redirectUrl")
-        }
+        return dispatchJourneyStep(stepPath, propertyOwnershipId, principal) { getStepModelAndView() }
     }
 
-    @PostMapping("{stepName}")
+    @PostMapping("/{*stepPath}")
     fun postUpdateStep(
         model: Model,
         principal: Principal,
         @PathVariable propertyOwnershipId: Long,
-        @PathVariable("stepName") stepName: String,
+        @PathVariable stepPath: String,
         @RequestParam formData: FormData,
     ): ModelAndView {
         throwErrorIfUserIsNotAuthorized(principal.name, propertyOwnershipId)
-        return try {
-            val journeyMap = journeyFactory.createJourneySteps(propertyOwnershipId)
-            journeyMap[stepName]?.postStepModelAndView(formData)
-                ?: throw ResponseStatusException(HttpStatus.NOT_FOUND, "Step not found")
-        } catch (_: NoSuchJourneyException) {
-            val journeyId = journeyFactory.initializeJourneyState(propertyOwnershipId, principal)
-            val redirectUrl = JourneyStateService.urlWithJourneyState(stepName, journeyId)
-            ModelAndView("redirect:$redirectUrl")
-        }
+        return dispatchJourneyStep(stepPath, propertyOwnershipId, principal) { postStepModelAndView(formData) }
     }
+
+    private fun dispatchJourneyStep(
+        stepPath: String,
+        propertyOwnershipId: Long,
+        principal: Principal,
+        dispatch: StepLifecycleOrchestrator.() -> ModelAndView,
+    ): ModelAndView =
+        JourneyStepDispatcher.handleInitialisableRequest(
+            rawStepPath = stepPath,
+            createRoutingMap = { journeyFactory.createJourneySteps(propertyOwnershipId) },
+            initialiseJourney = { journeyFactory.initializeJourneyState(propertyOwnershipId, principal) },
+            dispatch = dispatch,
+        )
 
     private fun throwErrorIfUserIsNotAuthorized(
         baseUserId: String,

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/UpdateElectricalSafetyController.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/UpdateElectricalSafetyController.kt
@@ -24,8 +24,8 @@ import uk.gov.communities.prsdb.webapp.helpers.CertificateFilenameHelper
 import uk.gov.communities.prsdb.webapp.helpers.CertificateUploadHelper
 import uk.gov.communities.prsdb.webapp.journeys.FormData
 import uk.gov.communities.prsdb.webapp.journeys.JourneyIdProvider
-import uk.gov.communities.prsdb.webapp.journeys.JourneyStateService
-import uk.gov.communities.prsdb.webapp.journeys.NoSuchJourneyException
+import uk.gov.communities.prsdb.webapp.journeys.JourneyStepDispatcher
+import uk.gov.communities.prsdb.webapp.journeys.StepLifecycleOrchestrator
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.HasElectricalCertStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.update.electricalSafety.UpdateElectricalSafetyJourneyFactory
 import uk.gov.communities.prsdb.webapp.services.CollectionKeyParameterService
@@ -41,40 +41,32 @@ class UpdateElectricalSafetyController(
     private val propertyOwnershipService: PropertyOwnershipService,
     private val certificateUploadHelper: CertificateUploadHelper,
 ) {
-    @GetMapping("{stepName}")
+    @GetMapping("/{*stepPath}")
     fun getUpdateStep(
         principal: Principal,
         @PathVariable propertyOwnershipId: Long,
-        @PathVariable("stepName") stepName: String,
+        @PathVariable stepPath: String,
     ): ModelAndView {
         throwErrorIfUserIsNotAuthorized(principal.name, propertyOwnershipId)
-        return try {
-            val journeyMap = journeyFactory.createJourneySteps(propertyOwnershipId)
-            journeyMap[stepName]?.getStepModelAndView()
-                ?: throw ResponseStatusException(HttpStatus.NOT_FOUND, "Step not found")
-        } catch (_: NoSuchJourneyException) {
-            val journeyId = journeyFactory.initializeJourneyState(propertyOwnershipId, principal)
-            val redirectUrl = JourneyStateService.urlWithJourneyState(stepName, journeyId)
-            ModelAndView("redirect:$redirectUrl")
-        }
+        return dispatchJourneyStep(stepPath, propertyOwnershipId, principal) { getStepModelAndView() }
     }
 
-    @PostMapping("{stepName}")
+    @PostMapping("/{*stepPath}")
     fun postUpdateStep(
         model: Model,
         principal: Principal,
         @PathVariable propertyOwnershipId: Long,
-        @PathVariable("stepName") stepName: String,
+        @PathVariable stepPath: String,
         @RequestParam formData: FormData,
     ): ModelAndView {
         throwErrorIfUserIsNotAuthorized(principal.name, propertyOwnershipId)
 
-        return postProcessedJourneyData(stepName, formData, principal, propertyOwnershipId)
+        return dispatchJourneyStep(stepPath, propertyOwnershipId, principal) { postStepModelAndView(formData) }
     }
 
-    @PostMapping("/{stepName}", consumes = [MediaType.MULTIPART_FORM_DATA_VALUE])
+    @PostMapping("/{*stepPath}", consumes = [MediaType.MULTIPART_FORM_DATA_VALUE])
     fun postFileUploadStep(
-        @PathVariable("stepName") stepName: String,
+        @PathVariable stepPath: String,
         @PathVariable propertyOwnershipId: Long,
         @RequestParam(JourneyIdProvider.PARAMETER_NAME) journeyId: String,
         @RequestParam(CollectionKeyParameterService.PARAMETER_NAME) memberId: String?,
@@ -85,6 +77,7 @@ class UpdateElectricalSafetyController(
     ): ModelAndView {
         throwErrorIfUserIsNotAuthorized(principal.name, propertyOwnershipId)
 
+        val stepName = stepPath.trimStart('/')
         val formData =
             certificateUploadHelper.uploadFileAndReturnFormModel(
                 CertificateFilenameHelper.getCertFilename(journeyId, stepName, memberId),
@@ -93,24 +86,21 @@ class UpdateElectricalSafetyController(
                 request,
             )
 
-        return postProcessedJourneyData(stepName, formData, principal, propertyOwnershipId)
+        return dispatchJourneyStep(stepPath, propertyOwnershipId, principal) { postStepModelAndView(formData) }
     }
 
-    private fun postProcessedJourneyData(
-        stepName: String,
-        formData: FormData,
-        principal: Principal,
+    private fun dispatchJourneyStep(
+        stepPath: String,
         propertyOwnershipId: Long,
+        principal: Principal,
+        dispatch: StepLifecycleOrchestrator.() -> ModelAndView,
     ): ModelAndView =
-        try {
-            val journeyMap = journeyFactory.createJourneySteps(propertyOwnershipId)
-            journeyMap[stepName]?.postStepModelAndView(formData)
-                ?: throw ResponseStatusException(HttpStatus.NOT_FOUND, "Step not found")
-        } catch (_: NoSuchJourneyException) {
-            val journeyId = journeyFactory.initializeJourneyState(propertyOwnershipId, principal)
-            val redirectUrl = JourneyStateService.urlWithJourneyState(stepName, journeyId)
-            ModelAndView("redirect:$redirectUrl")
-        }
+        JourneyStepDispatcher.handleInitialisableRequest(
+            rawStepPath = stepPath,
+            createRoutingMap = { journeyFactory.createJourneySteps(propertyOwnershipId) },
+            initialiseJourney = { journeyFactory.initializeJourneyState(propertyOwnershipId, principal) },
+            dispatch = dispatch,
+        )
 
     private fun throwErrorIfUserIsNotAuthorized(
         baseUserId: String,

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/UpdateEpcController.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/UpdateEpcController.kt
@@ -15,8 +15,8 @@ import uk.gov.communities.prsdb.webapp.constants.LANDLORD_PATH_SEGMENT
 import uk.gov.communities.prsdb.webapp.constants.PROPERTY_DETAILS_SEGMENT
 import uk.gov.communities.prsdb.webapp.controllers.UpdateEpcController.Companion.UPDATE_EPC_ROUTE
 import uk.gov.communities.prsdb.webapp.journeys.FormData
-import uk.gov.communities.prsdb.webapp.journeys.JourneyStateService
-import uk.gov.communities.prsdb.webapp.journeys.NoSuchJourneyException
+import uk.gov.communities.prsdb.webapp.journeys.JourneyStepDispatcher
+import uk.gov.communities.prsdb.webapp.journeys.StepLifecycleOrchestrator
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.StartEpcStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.update.epc.UpdateEpcJourneyFactory
 import uk.gov.communities.prsdb.webapp.services.PropertyOwnershipService
@@ -29,43 +29,40 @@ class UpdateEpcController(
     private val journeyFactory: UpdateEpcJourneyFactory,
     private val propertyOwnershipService: PropertyOwnershipService,
 ) {
-    @GetMapping("{stepName}")
+    @GetMapping("/{*stepPath}")
     fun getUpdateStep(
         principal: Principal,
         @PathVariable propertyOwnershipId: Long,
-        @PathVariable("stepName") stepName: String,
+        @PathVariable stepPath: String,
     ): ModelAndView {
         throwErrorIfUserIsNotAuthorized(principal.name, propertyOwnershipId)
-        return try {
-            val journeyMap = journeyFactory.createJourneySteps(propertyOwnershipId)
-            journeyMap[stepName]?.getStepModelAndView()
-                ?: throw ResponseStatusException(HttpStatus.NOT_FOUND, "Step not found")
-        } catch (_: NoSuchJourneyException) {
-            val journeyId = journeyFactory.initializeJourneyState(propertyOwnershipId, principal)
-            val redirectUrl = JourneyStateService.urlWithJourneyState(stepName, journeyId)
-            ModelAndView("redirect:$redirectUrl")
-        }
+        return dispatchJourneyStep(stepPath, propertyOwnershipId, principal) { getStepModelAndView() }
     }
 
-    @PostMapping("{stepName}")
+    @PostMapping("/{*stepPath}")
     fun postUpdateStep(
         model: Model,
         principal: Principal,
         @PathVariable propertyOwnershipId: Long,
-        @PathVariable("stepName") stepName: String,
+        @PathVariable stepPath: String,
         @RequestParam formData: FormData,
     ): ModelAndView {
         throwErrorIfUserIsNotAuthorized(principal.name, propertyOwnershipId)
-        return try {
-            val journeyMap = journeyFactory.createJourneySteps(propertyOwnershipId)
-            journeyMap[stepName]?.postStepModelAndView(formData)
-                ?: throw ResponseStatusException(HttpStatus.NOT_FOUND, "Step not found")
-        } catch (_: NoSuchJourneyException) {
-            val journeyId = journeyFactory.initializeJourneyState(propertyOwnershipId, principal)
-            val redirectUrl = JourneyStateService.urlWithJourneyState(stepName, journeyId)
-            ModelAndView("redirect:$redirectUrl")
-        }
+        return dispatchJourneyStep(stepPath, propertyOwnershipId, principal) { postStepModelAndView(formData) }
     }
+
+    private fun dispatchJourneyStep(
+        stepPath: String,
+        propertyOwnershipId: Long,
+        principal: Principal,
+        dispatch: StepLifecycleOrchestrator.() -> ModelAndView,
+    ): ModelAndView =
+        JourneyStepDispatcher.handleInitialisableRequest(
+            rawStepPath = stepPath,
+            createRoutingMap = { journeyFactory.createJourneySteps(propertyOwnershipId) },
+            initialiseJourney = { journeyFactory.initializeJourneyState(propertyOwnershipId, principal) },
+            dispatch = dispatch,
+        )
 
     private fun throwErrorIfUserIsNotAuthorized(
         baseUserId: String,

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/UpdateFurnishedStatusController.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/UpdateFurnishedStatusController.kt
@@ -15,8 +15,8 @@ import uk.gov.communities.prsdb.webapp.constants.LANDLORD_PATH_SEGMENT
 import uk.gov.communities.prsdb.webapp.constants.PROPERTY_DETAILS_SEGMENT
 import uk.gov.communities.prsdb.webapp.controllers.UpdateFurnishedStatusController.Companion.UPDATE_FURNISHED_STATUS_ROUTE
 import uk.gov.communities.prsdb.webapp.journeys.FormData
-import uk.gov.communities.prsdb.webapp.journeys.JourneyStateService
-import uk.gov.communities.prsdb.webapp.journeys.NoSuchJourneyException
+import uk.gov.communities.prsdb.webapp.journeys.JourneyStepDispatcher
+import uk.gov.communities.prsdb.webapp.journeys.StepLifecycleOrchestrator
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.update.furnishedStatus.UpdateFurnishedStatusJourneyFactory
 import uk.gov.communities.prsdb.webapp.services.PropertyOwnershipService
 import java.security.Principal
@@ -28,43 +28,40 @@ class UpdateFurnishedStatusController(
     private val journeyFactory: UpdateFurnishedStatusJourneyFactory,
     private val propertyOwnershipService: PropertyOwnershipService,
 ) {
-    @GetMapping("{stepName}")
+    @GetMapping("/{*stepPath}")
     fun getUpdateStep(
         principal: Principal,
         @PathVariable propertyOwnershipId: Long,
-        @PathVariable("stepName") stepName: String,
+        @PathVariable stepPath: String,
     ): ModelAndView {
         throwErrorIfUserIsNotAuthorized(principal.name, propertyOwnershipId)
-        return try {
-            val journeyMap = journeyFactory.createJourneySteps(propertyOwnershipId)
-            journeyMap[stepName]?.getStepModelAndView()
-                ?: throw ResponseStatusException(HttpStatus.NOT_FOUND, "Step not found")
-        } catch (_: NoSuchJourneyException) {
-            val journeyId = journeyFactory.initializeJourneyState(propertyOwnershipId, principal)
-            val redirectUrl = JourneyStateService.urlWithJourneyState(stepName, journeyId)
-            ModelAndView("redirect:$redirectUrl")
-        }
+        return dispatchJourneyStep(stepPath, propertyOwnershipId, principal) { getStepModelAndView() }
     }
 
-    @PostMapping("{stepName}")
+    @PostMapping("/{*stepPath}")
     fun postUpdateStep(
         model: Model,
         principal: Principal,
         @PathVariable propertyOwnershipId: Long,
-        @PathVariable("stepName") stepName: String,
+        @PathVariable stepPath: String,
         @RequestParam formData: FormData,
     ): ModelAndView {
         throwErrorIfUserIsNotAuthorized(principal.name, propertyOwnershipId)
-        return try {
-            val journeyMap = journeyFactory.createJourneySteps(propertyOwnershipId)
-            journeyMap[stepName]?.postStepModelAndView(formData)
-                ?: throw ResponseStatusException(HttpStatus.NOT_FOUND, "Step not found")
-        } catch (_: NoSuchJourneyException) {
-            val journeyId = journeyFactory.initializeJourneyState(propertyOwnershipId, principal)
-            val redirectUrl = JourneyStateService.urlWithJourneyState(stepName, journeyId)
-            ModelAndView("redirect:$redirectUrl")
-        }
+        return dispatchJourneyStep(stepPath, propertyOwnershipId, principal) { postStepModelAndView(formData) }
     }
+
+    private fun dispatchJourneyStep(
+        stepPath: String,
+        propertyOwnershipId: Long,
+        principal: Principal,
+        dispatch: StepLifecycleOrchestrator.() -> ModelAndView,
+    ): ModelAndView =
+        JourneyStepDispatcher.handleInitialisableRequest(
+            rawStepPath = stepPath,
+            createRoutingMap = { journeyFactory.createJourneySteps(propertyOwnershipId) },
+            initialiseJourney = { journeyFactory.initializeJourneyState(propertyOwnershipId, principal) },
+            dispatch = dispatch,
+        )
 
     private fun throwErrorIfUserIsNotAuthorized(
         baseUserId: String,

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/UpdateGasSafetyController.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/UpdateGasSafetyController.kt
@@ -24,8 +24,8 @@ import uk.gov.communities.prsdb.webapp.helpers.CertificateFilenameHelper
 import uk.gov.communities.prsdb.webapp.helpers.CertificateUploadHelper
 import uk.gov.communities.prsdb.webapp.journeys.FormData
 import uk.gov.communities.prsdb.webapp.journeys.JourneyIdProvider
-import uk.gov.communities.prsdb.webapp.journeys.JourneyStateService
-import uk.gov.communities.prsdb.webapp.journeys.NoSuchJourneyException
+import uk.gov.communities.prsdb.webapp.journeys.JourneyStepDispatcher
+import uk.gov.communities.prsdb.webapp.journeys.StepLifecycleOrchestrator
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.HasGasSupplyStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.update.gasSafety.UpdateGasSafetyJourneyFactory
 import uk.gov.communities.prsdb.webapp.services.CollectionKeyParameterService
@@ -41,40 +41,32 @@ class UpdateGasSafetyController(
     private val propertyOwnershipService: PropertyOwnershipService,
     private val certificateUploadHelper: CertificateUploadHelper,
 ) {
-    @GetMapping("{stepName}")
+    @GetMapping("/{*stepPath}")
     fun getUpdateStep(
         principal: Principal,
         @PathVariable propertyOwnershipId: Long,
-        @PathVariable("stepName") stepName: String,
+        @PathVariable stepPath: String,
     ): ModelAndView {
         throwErrorIfUserIsNotAuthorized(principal.name, propertyOwnershipId)
-        return try {
-            val journeyMap = journeyFactory.createJourneySteps(propertyOwnershipId)
-            journeyMap[stepName]?.getStepModelAndView()
-                ?: throw ResponseStatusException(HttpStatus.NOT_FOUND, "Step not found")
-        } catch (_: NoSuchJourneyException) {
-            val journeyId = journeyFactory.initializeJourneyState(propertyOwnershipId, principal)
-            val redirectUrl = JourneyStateService.urlWithJourneyState(stepName, journeyId)
-            ModelAndView("redirect:$redirectUrl")
-        }
+        return dispatchJourneyStep(stepPath, propertyOwnershipId, principal) { getStepModelAndView() }
     }
 
-    @PostMapping("{stepName}")
+    @PostMapping("/{*stepPath}")
     fun postUpdateStep(
         model: Model,
         principal: Principal,
         @PathVariable propertyOwnershipId: Long,
-        @PathVariable("stepName") stepName: String,
+        @PathVariable stepPath: String,
         @RequestParam formData: FormData,
     ): ModelAndView {
         throwErrorIfUserIsNotAuthorized(principal.name, propertyOwnershipId)
 
-        return postProcessedJourneyData(stepName, formData, principal, propertyOwnershipId)
+        return dispatchJourneyStep(stepPath, propertyOwnershipId, principal) { postStepModelAndView(formData) }
     }
 
-    @PostMapping("/{stepName}", consumes = [MediaType.MULTIPART_FORM_DATA_VALUE])
+    @PostMapping("/{*stepPath}", consumes = [MediaType.MULTIPART_FORM_DATA_VALUE])
     fun postFileUploadStep(
-        @PathVariable("stepName") stepName: String,
+        @PathVariable stepPath: String,
         @PathVariable propertyOwnershipId: Long,
         @RequestParam(JourneyIdProvider.PARAMETER_NAME) journeyId: String,
         @RequestParam(CollectionKeyParameterService.PARAMETER_NAME) memberId: String?,
@@ -85,6 +77,7 @@ class UpdateGasSafetyController(
     ): ModelAndView {
         throwErrorIfUserIsNotAuthorized(principal.name, propertyOwnershipId)
 
+        val stepName = stepPath.trimStart('/')
         val formData =
             certificateUploadHelper.uploadFileAndReturnFormModel(
                 CertificateFilenameHelper.getCertFilename(journeyId, stepName, memberId),
@@ -93,24 +86,21 @@ class UpdateGasSafetyController(
                 request,
             )
 
-        return postProcessedJourneyData(stepName, formData, principal, propertyOwnershipId)
+        return dispatchJourneyStep(stepPath, propertyOwnershipId, principal) { postStepModelAndView(formData) }
     }
 
-    private fun postProcessedJourneyData(
-        stepName: String,
-        formData: FormData,
-        principal: Principal,
+    private fun dispatchJourneyStep(
+        stepPath: String,
         propertyOwnershipId: Long,
+        principal: Principal,
+        dispatch: StepLifecycleOrchestrator.() -> ModelAndView,
     ): ModelAndView =
-        try {
-            val journeyMap = journeyFactory.createJourneySteps(propertyOwnershipId)
-            journeyMap[stepName]?.postStepModelAndView(formData)
-                ?: throw ResponseStatusException(HttpStatus.NOT_FOUND, "Step not found")
-        } catch (_: NoSuchJourneyException) {
-            val journeyId = journeyFactory.initializeJourneyState(propertyOwnershipId, principal)
-            val redirectUrl = JourneyStateService.urlWithJourneyState(stepName, journeyId)
-            ModelAndView("redirect:$redirectUrl")
-        }
+        JourneyStepDispatcher.handleInitialisableRequest(
+            rawStepPath = stepPath,
+            createRoutingMap = { journeyFactory.createJourneySteps(propertyOwnershipId) },
+            initialiseJourney = { journeyFactory.initializeJourneyState(propertyOwnershipId, principal) },
+            dispatch = dispatch,
+        )
 
     private fun throwErrorIfUserIsNotAuthorized(
         baseUserId: String,

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/UpdateHouseholdsAndTenantsController.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/UpdateHouseholdsAndTenantsController.kt
@@ -15,8 +15,8 @@ import uk.gov.communities.prsdb.webapp.constants.LANDLORD_PATH_SEGMENT
 import uk.gov.communities.prsdb.webapp.constants.PROPERTY_DETAILS_SEGMENT
 import uk.gov.communities.prsdb.webapp.controllers.UpdateHouseholdsAndTenantsController.Companion.UPDATE_HOUSEHOLDS_AND_TENANTS_ROUTE
 import uk.gov.communities.prsdb.webapp.journeys.FormData
-import uk.gov.communities.prsdb.webapp.journeys.JourneyStateService
-import uk.gov.communities.prsdb.webapp.journeys.NoSuchJourneyException
+import uk.gov.communities.prsdb.webapp.journeys.JourneyStepDispatcher
+import uk.gov.communities.prsdb.webapp.journeys.StepLifecycleOrchestrator
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.update.householdsAndTenants.UpdateHouseholdsAndTenantsJourneyFactory
 import uk.gov.communities.prsdb.webapp.services.PropertyOwnershipService
 import java.security.Principal
@@ -28,43 +28,40 @@ class UpdateHouseholdsAndTenantsController(
     private val journeyFactory: UpdateHouseholdsAndTenantsJourneyFactory,
     private val propertyOwnershipService: PropertyOwnershipService,
 ) {
-    @GetMapping("{stepName}")
+    @GetMapping("/{*stepPath}")
     fun getUpdateStep(
         principal: Principal,
         @PathVariable propertyOwnershipId: Long,
-        @PathVariable("stepName") stepName: String,
+        @PathVariable stepPath: String,
     ): ModelAndView {
         throwErrorIfUserIsNotAuthorized(principal.name, propertyOwnershipId)
-        return try {
-            val journeyMap = journeyFactory.createJourneySteps(propertyOwnershipId)
-            journeyMap[stepName]?.getStepModelAndView()
-                ?: throw ResponseStatusException(HttpStatus.NOT_FOUND, "Step not found")
-        } catch (_: NoSuchJourneyException) {
-            val journeyId = journeyFactory.initializeJourneyState(propertyOwnershipId, principal)
-            val redirectUrl = JourneyStateService.urlWithJourneyState(stepName, journeyId)
-            ModelAndView("redirect:$redirectUrl")
-        }
+        return dispatchJourneyStep(stepPath, propertyOwnershipId, principal) { getStepModelAndView() }
     }
 
-    @PostMapping("{stepName}")
+    @PostMapping("/{*stepPath}")
     fun postUpdateStep(
         model: Model,
         principal: Principal,
         @PathVariable propertyOwnershipId: Long,
-        @PathVariable("stepName") stepName: String,
+        @PathVariable stepPath: String,
         @RequestParam formData: FormData,
     ): ModelAndView {
         throwErrorIfUserIsNotAuthorized(principal.name, propertyOwnershipId)
-        return try {
-            val journeyMap = journeyFactory.createJourneySteps(propertyOwnershipId)
-            journeyMap[stepName]?.postStepModelAndView(formData)
-                ?: throw ResponseStatusException(HttpStatus.NOT_FOUND, "Step not found")
-        } catch (_: NoSuchJourneyException) {
-            val journeyId = journeyFactory.initializeJourneyState(propertyOwnershipId, principal)
-            val redirectUrl = JourneyStateService.urlWithJourneyState(stepName, journeyId)
-            ModelAndView("redirect:$redirectUrl")
-        }
+        return dispatchJourneyStep(stepPath, propertyOwnershipId, principal) { postStepModelAndView(formData) }
     }
+
+    private fun dispatchJourneyStep(
+        stepPath: String,
+        propertyOwnershipId: Long,
+        principal: Principal,
+        dispatch: StepLifecycleOrchestrator.() -> ModelAndView,
+    ): ModelAndView =
+        JourneyStepDispatcher.handleInitialisableRequest(
+            rawStepPath = stepPath,
+            createRoutingMap = { journeyFactory.createJourneySteps(propertyOwnershipId) },
+            initialiseJourney = { journeyFactory.initializeJourneyState(propertyOwnershipId, principal) },
+            dispatch = dispatch,
+        )
 
     private fun throwErrorIfUserIsNotAuthorized(
         baseUserId: String,

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/UpdateLandlordAddressController.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/UpdateLandlordAddressController.kt
@@ -1,21 +1,19 @@
 package uk.gov.communities.prsdb.webapp.controllers
 
-import org.springframework.http.HttpStatus
 import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
-import org.springframework.web.server.ResponseStatusException
 import org.springframework.web.servlet.ModelAndView
 import uk.gov.communities.prsdb.webapp.annotations.webAnnotations.PrsdbController
 import uk.gov.communities.prsdb.webapp.constants.LANDLORD_DETAILS_PATH_SEGMENT
 import uk.gov.communities.prsdb.webapp.constants.LANDLORD_PATH_SEGMENT
 import uk.gov.communities.prsdb.webapp.controllers.UpdateLandlordAddressController.Companion.UPDATE_ADDRESS_ROUTE
 import uk.gov.communities.prsdb.webapp.journeys.FormData
-import uk.gov.communities.prsdb.webapp.journeys.JourneyStateService
-import uk.gov.communities.prsdb.webapp.journeys.NoSuchJourneyException
+import uk.gov.communities.prsdb.webapp.journeys.JourneyStepDispatcher
+import uk.gov.communities.prsdb.webapp.journeys.StepLifecycleOrchestrator
 import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.update.address.UpdateAddressJourneyFactory
 import java.security.Principal
 
@@ -25,36 +23,30 @@ import java.security.Principal
 class UpdateLandlordAddressController(
     private val journeyFactory: UpdateAddressJourneyFactory,
 ) {
-    @GetMapping("{stepName}")
+    @GetMapping("/{*stepPath}")
     fun getUpdateStep(
         principal: Principal,
-        @PathVariable("stepName") stepName: String,
-    ): ModelAndView =
-        try {
-            val journeyMap = journeyFactory.createJourneySteps()
-            journeyMap[stepName]?.getStepModelAndView()
-                ?: throw ResponseStatusException(HttpStatus.NOT_FOUND, "Step not found")
-        } catch (_: NoSuchJourneyException) {
-            val journeyId = journeyFactory.initializeJourneyState(principal)
-            val redirectUrl = JourneyStateService.urlWithJourneyState(stepName, journeyId)
-            ModelAndView("redirect:$redirectUrl")
-        }
+        @PathVariable stepPath: String,
+    ): ModelAndView = dispatchJourneyStep(stepPath, principal) { getStepModelAndView() }
 
-    @PostMapping("{stepName}")
+    @PostMapping("/{*stepPath}")
     fun postUpdateStep(
         principal: Principal,
-        @PathVariable("stepName") stepName: String,
+        @PathVariable stepPath: String,
         @RequestParam formData: FormData,
+    ): ModelAndView = dispatchJourneyStep(stepPath, principal) { postStepModelAndView(formData) }
+
+    private fun dispatchJourneyStep(
+        stepPath: String,
+        principal: Principal,
+        dispatch: StepLifecycleOrchestrator.() -> ModelAndView,
     ): ModelAndView =
-        try {
-            val journeyMap = journeyFactory.createJourneySteps()
-            journeyMap[stepName]?.postStepModelAndView(formData)
-                ?: throw ResponseStatusException(HttpStatus.NOT_FOUND, "Step not found")
-        } catch (_: NoSuchJourneyException) {
-            val journeyId = journeyFactory.initializeJourneyState(principal)
-            val redirectUrl = JourneyStateService.urlWithJourneyState(stepName, journeyId)
-            ModelAndView("redirect:$redirectUrl")
-        }
+        JourneyStepDispatcher.handleInitialisableRequest(
+            rawStepPath = stepPath,
+            createRoutingMap = { journeyFactory.createJourneySteps() },
+            initialiseJourney = { journeyFactory.initializeJourneyState(principal) },
+            dispatch = dispatch,
+        )
 
     companion object {
         const val UPDATE_ADDRESS_ROUTE = "/$LANDLORD_PATH_SEGMENT/$LANDLORD_DETAILS_PATH_SEGMENT/update-address"

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/UpdateLandlordDateOfBirthController.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/UpdateLandlordDateOfBirthController.kt
@@ -1,21 +1,19 @@
 package uk.gov.communities.prsdb.webapp.controllers
 
-import org.springframework.http.HttpStatus
 import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
-import org.springframework.web.server.ResponseStatusException
 import org.springframework.web.servlet.ModelAndView
 import uk.gov.communities.prsdb.webapp.annotations.webAnnotations.PrsdbController
 import uk.gov.communities.prsdb.webapp.constants.LANDLORD_DETAILS_PATH_SEGMENT
 import uk.gov.communities.prsdb.webapp.constants.LANDLORD_PATH_SEGMENT
 import uk.gov.communities.prsdb.webapp.controllers.UpdateLandlordDateOfBirthController.Companion.UPDATE_DATE_OF_BIRTH_ROUTE
 import uk.gov.communities.prsdb.webapp.journeys.FormData
-import uk.gov.communities.prsdb.webapp.journeys.JourneyStateService
-import uk.gov.communities.prsdb.webapp.journeys.NoSuchJourneyException
+import uk.gov.communities.prsdb.webapp.journeys.JourneyStepDispatcher
+import uk.gov.communities.prsdb.webapp.journeys.StepLifecycleOrchestrator
 import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.update.dateOfBirth.UpdateDateOfBirthJourneyFactory
 import java.security.Principal
 
@@ -25,36 +23,30 @@ import java.security.Principal
 class UpdateLandlordDateOfBirthController(
     private val journeyFactory: UpdateDateOfBirthJourneyFactory,
 ) {
-    @GetMapping("{stepName}")
+    @GetMapping("/{*stepPath}")
     fun getUpdateStep(
         principal: Principal,
-        @PathVariable("stepName") stepName: String,
-    ): ModelAndView =
-        try {
-            val journeyMap = journeyFactory.createJourneySteps()
-            journeyMap[stepName]?.getStepModelAndView()
-                ?: throw ResponseStatusException(HttpStatus.NOT_FOUND, "Step not found")
-        } catch (_: NoSuchJourneyException) {
-            val journeyId = journeyFactory.initializeJourneyState(principal)
-            val redirectUrl = JourneyStateService.urlWithJourneyState(stepName, journeyId)
-            ModelAndView("redirect:$redirectUrl")
-        }
+        @PathVariable stepPath: String,
+    ): ModelAndView = dispatchJourneyStep(stepPath, principal) { getStepModelAndView() }
 
-    @PostMapping("{stepName}")
+    @PostMapping("/{*stepPath}")
     fun postUpdateStep(
         principal: Principal,
-        @PathVariable("stepName") stepName: String,
+        @PathVariable stepPath: String,
         @RequestParam formData: FormData,
+    ): ModelAndView = dispatchJourneyStep(stepPath, principal) { postStepModelAndView(formData) }
+
+    private fun dispatchJourneyStep(
+        stepPath: String,
+        principal: Principal,
+        dispatch: StepLifecycleOrchestrator.() -> ModelAndView,
     ): ModelAndView =
-        try {
-            val journeyMap = journeyFactory.createJourneySteps()
-            journeyMap[stepName]?.postStepModelAndView(formData)
-                ?: throw ResponseStatusException(HttpStatus.NOT_FOUND, "Step not found")
-        } catch (_: NoSuchJourneyException) {
-            val journeyId = journeyFactory.initializeJourneyState(principal)
-            val redirectUrl = JourneyStateService.urlWithJourneyState(stepName, journeyId)
-            ModelAndView("redirect:$redirectUrl")
-        }
+        JourneyStepDispatcher.handleInitialisableRequest(
+            rawStepPath = stepPath,
+            createRoutingMap = { journeyFactory.createJourneySteps() },
+            initialiseJourney = { journeyFactory.initializeJourneyState(principal) },
+            dispatch = dispatch,
+        )
 
     companion object {
         const val UPDATE_DATE_OF_BIRTH_ROUTE = "/$LANDLORD_PATH_SEGMENT/$LANDLORD_DETAILS_PATH_SEGMENT/update-date-of-birth"

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/UpdateLandlordEmailController.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/UpdateLandlordEmailController.kt
@@ -1,21 +1,19 @@
 package uk.gov.communities.prsdb.webapp.controllers
 
-import org.springframework.http.HttpStatus
 import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
-import org.springframework.web.server.ResponseStatusException
 import org.springframework.web.servlet.ModelAndView
 import uk.gov.communities.prsdb.webapp.annotations.webAnnotations.PrsdbController
 import uk.gov.communities.prsdb.webapp.constants.LANDLORD_DETAILS_PATH_SEGMENT
 import uk.gov.communities.prsdb.webapp.constants.LANDLORD_PATH_SEGMENT
 import uk.gov.communities.prsdb.webapp.controllers.UpdateLandlordEmailController.Companion.UPDATE_EMAIL_ROUTE
 import uk.gov.communities.prsdb.webapp.journeys.FormData
-import uk.gov.communities.prsdb.webapp.journeys.JourneyStateService
-import uk.gov.communities.prsdb.webapp.journeys.NoSuchJourneyException
+import uk.gov.communities.prsdb.webapp.journeys.JourneyStepDispatcher
+import uk.gov.communities.prsdb.webapp.journeys.StepLifecycleOrchestrator
 import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.update.email.UpdateEmailJourneyFactory
 import java.security.Principal
 
@@ -25,36 +23,30 @@ import java.security.Principal
 class UpdateLandlordEmailController(
     private val journeyFactory: UpdateEmailJourneyFactory,
 ) {
-    @GetMapping("{stepName}")
+    @GetMapping("/{*stepPath}")
     fun getUpdateStep(
         principal: Principal,
-        @PathVariable("stepName") stepName: String,
-    ): ModelAndView =
-        try {
-            val journeyMap = journeyFactory.createJourneySteps()
-            journeyMap[stepName]?.getStepModelAndView()
-                ?: throw ResponseStatusException(HttpStatus.NOT_FOUND, "Step not found")
-        } catch (_: NoSuchJourneyException) {
-            val journeyId = journeyFactory.initializeJourneyState(principal)
-            val redirectUrl = JourneyStateService.urlWithJourneyState(stepName, journeyId)
-            ModelAndView("redirect:$redirectUrl")
-        }
+        @PathVariable stepPath: String,
+    ): ModelAndView = dispatchJourneyStep(stepPath, principal) { getStepModelAndView() }
 
-    @PostMapping("{stepName}")
+    @PostMapping("/{*stepPath}")
     fun postUpdateStep(
         principal: Principal,
-        @PathVariable("stepName") stepName: String,
+        @PathVariable stepPath: String,
         @RequestParam formData: FormData,
+    ): ModelAndView = dispatchJourneyStep(stepPath, principal) { postStepModelAndView(formData) }
+
+    private fun dispatchJourneyStep(
+        stepPath: String,
+        principal: Principal,
+        dispatch: StepLifecycleOrchestrator.() -> ModelAndView,
     ): ModelAndView =
-        try {
-            val journeyMap = journeyFactory.createJourneySteps()
-            journeyMap[stepName]?.postStepModelAndView(formData)
-                ?: throw ResponseStatusException(HttpStatus.NOT_FOUND, "Step not found")
-        } catch (_: NoSuchJourneyException) {
-            val journeyId = journeyFactory.initializeJourneyState(principal)
-            val redirectUrl = JourneyStateService.urlWithJourneyState(stepName, journeyId)
-            ModelAndView("redirect:$redirectUrl")
-        }
+        JourneyStepDispatcher.handleInitialisableRequest(
+            rawStepPath = stepPath,
+            createRoutingMap = { journeyFactory.createJourneySteps() },
+            initialiseJourney = { journeyFactory.initializeJourneyState(principal) },
+            dispatch = dispatch,
+        )
 
     companion object {
         const val UPDATE_EMAIL_ROUTE = "/$LANDLORD_PATH_SEGMENT/$LANDLORD_DETAILS_PATH_SEGMENT/update-email"

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/UpdateLandlordNameController.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/UpdateLandlordNameController.kt
@@ -1,21 +1,19 @@
 package uk.gov.communities.prsdb.webapp.controllers
 
-import org.springframework.http.HttpStatus
 import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
-import org.springframework.web.server.ResponseStatusException
 import org.springframework.web.servlet.ModelAndView
 import uk.gov.communities.prsdb.webapp.annotations.webAnnotations.PrsdbController
 import uk.gov.communities.prsdb.webapp.constants.LANDLORD_DETAILS_PATH_SEGMENT
 import uk.gov.communities.prsdb.webapp.constants.LANDLORD_PATH_SEGMENT
 import uk.gov.communities.prsdb.webapp.controllers.UpdateLandlordNameController.Companion.UPDATE_NAME_ROUTE
 import uk.gov.communities.prsdb.webapp.journeys.FormData
-import uk.gov.communities.prsdb.webapp.journeys.JourneyStateService
-import uk.gov.communities.prsdb.webapp.journeys.NoSuchJourneyException
+import uk.gov.communities.prsdb.webapp.journeys.JourneyStepDispatcher
+import uk.gov.communities.prsdb.webapp.journeys.StepLifecycleOrchestrator
 import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.update.name.UpdateNameJourneyFactory
 import java.security.Principal
 
@@ -25,36 +23,30 @@ import java.security.Principal
 class UpdateLandlordNameController(
     private val journeyFactory: UpdateNameJourneyFactory,
 ) {
-    @GetMapping("{stepName}")
+    @GetMapping("/{*stepPath}")
     fun getUpdateStep(
         principal: Principal,
-        @PathVariable("stepName") stepName: String,
-    ): ModelAndView =
-        try {
-            val journeyMap = journeyFactory.createJourneySteps()
-            journeyMap[stepName]?.getStepModelAndView()
-                ?: throw ResponseStatusException(HttpStatus.NOT_FOUND, "Step not found")
-        } catch (_: NoSuchJourneyException) {
-            val journeyId = journeyFactory.initializeJourneyState(principal)
-            val redirectUrl = JourneyStateService.urlWithJourneyState(stepName, journeyId)
-            ModelAndView("redirect:$redirectUrl")
-        }
+        @PathVariable stepPath: String,
+    ): ModelAndView = dispatchJourneyStep(stepPath, principal) { getStepModelAndView() }
 
-    @PostMapping("{stepName}")
+    @PostMapping("/{*stepPath}")
     fun postUpdateStep(
         principal: Principal,
-        @PathVariable("stepName") stepName: String,
+        @PathVariable stepPath: String,
         @RequestParam formData: FormData,
+    ): ModelAndView = dispatchJourneyStep(stepPath, principal) { postStepModelAndView(formData) }
+
+    private fun dispatchJourneyStep(
+        stepPath: String,
+        principal: Principal,
+        dispatch: StepLifecycleOrchestrator.() -> ModelAndView,
     ): ModelAndView =
-        try {
-            val journeyMap = journeyFactory.createJourneySteps()
-            journeyMap[stepName]?.postStepModelAndView(formData)
-                ?: throw ResponseStatusException(HttpStatus.NOT_FOUND, "Step not found")
-        } catch (_: NoSuchJourneyException) {
-            val journeyId = journeyFactory.initializeJourneyState(principal)
-            val redirectUrl = JourneyStateService.urlWithJourneyState(stepName, journeyId)
-            ModelAndView("redirect:$redirectUrl")
-        }
+        JourneyStepDispatcher.handleInitialisableRequest(
+            rawStepPath = stepPath,
+            createRoutingMap = { journeyFactory.createJourneySteps() },
+            initialiseJourney = { journeyFactory.initializeJourneyState(principal) },
+            dispatch = dispatch,
+        )
 
     companion object {
         const val UPDATE_NAME_ROUTE = "/$LANDLORD_PATH_SEGMENT/$LANDLORD_DETAILS_PATH_SEGMENT/update-name"

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/UpdateLandlordPhoneNumberController.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/UpdateLandlordPhoneNumberController.kt
@@ -1,21 +1,19 @@
 package uk.gov.communities.prsdb.webapp.controllers
 
-import org.springframework.http.HttpStatus
 import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
-import org.springframework.web.server.ResponseStatusException
 import org.springframework.web.servlet.ModelAndView
 import uk.gov.communities.prsdb.webapp.annotations.webAnnotations.PrsdbController
 import uk.gov.communities.prsdb.webapp.constants.LANDLORD_DETAILS_PATH_SEGMENT
 import uk.gov.communities.prsdb.webapp.constants.LANDLORD_PATH_SEGMENT
 import uk.gov.communities.prsdb.webapp.controllers.UpdateLandlordPhoneNumberController.Companion.UPDATE_PHONE_NUMBER_ROUTE
 import uk.gov.communities.prsdb.webapp.journeys.FormData
-import uk.gov.communities.prsdb.webapp.journeys.JourneyStateService
-import uk.gov.communities.prsdb.webapp.journeys.NoSuchJourneyException
+import uk.gov.communities.prsdb.webapp.journeys.JourneyStepDispatcher
+import uk.gov.communities.prsdb.webapp.journeys.StepLifecycleOrchestrator
 import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.update.phoneNumber.UpdatePhoneNumberJourneyFactory
 import java.security.Principal
 
@@ -25,36 +23,30 @@ import java.security.Principal
 class UpdateLandlordPhoneNumberController(
     private val updatePhoneNumberJourneyFactory: UpdatePhoneNumberJourneyFactory,
 ) {
-    @GetMapping("/{stepName}")
+    @GetMapping("/{*stepPath}")
     fun getJourneyStep(
-        @PathVariable stepName: String,
+        @PathVariable stepPath: String,
         principal: Principal,
-    ): ModelAndView =
-        try {
-            val journeySteps = updatePhoneNumberJourneyFactory.createJourneySteps()
-            journeySteps[stepName]?.getStepModelAndView()
-                ?: throw ResponseStatusException(HttpStatus.NOT_FOUND, "Step not found")
-        } catch (_: NoSuchJourneyException) {
-            val journeyId = updatePhoneNumberJourneyFactory.initializeJourneyState(principal)
-            val redirectUrl = JourneyStateService.urlWithJourneyState(stepName, journeyId)
-            ModelAndView("redirect:$redirectUrl")
-        }
+    ): ModelAndView = dispatchJourneyStep(stepPath, principal) { getStepModelAndView() }
 
-    @PostMapping("/{stepName}")
+    @PostMapping("/{*stepPath}")
     fun postJourneyStep(
-        @PathVariable stepName: String,
+        @PathVariable stepPath: String,
         @RequestParam formData: FormData,
         principal: Principal,
+    ): ModelAndView = dispatchJourneyStep(stepPath, principal) { postStepModelAndView(formData) }
+
+    private fun dispatchJourneyStep(
+        stepPath: String,
+        principal: Principal,
+        dispatch: StepLifecycleOrchestrator.() -> ModelAndView,
     ): ModelAndView =
-        try {
-            val journeySteps = updatePhoneNumberJourneyFactory.createJourneySteps()
-            journeySteps[stepName]?.postStepModelAndView(formData)
-                ?: throw ResponseStatusException(HttpStatus.NOT_FOUND, "Step not found")
-        } catch (_: NoSuchJourneyException) {
-            val journeyId = updatePhoneNumberJourneyFactory.initializeJourneyState(principal)
-            val redirectUrl = JourneyStateService.urlWithJourneyState(stepName, journeyId)
-            ModelAndView("redirect:$redirectUrl")
-        }
+        JourneyStepDispatcher.handleInitialisableRequest(
+            rawStepPath = stepPath,
+            createRoutingMap = { updatePhoneNumberJourneyFactory.createJourneySteps() },
+            initialiseJourney = { updatePhoneNumberJourneyFactory.initializeJourneyState(principal) },
+            dispatch = dispatch,
+        )
 
     companion object {
         const val UPDATE_PHONE_NUMBER_ROUTE = "/$LANDLORD_PATH_SEGMENT/$LANDLORD_DETAILS_PATH_SEGMENT/update-phone-number"

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/UpdateLicensingController.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/UpdateLicensingController.kt
@@ -16,8 +16,8 @@ import uk.gov.communities.prsdb.webapp.constants.LANDLORD_PATH_SEGMENT
 import uk.gov.communities.prsdb.webapp.constants.PROPERTY_DETAILS_SEGMENT
 import uk.gov.communities.prsdb.webapp.controllers.UpdateLicensingController.Companion.UPDATE_LICENSING_ROUTE
 import uk.gov.communities.prsdb.webapp.journeys.FormData
-import uk.gov.communities.prsdb.webapp.journeys.JourneyStateService
-import uk.gov.communities.prsdb.webapp.journeys.NoSuchJourneyException
+import uk.gov.communities.prsdb.webapp.journeys.JourneyStepDispatcher
+import uk.gov.communities.prsdb.webapp.journeys.StepLifecycleOrchestrator
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.update.updateLicensing.UpdateLicensingJourneyFactory
 import uk.gov.communities.prsdb.webapp.services.PropertyOwnershipService
 import java.security.Principal
@@ -29,43 +29,40 @@ class UpdateLicensingController(
     private val journeyFactory: UpdateLicensingJourneyFactory,
     private val propertyOwnershipService: PropertyOwnershipService,
 ) {
-    @GetMapping("{stepName}")
+    @GetMapping("/{*stepPath}")
     fun getUpdateStep(
         principal: Principal,
         @PathVariable propertyOwnershipId: Long,
-        @PathVariable("stepName") stepName: String,
+        @PathVariable stepPath: String,
     ): ModelAndView {
         throwErrorIfUserIsNotAuthorized(principal.name, propertyOwnershipId)
-        return try {
-            val journeyMap = journeyFactory.createJourneySteps(propertyOwnershipId)
-            journeyMap[stepName]?.getStepModelAndView()
-                ?: throw ResponseStatusException(HttpStatus.NOT_FOUND, "Step not found")
-        } catch (_: NoSuchJourneyException) {
-            val journeyId = journeyFactory.initializeJourneyState(propertyOwnershipId, principal)
-            val redirectUrl = JourneyStateService.urlWithJourneyState(stepName, journeyId)
-            ModelAndView("redirect:$redirectUrl")
-        }
+        return dispatchJourneyStep(stepPath, propertyOwnershipId, principal) { getStepModelAndView() }
     }
 
-    @PostMapping("{stepName}")
+    @PostMapping("/{*stepPath}")
     fun postUpdateStep(
         model: Model,
         principal: Principal,
         @PathVariable propertyOwnershipId: Long,
-        @PathVariable("stepName") stepName: String,
+        @PathVariable stepPath: String,
         @RequestParam formData: FormData,
     ): ModelAndView {
         throwErrorIfUserIsNotAuthorized(principal.name, propertyOwnershipId)
-        return try {
-            val journeyMap = journeyFactory.createJourneySteps(propertyOwnershipId)
-            journeyMap[stepName]?.postStepModelAndView(formData)
-                ?: throw ResponseStatusException(HttpStatus.NOT_FOUND, "Step not found")
-        } catch (_: NoSuchJourneyException) {
-            val journeyId = journeyFactory.initializeJourneyState(propertyOwnershipId, principal)
-            val redirectUrl = JourneyStateService.urlWithJourneyState(stepName, journeyId)
-            ModelAndView("redirect:$redirectUrl")
-        }
+        return dispatchJourneyStep(stepPath, propertyOwnershipId, principal) { postStepModelAndView(formData) }
     }
+
+    private fun dispatchJourneyStep(
+        stepPath: String,
+        propertyOwnershipId: Long,
+        principal: Principal,
+        dispatch: StepLifecycleOrchestrator.() -> ModelAndView,
+    ): ModelAndView =
+        JourneyStepDispatcher.handleInitialisableRequest(
+            rawStepPath = stepPath,
+            createRoutingMap = { journeyFactory.createJourneySteps(propertyOwnershipId) },
+            initialiseJourney = { journeyFactory.initializeJourneyState(propertyOwnershipId, principal) },
+            dispatch = dispatch,
+        )
 
     private fun throwErrorIfUserIsNotAuthorized(
         baseUserId: String,

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/UpdateOccupancyController.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/UpdateOccupancyController.kt
@@ -15,8 +15,8 @@ import uk.gov.communities.prsdb.webapp.constants.LANDLORD_PATH_SEGMENT
 import uk.gov.communities.prsdb.webapp.constants.PROPERTY_DETAILS_SEGMENT
 import uk.gov.communities.prsdb.webapp.controllers.UpdateOccupancyController.Companion.UPDATE_OCCUPANCY_ROUTE
 import uk.gov.communities.prsdb.webapp.journeys.FormData
-import uk.gov.communities.prsdb.webapp.journeys.JourneyStateService
-import uk.gov.communities.prsdb.webapp.journeys.NoSuchJourneyException
+import uk.gov.communities.prsdb.webapp.journeys.JourneyStepDispatcher
+import uk.gov.communities.prsdb.webapp.journeys.StepLifecycleOrchestrator
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.update.occupancy.UpdateOccupancyJourneyFactory
 import uk.gov.communities.prsdb.webapp.services.PropertyOwnershipService
 import java.security.Principal
@@ -28,43 +28,40 @@ class UpdateOccupancyController(
     private val journeyFactory: UpdateOccupancyJourneyFactory,
     private val propertyOwnershipService: PropertyOwnershipService,
 ) {
-    @GetMapping("{stepName}")
+    @GetMapping("/{*stepPath}")
     fun getUpdateStep(
         principal: Principal,
         @PathVariable propertyOwnershipId: Long,
-        @PathVariable("stepName") stepName: String,
+        @PathVariable stepPath: String,
     ): ModelAndView {
         throwErrorIfUserIsNotAuthorized(principal.name, propertyOwnershipId)
-        return try {
-            val journeyMap = journeyFactory.createJourneySteps(propertyOwnershipId)
-            journeyMap[stepName]?.getStepModelAndView()
-                ?: throw ResponseStatusException(HttpStatus.NOT_FOUND, "Step not found")
-        } catch (_: NoSuchJourneyException) {
-            val journeyId = journeyFactory.initializeJourneyState(propertyOwnershipId, principal)
-            val redirectUrl = JourneyStateService.urlWithJourneyState(stepName, journeyId)
-            ModelAndView("redirect:$redirectUrl")
-        }
+        return dispatchJourneyStep(stepPath, propertyOwnershipId, principal) { getStepModelAndView() }
     }
 
-    @PostMapping("{stepName}")
+    @PostMapping("/{*stepPath}")
     fun postUpdateStep(
         model: Model,
         principal: Principal,
         @PathVariable propertyOwnershipId: Long,
-        @PathVariable("stepName") stepName: String,
+        @PathVariable stepPath: String,
         @RequestParam formData: FormData,
     ): ModelAndView {
         throwErrorIfUserIsNotAuthorized(principal.name, propertyOwnershipId)
-        return try {
-            val journeyMap = journeyFactory.createJourneySteps(propertyOwnershipId)
-            journeyMap[stepName]?.postStepModelAndView(formData)
-                ?: throw ResponseStatusException(HttpStatus.NOT_FOUND, "Step not found")
-        } catch (_: NoSuchJourneyException) {
-            val journeyId = journeyFactory.initializeJourneyState(propertyOwnershipId, principal)
-            val redirectUrl = JourneyStateService.urlWithJourneyState(stepName, journeyId)
-            ModelAndView("redirect:$redirectUrl")
-        }
+        return dispatchJourneyStep(stepPath, propertyOwnershipId, principal) { postStepModelAndView(formData) }
     }
+
+    private fun dispatchJourneyStep(
+        stepPath: String,
+        propertyOwnershipId: Long,
+        principal: Principal,
+        dispatch: StepLifecycleOrchestrator.() -> ModelAndView,
+    ): ModelAndView =
+        JourneyStepDispatcher.handleInitialisableRequest(
+            rawStepPath = stepPath,
+            createRoutingMap = { journeyFactory.createJourneySteps(propertyOwnershipId) },
+            initialiseJourney = { journeyFactory.initializeJourneyState(propertyOwnershipId, principal) },
+            dispatch = dispatch,
+        )
 
     private fun throwErrorIfUserIsNotAuthorized(
         baseUserId: String,

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/UpdateOwnershipTypeController.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/UpdateOwnershipTypeController.kt
@@ -16,8 +16,8 @@ import uk.gov.communities.prsdb.webapp.constants.LANDLORD_PATH_SEGMENT
 import uk.gov.communities.prsdb.webapp.constants.PROPERTY_DETAILS_SEGMENT
 import uk.gov.communities.prsdb.webapp.controllers.UpdateOwnershipTypeController.Companion.UPDATE_OWNERSHIP_TYPE_ROUTE
 import uk.gov.communities.prsdb.webapp.journeys.FormData
-import uk.gov.communities.prsdb.webapp.journeys.JourneyStateService
-import uk.gov.communities.prsdb.webapp.journeys.NoSuchJourneyException
+import uk.gov.communities.prsdb.webapp.journeys.JourneyStepDispatcher
+import uk.gov.communities.prsdb.webapp.journeys.StepLifecycleOrchestrator
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.update.ownershipType.UpdateOwnershipTypeJourneyFactory
 import uk.gov.communities.prsdb.webapp.services.PropertyOwnershipService
 import java.security.Principal
@@ -29,43 +29,40 @@ class UpdateOwnershipTypeController(
     private val journeyFactory: UpdateOwnershipTypeJourneyFactory,
     private val propertyOwnershipService: PropertyOwnershipService,
 ) {
-    @GetMapping("{stepName}")
+    @GetMapping("/{*stepPath}")
     fun getUpdateStep(
         principal: Principal,
         @PathVariable propertyOwnershipId: Long,
-        @PathVariable("stepName") stepName: String,
+        @PathVariable stepPath: String,
     ): ModelAndView {
         throwErrorIfUserIsNotAuthorized(principal.name, propertyOwnershipId)
-        return try {
-            val journeyMap = journeyFactory.createJourneySteps(propertyOwnershipId)
-            journeyMap[stepName]?.getStepModelAndView()
-                ?: throw ResponseStatusException(HttpStatus.NOT_FOUND, "Step not found")
-        } catch (_: NoSuchJourneyException) {
-            val journeyId = journeyFactory.initializeJourneyState(propertyOwnershipId, principal)
-            val redirectUrl = JourneyStateService.urlWithJourneyState(stepName, journeyId)
-            ModelAndView("redirect:$redirectUrl")
-        }
+        return dispatchJourneyStep(stepPath, propertyOwnershipId, principal) { getStepModelAndView() }
     }
 
-    @PostMapping("{stepName}")
+    @PostMapping("/{*stepPath}")
     fun postUpdateStep(
         model: Model,
         principal: Principal,
         @PathVariable propertyOwnershipId: Long,
-        @PathVariable("stepName") stepName: String,
+        @PathVariable stepPath: String,
         @RequestParam formData: FormData,
     ): ModelAndView {
         throwErrorIfUserIsNotAuthorized(principal.name, propertyOwnershipId)
-        return try {
-            val journeyMap = journeyFactory.createJourneySteps(propertyOwnershipId)
-            journeyMap[stepName]?.postStepModelAndView(formData)
-                ?: throw ResponseStatusException(HttpStatus.NOT_FOUND, "Step not found")
-        } catch (_: NoSuchJourneyException) {
-            val journeyId = journeyFactory.initializeJourneyState(propertyOwnershipId, principal)
-            val redirectUrl = JourneyStateService.urlWithJourneyState(stepName, journeyId)
-            ModelAndView("redirect:$redirectUrl")
-        }
+        return dispatchJourneyStep(stepPath, propertyOwnershipId, principal) { postStepModelAndView(formData) }
     }
+
+    private fun dispatchJourneyStep(
+        stepPath: String,
+        propertyOwnershipId: Long,
+        principal: Principal,
+        dispatch: StepLifecycleOrchestrator.() -> ModelAndView,
+    ): ModelAndView =
+        JourneyStepDispatcher.handleInitialisableRequest(
+            rawStepPath = stepPath,
+            createRoutingMap = { journeyFactory.createJourneySteps(propertyOwnershipId) },
+            initialiseJourney = { journeyFactory.initializeJourneyState(propertyOwnershipId, principal) },
+            dispatch = dispatch,
+        )
 
     private fun throwErrorIfUserIsNotAuthorized(
         baseUserId: String,

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/UpdateRentFrequencyAndAmountController.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/UpdateRentFrequencyAndAmountController.kt
@@ -14,8 +14,8 @@ import uk.gov.communities.prsdb.webapp.constants.LANDLORD_PATH_SEGMENT
 import uk.gov.communities.prsdb.webapp.constants.PROPERTY_DETAILS_SEGMENT
 import uk.gov.communities.prsdb.webapp.controllers.UpdateRentFrequencyAndAmountController.Companion.UPDATE_RENT_FREQUENCY_AND_AMOUNT_ROUTE
 import uk.gov.communities.prsdb.webapp.journeys.FormData
-import uk.gov.communities.prsdb.webapp.journeys.JourneyStateService
-import uk.gov.communities.prsdb.webapp.journeys.NoSuchJourneyException
+import uk.gov.communities.prsdb.webapp.journeys.JourneyStepDispatcher
+import uk.gov.communities.prsdb.webapp.journeys.StepLifecycleOrchestrator
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.update.rentFrequencyAndAmount.UpdateRentFrequencyAndAmountJourneyFactory
 import uk.gov.communities.prsdb.webapp.services.PropertyOwnershipService
 import java.security.Principal
@@ -27,42 +27,39 @@ class UpdateRentFrequencyAndAmountController(
     private val journeyFactory: UpdateRentFrequencyAndAmountJourneyFactory,
     private val propertyOwnershipService: PropertyOwnershipService,
 ) {
-    @GetMapping("{stepName}")
+    @GetMapping("/{*stepPath}")
     fun getUpdateStep(
         principal: Principal,
         @PathVariable propertyOwnershipId: Long,
-        @PathVariable("stepName") stepName: String,
+        @PathVariable stepPath: String,
     ): ModelAndView {
         throwErrorIfUserIsNotAuthorized(principal.name, propertyOwnershipId)
-        return try {
-            val journeyMap = journeyFactory.createJourneySteps(propertyOwnershipId)
-            journeyMap[stepName]?.getStepModelAndView()
-                ?: throw ResponseStatusException(HttpStatus.NOT_FOUND, "Step not found")
-        } catch (_: NoSuchJourneyException) {
-            val journeyId = journeyFactory.initializeJourneyState(propertyOwnershipId, principal)
-            val redirectUrl = JourneyStateService.urlWithJourneyState(stepName, journeyId)
-            ModelAndView("redirect:$redirectUrl")
-        }
+        return dispatchJourneyStep(stepPath, propertyOwnershipId, principal) { getStepModelAndView() }
     }
 
-    @PostMapping("{stepName}")
+    @PostMapping("/{*stepPath}")
     fun postUpdateStep(
         principal: Principal,
         @PathVariable propertyOwnershipId: Long,
-        @PathVariable("stepName") stepName: String,
+        @PathVariable stepPath: String,
         @RequestParam formData: FormData,
     ): ModelAndView {
         throwErrorIfUserIsNotAuthorized(principal.name, propertyOwnershipId)
-        return try {
-            val journeyMap = journeyFactory.createJourneySteps(propertyOwnershipId)
-            journeyMap[stepName]?.postStepModelAndView(formData)
-                ?: throw ResponseStatusException(HttpStatus.NOT_FOUND, "Step not found")
-        } catch (_: NoSuchJourneyException) {
-            val journeyId = journeyFactory.initializeJourneyState(propertyOwnershipId, principal)
-            val redirectUrl = JourneyStateService.urlWithJourneyState(stepName, journeyId)
-            ModelAndView("redirect:$redirectUrl")
-        }
+        return dispatchJourneyStep(stepPath, propertyOwnershipId, principal) { postStepModelAndView(formData) }
     }
+
+    private fun dispatchJourneyStep(
+        stepPath: String,
+        propertyOwnershipId: Long,
+        principal: Principal,
+        dispatch: StepLifecycleOrchestrator.() -> ModelAndView,
+    ): ModelAndView =
+        JourneyStepDispatcher.handleInitialisableRequest(
+            rawStepPath = stepPath,
+            createRoutingMap = { journeyFactory.createJourneySteps(propertyOwnershipId) },
+            initialiseJourney = { journeyFactory.initializeJourneyState(propertyOwnershipId, principal) },
+            dispatch = dispatch,
+        )
 
     private fun throwErrorIfUserIsNotAuthorized(
         baseUserId: String,

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/UpdateRentIncludesBillsController.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/UpdateRentIncludesBillsController.kt
@@ -14,8 +14,8 @@ import uk.gov.communities.prsdb.webapp.constants.LANDLORD_PATH_SEGMENT
 import uk.gov.communities.prsdb.webapp.constants.PROPERTY_DETAILS_SEGMENT
 import uk.gov.communities.prsdb.webapp.controllers.UpdateRentIncludesBillsController.Companion.UPDATE_RENT_INCLUDES_BILLS_ROUTE
 import uk.gov.communities.prsdb.webapp.journeys.FormData
-import uk.gov.communities.prsdb.webapp.journeys.JourneyStateService
-import uk.gov.communities.prsdb.webapp.journeys.NoSuchJourneyException
+import uk.gov.communities.prsdb.webapp.journeys.JourneyStepDispatcher
+import uk.gov.communities.prsdb.webapp.journeys.StepLifecycleOrchestrator
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.update.rentIncludesBills.UpdateRentIncludesBillsJourneyFactory
 import uk.gov.communities.prsdb.webapp.services.PropertyOwnershipService
 import java.security.Principal
@@ -27,42 +27,39 @@ class UpdateRentIncludesBillsController(
     private val journeyFactory: UpdateRentIncludesBillsJourneyFactory,
     private val propertyOwnershipService: PropertyOwnershipService,
 ) {
-    @GetMapping("{stepName}")
+    @GetMapping("/{*stepPath}")
     fun getUpdateStep(
         principal: Principal,
         @PathVariable propertyOwnershipId: Long,
-        @PathVariable("stepName") stepName: String,
+        @PathVariable stepPath: String,
     ): ModelAndView {
         throwErrorIfUserIsNotAuthorized(principal.name, propertyOwnershipId)
-        return try {
-            val journeyMap = journeyFactory.createJourneySteps(propertyOwnershipId)
-            journeyMap[stepName]?.getStepModelAndView()
-                ?: throw ResponseStatusException(HttpStatus.NOT_FOUND, "Step not found")
-        } catch (_: NoSuchJourneyException) {
-            val journeyId = journeyFactory.initializeJourneyState(propertyOwnershipId, principal)
-            val redirectUrl = JourneyStateService.urlWithJourneyState(stepName, journeyId)
-            ModelAndView("redirect:$redirectUrl")
-        }
+        return dispatchJourneyStep(stepPath, propertyOwnershipId, principal) { getStepModelAndView() }
     }
 
-    @PostMapping("{stepName}")
+    @PostMapping("/{*stepPath}")
     fun postUpdateStep(
         principal: Principal,
         @PathVariable propertyOwnershipId: Long,
-        @PathVariable("stepName") stepName: String,
+        @PathVariable stepPath: String,
         @RequestParam formData: FormData,
     ): ModelAndView {
         throwErrorIfUserIsNotAuthorized(principal.name, propertyOwnershipId)
-        return try {
-            val journeyMap = journeyFactory.createJourneySteps(propertyOwnershipId)
-            journeyMap[stepName]?.postStepModelAndView(formData)
-                ?: throw ResponseStatusException(HttpStatus.NOT_FOUND, "Step not found")
-        } catch (_: NoSuchJourneyException) {
-            val journeyId = journeyFactory.initializeJourneyState(propertyOwnershipId, principal)
-            val redirectUrl = JourneyStateService.urlWithJourneyState(stepName, journeyId)
-            ModelAndView("redirect:$redirectUrl")
-        }
+        return dispatchJourneyStep(stepPath, propertyOwnershipId, principal) { postStepModelAndView(formData) }
     }
+
+    private fun dispatchJourneyStep(
+        stepPath: String,
+        propertyOwnershipId: Long,
+        principal: Principal,
+        dispatch: StepLifecycleOrchestrator.() -> ModelAndView,
+    ): ModelAndView =
+        JourneyStepDispatcher.handleInitialisableRequest(
+            rawStepPath = stepPath,
+            createRoutingMap = { journeyFactory.createJourneySteps(propertyOwnershipId) },
+            initialiseJourney = { journeyFactory.initializeJourneyState(propertyOwnershipId, principal) },
+            dispatch = dispatch,
+        )
 
     private fun throwErrorIfUserIsNotAuthorized(
         baseUserId: String,

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/JourneyStepDispatcher.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/JourneyStepDispatcher.kt
@@ -25,6 +25,9 @@ object JourneyStepDispatcher {
         val request = (RequestContextHolder.currentRequestAttributes() as ServletRequestAttributes).request
         request.setAttribute(JourneyStateService.JOURNEY_BASE_PATH_ATTRIBUTE, deriveJourneyBasePath(request.requestURI, rawStepPath))
         val stepPath = rawStepPath.trimStart('/')
+        if (stepPath.isEmpty()) {
+            throw ResponseStatusException(HttpStatus.NOT_FOUND, "Step not found")
+        }
         return try {
             val routingMap = createRoutingMap()
             routingMap[stepPath]?.dispatch()
@@ -48,6 +51,9 @@ object JourneyStepDispatcher {
         val request = (RequestContextHolder.currentRequestAttributes() as ServletRequestAttributes).request
         request.setAttribute(JourneyStateService.JOURNEY_BASE_PATH_ATTRIBUTE, deriveJourneyBasePath(request.requestURI, rawStepPath))
         val stepPath = rawStepPath.trimStart('/')
+        if (stepPath.isEmpty()) {
+            throw ResponseStatusException(HttpStatus.NOT_FOUND, "Step not found")
+        }
         return try {
             val routingMap = createRoutingMap()
             routingMap[stepPath]?.dispatch()

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/controllers/CancelJointLandlordInvitationControllerTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/controllers/CancelJointLandlordInvitationControllerTests.kt
@@ -13,7 +13,6 @@ import org.springframework.web.context.WebApplicationContext
 import org.springframework.web.servlet.ModelAndView
 import uk.gov.communities.prsdb.webapp.constants.CONFIRMATION_PATH_SEGMENT
 import uk.gov.communities.prsdb.webapp.controllers.CancelJointLandlordInvitationController.Companion.CANCEL_JOINT_LANDLORD_INVITATION_ROUTE
-import uk.gov.communities.prsdb.webapp.journeys.JourneyStateService
 import uk.gov.communities.prsdb.webapp.journeys.NoSuchJourneyException
 import uk.gov.communities.prsdb.webapp.journeys.StepLifecycleOrchestrator
 import uk.gov.communities.prsdb.webapp.journeys.cancelJointLandlordInvitation.CancelJointLandlordInvitationJourneyFactory
@@ -95,10 +94,7 @@ class CancelJointLandlordInvitationControllerTests(
         whenever(journeyFactory.initializeJourneyState()).thenReturn(journeyId)
 
         val expectedRedirectUrl =
-            "$CANCEL_JOINT_LANDLORD_INVITATION_ROUTE/$testInvitationId/${JourneyStateService.urlWithJourneyState(
-                AreYouSureStep.ROUTE_SEGMENT,
-                journeyId,
-            )}"
+            "$CANCEL_JOINT_LANDLORD_INVITATION_ROUTE/$testInvitationId/${AreYouSureStep.ROUTE_SEGMENT}?journeyId=$journeyId"
 
         mvc
             .get("$CANCEL_JOINT_LANDLORD_INVITATION_ROUTE/$testInvitationId/${AreYouSureStep.ROUTE_SEGMENT}")

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/controllers/DeregisterLandlordControllerTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/controllers/DeregisterLandlordControllerTests.kt
@@ -11,7 +11,6 @@ import org.springframework.web.context.WebApplicationContext
 import org.springframework.web.servlet.ModelAndView
 import uk.gov.communities.prsdb.webapp.constants.CONFIRMATION_PATH_SEGMENT
 import uk.gov.communities.prsdb.webapp.controllers.DeregisterLandlordController.Companion.LANDLORD_DEREGISTRATION_ROUTE
-import uk.gov.communities.prsdb.webapp.journeys.JourneyStateService
 import uk.gov.communities.prsdb.webapp.journeys.NoSuchJourneyException
 import uk.gov.communities.prsdb.webapp.journeys.StepLifecycleOrchestrator
 import uk.gov.communities.prsdb.webapp.journeys.landlordDeregistration.LandlordDeregistrationJourneyFactory
@@ -99,7 +98,7 @@ class DeregisterLandlordControllerTests(
             .get("$LANDLORD_DEREGISTRATION_ROUTE/${AreYouSureStep.ROUTE_SEGMENT}")
             .andExpect {
                 status { is3xxRedirection() }
-                redirectedUrl(JourneyStateService.urlWithJourneyState(AreYouSureStep.ROUTE_SEGMENT, journeyId))
+                redirectedUrl("$LANDLORD_DEREGISTRATION_ROUTE/${AreYouSureStep.ROUTE_SEGMENT}?journeyId=$journeyId")
             }
     }
 

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/controllers/DeregisterPropertyControllerTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/controllers/DeregisterPropertyControllerTests.kt
@@ -18,7 +18,6 @@ import uk.gov.communities.prsdb.webapp.constants.LANDLORD_PATH_SEGMENT
 import uk.gov.communities.prsdb.webapp.controllers.DeregisterPropertyController.Companion.getPropertyDeregistrationBasePath
 import uk.gov.communities.prsdb.webapp.controllers.DeregisterPropertyController.Companion.getPropertyDeregistrationPath
 import uk.gov.communities.prsdb.webapp.exceptions.PropertyOwnershipMismatchException
-import uk.gov.communities.prsdb.webapp.journeys.JourneyStateService
 import uk.gov.communities.prsdb.webapp.journeys.NoSuchJourneyException
 import uk.gov.communities.prsdb.webapp.journeys.StepLifecycleOrchestrator
 import uk.gov.communities.prsdb.webapp.journeys.propertyDeregistration.PropertyDeregistrationJourneyFactory
@@ -98,7 +97,7 @@ class DeregisterPropertyControllerTests(
             .get(getPropertyDeregistrationPath(1))
             .andExpect {
                 status { is3xxRedirection() }
-                redirectedUrl(JourneyStateService.urlWithJourneyState(CheckCanDeregisterStep.ROUTE_SEGMENT, journeyId))
+                redirectedUrl("${getPropertyDeregistrationPath(1)}?journeyId=$journeyId")
             }
     }
 
@@ -119,7 +118,7 @@ class DeregisterPropertyControllerTests(
             .get(getPropertyDeregistrationPath(1))
             .andExpect {
                 status { is3xxRedirection() }
-                redirectedUrl(JourneyStateService.urlWithJourneyState(CheckCanDeregisterStep.ROUTE_SEGMENT, journeyId))
+                redirectedUrl("${getPropertyDeregistrationPath(1)}?journeyId=$journeyId")
             }
     }
 

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/controllers/LeavePropertyControllerTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/controllers/LeavePropertyControllerTests.kt
@@ -21,7 +21,6 @@ import uk.gov.communities.prsdb.webapp.constants.LEAVE_PROPERTY_JOURNEY_URL
 import uk.gov.communities.prsdb.webapp.controllers.LeavePropertyController.Companion.getLeavePropertyBasePath
 import uk.gov.communities.prsdb.webapp.controllers.LeavePropertyController.Companion.getLeavePropertyPath
 import uk.gov.communities.prsdb.webapp.exceptions.PropertyOwnershipMismatchException
-import uk.gov.communities.prsdb.webapp.journeys.JourneyStateService
 import uk.gov.communities.prsdb.webapp.journeys.NoSuchJourneyException
 import uk.gov.communities.prsdb.webapp.journeys.StepLifecycleOrchestrator
 import uk.gov.communities.prsdb.webapp.journeys.leaveProperty.LeavePropertyJourneyFactory
@@ -131,7 +130,7 @@ class LeavePropertyControllerTests(
             .get(getLeavePropertyPath(testPropertyOwnershipId))
             .andExpect {
                 status { is3xxRedirection() }
-                redirectedUrl(JourneyStateService.urlWithJourneyState(ConfirmStep.ROUTE_SEGMENT, journeyId))
+                redirectedUrl("${getLeavePropertyPath(testPropertyOwnershipId)}?journeyId=$journeyId")
             }
     }
 
@@ -151,7 +150,7 @@ class LeavePropertyControllerTests(
             .get(getLeavePropertyPath(testPropertyOwnershipId))
             .andExpect {
                 status { is3xxRedirection() }
-                redirectedUrl(JourneyStateService.urlWithJourneyState(ConfirmStep.ROUTE_SEGMENT, journeyId))
+                redirectedUrl("${getLeavePropertyPath(testPropertyOwnershipId)}?journeyId=$journeyId")
             }
     }
 
@@ -247,7 +246,7 @@ class LeavePropertyControllerTests(
                 with(csrf())
             }.andExpect {
                 status { is3xxRedirection() }
-                redirectedUrl(JourneyStateService.urlWithJourneyState(ConfirmStep.ROUTE_SEGMENT, journeyId))
+                redirectedUrl("${getLeavePropertyPath(testPropertyOwnershipId)}?journeyId=$journeyId")
             }
     }
 
@@ -268,7 +267,7 @@ class LeavePropertyControllerTests(
                 with(csrf())
             }.andExpect {
                 status { is3xxRedirection() }
-                redirectedUrl(JourneyStateService.urlWithJourneyState(ConfirmStep.ROUTE_SEGMENT, journeyId))
+                redirectedUrl("${getLeavePropertyPath(testPropertyOwnershipId)}?journeyId=$journeyId")
             }
     }
 

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/JourneyStepDispatcherTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/JourneyStepDispatcherTests.kt
@@ -75,6 +75,25 @@ class JourneyStepDispatcherTests {
                 result.viewName,
             )
         }
+
+        @Test
+        fun `throws 404 without initialising a journey when the path is empty`() {
+            var initialiseCalled = false
+            val result =
+                assertThrows<ResponseStatusException> {
+                    JourneyStepDispatcher.handleInitialisableRequest(
+                        rawStepPath = "/",
+                        createRoutingMap = { throw NoSuchJourneyException("none") },
+                        initialiseJourney = {
+                            initialiseCalled = true
+                            "journey-id"
+                        },
+                        dispatch = { ModelAndView("view") },
+                    )
+                }
+            assertEquals(404, result.statusCode.value())
+            assertEquals(false, initialiseCalled)
+        }
     }
 
     @Nested
@@ -126,6 +145,25 @@ class JourneyStepDispatcherTests {
                 )
 
             assertEquals(expected, result)
+        }
+
+        @Test
+        fun `throws 404 without invoking the fallback redirect when the path is empty`() {
+            var redirectCalled = false
+            val result =
+                assertThrows<ResponseStatusException> {
+                    JourneyStepDispatcher.handleUninitialisableRequest(
+                        rawStepPath = "/",
+                        createRoutingMap = { throw NoSuchJourneyException("none") },
+                        dispatch = { ModelAndView("view") },
+                        getRedirect = {
+                            redirectCalled = true
+                            ModelAndView("redirect:/base")
+                        },
+                    )
+                }
+            assertEquals(404, result.statusCode.value())
+            assertEquals(false, redirectCalled)
         }
     }
 }


### PR DESCRIPTION
## Ticket number

PDJB-896

## Goal of change

Migrate all remaining journey controllers to `JourneyStepDispatcher` so that dispatching a journey request (routing-map lookup, journey initialisation on missing state, and complex `stepPath` support) is handled by a single shared component instead of being repeated inline in every controller.

## Description of main change(s)

- Migrated 24 controllers (one commit each) from the hand-rolled `try { routingMap[stepName]?.… } catch (NoSuchJourneyException) { … }` pattern to `JourneyStepDispatcher.handleInitialisableRequest` (or `handleUninitialisableRequest`).
- Changed journey-step mappings from `"/{stepName}"` to `"/{*stepPath}"` so nested step paths are supported.
- Preserved every controller-specific concern: pre-dispatch authorisation checks, extra path variables (`propertyOwnershipId`, `invitationId`), confirmation/resume/invalid-link endpoints, multipart file-upload POST overloads, and any additional exceptions that should trigger a new-journey redirect (e.g. `PropertyOwnershipMismatchException` on `DeregisterPropertyController`, `LeavePropertyController`, `SwitchToIndividualController`; `InvalidInvitationException` on `RegisterLocalCouncilUserController`).
- Removed now-dead `initializeAndRedirect(...)` / `getJourneySteps(...)` helpers where no longer referenced.
- Updated 3 test files (`DeregisterLandlordControllerTests`, `DeregisterPropertyControllerTests`, `LeavePropertyControllerTests`) whose redirect-URL assertions previously used the relative `JourneyStateService.urlWithJourneyState(...)`; the dispatcher now sets `JOURNEY_BASE_PATH_ATTRIBUTE` on the request so generated URLs are absolute, matching the migrated exemplars.

## Anything you'd like to highlight to the reviewer?

- `CancelJointLandlordInvitationController` previously prepended `$invitationId` manually in its redirect helper. Post-migration this is redundant because the dispatcher stores the base path on the request and journey URLs are generated absolute; the manual prefix has been removed and the existing tests still pass.
- Two `Update*` controllers had no dedicated test class (`UpdateRentFrequencyAndAmountController`, and no direct test for `SwitchToIndividualController`). Compilation was verified via `./gradlew compileKotlin compileTestKotlin`; the full `testWithoutIntegration` suite passes.
- Three `PDJB-896` TODO comments (`OccupationTask.kt:26`, `InviteJointLandlordJourneyFactory.kt:74` and `:113`) are unrelated concerns (DuplicableTaskWithDependencies / addressable tasks) and are intentionally out of scope for this PR.

## Checklist

- [x] Controller tests for any new endpoints, including testing the relevant permissions
- [x] Test suite has been run in full locally and is passing
- [x] TODO comments referencing this JIRA ticket have been searched for and removed - if a future PR will address them, mention that here
- [x] This feature is not behind a feature flag. I've checked that this is appropriate and we're happy with this code becoming live as soon as we release
