### PR TITLE
PDJB-1353: Show "Not added" for missing bedroom counts on the property record

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/summaryModels/PropertyDetailsViewModelBase.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/summaryModels/PropertyDetailsViewModelBase.kt
@@ -109,7 +109,8 @@ abstract class PropertyDetailsViewModelBase(
     protected fun bedroomsRow(): SummaryListRowViewModel =
         row(
             "propertyDetails.propertyRecord.tenancyAndRentalInformation.numberOfBedrooms",
-            propertyOwnership.numBedrooms,
+            propertyOwnership.numBedrooms
+                ?: "propertyDetails.propertyRecord.tenancyAndRentalInformation.numberOfBedrooms.notAdded",
             changeLinkMessageKey,
             UpdateBedroomsController.getUpdateBedroomsRoute(propertyOwnership.id) +
                 "/${BedroomsStep.ROUTE_SEGMENT}",

--- a/src/main/resources/messages/propertyDetails.yml
+++ b/src/main/resources/messages/propertyDetails.yml
@@ -168,6 +168,7 @@ propertyRecord:
       changeLinkAriaLabel: Change number of households and tenants
     numberOfPeople: Number of tenants
     numberOfBedrooms: Number of bedrooms
+    'numberOfBedrooms.notAdded': Not added
     rentIncludesBills:
       rowName: Rent includes bills
       changeLinkAriaLabel: Change whether rent includes bills or which bills are included

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/summaryModels/PropertyDetailsBeforePdjb939ViewModelTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/summaryModels/PropertyDetailsBeforePdjb939ViewModelTests.kt
@@ -112,6 +112,30 @@ class PropertyDetailsBeforePdjb939ViewModelTests {
     }
 
     @Test
+    fun `Bedrooms row shows the not added message key when no bedroom count was entered`() {
+        // Arrange
+        val propertyOwnership = createOccupiedPropertyOwnership()
+        propertyOwnership.numBedrooms = null
+
+        // Act
+        val viewModel =
+            PropertyDetailsBeforePdjb939ViewModel(
+                propertyOwnership,
+                messageSource = mockMessageSource,
+            )
+        val bedroomsRow =
+            viewModel.beforePdjb939TenancyAndRentalInformation.single {
+                it.fieldHeading == "propertyDetails.propertyRecord.tenancyAndRentalInformation.numberOfBedrooms"
+            }
+
+        // Assert
+        assertEquals(
+            "propertyDetails.propertyRecord.tenancyAndRentalInformation.numberOfBedrooms.notAdded",
+            bedroomsRow.fieldValue,
+        )
+    }
+
+    @Test
     fun `Tenancy details are in the correct order when property is occupied and all conditional and custom fields are filled`() {
         // Arrange
         val propertyOwnership =

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/summaryModels/PropertyDetailsViewModelTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/summaryModels/PropertyDetailsViewModelTests.kt
@@ -1,22 +1,29 @@
 package uk.gov.communities.prsdb.webapp.models.viewModels.summaryModels
 
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotEquals
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
+import uk.gov.communities.prsdb.webapp.config.YamlMessageSource
 import uk.gov.communities.prsdb.webapp.constants.enums.LicensingType
 import uk.gov.communities.prsdb.webapp.constants.enums.RentFrequency
+import uk.gov.communities.prsdb.webapp.controllers.UpdateBedroomsController
 import uk.gov.communities.prsdb.webapp.database.entity.License
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.BedroomsStep
 import uk.gov.communities.prsdb.webapp.testHelpers.mockObjects.MockLandlordData.Companion.createAddress
 import uk.gov.communities.prsdb.webapp.testHelpers.mockObjects.MockLandlordData.Companion.createOccupiedPropertyOwnership
 import uk.gov.communities.prsdb.webapp.testHelpers.mockObjects.MockLandlordData.Companion.createPropertyOwnership
 import uk.gov.communities.prsdb.webapp.testHelpers.mockObjects.MockLandlordData.Companion.createUnoccupiedPropertyOwnership
 import uk.gov.communities.prsdb.webapp.testHelpers.mockObjects.MockMessageSource
 import java.time.LocalDate
+import java.util.Locale
 
 class PropertyDetailsViewModelTests {
     private val mockMessageSource = MockMessageSource()
+
+    private val yamlMessageSource = YamlMessageSource("classpath:messages")
 
     @Test
     fun `property details section is in the correct order`() {
@@ -53,6 +60,85 @@ class PropertyDetailsViewModelTests {
                 .fieldValue
 
         assertEquals(propertyOwnership.address.toMultiLineAddress().split("\n"), addressValue)
+    }
+
+    @Test
+    fun `bedrooms row shows the not added message key when no bedroom count was entered`() {
+        val propertyOwnership = createUnoccupiedPropertyOwnership()
+
+        val viewModel =
+            PropertyDetailsViewModel(propertyOwnership, messageSource = mockMessageSource)
+
+        assertEquals(
+            "propertyDetails.propertyRecord.tenancyAndRentalInformation.numberOfBedrooms.notAdded",
+            bedroomsRow(viewModel).fieldValue,
+        )
+    }
+
+    @Test
+    fun `bedrooms row shows the bedroom count when a bedroom count was entered`() {
+        val propertyOwnership = createOccupiedPropertyOwnership(numberOfBedrooms = 3)
+
+        val viewModel =
+            PropertyDetailsViewModel(propertyOwnership, messageSource = mockMessageSource)
+
+        assertEquals(3, bedroomsRow(viewModel).fieldValue)
+    }
+
+    @Test
+    fun `bedrooms row keeps its update action for a landlord when no bedroom count was entered`() {
+        val propertyOwnership = createUnoccupiedPropertyOwnership(id = 123)
+
+        val viewModel =
+            PropertyDetailsViewModel(
+                propertyOwnership,
+                isLandlordView = true,
+                messageSource = mockMessageSource,
+            )
+
+        assertEquals(
+            UpdateBedroomsController.getUpdateBedroomsRoute(propertyOwnership.id) + "/${BedroomsStep.ROUTE_SEGMENT}",
+            bedroomsRow(viewModel)
+                .actions
+                .single()
+                .url,
+        )
+    }
+
+    @Test
+    fun `bedrooms row shows the not added message key with no update action for a council`() {
+        val propertyOwnership = createUnoccupiedPropertyOwnership()
+
+        val viewModel =
+            PropertyDetailsViewModel(
+                propertyOwnership,
+                isLandlordView = false,
+                messageSource = mockMessageSource,
+            )
+
+        assertEquals(
+            "propertyDetails.propertyRecord.tenancyAndRentalInformation.numberOfBedrooms.notAdded",
+            bedroomsRow(viewModel).fieldValue,
+        )
+        assertTrue(bedroomsRow(viewModel).actions.isEmpty()) {
+            "The local council view must not show a change link for the bedrooms row"
+        }
+    }
+
+    @Test
+    fun `bedrooms not added message key resolves to a message`() {
+        val propertyOwnership = createUnoccupiedPropertyOwnership()
+
+        val viewModel =
+            PropertyDetailsViewModel(propertyOwnership, messageSource = mockMessageSource)
+
+        val messageKey = bedroomsRow(viewModel).fieldValue as String
+
+        val resolvedMessage = yamlMessageSource.getMessage(messageKey, null, messageKey, Locale.getDefault())
+
+        assertNotEquals(messageKey, resolvedMessage) {
+            "Message key '$messageKey' does not resolve — it would display as the raw key on the page"
+        }
     }
 
     @Test
@@ -342,4 +428,9 @@ class PropertyDetailsViewModelTests {
             rowValue("propertyDetails.propertyRecord.tenancyAndRentalInformation.rentAmount"),
         )
     }
+
+    private fun bedroomsRow(viewModel: PropertyDetailsViewModel): SummaryListRowViewModel =
+        viewModel.propertyDetailsSection.single {
+            it.fieldHeading == "propertyDetails.propertyRecord.tenancyAndRentalInformation.numberOfBedrooms"
+        }
 }


### PR DESCRIPTION
## Ticket number

PDJB-1353

## Goal of change

QA rework: the "Number of bedrooms" row renders broken on properties registered before the restructure flag was turned on, which never captured a bedroom count.

## Description of main change(s)

- The bedrooms row now shows **"Not added"** when no bedroom count has been entered, instead of rendering an empty value that collapses the summary list grid.
- The landlord keeps the "Change" link so they can add a count; the local council view shows "Not added" with no action.
- Applied in the shared row builder, so it covers the row in both its flag-on (Property details) and flag-off (Tenancy and rental information) placements.

## Anything you'd like to highlight to the reviewer?

- **Will likely conflict with #1568**, which rewrites `PropertyDetailsViewModel` into a base class and has the same bug in its own `bedroomsRow()`.
- **Why not "provide later"?** QA suggested reusing PDJB-1048's mechanism. It's unmerged, covers licensing and tenancy only, and means "deliberately deferred" — these properties are a migration gap, so a neutral placeholder fits better.
- Two pre-existing issues spotted nearby, not fixed: `localCouncil?.name` goes through the same builder and would collapse identically if null, and `complianceInformation.notAdded` in `propertyDetails.yml` looks unreferenced.

## Checklist

- [x] Unit tests for new logic (e.g. new service methods) have been added
- [x] Test suite has been run in full locally and is passing — `testWithoutIntegration` and `ktlintCheck` pass, and both roles were smoke tested with the flag enabled. Integration tests left to CI; no existing one asserts an empty bedrooms value.
- [x] Branch has been rebased onto main and run locally, with everything working as expected (both for your new feature and any related functionality)
- [x] TODO comments referencing this JIRA ticket have been searched for and removed - if a future PR will address them, mention that here
- [x] QA instructions have been added to the ticket (particularly if this is the last PR required to complete the ticket)
- [x] This feature is not behind a feature flag. I've checked that this is appropriate and we're happy with this code becoming live as soon as we release
