### PR TITLE
PDJB-NONE: Fix failing PDJB-1048 deploy

### DIFF
--- a/src/main/resources/data-integration.sql
+++ b/src/main/resources/data-integration.sql
@@ -500,7 +500,7 @@ VALUES (1, 5, '01/01/25', '01/01/25', null, true, null, null, null, null, null, 
        (45, 36, '01/01/25', null, null, null, null, null, null, null, null, null, null, null, true, true, true),
        (46, 37, '01/01/25', null, null, null, null, null, null, null, null, null, null, null, true, true, true),
        (47, 38, '01/01/25', null, null, null, null, null, null, null, null, null, null, null, true, true, true),
-       (48, 39, '01/01/25', null, null, null, null, null, null, null, null, null, null, null, true, true, true);
+       (48, 39, '01/01/25', null, null, null, null, null, null, null, null, null, null, null, true, true, true) ON CONFLICT DO NOTHING;
 
 SELECT setval(pg_get_serial_sequence('property_compliance', 'id'), (SELECT MAX(id) FROM property_compliance));
 

--- a/src/main/resources/data-local.sql
+++ b/src/main/resources/data-local.sql
@@ -489,7 +489,7 @@ VALUES
        -- banner variants (TENANCY / LICENSING / BOTH) render instead of COMBINED.
        (39, 41, '01/01/25', '01/01/25', null, false, '2035-01-01', null, 'https://find-energy-certificate-staging.digital.communities.gov.uk/energy-certificate/0000-0000-0000-0961-0832', '2035-01-01', null, 'c', null, null, true, true, true),
        (40, 42, '01/01/25', '01/01/25', null, false, '2035-01-01', null, 'https://find-energy-certificate-staging.digital.communities.gov.uk/energy-certificate/0000-0000-0000-0961-0832', '2035-01-01', null, 'c', null, null, true, true, true),
-       (41, 43, '01/01/25', '01/01/25', null, false, '2035-01-01', null, 'https://find-energy-certificate-staging.digital.communities.gov.uk/energy-certificate/0000-0000-0000-0961-0832', '2035-01-01', null, 'c', null, null, true, true, true);
+       (41, 43, '01/01/25', '01/01/25', null, false, '2035-01-01', null, 'https://find-energy-certificate-staging.digital.communities.gov.uk/energy-certificate/0000-0000-0000-0961-0832', '2035-01-01', null, 'c', null, null, true, true, true) ON CONFLICT DO NOTHING;
 
 SELECT setval(pg_get_serial_sequence('property_compliance', 'id'), (SELECT MAX(id) FROM property_compliance));
 

--- a/src/main/resources/data-test.sql
+++ b/src/main/resources/data-test.sql
@@ -456,7 +456,7 @@ VALUES (1, 6, '2026-04-14', '2026-04-14', '2026-01-15', true, null, null,
        (14, 2, '2026-04-14', null, null, null, null, null, null, null, null, null, null, null, true, true, true),
        (15, 3, '2026-04-14', null, null, null, null, null, null, null, null, null, null, null, true, true, true),
        (16, 4, '2026-04-14', null, null, null, null, null, null, null, null, null, null, null, true, true, true),
-       (17, 5, '2026-04-14', null, null, null, null, null, null, null, null, null, null, null, true, true, true);
+       (17, 5, '2026-04-14', null, null, null, null, null, null, null, null, null, null, null, true, true, true) ON CONFLICT DO NOTHING;
 
 SELECT setval(pg_get_serial_sequence('property_compliance', 'id'), (SELECT MAX(id) FROM property_compliance));
 


### PR DESCRIPTION
## Ticket number

PDJB-NONE

## Goal of change

add on conflict do nothing to previous compliance rows

## Description of main change(s)

Previously there was just 1 call to add data to property compliance. Now we've added a 2nd call site, it breaks as the seeding is rerun every time.
