### PR TITLE
PDJB-NONE: Tag the leave-property commit step for the Transaction metric

### DIFF
--- a/.github/instructions/journeys.instructions.md
+++ b/.github/instructions/journeys.instructions.md
@@ -50,6 +50,9 @@ class PropertyComplianceJourneyFactory(
 }
 ```
 
+### Transaction Metric Tagging
+A journey's final commit step must render its submit button via `transactionSubmitButton` (or `transactionWarningButton` for destructive actions) so the completion is counted in the transaction metric — either hardcoded in a commit-only template, or opted into with `"submitButton" to "transactionSubmitButton"` in `withAdditionalContentProperties` where the template is shared with non-commit steps. Tag exactly one button per completed journey; where that is not possible, record the gap in [MetricsReadMe](../../docs/MetricsReadMe.md) rather than risk double-counting.
+
 ### Page Class Conventions
 Page class hierarchy:
 ```

--- a/docs/MetricsReadMe.md
+++ b/docs/MetricsReadMe.md
@@ -51,15 +51,22 @@ The summary list contains 19 rows, in display order:
 
 ## Transaction counts
 
-Completed transactions — registrations, deregistrations, updates, switch-to-individual, and accepting a
-joint landlord invitation — are counted from a dedicated Plausible `Transaction` custom event. The event
+Completed transactions — registrations, deregistrations, updates, switch-to-individual, accepting a
+joint landlord invitation, and leaving a property as a joint landlord — are counted from a dedicated
+Plausible `Transaction` custom event. The event
 is fired by a button press on each journey's final commit step: the commit button is rendered from a
 fragment tagged `data-plausible-event="Transaction"` (`transactionSubmitButton` / `transactionWarningButton`).
 For reporting periods before the configured cutover date (`plausible.transaction-event-start-date`) the
 legacy Flow event is used instead. See [AnalyticsReadMe](AnalyticsReadMe.md) and `PlausibleMetricsService`
 for details.
 
-### Known coverage gap: landlord deregistration with no registered properties
+### Known coverage gaps
+
+Three journeys are intentionally not counted. In each case there is no place to fire the event
+exactly once per completion, and the project's standing preference is to **under-count rather than
+over-count**.
+
+#### Landlord deregistration with no registered properties
 
 A landlord who has **no registered properties** deregisters via the `are-you-sure` page, which goes
 straight to the internal deregistration step and skips the `reason` page that carries the `Transaction`
@@ -71,6 +78,32 @@ deregistration step itself has no button to tag.
 minimal (a landlord with no properties leaving the service) and there is no clean solution that avoids
 over-counting. Landlord deregistrations where the landlord *does* have properties, and all property
 deregistrations, are counted as normal.
+
+#### Cancelling a joint landlord invitation
+
+The `cancelJointLandlordInvitation` journey's only button is on its `are-you-sure` page, and the
+following `cancelInvitationStep` is internal with no button.
+
+**Decision:** cancelled invitations are intentionally **not counted**, for the same reason as above —
+there is no place to fire the event that does not also fire it when the user answers "no".
+
+#### Landlord address updates
+
+The landlord address update journey commits on either `select-address` (a looked-up address was
+chosen) or `manual-address` (reached by choosing "Add address manually" on the select-address page,
+or when the lookup found no addresses). Tagging a step's button is a render-time decision, taken
+before the user's radio selection is known, so tagging both steps would fire `Transaction` twice for
+a single update whenever the user reaches `manual-address` *via* `select-address`.
+
+**Decision:** address updates are intentionally **not counted**. Tagging only `manual-address` would
+count an arbitrary subset (missing the common "pick an address from the list" route), and suppressing
+the event with JavaScript keyed on the selected radio would introduce a new tagging mechanism for a
+single path. Under-counting was preferred to double-counting. The other four landlord detail updates
+(name, email, phone number and date of birth) are counted as normal.
+
+Note that `forms/selectAddressForm.html` and `forms/manualAddressForm.html` are shared with the
+landlord registration, property registration, governing body member address and trustee address
+journeys, so any future fix must tag the update journey without affecting those.
 
 ## Cost and cost per transaction
 

--- a/src/main/resources/templates/forms/confirmLeavePropertyForm.html
+++ b/src/main/resources/templates/forms/confirmLeavePropertyForm.html
@@ -25,7 +25,7 @@
             <div th:replace="~{fragments/warningText :: warningText(#{leaveProperty.confirm.warning})}"></div>
             <form th:action="@{''}" method="post" novalidate>
                 <div class="govuk-button-group">
-                    <button th:replace="~{fragments/buttons/warningButton :: warningButton(#{leaveProperty.confirm.confirmButton})}"></button>
+                    <button th:replace="~{fragments/buttons/transactionWarningButton :: transactionWarningButton(#{leaveProperty.confirm.confirmButton})}"></button>
                     <a th:href="@{${cancelLinkUrl}}" class="govuk-link" th:text="#{leaveProperty.confirm.cancelLink}">
                         leaveProperty.confirm.cancelLink
                     </a>

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/TransactionEventTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/TransactionEventTests.kt
@@ -21,6 +21,7 @@ import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.landlordReg
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.landlordRegistrationJourneyPages.PhoneNumberFormPageLandlordRegistration
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.landlordRegistrationJourneyPages.PrivacyNoticePageLandlordRegistration
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.landlordRegistrationJourneyPages.SelectAddressFormPageLandlordRegistration
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.leavePropertyJourneyPages.ConfirmPageLeaveProperty
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.propertyDetailsUpdateJourneyPages.NumberOfBedroomsFormPagePropertyDetailsUpdate
 import uk.gov.communities.prsdb.webapp.models.dataModels.VerifiedIdentityDataModel
 import uk.gov.communities.prsdb.webapp.models.viewModels.emailModels.LandlordRegistrationConfirmationEmail
@@ -154,6 +155,23 @@ class AcceptJointLandlordInvitationTransactionEventTests :
         acceptOrRejectPage.acceptInvitation()
 
         assertPageIs(page, ConfirmYouAreALandlordForThisPropertyPage::class)
+        assertThat(page.locator(TAGGED_BUTTON_SELECTOR)).isVisible()
+    }
+}
+
+class LeavePropertyTransactionEventTests :
+    IntegrationTestWithImmutableData("data-mockuser-landlord-with-sole-and-joint-properties.sql") {
+    private val jointPropertyOwnershipId = 2L
+
+    @Test
+    fun `the leave property commit button is tagged for the Plausible Transaction event`(page: Page) {
+        navigator.goToLeavePropertyConfirmPage(jointPropertyOwnershipId)
+
+        assertPageIs(
+            page,
+            ConfirmPageLeaveProperty::class,
+            mapOf("propertyOwnershipId" to jointPropertyOwnershipId.toString()),
+        )
         assertThat(page.locator(TAGGED_BUTTON_SELECTOR)).isVisible()
     }
 }


### PR DESCRIPTION
## Ticket number

PDJB-NONE

## Goal of change

The "no longer a joint landlord" journey was not being counted in the "Total number of transactions" metric on `/system-operator/metrics`.

## Description of main change(s)

- Completing the leave property journey now fires the Plausible `Transaction` event, so it is counted alongside the other journeys. The commit button was rendering from the untagged `warningButton` fragment; it now uses `transactionWarningButton`, matching how property deregistration already does it. Same red destructive button, no visual change.
- Documents two accepted coverage gaps in `MetricsReadMe`: cancelling a joint landlord invitation, and landlord address updates.
- Adds a tagging rule to the journey instructions so new journeys don't repeat the omission.

## Anything you'd like to highlight to the reviewer?

**Landlord address updates are deliberately left uncounted.** They're the other journey missing the tag, but `AddressTask` has three routes to its commit and the button fragment is chosen at render time, before the user's radio selection is known — so tagging both `select-address` and `manual-address` would fire the event twice whenever someone picks "Add address manually" from the select-address page. Tagging only `manual-address` would count an arbitrary subset instead. I originally implemented the double-tagged version, then backed it out: under-counting is preferable to double-counting, and the gap is now recorded in `MetricsReadMe` with the reasoning. Happy to revisit if you'd rather have a JavaScript opt-out keyed on the selected radio.

The same reasoning applies to cancelling a joint landlord invitation, which is structurally identical to the already-documented landlord-deregistration-with-no-properties gap: its only button is on a yes/no `are-you-sure` page, so tagging it would fire the event even when the user answers "no".

## Checklist

- [x] TODO comments referencing this JIRA ticket have been searched for and removed - if a future PR will address them, mention that here
- [x] Test suite has been run in full locally and is passing
- [x] Branch has been rebased onto main and run locally, with everything working as expected (both for your new feature and any related functionality)
- [x] This feature is not behind a feature flag. 
