### PR TITLE
PDJB-896: Migrate compliance tasks to Duplicable

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/builders/SubJourneyBuilder.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/builders/SubJourneyBuilder.kt
@@ -120,6 +120,17 @@ abstract class AbstractJourneyBuilder<TInternalState : JourneyState, TJourneySta
         registerTransparentBuilder(builder)
     }
 
+    fun <TEmbeddedState, TDependencies : Any> fromTask(
+        task: TEmbeddedState,
+        dependencies: TDependencies,
+        init: EmbedBuilder<TEmbeddedState, TInternalState>.() -> Unit,
+    ) where TEmbeddedState : JourneyState, TEmbeddedState : DuplicableTaskWithDependencies<*, TDependencies> {
+        val builder = EmbedBuilder(task, privateJourney)
+        task.bindDependencies(dependencies)
+        builder.init()
+        registerTransparentBuilder(builder)
+    }
+
     // Splices a sub-builder's elements into this journey so that its steps are built inline while remaining
     // reachable, by declared identity, to this builder's configuration (via additionalElements). Used by both
     // embed and section so outer configuration is applied transparently to the sub-builder's owned elements.

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/ElectricalSafetyRegistrationCyaSummaryRowsFactory.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/ElectricalSafetyRegistrationCyaSummaryRowsFactory.kt
@@ -3,7 +3,7 @@ package uk.gov.communities.prsdb.webapp.journeys.propertyRegistration
 import uk.gov.communities.prsdb.webapp.constants.enums.HasElectricalSafetyCertificate
 import uk.gov.communities.prsdb.webapp.journeys.Destination
 import uk.gov.communities.prsdb.webapp.journeys.JourneyStep
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.ElectricalSafetyState
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.ElectricalSafetyDetailState
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.ElectricalSafetyScenario
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.HasElectricalCertMode
 import uk.gov.communities.prsdb.webapp.models.viewModels.summaryModels.SummaryListRowViewModel
@@ -11,7 +11,7 @@ import uk.gov.communities.prsdb.webapp.models.viewModels.summaryModels.propertyC
 import uk.gov.communities.prsdb.webapp.services.UploadService
 
 class ElectricalSafetyRegistrationCyaSummaryRowsFactory(
-    private val state: ElectricalSafetyState,
+    private val state: ElectricalSafetyDetailState,
     private val uploadService: UploadService,
     private val destinationProvider: (JourneyStep.RequestableStep<*, *, *>) -> Destination = { Destination(it) },
 ) {
@@ -112,7 +112,7 @@ class ElectricalSafetyRegistrationCyaSummaryRowsFactory(
             destination = destinationProvider(state.hasElectricalCertStep),
         )
 
-    private fun determineScenario(state: ElectricalSafetyState): ElectricalSafetyScenario =
+    private fun determineScenario(state: ElectricalSafetyDetailState): ElectricalSafetyScenario =
         when (state.hasElectricalCertStep.outcome) {
             HasElectricalCertMode.PROVIDE_THIS_LATER -> {
                 ElectricalSafetyScenario.PROVIDE_LATER

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/EpcRegistrationCyaSummaryRowsFactory.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/EpcRegistrationCyaSummaryRowsFactory.kt
@@ -2,7 +2,7 @@ package uk.gov.communities.prsdb.webapp.journeys.propertyRegistration
 
 import uk.gov.communities.prsdb.webapp.journeys.Destination
 import uk.gov.communities.prsdb.webapp.journeys.JourneyStep
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.EpcState
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.EpcDetailState
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.EpcAgeCheckMode
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.EpcEnergyRatingCheckMode
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.EpcInDateAtStartOfTenancyCheckMode
@@ -15,12 +15,12 @@ import uk.gov.communities.prsdb.webapp.services.EpcCertificateUrlProvider
 
 class EpcRegistrationCyaSummaryRowsFactory(
     private val epcCertificateUrlProvider: EpcCertificateUrlProvider,
-    private val state: EpcState,
+    private val state: EpcDetailState,
     private val destinationProvider: (JourneyStep.RequestableStep<*, *, *>) -> Destination = { Destination(it) },
 ) {
     private val scenario: EpcScenario = determineScenario(state)
 
-    private fun determineScenario(state: EpcState): EpcScenario {
+    private fun determineScenario(state: EpcDetailState): EpcScenario {
         val isOccupied = state.isOccupied == true
         return when {
             state.hasEpcStep.outcome == HasEpcMode.PROVIDE_LATER -> {
@@ -38,7 +38,7 @@ class EpcRegistrationCyaSummaryRowsFactory(
     }
 
     private fun determineNoEpcScenario(
-        state: EpcState,
+        state: EpcDetailState,
         isOccupied: Boolean,
     ): EpcScenario =
         when {
@@ -48,7 +48,7 @@ class EpcRegistrationCyaSummaryRowsFactory(
         }
 
     private fun determineEpcPresentScenario(
-        state: EpcState,
+        state: EpcDetailState,
         isOccupied: Boolean,
     ): EpcScenario {
         val isExpired = state.epcAgeCheckStep.outcome == EpcAgeCheckMode.EPC_OLDER_THAN_10_YEARS
@@ -60,7 +60,7 @@ class EpcRegistrationCyaSummaryRowsFactory(
     }
 
     private fun determineNotExpiredEpcScenario(
-        state: EpcState,
+        state: EpcDetailState,
         isOccupied: Boolean,
     ): EpcScenario {
         if (state.epcEnergyRatingCheckStep.outcome != EpcEnergyRatingCheckMode.EPC_LOW_ENERGY_RATING) {
@@ -74,7 +74,7 @@ class EpcRegistrationCyaSummaryRowsFactory(
     }
 
     private fun determineExpiredEpcScenario(
-        state: EpcState,
+        state: EpcDetailState,
         isOccupied: Boolean,
     ): EpcScenario {
         if (!isOccupied) return EpcScenario.EPC_EXPIRED_UNOCCUPIED

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/GasSafetyRegistrationCyaSummaryRowsFactory.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/GasSafetyRegistrationCyaSummaryRowsFactory.kt
@@ -2,7 +2,7 @@ package uk.gov.communities.prsdb.webapp.journeys.propertyRegistration
 
 import uk.gov.communities.prsdb.webapp.journeys.Destination
 import uk.gov.communities.prsdb.webapp.journeys.JourneyStep
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.GasSafetyState
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.GasSafetyDetailState
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.GasSafetyScenario
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.HasGasCertMode
 import uk.gov.communities.prsdb.webapp.journeys.shared.YesOrNo
@@ -11,7 +11,7 @@ import uk.gov.communities.prsdb.webapp.models.viewModels.summaryModels.propertyC
 import uk.gov.communities.prsdb.webapp.services.UploadService
 
 class GasSafetyRegistrationCyaSummaryRowsFactory(
-    private val state: GasSafetyState,
+    private val state: GasSafetyDetailState,
     private val uploadService: UploadService,
     private val destinationProvider: (JourneyStep.RequestableStep<*, *, *>) -> Destination = { Destination(it) },
 ) {
@@ -111,7 +111,7 @@ class GasSafetyRegistrationCyaSummaryRowsFactory(
             "checkGasSafety.provideThisLater.unoccupied"
         }
 
-    private fun determineScenario(state: GasSafetyState): GasSafetyScenario {
+    private fun determineScenario(state: GasSafetyDetailState): GasSafetyScenario {
         if (state.hasGasSupplyStep.outcome == YesOrNo.NO) return GasSafetyScenario.NO_GAS_SUPPLY
         return when (state.hasGasCertStep.outcome) {
             HasGasCertMode.PROVIDE_THIS_LATER -> {

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/PropertyRegistrationJourneyFactory.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/PropertyRegistrationJourneyFactory.kt
@@ -215,7 +215,7 @@ class PropertyRegistrationJourneyFactory(
                 CheckElectricalCertUploadsStep.ROUTE_SEGMENT,
                 -> {
                     fromTask(journey.electricalSafetyTask, journey) {
-                        checkAnswerTask(task.electricalSafetyDetailsTask)
+                        duplicableCheckAnswerTask(task.electricalSafetyDetailsTask)
                     }
                 }
 

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/PropertyRegistrationJourneyFactory.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/PropertyRegistrationJourneyFactory.kt
@@ -26,24 +26,13 @@ import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.Occu
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.BedroomsStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.BillsIncludedStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.CheckElectricalCertUploadsStep
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.CheckEpcAnswersStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.CheckGasCertUploadsStep
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.ConfirmEpcDetailsRetrievedByCertificateNumberStep
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.ConfirmEpcRetrievedByUprnStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.ConfirmMissingComplianceCheckResult
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.ConfirmMissingComplianceMode
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.ConfirmMissingComplianceStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.ElectricalCertExpiryDateStep
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.EpcAgeCheckStep
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.EpcEnergyRatingCheckStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.EpcExemptionStep
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.EpcExpiredStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.EpcInDateAtStartOfTenancyCheckStep
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.EpcLookupByUprnStep
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.EpcMissingStep
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.EpcNotFoundStep
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.EpcSuperseededStep
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.FindYourEpcStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.FinishCyaJourneyStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.FurnishedStatusStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.GasCertIssueDateStep
@@ -60,15 +49,12 @@ import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.House
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.IsEpcRequiredStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.LicensingTypeStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.LocalCouncilStep
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.LowEnergyRatingStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.MeesExemptionStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.OccupiedStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.OwnershipTypeStep
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.PropertyOccupiedCheckStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.PropertyRegistrationCyaStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.PropertyRegistrationTaskListStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.PropertyTypeStep
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.ProvideEpcLaterStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.RentAmountStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.RentFrequencyStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.RentIncludesBillsStep
@@ -78,7 +64,7 @@ import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.Start
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.TenantsStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.ElectricalSafetyDependencies
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.ElectricalSafetyTask
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.EpcDetailsTask
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.EpcDependencies
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.EpcTask
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.GasSafetyDependencies
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.GasSafetyTask
@@ -97,7 +83,6 @@ import uk.gov.communities.prsdb.webapp.journeys.shared.states.CheckYourAnswersJo
 import uk.gov.communities.prsdb.webapp.journeys.shared.states.CheckYourAnswersJourneyState.Companion.checkAnswerTask
 import uk.gov.communities.prsdb.webapp.journeys.shared.states.CheckYourAnswersJourneyState.Companion.duplicableCheckAnswerTask
 import uk.gov.communities.prsdb.webapp.journeys.shared.stepConfig.LookupAddressStep
-import uk.gov.communities.prsdb.webapp.models.dataModels.EpcDataModel
 import uk.gov.communities.prsdb.webapp.models.viewModels.SectionHeaderViewModel
 import uk.gov.communities.prsdb.webapp.services.LandlordService
 import java.security.Principal
@@ -227,7 +212,9 @@ class PropertyRegistrationJourneyFactory(
                 IsEpcRequiredStep.ROUTE_SEGMENT,
                 EpcExemptionStep.ROUTE_SEGMENT,
                 -> {
-                    checkAnswerTask(journey.epcDetailsTask)
+                    fromTask(journey.epcTask, journey) {
+                        checkAnswerTask(task.epcDetailsTask)
+                    }
                 }
 
                 else -> {
@@ -332,7 +319,8 @@ class PropertyRegistrationJourneyFactory(
                     nextStep { journey.taskListStep }
                     saveProgress()
                 }
-                task(journey.epcTask) {
+                duplicableTask(journey.epcTask) {
+                    withDependencies { journey }
                     parents { journey.electricalSafetyTask.isComplete() }
                     backStep { journey.taskListStep }
                     nextStep { journey.taskListStep }
@@ -418,7 +406,7 @@ class PropertyRegistrationJourneyFactory(
             listOf(
                 journey.gasSafetyTask.checkGasSafetyAnswersStep,
                 journey.electricalSafetyTask.checkElectricalSafetyAnswersStep,
-                journey.checkEpcAnswersStep,
+                journey.epcTask.checkEpcAnswersStep,
             ).forEach { checkAnswersStep ->
                 configureStep(checkAnswersStep) {
                     withAdditionalContentProperty { "sectionHeaderInfo" to null }
@@ -489,7 +477,8 @@ class PropertyRegistrationJourneyFactory(
             }
             section {
                 withHeadingMessageKey("registerProperty.taskList.epc", shouldUseNumbering = false)
-                task(journey.epcTask) {
+                duplicableTask(journey.epcTask) {
+                    withDependencies { journey }
                     parents { journey.electricalSafetyTask.isComplete() }
                     backStep { journey.taskListStep }
                     nextStep { journey.taskListStep }
@@ -598,28 +587,6 @@ class PropertyRegistrationJourney(
     override val electricalSafetyTask: ElectricalSafetyTask,
     // EPC task
     override val epcTask: EpcTask,
-    override val epcDetailsTask: EpcDetailsTask,
-    override val startEpcStep: StartEpcStep,
-    override val epcLookupByUprnStep: EpcLookupByUprnStep,
-    override val hasEpcStep: HasEpcStep,
-    override val checkUprnMatchedEpcStep: ConfirmEpcRetrievedByUprnStep,
-    override val epcAgeCheckStep: EpcAgeCheckStep,
-    override val epcEnergyRatingCheckStep: EpcEnergyRatingCheckStep,
-    override val isPropertyOccupiedCheckStep: PropertyOccupiedCheckStep,
-    override val confirmEpcDetailsRetrievedByCertificateNumberStep: ConfirmEpcDetailsRetrievedByCertificateNumberStep,
-    override val findYourEpcStep: FindYourEpcStep,
-    override val checkSupersededEpcStep: EpcSuperseededStep,
-    override val epcNotFoundStep: EpcNotFoundStep,
-    override val epcInDateAtStartOfTenancyCheckStep: EpcInDateAtStartOfTenancyCheckStep,
-    override val hasMeesExemptionStep: HasMeesExemptionStep,
-    override val meesExemptionStep: MeesExemptionStep,
-    override val lowEnergyRatingStep: LowEnergyRatingStep,
-    override val epcExpiredStep: EpcExpiredStep,
-    override val isEpcRequiredStep: IsEpcRequiredStep,
-    override val epcExemptionStep: EpcExemptionStep,
-    override val epcMissingStep: EpcMissingStep,
-    override val provideEpcLaterStep: ProvideEpcLaterStep,
-    override val checkEpcAnswersStep: CheckEpcAnswersStep,
     // Check your answers step
     override val cyaStep: PropertyRegistrationCyaStep,
     override val finishCyaStep: FinishCyaJourneyStep,
@@ -638,16 +605,6 @@ class PropertyRegistrationJourney(
     override var originalJourneyUpdated: Instant? by delegateProvider.nullableDelegate("originalJourneyUpdated")
 
     override var checkingAnswersFor: String? by delegateProvider.nullableDelegate("checkingAnswersFor")
-
-    override var epcRetrievedByUprn: EpcDataModel? by delegateProvider.nullableDelegate("epcRetrievedByUprn")
-    override var epcRetrievedByUprnUpdatedSinceUserReview: Boolean?
-        by delegateProvider.nullableDelegate("epcRetrievedByUprnUpdatedSinceUserReview")
-    override var epcRetrievedByCertificateNumber: EpcDataModel? by delegateProvider.nullableDelegate("epcRetrievedByCertificateNumber")
-    override var epcRetrievedByCertificateNumberUpdatedSinceUserReview: Boolean?
-        by delegateProvider.nullableDelegate("epcRetrievedByCertificateNumberUpdatedSinceUserReview")
-    override var updatedEpcRetrievedByCertificateNumber: EpcDataModel? by delegateProvider
-        .nullableDelegate("updatedEpcRetrievedByCertificateNumber")
-    override var acceptedEpc: EpcDataModel? by delegateProvider.nullableDelegate("acceptedEpc")
 
     override var cyaUrlPath: String? by delegateProvider.nullableDelegate("cyaRouteSegment")
 
@@ -709,6 +666,7 @@ interface PropertyRegistrationJourneyState :
     InviteJointLandlordsTaskDependencies,
     GasSafetyDependencies,
     ElectricalSafetyDependencies,
+    EpcDependencies,
     CombinedComplianceCheckState,
     CheckYourAnswersJourneyState {
     val taskListStep: PropertyRegistrationTaskListStep
@@ -725,7 +683,7 @@ interface PropertyRegistrationJourneyState :
     override val finishCyaStep: FinishCyaJourneyStep
     override val gasSafetyTask: GasSafetyTask
     override val electricalSafetyTask: ElectricalSafetyTask
-    val epcTask: EpcTask
+    override val epcTask: EpcTask
     override val cyaStep: PropertyRegistrationCyaStep
     val hasMissingComplianceStep: HasMissingComplianceStep
     val confirmMissingComplianceStep: ConfirmMissingComplianceStep

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/PropertyRegistrationJourneyFactory.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/PropertyRegistrationJourneyFactory.kt
@@ -213,7 +213,7 @@ class PropertyRegistrationJourneyFactory(
                 EpcExemptionStep.ROUTE_SEGMENT,
                 -> {
                     fromTask(journey.epcTask, journey) {
-                        checkAnswerTask(task.epcDetailsTask)
+                        duplicableCheckAnswerTask(task.epcDetailsTask)
                     }
                 }
 

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/PropertyRegistrationJourneyFactory.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/PropertyRegistrationJourneyFactory.kt
@@ -214,7 +214,7 @@ class PropertyRegistrationJourneyFactory(
                 CheckGasCertUploadsStep.ROUTE_SEGMENT,
                 -> {
                     fromTask(journey.gasSafetyTask, journey) {
-                        checkAnswerTask(task.gasSafetyDetailsTask)
+                        duplicableCheckAnswerTask(task.gasSafetyDetailsTask)
                     }
                 }
 

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/PropertyRegistrationJourneyFactory.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/PropertyRegistrationJourneyFactory.kt
@@ -21,13 +21,11 @@ import uk.gov.communities.prsdb.webapp.journeys.always
 import uk.gov.communities.prsdb.webapp.journeys.builders.JourneyBuilder.Companion.journey
 import uk.gov.communities.prsdb.webapp.journeys.hasOutcome
 import uk.gov.communities.prsdb.webapp.journeys.isComplete
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.CertificateUpload
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.CombinedComplianceCheckState
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.OccupationState
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.BedroomsStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.BillsIncludedStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.CheckElectricalCertUploadsStep
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.CheckElectricalSafetyAnswersStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.CheckEpcAnswersStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.CheckGasCertUploadsStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.ConfirmEpcDetailsRetrievedByCertificateNumberStep
@@ -35,9 +33,7 @@ import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.Confi
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.ConfirmMissingComplianceCheckResult
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.ConfirmMissingComplianceMode
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.ConfirmMissingComplianceStep
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.ElectricalCertExpiredStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.ElectricalCertExpiryDateStep
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.ElectricalCertMissingStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.EpcAgeCheckStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.EpcEnergyRatingCheckStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.EpcExemptionStep
@@ -51,7 +47,6 @@ import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.FindY
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.FinishCyaJourneyStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.FurnishedStatusStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.GasCertIssueDateStep
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.HasAnyInCollectionStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.HasElectricalCertStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.HasEpcStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.HasGasCertStep
@@ -73,9 +68,7 @@ import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.Prope
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.PropertyRegistrationCyaStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.PropertyRegistrationTaskListStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.PropertyTypeStep
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.ProvideElectricalCertLaterStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.ProvideEpcLaterStep
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.RemoveElectricalCertUploadStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.RentAmountStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.RentFrequencyStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.RentIncludesBillsStep
@@ -83,8 +76,7 @@ import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.SaveP
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.SelectiveLicenceStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.StartEpcStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.TenantsStep
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.UploadElectricalCertStep
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.ElectricalSafetyDetailsTask
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.ElectricalSafetyDependencies
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.ElectricalSafetyTask
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.EpcDetailsTask
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.EpcTask
@@ -222,7 +214,9 @@ class PropertyRegistrationJourneyFactory(
                 ElectricalCertExpiryDateStep.ROUTE_SEGMENT,
                 CheckElectricalCertUploadsStep.ROUTE_SEGMENT,
                 -> {
-                    checkAnswerTask(journey.electricalSafetyDetailsTask)
+                    fromTask(journey.electricalSafetyTask, journey) {
+                        checkAnswerTask(task.electricalSafetyDetailsTask)
+                    }
                 }
 
                 StartEpcStep.ROUTE_SEGMENT,
@@ -331,7 +325,8 @@ class PropertyRegistrationJourneyFactory(
                     nextStep { journey.taskListStep }
                     saveProgress()
                 }
-                task(journey.electricalSafetyTask) {
+                duplicableTask(journey.electricalSafetyTask) {
+                    withDependencies { journey }
                     parents { journey.gasSafetyTask.isComplete() }
                     backStep { journey.taskListStep }
                     nextStep { journey.taskListStep }
@@ -422,7 +417,7 @@ class PropertyRegistrationJourneyFactory(
             // We don't have a section header for these pages, as their titles are the same as the respective page header
             listOf(
                 journey.gasSafetyTask.checkGasSafetyAnswersStep,
-                journey.checkElectricalSafetyAnswersStep,
+                journey.electricalSafetyTask.checkElectricalSafetyAnswersStep,
                 journey.checkEpcAnswersStep,
             ).forEach { checkAnswersStep ->
                 configureStep(checkAnswersStep) {
@@ -484,7 +479,8 @@ class PropertyRegistrationJourneyFactory(
             }
             section {
                 withHeadingMessageKey("registerProperty.taskList.electricalSafety", shouldUseNumbering = false)
-                task(journey.electricalSafetyTask) {
+                duplicableTask(journey.electricalSafetyTask) {
+                    withDependencies { journey }
                     parents { journey.gasSafetyTask.isComplete() }
                     backStep { journey.taskListStep }
                     nextStep { journey.taskListStep }
@@ -600,17 +596,6 @@ class PropertyRegistrationJourney(
     override val gasSafetyTask: GasSafetyTask,
     // Electrical safety task
     override val electricalSafetyTask: ElectricalSafetyTask,
-    override val electricalSafetyDetailsTask: ElectricalSafetyDetailsTask,
-    override val hasElectricalCertStep: HasElectricalCertStep,
-    override val electricalCertExpiryDateStep: ElectricalCertExpiryDateStep,
-    override val uploadElectricalCertStep: UploadElectricalCertStep,
-    override val hasUploadedElectricalCert: HasAnyInCollectionStep,
-    override val checkElectricalCertUploadsStep: CheckElectricalCertUploadsStep,
-    override val removeElectricalCertUploadStep: RemoveElectricalCertUploadStep,
-    override val electricalCertExpiredStep: ElectricalCertExpiredStep,
-    override val electricalCertMissingStep: ElectricalCertMissingStep,
-    override val provideElectricalCertLaterStep: ProvideElectricalCertLaterStep,
-    override val checkElectricalSafetyAnswersStep: CheckElectricalSafetyAnswersStep,
     // EPC task
     override val epcTask: EpcTask,
     override val epcDetailsTask: EpcDetailsTask,
@@ -684,9 +669,6 @@ class PropertyRegistrationJourney(
     override val rentFrequencyAndAmountTask = tenancyDetailsTask.rentFrequencyAndAmountTask
     override val furnishedStatus = tenancyDetailsTask.furnishedStatus
 
-    override var electricalUploadMap: Map<Int, CertificateUpload> by delegateProvider.requiredDelegate("electricalUploadMap", mapOf())
-    override var highestAssignedElectricalMemberId: Int? by delegateProvider.nullableDelegate("highestAssignedElectricalMemberId")
-
     override var registrationNumberValue: Long? by delegateProvider.nullableDelegate("registrationNumberValue")
 
     // Cache reasoning matches isOccupied above. The cached value is the raw selected address string so we can
@@ -726,6 +708,7 @@ interface PropertyRegistrationJourneyState :
     OccupationState,
     InviteJointLandlordsTaskDependencies,
     GasSafetyDependencies,
+    ElectricalSafetyDependencies,
     CombinedComplianceCheckState,
     CheckYourAnswersJourneyState {
     val taskListStep: PropertyRegistrationTaskListStep
@@ -741,7 +724,7 @@ interface PropertyRegistrationJourneyState :
     val tenancyDetailsTask: TenancyDetailsTask
     override val finishCyaStep: FinishCyaJourneyStep
     override val gasSafetyTask: GasSafetyTask
-    val electricalSafetyTask: ElectricalSafetyTask
+    override val electricalSafetyTask: ElectricalSafetyTask
     val epcTask: EpcTask
     override val cyaStep: PropertyRegistrationCyaStep
     val hasMissingComplianceStep: HasMissingComplianceStep

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/PropertyRegistrationJourneyFactory.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/PropertyRegistrationJourneyFactory.kt
@@ -191,7 +191,7 @@ class PropertyRegistrationJourneyFactory(
                 CheckGasCertUploadsStep.ROUTE_SEGMENT,
                 -> {
                     fromTask(journey.gasSafetyTask, journey) {
-                        duplicableCheckAnswerTask(task.gasSafetyDetailsTask)
+                        duplicableCheckAnswerTask(task.gasSafetyDetailsTask, { journey })
                     }
                 }
 
@@ -200,7 +200,7 @@ class PropertyRegistrationJourneyFactory(
                 CheckElectricalCertUploadsStep.ROUTE_SEGMENT,
                 -> {
                     fromTask(journey.electricalSafetyTask, journey) {
-                        duplicableCheckAnswerTask(task.electricalSafetyDetailsTask)
+                        duplicableCheckAnswerTask(task.electricalSafetyDetailsTask, { journey })
                     }
                 }
 
@@ -213,7 +213,7 @@ class PropertyRegistrationJourneyFactory(
                 EpcExemptionStep.ROUTE_SEGMENT,
                 -> {
                     fromTask(journey.epcTask, journey) {
-                        duplicableCheckAnswerTask(task.epcDetailsTask)
+                        duplicableCheckAnswerTask(task.epcDetailsTask, { journey })
                     }
                 }
 

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/PropertyRegistrationJourneyFactory.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/PropertyRegistrationJourneyFactory.kt
@@ -30,7 +30,6 @@ import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.Check
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.CheckElectricalSafetyAnswersStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.CheckEpcAnswersStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.CheckGasCertUploadsStep
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.CheckGasSafetyAnswersStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.ConfirmEpcDetailsRetrievedByCertificateNumberStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.ConfirmEpcRetrievedByUprnStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.ConfirmMissingComplianceCheckResult
@@ -51,9 +50,7 @@ import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.EpcSu
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.FindYourEpcStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.FinishCyaJourneyStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.FurnishedStatusStep
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.GasCertExpiredStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.GasCertIssueDateStep
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.GasCertMissingStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.HasAnyInCollectionStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.HasElectricalCertStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.HasEpcStep
@@ -78,9 +75,7 @@ import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.Prope
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.PropertyTypeStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.ProvideElectricalCertLaterStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.ProvideEpcLaterStep
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.ProvideGasCertLaterStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.RemoveElectricalCertUploadStep
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.RemoveGasCertUploadStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.RentAmountStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.RentFrequencyStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.RentIncludesBillsStep
@@ -89,12 +84,11 @@ import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.Selec
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.StartEpcStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.TenantsStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.UploadElectricalCertStep
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.UploadGasCertStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.ElectricalSafetyDetailsTask
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.ElectricalSafetyTask
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.EpcDetailsTask
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.EpcTask
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.GasSafetyDetailsTask
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.GasSafetyDependencies
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.GasSafetyTask
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.HouseHoldsAndTenantsDependencies
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.LicensingTask
@@ -219,7 +213,9 @@ class PropertyRegistrationJourneyFactory(
                 GasCertIssueDateStep.ROUTE_SEGMENT,
                 CheckGasCertUploadsStep.ROUTE_SEGMENT,
                 -> {
-                    checkAnswerTask(journey.gasSafetyDetailsTask)
+                    fromTask(journey.gasSafetyTask, journey) {
+                        checkAnswerTask(task.gasSafetyDetailsTask)
+                    }
                 }
 
                 HasElectricalCertStep.ROUTE_SEGMENT,
@@ -329,7 +325,8 @@ class PropertyRegistrationJourneyFactory(
                     nextStep { journey.gasSafetyTask.firstStep }
                     saveProgress()
                 }
-                task(journey.gasSafetyTask) {
+                duplicableTask(journey.gasSafetyTask) {
+                    withDependencies { journey }
                     parents { journey.ownershipAndLandlordsTask.jointLandlordsTask.isComplete() }
                     nextStep { journey.taskListStep }
                     saveProgress()
@@ -424,7 +421,7 @@ class PropertyRegistrationJourneyFactory(
             }
             // We don't have a section header for these pages, as their titles are the same as the respective page header
             listOf(
-                journey.checkGasSafetyAnswersStep,
+                journey.gasSafetyTask.checkGasSafetyAnswersStep,
                 journey.checkElectricalSafetyAnswersStep,
                 journey.checkEpcAnswersStep,
             ).forEach { checkAnswersStep ->
@@ -478,7 +475,8 @@ class PropertyRegistrationJourneyFactory(
             }
             section {
                 withHeadingMessageKey("registerProperty.taskList.gasSafety", shouldUseNumbering = false)
-                task(journey.gasSafetyTask) {
+                duplicableTask(journey.gasSafetyTask) {
+                    withDependencies { journey }
                     parents { journey.licensingTask.isComplete() }
                     nextStep { journey.taskListStep }
                     saveProgress()
@@ -600,18 +598,6 @@ class PropertyRegistrationJourney(
     override val tenancyDetailsTask: TenancyDetailsTask,
     // Gas safety task
     override val gasSafetyTask: GasSafetyTask,
-    override val gasSafetyDetailsTask: GasSafetyDetailsTask,
-    override val hasUploadedCert: HasAnyInCollectionStep,
-    override val hasGasSupplyStep: HasGasSupplyStep,
-    override val hasGasCertStep: HasGasCertStep,
-    override val gasCertIssueDateStep: GasCertIssueDateStep,
-    override val uploadGasCertStep: UploadGasCertStep,
-    override val checkGasCertUploadsStep: CheckGasCertUploadsStep,
-    override val removeGasCertUploadStep: RemoveGasCertUploadStep,
-    override val gasCertExpiredStep: GasCertExpiredStep,
-    override val gasCertMissingStep: GasCertMissingStep,
-    override val provideGasCertLaterStep: ProvideGasCertLaterStep,
-    override val checkGasSafetyAnswersStep: CheckGasSafetyAnswersStep,
     // Electrical safety task
     override val electricalSafetyTask: ElectricalSafetyTask,
     override val electricalSafetyDetailsTask: ElectricalSafetyDetailsTask,
@@ -698,9 +684,6 @@ class PropertyRegistrationJourney(
     override val rentFrequencyAndAmountTask = tenancyDetailsTask.rentFrequencyAndAmountTask
     override val furnishedStatus = tenancyDetailsTask.furnishedStatus
 
-    override var gasUploadMap: Map<Int, CertificateUpload> by delegateProvider.requiredDelegate("gasUploadMap", mapOf())
-    override var highestAssignedGasMemberId: Int? by delegateProvider.nullableDelegate("highestGasUploadMemberId")
-
     override var electricalUploadMap: Map<Int, CertificateUpload> by delegateProvider.requiredDelegate("electricalUploadMap", mapOf())
     override var highestAssignedElectricalMemberId: Int? by delegateProvider.nullableDelegate("highestAssignedElectricalMemberId")
 
@@ -742,6 +725,7 @@ class PropertyRegistrationJourney(
 interface PropertyRegistrationJourneyState :
     OccupationState,
     InviteJointLandlordsTaskDependencies,
+    GasSafetyDependencies,
     CombinedComplianceCheckState,
     CheckYourAnswersJourneyState {
     val taskListStep: PropertyRegistrationTaskListStep
@@ -756,7 +740,7 @@ interface PropertyRegistrationJourneyState :
     val ownershipAndLandlordsTask: OwnershipAndLandlordsTask
     val tenancyDetailsTask: TenancyDetailsTask
     override val finishCyaStep: FinishCyaJourneyStep
-    val gasSafetyTask: GasSafetyTask
+    override val gasSafetyTask: GasSafetyTask
     val electricalSafetyTask: ElectricalSafetyTask
     val epcTask: EpcTask
     override val cyaStep: PropertyRegistrationCyaStep

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/PropertyRegistrationJourneyFactory.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/PropertyRegistrationJourneyFactory.kt
@@ -190,18 +190,14 @@ class PropertyRegistrationJourneyFactory(
                 GasCertIssueDateStep.ROUTE_SEGMENT,
                 CheckGasCertUploadsStep.ROUTE_SEGMENT,
                 -> {
-                    fromTask(journey.gasSafetyTask, journey) {
-                        duplicableCheckAnswerTask(task.gasSafetyDetailsTask, { journey })
-                    }
+                    duplicableCheckAnswerTask(journey.gasSafetyTask.gasSafetyDetailsTask, { journey })
                 }
 
                 HasElectricalCertStep.ROUTE_SEGMENT,
                 ElectricalCertExpiryDateStep.ROUTE_SEGMENT,
                 CheckElectricalCertUploadsStep.ROUTE_SEGMENT,
                 -> {
-                    fromTask(journey.electricalSafetyTask, journey) {
-                        duplicableCheckAnswerTask(task.electricalSafetyDetailsTask, { journey })
-                    }
+                    duplicableCheckAnswerTask(journey.electricalSafetyTask.electricalSafetyDetailsTask, { journey })
                 }
 
                 StartEpcStep.ROUTE_SEGMENT,
@@ -212,9 +208,7 @@ class PropertyRegistrationJourneyFactory(
                 IsEpcRequiredStep.ROUTE_SEGMENT,
                 EpcExemptionStep.ROUTE_SEGMENT,
                 -> {
-                    fromTask(journey.epcTask, journey) {
-                        duplicableCheckAnswerTask(task.epcDetailsTask, { journey })
-                    }
+                    duplicableCheckAnswerTask(journey.epcTask.epcDetailsTask, { journey })
                 }
 
                 else -> {

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/states/CombinedComplianceCheckState.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/states/CombinedComplianceCheckState.kt
@@ -1,7 +1,10 @@
 package uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states
 
-interface CombinedComplianceCheckState : EpcState {
-    override val isOccupied: Boolean
+import uk.gov.communities.prsdb.webapp.journeys.JourneyState
+
+interface CombinedComplianceCheckState : JourneyState {
+    val isOccupied: Boolean
     val gasSafetyTask: GasSafetyState
     val electricalSafetyTask: ElectricalSafetyState
+    val epcTask: EpcState
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/states/CombinedComplianceCheckState.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/states/CombinedComplianceCheckState.kt
@@ -1,7 +1,7 @@
 package uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states
 
-interface CombinedComplianceCheckState :
-    ElectricalSafetyState,
-    EpcState {
+interface CombinedComplianceCheckState : EpcState {
+    override val isOccupied: Boolean
     val gasSafetyTask: GasSafetyState
+    val electricalSafetyTask: ElectricalSafetyState
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/states/CombinedComplianceCheckState.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/states/CombinedComplianceCheckState.kt
@@ -1,6 +1,7 @@
 package uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states
 
 interface CombinedComplianceCheckState :
-    GasSafetyState,
     ElectricalSafetyState,
-    EpcState
+    EpcState {
+    val gasSafetyTask: GasSafetyState
+}

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/states/ElectricalSafetyState.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/states/ElectricalSafetyState.kt
@@ -17,9 +17,24 @@ import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.Uploa
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.ElectricalSafetyDetailsTask
 
 interface ElectricalSafetyState : JourneyState {
-    val allowProvideCertificateLaterRoute: Boolean
-
     val electricalSafetyDetailsTask: ElectricalSafetyDetailsTask
+
+    val checkElectricalSafetyAnswersStep: CheckElectricalSafetyAnswersStep
+}
+
+interface ElectricalSafetyDetailState : JourneyState {
+    val hasElectricalCertStep: HasElectricalCertStep
+    val electricalCertExpiryDateStep: ElectricalCertExpiryDateStep
+    val uploadElectricalCertStep: UploadElectricalCertStep
+    val hasUploadedElectricalCert: HasAnyInCollectionStep
+    val checkElectricalCertUploadsStep: CheckElectricalCertUploadsStep
+    val removeElectricalCertUploadStep: RemoveElectricalCertUploadStep
+    val electricalCertExpiredStep: ElectricalCertExpiredStep
+    val electricalCertMissingStep: ElectricalCertMissingStep
+    val provideElectricalCertLaterStep: ProvideElectricalCertLaterStep
+
+    val isOccupied: Boolean
+    val allowProvideCertificateLaterRoute: Boolean
 
     fun getElectricalCertificateExpiryDateIfReachable() =
         electricalCertExpiryDateStep.formModelIfReachableOrNull?.let { date ->
@@ -41,28 +56,15 @@ interface ElectricalSafetyState : JourneyState {
             else -> null
         }
 
-    val electricalUploadIds: List<Long> get() =
-        if (uploadElectricalCertStep.isStepReachable) {
-            electricalUploadMap.values.map { it.fileUploadId }
-        } else {
-            emptyList()
-        }
-
-    val isOccupied: Boolean
-
+    val electricalUploadIds: List<Long>
+        get() =
+            if (uploadElectricalCertStep.isStepReachable) {
+                electricalUploadMap.values.map { it.fileUploadId }
+            } else {
+                emptyList()
+            }
     var electricalUploadMap: Map<Int, CertificateUpload>
     var highestAssignedElectricalMemberId: Int?
 
     fun getNextElectricalUploadMemberId(): Int = highestAssignedElectricalMemberId?.let { it + 1 } ?: 1
-
-    val hasElectricalCertStep: HasElectricalCertStep
-    val electricalCertExpiryDateStep: ElectricalCertExpiryDateStep
-    val uploadElectricalCertStep: UploadElectricalCertStep
-    val hasUploadedElectricalCert: HasAnyInCollectionStep
-    val checkElectricalCertUploadsStep: CheckElectricalCertUploadsStep
-    val removeElectricalCertUploadStep: RemoveElectricalCertUploadStep
-    val electricalCertExpiredStep: ElectricalCertExpiredStep
-    val electricalCertMissingStep: ElectricalCertMissingStep
-    val provideElectricalCertLaterStep: ProvideElectricalCertLaterStep
-    val checkElectricalSafetyAnswersStep: CheckElectricalSafetyAnswersStep
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/states/EpcState.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/states/EpcState.kt
@@ -31,6 +31,10 @@ import uk.gov.communities.prsdb.webapp.models.dataModels.EpcDataModel
 interface EpcState : JourneyState {
     val epcDetailsTask: EpcDetailsTask
 
+    val checkEpcAnswersStep: CheckEpcAnswersStep
+}
+
+interface EpcDetailState : JourneyState {
     val isOccupied: Boolean?
     val uprn: Long?
     var epcRetrievedByUprn: EpcDataModel?
@@ -73,7 +77,6 @@ interface EpcState : JourneyState {
     val epcExemptionStep: EpcExemptionStep
     val epcMissingStep: EpcMissingStep
     val provideEpcLaterStep: ProvideEpcLaterStep
-    val checkEpcAnswersStep: CheckEpcAnswersStep
 
     fun getNotNullAcceptedEpc() = acceptedEpc ?: throw PrsdbWebException("Attempting to access accepted EPC when it is null in state")
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/states/GasSafetyState.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/states/GasSafetyState.kt
@@ -21,8 +21,22 @@ import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.GasSa
 interface GasSafetyState : JourneyState {
     val gasSafetyDetailsTask: GasSafetyDetailsTask
 
-    val isOccupied: Boolean
+    val checkGasSafetyAnswersStep: CheckGasSafetyAnswersStep
+}
 
+interface GasSafetyDetailState : JourneyState {
+    val hasGasSupplyStep: HasGasSupplyStep
+    val hasGasCertStep: HasGasCertStep
+    val gasCertIssueDateStep: GasCertIssueDateStep
+    val uploadGasCertStep: UploadGasCertStep
+    val checkGasCertUploadsStep: CheckGasCertUploadsStep
+    val removeGasCertUploadStep: RemoveGasCertUploadStep
+    val gasCertExpiredStep: GasCertExpiredStep
+    val gasCertMissingStep: GasCertMissingStep
+    val provideGasCertLaterStep: ProvideGasCertLaterStep
+    val hasUploadedCert: HasAnyInCollectionStep
+
+    val isOccupied: Boolean
     val allowProvideCertificateLaterRoute: Boolean
 
     fun getGasSafetyCertificateIssueDateIfReachable() =
@@ -35,27 +49,15 @@ interface GasSafetyState : JourneyState {
             DateTimeHelper().getCurrentDateInUK() > issueDate.plus(DatePeriod(years = GAS_SAFETY_CERT_VALIDITY_YEARS))
         }
 
-    val gasUploadIds: List<Long> get() =
-        if (uploadGasCertStep.isStepReachable) {
-            gasUploadMap.values.map { it.fileUploadId }
-        } else {
-            emptyList()
-        }
-
+    val gasUploadIds: List<Long>
+        get() =
+            if (uploadGasCertStep.isStepReachable) {
+                gasUploadMap.values.map { it.fileUploadId }
+            } else {
+                emptyList()
+            }
     var gasUploadMap: Map<Int, CertificateUpload>
     var highestAssignedGasMemberId: Int?
 
     fun getNextGasUploadMemberId(): Int = highestAssignedGasMemberId?.let { it + 1 } ?: 1
-
-    val hasGasSupplyStep: HasGasSupplyStep
-    val hasGasCertStep: HasGasCertStep
-    val gasCertIssueDateStep: GasCertIssueDateStep
-    val uploadGasCertStep: UploadGasCertStep
-    val checkGasCertUploadsStep: CheckGasCertUploadsStep
-    val removeGasCertUploadStep: RemoveGasCertUploadStep
-    val gasCertExpiredStep: GasCertExpiredStep
-    val gasCertMissingStep: GasCertMissingStep
-    val provideGasCertLaterStep: ProvideGasCertLaterStep
-    val checkGasSafetyAnswersStep: CheckGasSafetyAnswersStep
-    val hasUploadedCert: HasAnyInCollectionStep
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/AbstractConfirmEpcDetailsStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/AbstractConfirmEpcDetailsStepConfig.kt
@@ -1,14 +1,14 @@
 package uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps
 
 import uk.gov.communities.prsdb.webapp.journeys.AbstractRequestableStepConfig
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.EpcState
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.EpcDetailState
 import uk.gov.communities.prsdb.webapp.journeys.shared.YesOrNo
 import uk.gov.communities.prsdb.webapp.models.dataModels.EpcDataModel
 import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.MatchedEpcFormModel
 
 abstract class AbstractConfirmEpcDetailsStepConfig<FormModel : MatchedEpcFormModel> :
-    AbstractRequestableStepConfig<YesOrNo, FormModel, EpcState>() {
-    override fun mode(state: EpcState) =
+    AbstractRequestableStepConfig<YesOrNo, FormModel, EpcDetailState>() {
+    override fun mode(state: EpcDetailState) =
         when (getFormModelFromStateOrNull(state)?.matchedEpcIsCorrect) {
             null -> null
             false -> YesOrNo.NO
@@ -17,14 +17,14 @@ abstract class AbstractConfirmEpcDetailsStepConfig<FormModel : MatchedEpcFormMod
 
     override fun isSubClassInitialised(): Boolean = ::getRelevantEpc.isInitialized
 
-    lateinit var getRelevantEpc: (EpcState) -> EpcDataModel?
+    lateinit var getRelevantEpc: (EpcDetailState) -> EpcDataModel?
 
-    fun usingEpc(getRelevantEpc: EpcState.() -> EpcDataModel?): AbstractConfirmEpcDetailsStepConfig<FormModel> {
+    fun usingEpc(getRelevantEpc: EpcDetailState.() -> EpcDataModel?): AbstractConfirmEpcDetailsStepConfig<FormModel> {
         this.getRelevantEpc = getRelevantEpc
         return this
     }
 
-    override fun afterStepDataIsAdded(state: EpcState) {
+    override fun afterStepDataIsAdded(state: EpcDetailState) {
         if (getFormModelFromStateOrNull(state)?.matchedEpcIsCorrect == true) {
             state.acceptedEpc = getRelevantEpc(state)
         } else if (getFormModelFromStateOrNull(state)?.matchedEpcIsCorrect == false && state.acceptedEpc == getRelevantEpc(state)) {

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/CheckElectricalCertUploadsStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/CheckElectricalCertUploadsStepConfig.kt
@@ -5,7 +5,7 @@ import uk.gov.communities.prsdb.webapp.helpers.converters.MessageKeyConverter
 import uk.gov.communities.prsdb.webapp.journeys.AbstractRequestableStepConfig
 import uk.gov.communities.prsdb.webapp.journeys.Destination
 import uk.gov.communities.prsdb.webapp.journeys.JourneyStep.RequestableStep
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.ElectricalSafetyState
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.ElectricalSafetyDetailState
 import uk.gov.communities.prsdb.webapp.journeys.shared.Complete
 import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.NoInputFormModel
 import uk.gov.communities.prsdb.webapp.services.CollectionKeyParameterService
@@ -15,10 +15,10 @@ import uk.gov.communities.prsdb.webapp.services.UploadService
 class CheckElectricalCertUploadsStepConfig(
     private val memberIdService: CollectionKeyParameterService,
     private val uploadService: UploadService,
-) : AbstractRequestableStepConfig<Complete, NoInputFormModel, ElectricalSafetyState>() {
+) : AbstractRequestableStepConfig<Complete, NoInputFormModel, ElectricalSafetyDetailState>() {
     override val formModelClass = NoInputFormModel::class
 
-    override fun getStepSpecificContent(state: ElectricalSafetyState) =
+    override fun getStepSpecificContent(state: ElectricalSafetyDetailState) =
         mapOf(
             "addAnotherTitle" to "uploads.checkUploads.heading",
             "optionalAddAnotherTitleParam" to getUploadCount(state),
@@ -33,7 +33,7 @@ class CheckElectricalCertUploadsStepConfig(
                     .toUrlStringOrNull(),
         )
 
-    private fun getUploadRows(state: ElectricalSafetyState): List<UploadRow> =
+    private fun getUploadRows(state: ElectricalSafetyDetailState): List<UploadRow> =
         state.electricalUploadMap
             .toList()
             .sortedBy { it.first }
@@ -50,17 +50,17 @@ class CheckElectricalCertUploadsStepConfig(
                 )
             }
 
-    override fun chooseTemplate(state: ElectricalSafetyState): String = "forms/addAnotherFormWithFileUploadTable"
+    override fun chooseTemplate(state: ElectricalSafetyDetailState): String = "forms/addAnotherFormWithFileUploadTable"
 
-    override fun mode(state: ElectricalSafetyState) = if (state.electricalUploadMap.isNotEmpty()) Complete.COMPLETE else null
+    override fun mode(state: ElectricalSafetyDetailState) = if (state.electricalUploadMap.isNotEmpty()) Complete.COMPLETE else null
 
-    private fun getUploadCount(state: ElectricalSafetyState): Int = getUploadRows(state).size
+    private fun getUploadCount(state: ElectricalSafetyDetailState): Int = getUploadRows(state).size
 }
 
 @JourneyFrameworkComponent
 final class CheckElectricalCertUploadsStep(
     stepConfig: CheckElectricalCertUploadsStepConfig,
-) : RequestableStep<Complete, NoInputFormModel, ElectricalSafetyState>(stepConfig) {
+) : RequestableStep<Complete, NoInputFormModel, ElectricalSafetyDetailState>(stepConfig) {
     companion object {
         const val ROUTE_SEGMENT = "check-electrical-safety-certificate-uploads"
     }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/CheckElectricalSafetyAnswersStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/CheckElectricalSafetyAnswersStepConfig.kt
@@ -16,7 +16,7 @@ class CheckElectricalSafetyAnswersStepConfig(
     override val formModelClass = NoInputFormModel::class
 
     override fun getStepSpecificContent(state: ElectricalSafetyState): Map<String, Any?> {
-        val factory = ElectricalSafetyRegistrationCyaSummaryRowsFactory(state, uploadService)
+        val factory = ElectricalSafetyRegistrationCyaSummaryRowsFactory(state.electricalSafetyDetailsTask, uploadService)
         return mapOf(
             "rows" to factory.createRows(),
             "insetTextKey" to factory.getInsetTextKey(),

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/CheckEpcAnswersStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/CheckEpcAnswersStepConfig.kt
@@ -16,7 +16,7 @@ class CheckEpcAnswersStepConfig(
     override val formModelClass = NoInputFormModel::class
 
     override fun getStepSpecificContent(state: EpcState): Map<String, Any?> {
-        val factory = EpcRegistrationCyaSummaryRowsFactory(epcCertificateUrlProvider, state)
+        val factory = EpcRegistrationCyaSummaryRowsFactory(epcCertificateUrlProvider, state.epcDetailsTask)
         return mapOf(
             "epcCardTitle" to factory.createEpcCardTitle(),
             "epcCardActions" to factory.createEpcCardActions(),

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/CheckGasCertUploadsStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/CheckGasCertUploadsStepConfig.kt
@@ -5,7 +5,7 @@ import uk.gov.communities.prsdb.webapp.helpers.converters.MessageKeyConverter
 import uk.gov.communities.prsdb.webapp.journeys.AbstractRequestableStepConfig
 import uk.gov.communities.prsdb.webapp.journeys.Destination
 import uk.gov.communities.prsdb.webapp.journeys.JourneyStep.RequestableStep
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.GasSafetyState
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.GasSafetyDetailState
 import uk.gov.communities.prsdb.webapp.journeys.shared.Complete
 import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.NoInputFormModel
 import uk.gov.communities.prsdb.webapp.services.CollectionKeyParameterService
@@ -15,10 +15,10 @@ import uk.gov.communities.prsdb.webapp.services.UploadService
 class CheckGasCertUploadsStepConfig(
     private val memberIdService: CollectionKeyParameterService,
     private val uploadService: UploadService,
-) : AbstractRequestableStepConfig<Complete, NoInputFormModel, GasSafetyState>() {
+) : AbstractRequestableStepConfig<Complete, NoInputFormModel, GasSafetyDetailState>() {
     override val formModelClass = NoInputFormModel::class
 
-    override fun getStepSpecificContent(state: GasSafetyState) =
+    override fun getStepSpecificContent(state: GasSafetyDetailState) =
         mapOf(
             "addAnotherTitle" to "uploads.checkUploads.heading",
             "optionalAddAnotherTitleParam" to getUploadCount(state),
@@ -33,7 +33,7 @@ class CheckGasCertUploadsStepConfig(
                     .toUrlStringOrNull(),
         )
 
-    private fun getUploadRows(state: GasSafetyState): List<UploadRow> =
+    private fun getUploadRows(state: GasSafetyDetailState): List<UploadRow> =
         state.gasUploadMap
             .toList()
             .sortedBy { it.first }
@@ -50,17 +50,17 @@ class CheckGasCertUploadsStepConfig(
                 )
             }
 
-    override fun chooseTemplate(state: GasSafetyState): String = "forms/addAnotherFormWithFileUploadTable"
+    override fun chooseTemplate(state: GasSafetyDetailState): String = "forms/addAnotherFormWithFileUploadTable"
 
-    override fun mode(state: GasSafetyState) = if (state.gasUploadMap.isNotEmpty()) Complete.COMPLETE else null
+    override fun mode(state: GasSafetyDetailState) = if (state.gasUploadMap.isNotEmpty()) Complete.COMPLETE else null
 
-    private fun getUploadCount(state: GasSafetyState): Int = getUploadRows(state).size
+    private fun getUploadCount(state: GasSafetyDetailState): Int = getUploadRows(state).size
 }
 
 @JourneyFrameworkComponent
 final class CheckGasCertUploadsStep(
     stepConfig: CheckGasCertUploadsStepConfig,
-) : RequestableStep<Complete, NoInputFormModel, GasSafetyState>(stepConfig) {
+) : RequestableStep<Complete, NoInputFormModel, GasSafetyDetailState>(stepConfig) {
     companion object {
         const val ROUTE_SEGMENT = "check-gas-safety-certificate-uploads"
     }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/CheckGasSafetyAnswersStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/CheckGasSafetyAnswersStepConfig.kt
@@ -16,7 +16,7 @@ class CheckGasSafetyAnswersStepConfig(
     override val formModelClass = NoInputFormModel::class
 
     override fun getStepSpecificContent(state: GasSafetyState): Map<String, Any?> {
-        val factory = GasSafetyRegistrationCyaSummaryRowsFactory(state, uploadService)
+        val factory = GasSafetyRegistrationCyaSummaryRowsFactory(state.gasSafetyDetailsTask, uploadService)
         return mapOf(
             "gasSupplyRows" to factory.createGasSupplyRows(),
             "certRows" to factory.createCertRows(),

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/ConfirmEpcDetailsRetrievedByCertificateNumberStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/ConfirmEpcDetailsRetrievedByCertificateNumberStepConfig.kt
@@ -3,7 +3,7 @@ package uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps
 import uk.gov.communities.prsdb.webapp.annotations.webAnnotations.JourneyFrameworkComponent
 import uk.gov.communities.prsdb.webapp.exceptions.NotNullFormModelValueIsNullException
 import uk.gov.communities.prsdb.webapp.journeys.JourneyStep
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.EpcState
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.EpcDetailState
 import uk.gov.communities.prsdb.webapp.journeys.shared.YesOrNo
 import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.ConfirmEpcDetailsFromCertificateNumberFormModel
 import uk.gov.communities.prsdb.webapp.models.viewModels.formModels.RadiosButtonViewModel
@@ -18,7 +18,7 @@ class ConfirmEpcDetailsRetrievedByCertificateNumberStepConfig(
     override val formModelClass = ConfirmEpcDetailsFromCertificateNumberFormModel::class
 
     // TODO PDJB-746 - update content as required
-    override fun getStepSpecificContent(state: EpcState) =
+    override fun getStepSpecificContent(state: EpcDetailState) =
         getRelevantEpc(state)?.let { epcDetails ->
             mapOf(
                 "summaryCardTitle" to "propertyCompliance.epcTask.confirmEpcDetailsFromCertificateNumber.summaryCard.title",
@@ -69,9 +69,9 @@ class ConfirmEpcDetailsRetrievedByCertificateNumberStepConfig(
             "Attempting to access relevantEpc for ConfirmEpcDetailsRetrievedByCertificateNumberStepConfig but it was null.",
         )
 
-    override fun chooseTemplate(state: EpcState): String = "forms/confirmEpcDetailsRetrievedByCertificateNumberForm"
+    override fun chooseTemplate(state: EpcDetailState): String = "forms/confirmEpcDetailsRetrievedByCertificateNumberForm"
 
-    override fun afterStepIsReached(state: EpcState) {
+    override fun afterStepIsReached(state: EpcDetailState) {
         if (state.epcRetrievedByCertificateNumberUpdatedSinceUserReview == true) {
             state.clearStepData(stepDataKey)
             state.epcRetrievedByCertificateNumberUpdatedSinceUserReview = false
@@ -82,7 +82,7 @@ class ConfirmEpcDetailsRetrievedByCertificateNumberStepConfig(
 @JourneyFrameworkComponent
 final class ConfirmEpcDetailsRetrievedByCertificateNumberStep(
     stepConfig: ConfirmEpcDetailsRetrievedByCertificateNumberStepConfig,
-) : JourneyStep.RequestableStep<YesOrNo, ConfirmEpcDetailsFromCertificateNumberFormModel, EpcState>(stepConfig) {
+) : JourneyStep.RequestableStep<YesOrNo, ConfirmEpcDetailsFromCertificateNumberFormModel, EpcDetailState>(stepConfig) {
     companion object {
         const val ROUTE_SEGMENT = "confirm-epc-details"
     }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/ConfirmEpcRetrievedByUprnStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/ConfirmEpcRetrievedByUprnStepConfig.kt
@@ -5,7 +5,7 @@ import uk.gov.communities.prsdb.webapp.constants.EPC_GUIDE_URL
 import uk.gov.communities.prsdb.webapp.constants.MEES_EXEMPTION_GUIDE_URL
 import uk.gov.communities.prsdb.webapp.exceptions.NotNullFormModelValueIsNullException
 import uk.gov.communities.prsdb.webapp.journeys.JourneyStep
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.EpcState
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.EpcDetailState
 import uk.gov.communities.prsdb.webapp.journeys.shared.YesOrNo
 import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.ConfirmEpcDetailsFromUprnFormModel
 import uk.gov.communities.prsdb.webapp.models.viewModels.formModels.RadiosViewModel
@@ -19,7 +19,7 @@ class ConfirmEpcRetrievedByUprnStepConfig(
 ) : AbstractConfirmEpcDetailsStepConfig<ConfirmEpcDetailsFromUprnFormModel>() {
     override val formModelClass = ConfirmEpcDetailsFromUprnFormModel::class
 
-    override fun getStepSpecificContent(state: EpcState) =
+    override fun getStepSpecificContent(state: EpcDetailState) =
         getRelevantEpc(state)?.let { epcDetails ->
             mapOf(
                 "summaryCardTitle" to "propertyCompliance.epcTask.confirmEpcDetailsFromUprn.summaryCard.title",
@@ -59,9 +59,9 @@ class ConfirmEpcRetrievedByUprnStepConfig(
             "Attempting to access relevantEpc for ConfirmEpcRetrievedByUprnStepConfig but it was null.",
         )
 
-    override fun chooseTemplate(state: EpcState): String = "forms/confirmEpcDetailsByUprnForm"
+    override fun chooseTemplate(state: EpcDetailState): String = "forms/confirmEpcDetailsByUprnForm"
 
-    override fun afterStepIsReached(state: EpcState) {
+    override fun afterStepIsReached(state: EpcDetailState) {
         if (state.epcRetrievedByUprnUpdatedSinceUserReview == true) {
             state.clearStepData(stepDataKey)
             state.epcRetrievedByUprnUpdatedSinceUserReview = false
@@ -72,7 +72,7 @@ class ConfirmEpcRetrievedByUprnStepConfig(
 @JourneyFrameworkComponent
 final class ConfirmEpcRetrievedByUprnStep(
     stepConfig: ConfirmEpcRetrievedByUprnStepConfig,
-) : JourneyStep.RequestableStep<YesOrNo, ConfirmEpcDetailsFromUprnFormModel, EpcState>(stepConfig) {
+) : JourneyStep.RequestableStep<YesOrNo, ConfirmEpcDetailsFromUprnFormModel, EpcDetailState>(stepConfig) {
     companion object {
         const val ROUTE_SEGMENT = "check-epc-details"
     }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/ConfirmMissingComplianceStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/ConfirmMissingComplianceStepConfig.kt
@@ -16,7 +16,7 @@ class ConfirmMissingComplianceStepConfig :
         mapOf(
             "title" to "registerProperty.confirmMissingCompliance.heading",
             "isGasMissing" to HasMissingComplianceStepConfig.isGasCertInvalid(state.gasSafetyTask),
-            "isElectricalMissing" to HasMissingComplianceStepConfig.isElectricalCertInvalid(state),
+            "isElectricalMissing" to HasMissingComplianceStepConfig.isElectricalCertInvalid(state.electricalSafetyTask),
             "isEpcMissing" to HasMissingComplianceStepConfig.isEpcInvalid(state),
             "radioOptions" to
                 listOf(

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/ConfirmMissingComplianceStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/ConfirmMissingComplianceStepConfig.kt
@@ -17,7 +17,7 @@ class ConfirmMissingComplianceStepConfig :
             "title" to "registerProperty.confirmMissingCompliance.heading",
             "isGasMissing" to HasMissingComplianceStepConfig.isGasCertInvalid(state.gasSafetyTask),
             "isElectricalMissing" to HasMissingComplianceStepConfig.isElectricalCertInvalid(state.electricalSafetyTask),
-            "isEpcMissing" to HasMissingComplianceStepConfig.isEpcInvalid(state),
+            "isEpcMissing" to HasMissingComplianceStepConfig.isEpcInvalid(state.epcTask),
             "radioOptions" to
                 listOf(
                     RadiosButtonViewModel(

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/ConfirmMissingComplianceStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/ConfirmMissingComplianceStepConfig.kt
@@ -15,7 +15,7 @@ class ConfirmMissingComplianceStepConfig :
     override fun getStepSpecificContent(state: PropertyRegistrationJourneyState) =
         mapOf(
             "title" to "registerProperty.confirmMissingCompliance.heading",
-            "isGasMissing" to HasMissingComplianceStepConfig.isGasCertInvalid(state),
+            "isGasMissing" to HasMissingComplianceStepConfig.isGasCertInvalid(state.gasSafetyTask),
             "isElectricalMissing" to HasMissingComplianceStepConfig.isElectricalCertInvalid(state),
             "isEpcMissing" to HasMissingComplianceStepConfig.isEpcInvalid(state),
             "radioOptions" to

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/ElectricalCertExpiredStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/ElectricalCertExpiredStepConfig.kt
@@ -6,15 +6,15 @@ import uk.gov.communities.prsdb.webapp.constants.ELECTRICAL_SAFETY_STANDARDS_URL
 import uk.gov.communities.prsdb.webapp.journeys.AbstractRequestableStepConfig
 import uk.gov.communities.prsdb.webapp.journeys.Destination
 import uk.gov.communities.prsdb.webapp.journeys.JourneyStep.RequestableStep
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.ElectricalSafetyState
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.ElectricalSafetyDetailState
 import uk.gov.communities.prsdb.webapp.journeys.shared.Complete
 import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.NoInputFormModel
 
 @JourneyFrameworkComponent
-class ElectricalCertExpiredStepConfig : AbstractRequestableStepConfig<Complete, NoInputFormModel, ElectricalSafetyState>() {
+class ElectricalCertExpiredStepConfig : AbstractRequestableStepConfig<Complete, NoInputFormModel, ElectricalSafetyDetailState>() {
     override val formModelClass = NoInputFormModel::class
 
-    override fun getStepSpecificContent(state: ElectricalSafetyState) =
+    override fun getStepSpecificContent(state: ElectricalSafetyDetailState) =
         mapOf(
             "expiryDate" to state.getElectricalCertificateExpiryDateIfReachable()?.toJavaLocalDate(),
             "changeExpiryDateUrl" to Destination.VisitableStep(state.electricalCertExpiryDateStep, state.journeyId).toUrlStringOrNull(),
@@ -23,20 +23,20 @@ class ElectricalCertExpiredStepConfig : AbstractRequestableStepConfig<Complete, 
                 if (state.isOccupied) "forms.buttons.continueWithoutElectricalSafety" else "forms.buttons.saveAndContinue",
         )
 
-    override fun chooseTemplate(state: ElectricalSafetyState) =
+    override fun chooseTemplate(state: ElectricalSafetyDetailState) =
         if (state.isOccupied) {
             "forms/electricalSafetyCertificateExpiredForOccupiedProperty"
         } else {
             "forms/electricalSafetyCertificateExpiredForUnoccupiedProperty"
         }
 
-    override fun mode(state: ElectricalSafetyState) = getFormModelFromStateOrNull(state)?.let { Complete.COMPLETE }
+    override fun mode(state: ElectricalSafetyDetailState) = getFormModelFromStateOrNull(state)?.let { Complete.COMPLETE }
 }
 
 @JourneyFrameworkComponent
 final class ElectricalCertExpiredStep(
     stepConfig: ElectricalCertExpiredStepConfig,
-) : RequestableStep<Complete, NoInputFormModel, ElectricalSafetyState>(stepConfig) {
+) : RequestableStep<Complete, NoInputFormModel, ElectricalSafetyDetailState>(stepConfig) {
     companion object {
         const val ROUTE_SEGMENT = "electrical-safety-certificate-expired"
     }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/ElectricalCertExpiryDateStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/ElectricalCertExpiryDateStepConfig.kt
@@ -4,15 +4,15 @@ import uk.gov.communities.prsdb.webapp.annotations.webAnnotations.JourneyFramewo
 import uk.gov.communities.prsdb.webapp.constants.enums.HasElectricalSafetyCertificate
 import uk.gov.communities.prsdb.webapp.journeys.AbstractRequestableStepConfig
 import uk.gov.communities.prsdb.webapp.journeys.JourneyStep.RequestableStep
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.ElectricalSafetyState
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.ElectricalSafetyDetailState
 import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.AnyDateFormModel
 
 @JourneyFrameworkComponent
 class ElectricalCertExpiryDateStepConfig :
-    AbstractRequestableStepConfig<ElectricalCertExpiryDateMode, AnyDateFormModel, ElectricalSafetyState>() {
+    AbstractRequestableStepConfig<ElectricalCertExpiryDateMode, AnyDateFormModel, ElectricalSafetyDetailState>() {
     override val formModelClass = AnyDateFormModel::class
 
-    override fun getStepSpecificContent(state: ElectricalSafetyState): Map<String, Any?> {
+    override fun getStepSpecificContent(state: ElectricalSafetyDetailState): Map<String, Any?> {
         val certType = state.hasElectricalCertStep.formModelIfReachableOrNull?.electricalCertType
         val headingKey =
             if (certType == HasElectricalSafetyCertificate.HAS_EIC) {
@@ -26,9 +26,9 @@ class ElectricalCertExpiryDateStepConfig :
         )
     }
 
-    override fun chooseTemplate(state: ElectricalSafetyState): String = "forms/dateForm"
+    override fun chooseTemplate(state: ElectricalSafetyDetailState): String = "forms/dateForm"
 
-    override fun mode(state: ElectricalSafetyState) =
+    override fun mode(state: ElectricalSafetyDetailState) =
         state.getElectricalCertificateIsOutdated()?.let {
             when (it) {
                 true -> ElectricalCertExpiryDateMode.ELECTRICAL_SAFETY_CERTIFICATE_OUTDATED
@@ -40,7 +40,7 @@ class ElectricalCertExpiryDateStepConfig :
 @JourneyFrameworkComponent
 final class ElectricalCertExpiryDateStep(
     stepConfig: ElectricalCertExpiryDateStepConfig,
-) : RequestableStep<ElectricalCertExpiryDateMode, AnyDateFormModel, ElectricalSafetyState>(stepConfig) {
+) : RequestableStep<ElectricalCertExpiryDateMode, AnyDateFormModel, ElectricalSafetyDetailState>(stepConfig) {
     companion object {
         const val ROUTE_SEGMENT = "electrical-safety-certificate-expiry-date"
     }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/ElectricalCertMissingStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/ElectricalCertMissingStepConfig.kt
@@ -4,35 +4,35 @@ import uk.gov.communities.prsdb.webapp.annotations.webAnnotations.JourneyFramewo
 import uk.gov.communities.prsdb.webapp.constants.ELECTRICAL_SAFETY_STANDARDS_URL
 import uk.gov.communities.prsdb.webapp.journeys.AbstractRequestableStepConfig
 import uk.gov.communities.prsdb.webapp.journeys.JourneyStep.RequestableStep
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.ElectricalSafetyState
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.ElectricalSafetyDetailState
 import uk.gov.communities.prsdb.webapp.journeys.shared.Complete
 import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.NoInputFormModel
 
 @JourneyFrameworkComponent
-class ElectricalCertMissingStepConfig : AbstractRequestableStepConfig<Complete, NoInputFormModel, ElectricalSafetyState>() {
+class ElectricalCertMissingStepConfig : AbstractRequestableStepConfig<Complete, NoInputFormModel, ElectricalSafetyDetailState>() {
     override val formModelClass = NoInputFormModel::class
 
-    override fun getStepSpecificContent(state: ElectricalSafetyState) =
+    override fun getStepSpecificContent(state: ElectricalSafetyDetailState) =
         mapOf(
             "electricalSafetyStandardsUrl" to ELECTRICAL_SAFETY_STANDARDS_URL,
             "submitButtonText" to
                 if (state.isOccupied) "forms.buttons.continueWithoutElectricalSafety" else "forms.buttons.continue",
         )
 
-    override fun chooseTemplate(state: ElectricalSafetyState) =
+    override fun chooseTemplate(state: ElectricalSafetyDetailState) =
         if (state.isOccupied) {
             "forms/electricalSafetyCertificateMissingForOccupiedProperty"
         } else {
             "forms/electricalSafetyCertificateMissingForUnoccupiedProperty"
         }
 
-    override fun mode(state: ElectricalSafetyState) = getFormModelFromStateOrNull(state)?.let { Complete.COMPLETE }
+    override fun mode(state: ElectricalSafetyDetailState) = getFormModelFromStateOrNull(state)?.let { Complete.COMPLETE }
 }
 
 @JourneyFrameworkComponent
 final class ElectricalCertMissingStep(
     stepConfig: ElectricalCertMissingStepConfig,
-) : RequestableStep<Complete, NoInputFormModel, ElectricalSafetyState>(stepConfig) {
+) : RequestableStep<Complete, NoInputFormModel, ElectricalSafetyDetailState>(stepConfig) {
     companion object {
         const val ROUTE_SEGMENT = "electrical-safety-certificate-missing"
     }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/EpcAgeCheckStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/EpcAgeCheckStepConfig.kt
@@ -4,11 +4,11 @@ import uk.gov.communities.prsdb.webapp.annotations.webAnnotations.JourneyFramewo
 import uk.gov.communities.prsdb.webapp.exceptions.NotNullFormModelValueIsNullException
 import uk.gov.communities.prsdb.webapp.journeys.AbstractInternalStepConfig
 import uk.gov.communities.prsdb.webapp.journeys.JourneyStep
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.EpcState
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.EpcDetailState
 
 @JourneyFrameworkComponent
-class EpcAgeCheckStepConfig : AbstractInternalStepConfig<EpcAgeCheckMode, EpcState>() {
-    override fun mode(state: EpcState): EpcAgeCheckMode? {
+class EpcAgeCheckStepConfig : AbstractInternalStepConfig<EpcAgeCheckMode, EpcDetailState>() {
+    override fun mode(state: EpcDetailState): EpcAgeCheckMode? {
         val epcDetails =
             state.acceptedEpc
                 ?: throw NotNullFormModelValueIsNullException("acceptedEpc must be present before evaluating EPC age")
@@ -19,7 +19,7 @@ class EpcAgeCheckStepConfig : AbstractInternalStepConfig<EpcAgeCheckMode, EpcSta
 @JourneyFrameworkComponent
 final class EpcAgeCheckStep(
     stepConfig: EpcAgeCheckStepConfig,
-) : JourneyStep.InternalStep<EpcAgeCheckMode, EpcState>(stepConfig)
+) : JourneyStep.InternalStep<EpcAgeCheckMode, EpcDetailState>(stepConfig)
 
 enum class EpcAgeCheckMode {
     EPC_10_YEARS_OR_NEWER,

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/EpcEnergyRatingCheckStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/EpcEnergyRatingCheckStepConfig.kt
@@ -4,11 +4,11 @@ import uk.gov.communities.prsdb.webapp.annotations.webAnnotations.JourneyFramewo
 import uk.gov.communities.prsdb.webapp.exceptions.NotNullFormModelValueIsNullException
 import uk.gov.communities.prsdb.webapp.journeys.AbstractInternalStepConfig
 import uk.gov.communities.prsdb.webapp.journeys.JourneyStep
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.EpcState
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.EpcDetailState
 
 @JourneyFrameworkComponent
-class EpcEnergyRatingCheckStepConfig : AbstractInternalStepConfig<EpcEnergyRatingCheckMode, EpcState>() {
-    override fun mode(state: EpcState): EpcEnergyRatingCheckMode? {
+class EpcEnergyRatingCheckStepConfig : AbstractInternalStepConfig<EpcEnergyRatingCheckMode, EpcDetailState>() {
+    override fun mode(state: EpcDetailState): EpcEnergyRatingCheckMode? {
         val epcDetails =
             state.acceptedEpc
                 ?: throw NotNullFormModelValueIsNullException("acceptedEpc must be present before evaluating EPC energy rating")
@@ -23,7 +23,7 @@ class EpcEnergyRatingCheckStepConfig : AbstractInternalStepConfig<EpcEnergyRatin
 @JourneyFrameworkComponent
 final class EpcEnergyRatingCheckStep(
     stepConfig: EpcEnergyRatingCheckStepConfig,
-) : JourneyStep.InternalStep<EpcEnergyRatingCheckMode, EpcState>(stepConfig)
+) : JourneyStep.InternalStep<EpcEnergyRatingCheckMode, EpcDetailState>(stepConfig)
 
 enum class EpcEnergyRatingCheckMode {
     EPC_MEETS_ENERGY_REQUIREMENTS,

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/EpcExpiredStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/EpcExpiredStepConfig.kt
@@ -5,15 +5,15 @@ import uk.gov.communities.prsdb.webapp.constants.GET_NEW_EPC_URL
 import uk.gov.communities.prsdb.webapp.constants.REGISTERED_ENERGY_EXEMPTION_GUIDE_URL
 import uk.gov.communities.prsdb.webapp.journeys.AbstractRequestableStepConfig
 import uk.gov.communities.prsdb.webapp.journeys.JourneyStep.RequestableStep
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.EpcState
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.EpcDetailState
 import uk.gov.communities.prsdb.webapp.journeys.shared.Complete
 import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.NoInputFormModel
 
 @JourneyFrameworkComponent("propertyRegistrationEpcExpiredStepConfig")
-class EpcExpiredStepConfig : AbstractRequestableStepConfig<Complete, NoInputFormModel, EpcState>() {
+class EpcExpiredStepConfig : AbstractRequestableStepConfig<Complete, NoInputFormModel, EpcDetailState>() {
     override val formModelClass = NoInputFormModel::class
 
-    override fun getStepSpecificContent(state: EpcState) =
+    override fun getStepSpecificContent(state: EpcDetailState) =
         state.isOccupied?.let { isOccupied ->
             mapOf(
                 "expiryDate" to state.getNotNullAcceptedEpc().expiryDateAsJavaLocalDate,
@@ -24,7 +24,7 @@ class EpcExpiredStepConfig : AbstractRequestableStepConfig<Complete, NoInputForm
             )
         } ?: throw IllegalStateException("EpcExpiredStep should not be reachable before isOccupied is set")
 
-    override fun chooseTemplate(state: EpcState): String =
+    override fun chooseTemplate(state: EpcDetailState): String =
         state.isOccupied?.let { isOccupied ->
             if (isOccupied) {
                 "forms/epcExpiredForOccupiedPropertyRegistration"
@@ -33,13 +33,13 @@ class EpcExpiredStepConfig : AbstractRequestableStepConfig<Complete, NoInputForm
             }
         } ?: throw IllegalStateException("EpcExpiredStep should not be reachable before isOccupied is set")
 
-    override fun mode(state: EpcState): Complete? = getFormModelFromStateOrNull(state)?.let { Complete.COMPLETE }
+    override fun mode(state: EpcDetailState): Complete? = getFormModelFromStateOrNull(state)?.let { Complete.COMPLETE }
 }
 
 @JourneyFrameworkComponent("propertyRegistrationEpcExpiredStep")
 final class EpcExpiredStep(
     stepConfig: EpcExpiredStepConfig,
-) : RequestableStep<Complete, NoInputFormModel, EpcState>(stepConfig) {
+) : RequestableStep<Complete, NoInputFormModel, EpcDetailState>(stepConfig) {
     companion object {
         const val ROUTE_SEGMENT = "epc-expired"
     }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/EpcInDateAtStartOfTenancyCheckStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/EpcInDateAtStartOfTenancyCheckStepConfig.kt
@@ -3,16 +3,16 @@ package uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps
 import uk.gov.communities.prsdb.webapp.annotations.webAnnotations.JourneyFrameworkComponent
 import uk.gov.communities.prsdb.webapp.journeys.AbstractRequestableStepConfig
 import uk.gov.communities.prsdb.webapp.journeys.JourneyStep.RequestableStep
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.EpcState
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.EpcDetailState
 import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.EpcInDateAtStartOfTenancyCheckFormModel
 import uk.gov.communities.prsdb.webapp.models.viewModels.formModels.RadiosButtonViewModel
 
 @JourneyFrameworkComponent("propertyRegistrationEpcInDateAtStartOfTenancyCheckStepConfig")
 class EpcInDateAtStartOfTenancyCheckStepConfig :
-    AbstractRequestableStepConfig<EpcInDateAtStartOfTenancyCheckMode, EpcInDateAtStartOfTenancyCheckFormModel, EpcState>() {
+    AbstractRequestableStepConfig<EpcInDateAtStartOfTenancyCheckMode, EpcInDateAtStartOfTenancyCheckFormModel, EpcDetailState>() {
     override val formModelClass = EpcInDateAtStartOfTenancyCheckFormModel::class
 
-    override fun getStepSpecificContent(state: EpcState): Map<String, Any?> {
+    override fun getStepSpecificContent(state: EpcDetailState): Map<String, Any?> {
         val expiryDate = state.getNotNullAcceptedEpc().expiryDateAsJavaLocalDate
         return mapOf(
             "expiryDate" to expiryDate,
@@ -34,9 +34,9 @@ class EpcInDateAtStartOfTenancyCheckStepConfig :
         )
     }
 
-    override fun chooseTemplate(state: EpcState) = "forms/epcInDateAtStartOfTenancyCheckForm"
+    override fun chooseTemplate(state: EpcDetailState) = "forms/epcInDateAtStartOfTenancyCheckForm"
 
-    override fun mode(state: EpcState) =
+    override fun mode(state: EpcDetailState) =
         getFormModelFromStateOrNull(state)?.let {
             when (it.tenancyStartedBeforeExpiry) {
                 true -> EpcInDateAtStartOfTenancyCheckMode.IN_DATE
@@ -49,7 +49,7 @@ class EpcInDateAtStartOfTenancyCheckStepConfig :
 @JourneyFrameworkComponent("propertyRegistrationEpcInDateAtStartOfTenancyCheckStep")
 final class EpcInDateAtStartOfTenancyCheckStep(
     stepConfig: EpcInDateAtStartOfTenancyCheckStepConfig,
-) : RequestableStep<EpcInDateAtStartOfTenancyCheckMode, EpcInDateAtStartOfTenancyCheckFormModel, EpcState>(stepConfig) {
+) : RequestableStep<EpcInDateAtStartOfTenancyCheckMode, EpcInDateAtStartOfTenancyCheckFormModel, EpcDetailState>(stepConfig) {
     companion object {
         const val ROUTE_SEGMENT = "epc-in-date-at-start-of-tenancy-check"
     }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/EpcLookupByUprnStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/EpcLookupByUprnStepConfig.kt
@@ -3,17 +3,17 @@ package uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps
 import uk.gov.communities.prsdb.webapp.annotations.webAnnotations.JourneyFrameworkComponent
 import uk.gov.communities.prsdb.webapp.journeys.AbstractInternalStepConfig
 import uk.gov.communities.prsdb.webapp.journeys.JourneyStep
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.EpcState
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.EpcDetailState
 import uk.gov.communities.prsdb.webapp.services.EpcLookupService
 
 @JourneyFrameworkComponent
 class EpcLookupByUprnStepConfig(
     private val epcLookupService: EpcLookupService,
-) : AbstractInternalStepConfig<EpcLookupByUprnMode, EpcState>() {
-    override fun mode(state: EpcState): EpcLookupByUprnMode? =
+) : AbstractInternalStepConfig<EpcLookupByUprnMode, EpcDetailState>() {
+    override fun mode(state: EpcDetailState): EpcLookupByUprnMode? =
         if (state.epcRetrievedByUprn != null) EpcLookupByUprnMode.EPC_FOUND else EpcLookupByUprnMode.NOT_FOUND
 
-    override fun afterStepIsReached(state: EpcState) {
+    override fun afterStepIsReached(state: EpcDetailState) {
         val previousEpcRetrievedByUprn = state.epcRetrievedByUprn
         val newEpcRetrievedByUprn = state.uprn?.let { epcLookupService.getEpcByUprn(it) }
         state.epcRetrievedByUprn = newEpcRetrievedByUprn
@@ -26,7 +26,7 @@ class EpcLookupByUprnStepConfig(
 @JourneyFrameworkComponent
 final class EpcLookupByUprnStep(
     stepConfig: EpcLookupByUprnStepConfig,
-) : JourneyStep.InternalStep<EpcLookupByUprnMode, EpcState>(stepConfig)
+) : JourneyStep.InternalStep<EpcLookupByUprnMode, EpcDetailState>(stepConfig)
 
 enum class EpcLookupByUprnMode {
     EPC_FOUND,

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/EpcMissingStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/EpcMissingStepConfig.kt
@@ -5,15 +5,15 @@ import uk.gov.communities.prsdb.webapp.constants.GET_NEW_EPC_URL
 import uk.gov.communities.prsdb.webapp.constants.REGISTERED_ENERGY_EXEMPTION_GUIDE_URL
 import uk.gov.communities.prsdb.webapp.journeys.AbstractRequestableStepConfig
 import uk.gov.communities.prsdb.webapp.journeys.JourneyStep.RequestableStep
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.EpcState
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.EpcDetailState
 import uk.gov.communities.prsdb.webapp.journeys.shared.Complete
 import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.NoInputFormModel
 
 @JourneyFrameworkComponent("propertyRegistrationEpcMissingStepConfig")
-class EpcMissingStepConfig : AbstractRequestableStepConfig<Complete, NoInputFormModel, EpcState>() {
+class EpcMissingStepConfig : AbstractRequestableStepConfig<Complete, NoInputFormModel, EpcDetailState>() {
     override val formModelClass = NoInputFormModel::class
 
-    override fun getStepSpecificContent(state: EpcState) =
+    override fun getStepSpecificContent(state: EpcDetailState) =
         state.isOccupied?.let { isOccupied ->
             mapOf(
                 "getNewEpcUrl" to GET_NEW_EPC_URL,
@@ -23,18 +23,18 @@ class EpcMissingStepConfig : AbstractRequestableStepConfig<Complete, NoInputForm
             )
         } ?: throw IllegalStateException("EpcMissingStep should not be reachable before isOccupied is set")
 
-    override fun chooseTemplate(state: EpcState): String =
+    override fun chooseTemplate(state: EpcDetailState): String =
         state.isOccupied?.let { isOccupied ->
             if (isOccupied) "forms/epcMissingForOccupiedProperty" else "forms/epcMissingForUnoccupiedProperty"
         } ?: throw IllegalStateException("EpcMissingStep should not be reachable before isOccupied is set")
 
-    override fun mode(state: EpcState): Complete? = getFormModelFromStateOrNull(state)?.let { Complete.COMPLETE }
+    override fun mode(state: EpcDetailState): Complete? = getFormModelFromStateOrNull(state)?.let { Complete.COMPLETE }
 }
 
 @JourneyFrameworkComponent("propertyRegistrationEpcMissingStep")
 final class EpcMissingStep(
     stepConfig: EpcMissingStepConfig,
-) : RequestableStep<Complete, NoInputFormModel, EpcState>(stepConfig) {
+) : RequestableStep<Complete, NoInputFormModel, EpcDetailState>(stepConfig) {
     companion object {
         const val ROUTE_SEGMENT = "epc-missing"
     }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/EpcNotFoundStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/EpcNotFoundStepConfig.kt
@@ -4,30 +4,30 @@ import uk.gov.communities.prsdb.webapp.annotations.webAnnotations.JourneyFramewo
 import uk.gov.communities.prsdb.webapp.journeys.AbstractRequestableStepConfig
 import uk.gov.communities.prsdb.webapp.journeys.Destination
 import uk.gov.communities.prsdb.webapp.journeys.JourneyStep.RequestableStep
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.EpcState
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.EpcDetailState
 import uk.gov.communities.prsdb.webapp.journeys.shared.Complete
 import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.NoInputFormModel
 
 @JourneyFrameworkComponent("propertyRegistrationEpcNotFoundStepConfig")
-class EpcNotFoundStepConfig : AbstractRequestableStepConfig<Complete, NoInputFormModel, EpcState>() {
+class EpcNotFoundStepConfig : AbstractRequestableStepConfig<Complete, NoInputFormModel, EpcDetailState>() {
     override val formModelClass = NoInputFormModel::class
 
-    override fun getStepSpecificContent(state: EpcState) =
+    override fun getStepSpecificContent(state: EpcDetailState) =
         mapOf(
             "certificateNumber" to state.findYourEpcStep.formModelOrNull?.certificateNumber,
             "searchAgainUrl" to Destination.VisitableStep(state.findYourEpcStep, state.journeyId).toUrlStringOrNull(),
             "submitButtonText" to "forms.buttons.iDoNotHaveAnEpc",
         )
 
-    override fun chooseTemplate(state: EpcState) = "forms/epcNotFoundPropertyRegistrationForm"
+    override fun chooseTemplate(state: EpcDetailState) = "forms/epcNotFoundPropertyRegistrationForm"
 
-    override fun mode(state: EpcState) = getFormModelFromStateOrNull(state)?.let { Complete.COMPLETE }
+    override fun mode(state: EpcDetailState) = getFormModelFromStateOrNull(state)?.let { Complete.COMPLETE }
 }
 
 @JourneyFrameworkComponent("propertyRegistrationEpcNotFoundStep")
 final class EpcNotFoundStep(
     stepConfig: EpcNotFoundStepConfig,
-) : RequestableStep<Complete, NoInputFormModel, EpcState>(stepConfig) {
+) : RequestableStep<Complete, NoInputFormModel, EpcDetailState>(stepConfig) {
     companion object {
         const val ROUTE_SEGMENT = "epc-not-found"
     }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/EpcSuperseededStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/EpcSuperseededStepConfig.kt
@@ -4,7 +4,7 @@ import uk.gov.communities.prsdb.webapp.annotations.webAnnotations.JourneyFramewo
 import uk.gov.communities.prsdb.webapp.journeys.AbstractRequestableStepConfig
 import uk.gov.communities.prsdb.webapp.journeys.Destination
 import uk.gov.communities.prsdb.webapp.journeys.JourneyStep.RequestableStep
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.EpcState
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.EpcDetailState
 import uk.gov.communities.prsdb.webapp.journeys.shared.Complete
 import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.NoInputFormModel
 import uk.gov.communities.prsdb.webapp.models.viewModels.TicketPanelLinkViewModel
@@ -14,10 +14,10 @@ import uk.gov.communities.prsdb.webapp.services.EpcCertificateUrlProvider
 @JourneyFrameworkComponent
 class EpcSuperseededStepConfig(
     private val epcCertificateUrlProvider: EpcCertificateUrlProvider,
-) : AbstractRequestableStepConfig<Complete, NoInputFormModel, EpcState>() {
+) : AbstractRequestableStepConfig<Complete, NoInputFormModel, EpcDetailState>() {
     override val formModelClass = NoInputFormModel::class
 
-    override fun getStepSpecificContent(state: EpcState): Map<String, Any?> {
+    override fun getStepSpecificContent(state: EpcDetailState): Map<String, Any?> {
         val supersededEpc = state.epcRetrievedByCertificateNumber
         val latestEpc = state.updatedEpcRetrievedByCertificateNumber
         val messageKeyPrefix = "propertyCompliance.epcTask.epcSuperseded"
@@ -74,11 +74,11 @@ class EpcSuperseededStepConfig(
         )
     }
 
-    override fun chooseTemplate(state: EpcState) = "forms/confirmUpdatedEpcForm"
+    override fun chooseTemplate(state: EpcDetailState) = "forms/confirmUpdatedEpcForm"
 
-    override fun mode(state: EpcState) = getFormModelFromStateOrNull(state)?.let { Complete.COMPLETE }
+    override fun mode(state: EpcDetailState) = getFormModelFromStateOrNull(state)?.let { Complete.COMPLETE }
 
-    override fun afterStepDataIsAdded(state: EpcState) {
+    override fun afterStepDataIsAdded(state: EpcDetailState) {
         state.acceptedEpc = state.updatedEpcRetrievedByCertificateNumber
     }
 }
@@ -86,7 +86,7 @@ class EpcSuperseededStepConfig(
 @JourneyFrameworkComponent
 final class EpcSuperseededStep(
     stepConfig: EpcSuperseededStepConfig,
-) : RequestableStep<Complete, NoInputFormModel, EpcState>(stepConfig) {
+) : RequestableStep<Complete, NoInputFormModel, EpcDetailState>(stepConfig) {
     companion object {
         const val ROUTE_SEGMENT = "epc-superseded"
     }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/FindYourEpcStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/FindYourEpcStepConfig.kt
@@ -4,25 +4,25 @@ import uk.gov.communities.prsdb.webapp.annotations.webAnnotations.JourneyFramewo
 import uk.gov.communities.prsdb.webapp.constants.FIND_EPC_URL
 import uk.gov.communities.prsdb.webapp.journeys.AbstractRequestableStepConfig
 import uk.gov.communities.prsdb.webapp.journeys.JourneyStep.RequestableStep
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.EpcState
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.EpcDetailState
 import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.FindEpcByCertificateNumberFormModel
 import uk.gov.communities.prsdb.webapp.services.EpcLookupService
 
 @JourneyFrameworkComponent
 class FindYourEpcStepConfig(
     private val epcLookupService: EpcLookupService,
-) : AbstractRequestableStepConfig<FindYourEpcMode, FindEpcByCertificateNumberFormModel, EpcState>() {
+) : AbstractRequestableStepConfig<FindYourEpcMode, FindEpcByCertificateNumberFormModel, EpcDetailState>() {
     override val formModelClass = FindEpcByCertificateNumberFormModel::class
 
-    override fun getStepSpecificContent(state: EpcState) =
+    override fun getStepSpecificContent(state: EpcDetailState) =
         mapOf(
             "fieldSetHeading" to "propertyCompliance.epcTask.findYourEpc.fieldSetHeading",
             "findEpcUrl" to FIND_EPC_URL,
         )
 
-    override fun chooseTemplate(state: EpcState) = "forms/findYourEpcForm"
+    override fun chooseTemplate(state: EpcDetailState) = "forms/findYourEpcForm"
 
-    override fun mode(state: EpcState): FindYourEpcMode? {
+    override fun mode(state: EpcDetailState): FindYourEpcMode? {
         val epc = state.epcRetrievedByCertificateNumber
         return when {
             epc == null -> FindYourEpcMode.NOT_FOUND
@@ -31,7 +31,7 @@ class FindYourEpcStepConfig(
         }
     }
 
-    override fun afterStepDataIsAdded(state: EpcState) {
+    override fun afterStepDataIsAdded(state: EpcDetailState) {
         val epcPreviouslyReviewedByUser = state.epcRetrievedByCertificateNumber
         val formModel = getFormModelFromState(state)
         state.epcRetrievedByCertificateNumber = epcLookupService.getEpcByCertificateNumber(formModel.certificateNumber)
@@ -48,7 +48,7 @@ class FindYourEpcStepConfig(
 @JourneyFrameworkComponent
 final class FindYourEpcStep(
     stepConfig: FindYourEpcStepConfig,
-) : RequestableStep<FindYourEpcMode, FindEpcByCertificateNumberFormModel, EpcState>(stepConfig) {
+) : RequestableStep<FindYourEpcMode, FindEpcByCertificateNumberFormModel, EpcDetailState>(stepConfig) {
     companion object {
         const val ROUTE_SEGMENT = "find-your-epc"
     }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/GasCertExpiredStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/GasCertExpiredStepConfig.kt
@@ -5,15 +5,15 @@ import uk.gov.communities.prsdb.webapp.constants.LANDLORD_GAS_SAFETY_URL
 import uk.gov.communities.prsdb.webapp.journeys.AbstractRequestableStepConfig
 import uk.gov.communities.prsdb.webapp.journeys.Destination
 import uk.gov.communities.prsdb.webapp.journeys.JourneyStep.RequestableStep
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.GasSafetyState
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.GasSafetyDetailState
 import uk.gov.communities.prsdb.webapp.journeys.shared.Complete
 import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.NoInputFormModel
 
 @JourneyFrameworkComponent
-class GasCertExpiredStepConfig : AbstractRequestableStepConfig<Complete, NoInputFormModel, GasSafetyState>() {
+class GasCertExpiredStepConfig : AbstractRequestableStepConfig<Complete, NoInputFormModel, GasSafetyDetailState>() {
     override val formModelClass = NoInputFormModel::class
 
-    override fun getStepSpecificContent(state: GasSafetyState) =
+    override fun getStepSpecificContent(state: GasSafetyDetailState) =
         mapOf(
             "issueDate" to
                 state.gasCertIssueDateStep.formModelOrNull
@@ -24,7 +24,7 @@ class GasCertExpiredStepConfig : AbstractRequestableStepConfig<Complete, NoInput
                 if (state.isOccupied == true) "forms.buttons.continueWithoutGasSafety" else "forms.buttons.saveAndContinue",
         )
 
-    override fun chooseTemplate(state: GasSafetyState) =
+    override fun chooseTemplate(state: GasSafetyDetailState) =
         state.isOccupied?.let { isOccupied ->
             if (isOccupied) {
                 "forms/gasSafetyCertificateExpiredForOccupiedProperty"
@@ -33,13 +33,13 @@ class GasCertExpiredStepConfig : AbstractRequestableStepConfig<Complete, NoInput
             }
         } ?: throw IllegalStateException("GasCertExpiredStep should not reachable before isOccupied is set")
 
-    override fun mode(state: GasSafetyState) = getFormModelFromStateOrNull(state)?.let { Complete.COMPLETE }
+    override fun mode(state: GasSafetyDetailState) = getFormModelFromStateOrNull(state)?.let { Complete.COMPLETE }
 }
 
 @JourneyFrameworkComponent
 final class GasCertExpiredStep(
     stepConfig: GasCertExpiredStepConfig,
-) : RequestableStep<Complete, NoInputFormModel, GasSafetyState>(stepConfig) {
+) : RequestableStep<Complete, NoInputFormModel, GasSafetyDetailState>(stepConfig) {
     companion object {
         const val ROUTE_SEGMENT = "gas-safety-certificate-expired"
     }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/GasCertIssueDateStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/GasCertIssueDateStepConfig.kt
@@ -3,23 +3,23 @@ package uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps
 import uk.gov.communities.prsdb.webapp.annotations.webAnnotations.JourneyFrameworkComponent
 import uk.gov.communities.prsdb.webapp.journeys.AbstractRequestableStepConfig
 import uk.gov.communities.prsdb.webapp.journeys.JourneyStep.RequestableStep
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.GasSafetyState
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.GasSafetyDetailState
 import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.TodayOrPastDateFormModel
 
 @JourneyFrameworkComponent
-class GasCertIssueDateStepConfig : AbstractRequestableStepConfig<GasCertIssueDateMode, TodayOrPastDateFormModel, GasSafetyState>() {
+class GasCertIssueDateStepConfig : AbstractRequestableStepConfig<GasCertIssueDateMode, TodayOrPastDateFormModel, GasSafetyDetailState>() {
     override val formModelClass = TodayOrPastDateFormModel::class
 
-    override fun getStepSpecificContent(state: GasSafetyState): Map<String, Any?> =
+    override fun getStepSpecificContent(state: GasSafetyDetailState): Map<String, Any?> =
         mapOf(
             "fieldSetHeading" to "propertyCompliance.gasSafetyTask.gasSafetyCertIssueDate.fieldSetHeading",
             "fieldSetHint" to "propertyCompliance.gasSafetyTask.gasSafetyCertIssueDate.fieldSetHint",
             "submitButtonText" to "forms.buttons.saveAndContinue",
         )
 
-    override fun chooseTemplate(state: GasSafetyState): String = "forms/dateForm"
+    override fun chooseTemplate(state: GasSafetyDetailState): String = "forms/dateForm"
 
-    override fun mode(state: GasSafetyState) =
+    override fun mode(state: GasSafetyDetailState) =
         state.getGasSafetyCertificateIsOutdated()?.let {
             when (it) {
                 true -> GasCertIssueDateMode.GAS_SAFETY_CERTIFICATE_OUTDATED
@@ -31,7 +31,7 @@ class GasCertIssueDateStepConfig : AbstractRequestableStepConfig<GasCertIssueDat
 @JourneyFrameworkComponent
 final class GasCertIssueDateStep(
     stepConfig: GasCertIssueDateStepConfig,
-) : RequestableStep<GasCertIssueDateMode, TodayOrPastDateFormModel, GasSafetyState>(stepConfig) {
+) : RequestableStep<GasCertIssueDateMode, TodayOrPastDateFormModel, GasSafetyDetailState>(stepConfig) {
     companion object {
         const val ROUTE_SEGMENT = "gas-safety-certificate-issue-date"
     }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/GasCertMissingStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/GasCertMissingStepConfig.kt
@@ -4,21 +4,21 @@ import uk.gov.communities.prsdb.webapp.annotations.webAnnotations.JourneyFramewo
 import uk.gov.communities.prsdb.webapp.constants.LANDLORD_GAS_SAFETY_URL
 import uk.gov.communities.prsdb.webapp.journeys.AbstractRequestableStepConfig
 import uk.gov.communities.prsdb.webapp.journeys.JourneyStep.RequestableStep
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.GasSafetyState
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.GasSafetyDetailState
 import uk.gov.communities.prsdb.webapp.journeys.shared.Complete
 import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.NoInputFormModel
 
 @JourneyFrameworkComponent
-class GasCertMissingStepConfig : AbstractRequestableStepConfig<Complete, NoInputFormModel, GasSafetyState>() {
+class GasCertMissingStepConfig : AbstractRequestableStepConfig<Complete, NoInputFormModel, GasSafetyDetailState>() {
     override val formModelClass = NoInputFormModel::class
 
-    override fun getStepSpecificContent(state: GasSafetyState) =
+    override fun getStepSpecificContent(state: GasSafetyDetailState) =
         mapOf(
             "landlordGasSafetyUrl" to LANDLORD_GAS_SAFETY_URL,
             "submitButtonText" to if (state.isOccupied == true) "forms.buttons.continueWithoutGasSafety" else "forms.buttons.continue",
         )
 
-    override fun chooseTemplate(state: GasSafetyState) =
+    override fun chooseTemplate(state: GasSafetyDetailState) =
         state.isOccupied?.let { isOccupied ->
             if (isOccupied) {
                 "forms/gasSafetyCertificateMissingForOccupiedProperty"
@@ -27,13 +27,13 @@ class GasCertMissingStepConfig : AbstractRequestableStepConfig<Complete, NoInput
             }
         } ?: throw IllegalStateException("GasCertMissingStep should not reachable before isOccupied is set")
 
-    override fun mode(state: GasSafetyState) = getFormModelFromStateOrNull(state)?.let { Complete.COMPLETE }
+    override fun mode(state: GasSafetyDetailState) = getFormModelFromStateOrNull(state)?.let { Complete.COMPLETE }
 }
 
 @JourneyFrameworkComponent
 final class GasCertMissingStep(
     stepConfig: GasCertMissingStepConfig,
-) : RequestableStep<Complete, NoInputFormModel, GasSafetyState>(stepConfig) {
+) : RequestableStep<Complete, NoInputFormModel, GasSafetyDetailState>(stepConfig) {
     companion object {
         const val ROUTE_SEGMENT = "gas-safety-certificate-missing"
     }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/HasElectricalCertStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/HasElectricalCertStepConfig.kt
@@ -7,17 +7,17 @@ import uk.gov.communities.prsdb.webapp.constants.enums.HasElectricalSafetyCertif
 import uk.gov.communities.prsdb.webapp.journeys.AbstractRequestableStepConfig
 import uk.gov.communities.prsdb.webapp.journeys.JourneyStep.RequestableStep
 import uk.gov.communities.prsdb.webapp.journeys.UnrecoverableJourneyStateException
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.ElectricalSafetyState
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.ElectricalSafetyDetailState
 import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.HasElectricalCertFormModel
 import uk.gov.communities.prsdb.webapp.models.viewModels.formModels.RadiosButtonViewModel
 import uk.gov.communities.prsdb.webapp.models.viewModels.formModels.RadiosDividerViewModel
 
 @JourneyFrameworkComponent
 class HasElectricalCertStepConfig :
-    AbstractRequestableStepConfig<HasElectricalCertMode, HasElectricalCertFormModel, ElectricalSafetyState>() {
+    AbstractRequestableStepConfig<HasElectricalCertMode, HasElectricalCertFormModel, ElectricalSafetyDetailState>() {
     override val formModelClass = HasElectricalCertFormModel::class
 
-    override fun getStepSpecificContent(state: ElectricalSafetyState) =
+    override fun getStepSpecificContent(state: ElectricalSafetyDetailState) =
         mapOf(
             "fieldSetHeading" to "propertyCompliance.electricalSafetyTask.electricalCert.heading",
             "fieldSetHint" to "propertyCompliance.electricalSafetyTask.electricalCert.hint",
@@ -48,9 +48,9 @@ class HasElectricalCertStepConfig :
                 ),
         )
 
-    override fun chooseTemplate(state: ElectricalSafetyState) = "forms/hasElectricalCertForm"
+    override fun chooseTemplate(state: ElectricalSafetyDetailState) = "forms/hasElectricalCertForm"
 
-    override fun mode(state: ElectricalSafetyState) =
+    override fun mode(state: ElectricalSafetyDetailState) =
         getFormModelFromStateOrNull(state)?.let {
             if (it.action == PROVIDE_THIS_LATER_BUTTON_ACTION_NAME) {
                 if (state.allowProvideCertificateLaterRoute) {
@@ -77,7 +77,7 @@ class HasElectricalCertStepConfig :
 @JourneyFrameworkComponent
 final class HasElectricalCertStep(
     stepConfig: HasElectricalCertStepConfig,
-) : RequestableStep<HasElectricalCertMode, HasElectricalCertFormModel, ElectricalSafetyState>(stepConfig) {
+) : RequestableStep<HasElectricalCertMode, HasElectricalCertFormModel, ElectricalSafetyDetailState>(stepConfig) {
     companion object {
         const val ROUTE_SEGMENT = "has-electrical-safety"
     }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/HasEpcStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/HasEpcStepConfig.kt
@@ -8,15 +8,15 @@ import uk.gov.communities.prsdb.webapp.constants.PROVIDE_THIS_LATER_BUTTON_ACTIO
 import uk.gov.communities.prsdb.webapp.journeys.AbstractRequestableStepConfig
 import uk.gov.communities.prsdb.webapp.journeys.JourneyStep.RequestableStep
 import uk.gov.communities.prsdb.webapp.journeys.UnrecoverableJourneyStateException
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.EpcState
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.EpcDetailState
 import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.HasEpcFormModel
 import uk.gov.communities.prsdb.webapp.models.viewModels.formModels.RadiosButtonViewModel
 
 @JourneyFrameworkComponent
-class HasEpcStepConfig : AbstractRequestableStepConfig<HasEpcMode, HasEpcFormModel, EpcState>() {
+class HasEpcStepConfig : AbstractRequestableStepConfig<HasEpcMode, HasEpcFormModel, EpcDetailState>() {
     override val formModelClass = HasEpcFormModel::class
 
-    override fun getStepSpecificContent(state: EpcState) =
+    override fun getStepSpecificContent(state: EpcDetailState) =
         mapOf(
             "fieldSetHeading" to "propertyCompliance.epcTask.hasEpc.fieldSetHeading",
             "submitButtonText" to "forms.buttons.saveAndContinue",
@@ -29,9 +29,9 @@ class HasEpcStepConfig : AbstractRequestableStepConfig<HasEpcMode, HasEpcFormMod
             "epcGuideUrl" to EPC_GUIDE_URL,
         )
 
-    override fun chooseTemplate(state: EpcState) = "forms/hasEpcForm"
+    override fun chooseTemplate(state: EpcDetailState) = "forms/hasEpcForm"
 
-    override fun mode(state: EpcState) =
+    override fun mode(state: EpcDetailState) =
         getFormModelFromStateOrNull(state)?.let {
             if (it.action == PROVIDE_THIS_LATER_BUTTON_ACTION_NAME) {
                 if (state.allowProvideCertificateLaterRoute) {
@@ -69,7 +69,7 @@ class HasEpcStepConfig : AbstractRequestableStepConfig<HasEpcMode, HasEpcFormMod
 @JourneyFrameworkComponent
 final class HasEpcStep(
     stepConfig: HasEpcStepConfig,
-) : RequestableStep<HasEpcMode, HasEpcFormModel, EpcState>(stepConfig) {
+) : RequestableStep<HasEpcMode, HasEpcFormModel, EpcDetailState>(stepConfig) {
     companion object {
         const val ROUTE_SEGMENT = "has-epc"
     }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/HasGasCertStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/HasGasCertStepConfig.kt
@@ -6,15 +6,15 @@ import uk.gov.communities.prsdb.webapp.constants.PROVIDE_THIS_LATER_BUTTON_ACTIO
 import uk.gov.communities.prsdb.webapp.journeys.AbstractRequestableStepConfig
 import uk.gov.communities.prsdb.webapp.journeys.JourneyStep.RequestableStep
 import uk.gov.communities.prsdb.webapp.journeys.UnrecoverableJourneyStateException
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.GasSafetyState
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.GasSafetyDetailState
 import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.HasGasCertFormModel
 import uk.gov.communities.prsdb.webapp.models.viewModels.formModels.RadiosViewModel
 
 @JourneyFrameworkComponent
-class HasGasCertStepConfig : AbstractRequestableStepConfig<HasGasCertMode, HasGasCertFormModel, GasSafetyState>() {
+class HasGasCertStepConfig : AbstractRequestableStepConfig<HasGasCertMode, HasGasCertFormModel, GasSafetyDetailState>() {
     override val formModelClass = HasGasCertFormModel::class
 
-    override fun getStepSpecificContent(state: GasSafetyState) =
+    override fun getStepSpecificContent(state: GasSafetyDetailState) =
         mapOf(
             "fieldSetHeading" to "propertyCompliance.gasSafetyTask.gasCert.heading",
             "fieldSetHint" to "propertyCompliance.gasSafetyTask.gasCert.hint",
@@ -29,9 +29,9 @@ class HasGasCertStepConfig : AbstractRequestableStepConfig<HasGasCertMode, HasGa
                 ),
         )
 
-    override fun chooseTemplate(state: GasSafetyState) = "forms/hasGasCertForm"
+    override fun chooseTemplate(state: GasSafetyDetailState) = "forms/hasGasCertForm"
 
-    override fun mode(state: GasSafetyState) =
+    override fun mode(state: GasSafetyDetailState) =
         getFormModelFromStateOrNull(state)?.let {
             if (it.action == PROVIDE_THIS_LATER_BUTTON_ACTION_NAME) {
                 if (state.allowProvideCertificateLaterRoute) {
@@ -57,7 +57,7 @@ class HasGasCertStepConfig : AbstractRequestableStepConfig<HasGasCertMode, HasGa
 @JourneyFrameworkComponent
 final class HasGasCertStep(
     stepConfig: HasGasCertStepConfig,
-) : RequestableStep<HasGasCertMode, HasGasCertFormModel, GasSafetyState>(stepConfig) {
+) : RequestableStep<HasGasCertMode, HasGasCertFormModel, GasSafetyDetailState>(stepConfig) {
     companion object {
         const val ROUTE_SEGMENT = "has-gas-safety"
     }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/HasMissingComplianceStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/HasMissingComplianceStepConfig.kt
@@ -11,7 +11,10 @@ import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.GasS
 @JourneyFrameworkComponent
 class HasMissingComplianceStepConfig : AbstractInternalStepConfig<ConfirmMissingComplianceCheckResult, CombinedComplianceCheckState>() {
     override fun mode(state: CombinedComplianceCheckState): ConfirmMissingComplianceCheckResult {
-        val anyInvalid = isGasCertInvalid(state.gasSafetyTask) || isElectricalCertInvalid(state.electricalSafetyTask) || isEpcInvalid(state)
+        val anyInvalid =
+            isGasCertInvalid(state.gasSafetyTask) ||
+                isElectricalCertInvalid(state.electricalSafetyTask) ||
+                isEpcInvalid(state.epcTask)
         return if (state.isOccupied && anyInvalid) {
             ConfirmMissingComplianceCheckResult.OCCUPIED_AND_HAS_INVALID_CERTIFICATES
         } else {

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/HasMissingComplianceStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/HasMissingComplianceStepConfig.kt
@@ -41,18 +41,18 @@ class HasMissingComplianceStepConfig : AbstractInternalStepConfig<ConfirmMissing
         }
 
         fun isEpcInvalid(state: EpcState): Boolean {
-            if (state.hasEpcStep.outcome == HasEpcMode.PROVIDE_LATER) return false
+            if (state.epcDetailsTask.hasEpcStep.outcome == HasEpcMode.PROVIDE_LATER) return false
             val acceptedEpc =
-                state.acceptedEpcIfStillAccepted
-                    ?: return state.epcExemptionStep.formModelIfReachableOrNull?.exemptionReason == null
+                state.epcDetailsTask.acceptedEpcIfStillAccepted
+                    ?: return state.epcDetailsTask.epcExemptionStep.formModelIfReachableOrNull?.exemptionReason == null
             return (
                 (
                     acceptedEpc.isPastExpiryDate() &&
-                        (state.epcInDateAtStartOfTenancyCheckStep.outcome != EpcInDateAtStartOfTenancyCheckMode.IN_DATE)
+                        (state.epcDetailsTask.epcInDateAtStartOfTenancyCheckStep.outcome != EpcInDateAtStartOfTenancyCheckMode.IN_DATE)
                 ) ||
                     (
                         !acceptedEpc.isEnergyRatingEOrBetter() &&
-                            (state.meesExemptionStep.formModelIfReachableOrNull?.exemptionReason == null)
+                            (state.epcDetailsTask.meesExemptionStep.formModelIfReachableOrNull?.exemptionReason == null)
                     )
             )
         }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/HasMissingComplianceStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/HasMissingComplianceStepConfig.kt
@@ -32,8 +32,8 @@ class HasMissingComplianceStepConfig : AbstractInternalStepConfig<ConfirmMissing
         }
 
         fun isElectricalCertInvalid(state: ElectricalSafetyState): Boolean {
-            if (state.hasElectricalCertStep.outcome == HasElectricalCertMode.PROVIDE_THIS_LATER) return false
-            val isOutdated = state.getElectricalCertificateIsOutdated()
+            if (state.electricalSafetyDetailsTask.hasElectricalCertStep.outcome == HasElectricalCertMode.PROVIDE_THIS_LATER) return false
+            val isOutdated = state.electricalSafetyDetailsTask.getElectricalCertificateIsOutdated()
             return isOutdated == null || isOutdated
         }
 

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/HasMissingComplianceStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/HasMissingComplianceStepConfig.kt
@@ -11,7 +11,7 @@ import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.GasS
 @JourneyFrameworkComponent
 class HasMissingComplianceStepConfig : AbstractInternalStepConfig<ConfirmMissingComplianceCheckResult, CombinedComplianceCheckState>() {
     override fun mode(state: CombinedComplianceCheckState): ConfirmMissingComplianceCheckResult {
-        val anyInvalid = isGasCertInvalid(state) || isElectricalCertInvalid(state) || isEpcInvalid(state)
+        val anyInvalid = isGasCertInvalid(state.gasSafetyTask) || isElectricalCertInvalid(state) || isEpcInvalid(state)
         return if (state.isOccupied && anyInvalid) {
             ConfirmMissingComplianceCheckResult.OCCUPIED_AND_HAS_INVALID_CERTIFICATES
         } else {

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/HasMissingComplianceStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/HasMissingComplianceStepConfig.kt
@@ -11,7 +11,7 @@ import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.GasS
 @JourneyFrameworkComponent
 class HasMissingComplianceStepConfig : AbstractInternalStepConfig<ConfirmMissingComplianceCheckResult, CombinedComplianceCheckState>() {
     override fun mode(state: CombinedComplianceCheckState): ConfirmMissingComplianceCheckResult {
-        val anyInvalid = isGasCertInvalid(state.gasSafetyTask) || isElectricalCertInvalid(state) || isEpcInvalid(state)
+        val anyInvalid = isGasCertInvalid(state.gasSafetyTask) || isElectricalCertInvalid(state.electricalSafetyTask) || isEpcInvalid(state)
         return if (state.isOccupied && anyInvalid) {
             ConfirmMissingComplianceCheckResult.OCCUPIED_AND_HAS_INVALID_CERTIFICATES
         } else {

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/HasMissingComplianceStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/HasMissingComplianceStepConfig.kt
@@ -21,9 +21,13 @@ class HasMissingComplianceStepConfig : AbstractInternalStepConfig<ConfirmMissing
 
     companion object {
         fun isGasCertInvalid(state: GasSafetyState): Boolean {
-            if (state.hasGasSupplyStep.formModelIfReachableOrNull?.hasGasSupply != true) return false
-            if (state.hasGasCertStep.outcome == HasGasCertMode.PROVIDE_THIS_LATER) return false
-            val isOutdated = state.getGasSafetyCertificateIsOutdated()
+            if (state.gasSafetyDetailsTask.hasGasSupplyStep.formModelIfReachableOrNull
+                    ?.hasGasSupply != true
+            ) {
+                return false
+            }
+            if (state.gasSafetyDetailsTask.hasGasCertStep.outcome == HasGasCertMode.PROVIDE_THIS_LATER) return false
+            val isOutdated = state.gasSafetyDetailsTask.getGasSafetyCertificateIsOutdated()
             return isOutdated == null || isOutdated
         }
 

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/IsPropertyOccupiedCheckStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/IsPropertyOccupiedCheckStepConfig.kt
@@ -3,12 +3,12 @@ package uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps
 import uk.gov.communities.prsdb.webapp.annotations.webAnnotations.JourneyFrameworkComponent
 import uk.gov.communities.prsdb.webapp.journeys.AbstractInternalStepConfig
 import uk.gov.communities.prsdb.webapp.journeys.JourneyStep
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.EpcState
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.EpcDetailState
 import uk.gov.communities.prsdb.webapp.journeys.shared.YesOrNo
 
 @JourneyFrameworkComponent
-class PropertyOccupiedCheckStepConfig : AbstractInternalStepConfig<YesOrNo, EpcState>() {
-    override fun mode(state: EpcState): YesOrNo? =
+class PropertyOccupiedCheckStepConfig : AbstractInternalStepConfig<YesOrNo, EpcDetailState>() {
+    override fun mode(state: EpcDetailState): YesOrNo? =
         when (state.isOccupied) {
             true -> YesOrNo.YES
             false -> YesOrNo.NO
@@ -19,4 +19,4 @@ class PropertyOccupiedCheckStepConfig : AbstractInternalStepConfig<YesOrNo, EpcS
 @JourneyFrameworkComponent
 final class PropertyOccupiedCheckStep(
     stepConfig: PropertyOccupiedCheckStepConfig,
-) : JourneyStep.InternalStep<YesOrNo, EpcState>(stepConfig)
+) : JourneyStep.InternalStep<YesOrNo, EpcDetailState>(stepConfig)

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/LowEnergyRatingStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/LowEnergyRatingStepConfig.kt
@@ -5,15 +5,15 @@ import uk.gov.communities.prsdb.webapp.constants.GET_NEW_EPC_URL
 import uk.gov.communities.prsdb.webapp.constants.REGISTERED_ENERGY_EXEMPTION_GUIDE_URL
 import uk.gov.communities.prsdb.webapp.journeys.AbstractRequestableStepConfig
 import uk.gov.communities.prsdb.webapp.journeys.JourneyStep.RequestableStep
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.EpcState
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.EpcDetailState
 import uk.gov.communities.prsdb.webapp.journeys.shared.Complete
 import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.NoInputFormModel
 
 @JourneyFrameworkComponent("propertyRegistrationLowEnergyRatingStepConfig")
-class LowEnergyRatingStepConfig : AbstractRequestableStepConfig<Complete, NoInputFormModel, EpcState>() {
+class LowEnergyRatingStepConfig : AbstractRequestableStepConfig<Complete, NoInputFormModel, EpcDetailState>() {
     override val formModelClass = NoInputFormModel::class
 
-    override fun getStepSpecificContent(state: EpcState) =
+    override fun getStepSpecificContent(state: EpcDetailState) =
         mapOf(
             "getNewEpcUrl" to GET_NEW_EPC_URL,
             "registeredEnergyExemptionGuideUrl" to REGISTERED_ENERGY_EXEMPTION_GUIDE_URL,
@@ -21,18 +21,18 @@ class LowEnergyRatingStepConfig : AbstractRequestableStepConfig<Complete, NoInpu
                 if (state.isOccupied == true) "forms.buttons.continueAnyway" else "forms.buttons.continue",
         )
 
-    override fun chooseTemplate(state: EpcState): String =
+    override fun chooseTemplate(state: EpcDetailState): String =
         state.isOccupied?.let { isOccupied ->
             if (isOccupied) "forms/lowEnergyRatingOccupiedForm" else "forms/lowEnergyRatingUnoccupiedForm"
         } ?: throw IllegalStateException("LowEnergyRatingStep should not be reachable before isOccupied is set")
 
-    override fun mode(state: EpcState): Complete? = getFormModelFromStateOrNull(state)?.let { Complete.COMPLETE }
+    override fun mode(state: EpcDetailState): Complete? = getFormModelFromStateOrNull(state)?.let { Complete.COMPLETE }
 }
 
 @JourneyFrameworkComponent("propertyRegistrationLowEnergyRatingStep")
 final class LowEnergyRatingStep(
     stepConfig: LowEnergyRatingStepConfig,
-) : RequestableStep<Complete, NoInputFormModel, EpcState>(stepConfig) {
+) : RequestableStep<Complete, NoInputFormModel, EpcDetailState>(stepConfig) {
     companion object {
         const val ROUTE_SEGMENT = "low-energy-rating"
     }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/PropertyRegistrationCyaStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/PropertyRegistrationCyaStepConfig.kt
@@ -58,7 +58,7 @@ class PropertyRegistrationCyaStepConfig(
 
         content += complianceDetailsHelper.getGasSafetyCyaContent(state, state.gasSafetyTask)
         content += complianceDetailsHelper.getElectricalSafetyCyaContent(state, state.electricalSafetyTask)
-        content += complianceDetailsHelper.getEpcCyaContent(state)
+        content += complianceDetailsHelper.getEpcCyaContent(state, state.epcTask)
 
         return content
     }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/PropertyRegistrationCyaStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/PropertyRegistrationCyaStepConfig.kt
@@ -35,7 +35,10 @@ class PropertyRegistrationCyaStepConfig(
                 "title" to "registerProperty.title",
                 "submitButtonText" to "forms.buttons.completeRegistration",
                 "insetText" to true,
-                "propertyName" to state.propertyDetailsTask.addressTask.getAddress().singleLineAddress,
+                "propertyName" to
+                    state.propertyDetailsTask.addressTask
+                        .getAddress()
+                        .singleLineAddress,
                 "propertyDetails" to
                     if (isRestructured) {
                         getRestructuredPropertyDetailsSummaryList(state)
@@ -53,7 +56,7 @@ class PropertyRegistrationCyaStepConfig(
 
         content["jointLandlordsDetails"] = getJointLandLordsSummaryRow(state)
 
-        content += complianceDetailsHelper.getGasSafetyCyaContent(state)
+        content += complianceDetailsHelper.getGasSafetyCyaContent(state, state.gasSafetyTask)
         content += complianceDetailsHelper.getElectricalSafetyCyaContent(state)
         content += complianceDetailsHelper.getEpcCyaContent(state)
 

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/PropertyRegistrationCyaStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/PropertyRegistrationCyaStepConfig.kt
@@ -57,7 +57,7 @@ class PropertyRegistrationCyaStepConfig(
         content["jointLandlordsDetails"] = getJointLandLordsSummaryRow(state)
 
         content += complianceDetailsHelper.getGasSafetyCyaContent(state, state.gasSafetyTask)
-        content += complianceDetailsHelper.getElectricalSafetyCyaContent(state)
+        content += complianceDetailsHelper.getElectricalSafetyCyaContent(state, state.electricalSafetyTask)
         content += complianceDetailsHelper.getEpcCyaContent(state)
 
         return content

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/ProvideElectricalCertLaterStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/ProvideElectricalCertLaterStepConfig.kt
@@ -1,37 +1,37 @@
-﻿package uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps
+package uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps
 
 import uk.gov.communities.prsdb.webapp.annotations.webAnnotations.JourneyFrameworkComponent
 import uk.gov.communities.prsdb.webapp.constants.ELECTRICAL_SAFETY_STANDARDS_URL
 import uk.gov.communities.prsdb.webapp.journeys.AbstractRequestableStepConfig
 import uk.gov.communities.prsdb.webapp.journeys.JourneyStep.RequestableStep
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.ElectricalSafetyState
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.ElectricalSafetyDetailState
 import uk.gov.communities.prsdb.webapp.journeys.shared.Complete
 import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.NoInputFormModel
 
 @JourneyFrameworkComponent
-class ProvideElectricalCertLaterStepConfig : AbstractRequestableStepConfig<Complete, NoInputFormModel, ElectricalSafetyState>() {
+class ProvideElectricalCertLaterStepConfig : AbstractRequestableStepConfig<Complete, NoInputFormModel, ElectricalSafetyDetailState>() {
     override val formModelClass = NoInputFormModel::class
 
-    override fun getStepSpecificContent(state: ElectricalSafetyState) =
+    override fun getStepSpecificContent(state: ElectricalSafetyDetailState) =
         mapOf(
             "electricalSafetyStandardsUrl" to ELECTRICAL_SAFETY_STANDARDS_URL,
             "submitButtonText" to "forms.buttons.saveAndContinue",
         )
 
-    override fun chooseTemplate(state: ElectricalSafetyState) =
+    override fun chooseTemplate(state: ElectricalSafetyDetailState) =
         if (state.isOccupied) {
             "forms/provideElectricalSafetyCertificateLaterForOccupiedProperty"
         } else {
             "forms/provideElectricalSafetyCertificateLaterForUnoccupiedProperty"
         }
 
-    override fun mode(state: ElectricalSafetyState) = getFormModelFromStateOrNull(state)?.let { Complete.COMPLETE }
+    override fun mode(state: ElectricalSafetyDetailState) = getFormModelFromStateOrNull(state)?.let { Complete.COMPLETE }
 }
 
 @JourneyFrameworkComponent
 final class ProvideElectricalCertLaterStep(
     stepConfig: ProvideElectricalCertLaterStepConfig,
-) : RequestableStep<Complete, NoInputFormModel, ElectricalSafetyState>(stepConfig) {
+) : RequestableStep<Complete, NoInputFormModel, ElectricalSafetyDetailState>(stepConfig) {
     companion object {
         const val ROUTE_SEGMENT = "provide-electrical-safety-certificate-later"
     }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/ProvideEpcLaterStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/ProvideEpcLaterStepConfig.kt
@@ -4,32 +4,32 @@ import uk.gov.communities.prsdb.webapp.annotations.webAnnotations.JourneyFramewo
 import uk.gov.communities.prsdb.webapp.constants.GET_NEW_EPC_URL
 import uk.gov.communities.prsdb.webapp.journeys.AbstractRequestableStepConfig
 import uk.gov.communities.prsdb.webapp.journeys.JourneyStep.RequestableStep
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.EpcState
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.EpcDetailState
 import uk.gov.communities.prsdb.webapp.journeys.shared.Complete
 import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.NoInputFormModel
 
 @JourneyFrameworkComponent
-class ProvideEpcLaterStepConfig : AbstractRequestableStepConfig<Complete, NoInputFormModel, EpcState>() {
+class ProvideEpcLaterStepConfig : AbstractRequestableStepConfig<Complete, NoInputFormModel, EpcDetailState>() {
     override val formModelClass = NoInputFormModel::class
 
-    override fun getStepSpecificContent(state: EpcState) =
+    override fun getStepSpecificContent(state: EpcDetailState) =
         mapOf(
             "getNewEpcUrl" to GET_NEW_EPC_URL,
             "submitButtonText" to "forms.buttons.saveAndContinue",
         )
 
-    override fun chooseTemplate(state: EpcState): String =
+    override fun chooseTemplate(state: EpcDetailState): String =
         state.isOccupied?.let { isOccupied ->
             if (isOccupied) "forms/provideEpcLaterOccupiedForm" else "forms/provideEpcLaterUnoccupiedForm"
         } ?: throw IllegalStateException("ProvideEpcLaterStep should not be reachable before isOccupied is set")
 
-    override fun mode(state: EpcState) = getFormModelFromStateOrNull(state)?.let { Complete.COMPLETE }
+    override fun mode(state: EpcDetailState) = getFormModelFromStateOrNull(state)?.let { Complete.COMPLETE }
 }
 
 @JourneyFrameworkComponent
 final class ProvideEpcLaterStep(
     stepConfig: ProvideEpcLaterStepConfig,
-) : RequestableStep<Complete, NoInputFormModel, EpcState>(stepConfig) {
+) : RequestableStep<Complete, NoInputFormModel, EpcDetailState>(stepConfig) {
     companion object {
         const val ROUTE_SEGMENT = "provide-epc-later"
     }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/ProvideGasCertLaterStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/ProvideGasCertLaterStepConfig.kt
@@ -4,22 +4,22 @@ import uk.gov.communities.prsdb.webapp.annotations.webAnnotations.JourneyFramewo
 import uk.gov.communities.prsdb.webapp.constants.LANDLORD_GAS_SAFETY_URL
 import uk.gov.communities.prsdb.webapp.journeys.AbstractRequestableStepConfig
 import uk.gov.communities.prsdb.webapp.journeys.JourneyStep.RequestableStep
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.GasSafetyState
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.GasSafetyDetailState
 import uk.gov.communities.prsdb.webapp.journeys.shared.Complete
 import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.NoInputFormModel
 
 @JourneyFrameworkComponent
-class ProvideGasCertLaterStepConfig : AbstractRequestableStepConfig<Complete, NoInputFormModel, GasSafetyState>() {
+class ProvideGasCertLaterStepConfig : AbstractRequestableStepConfig<Complete, NoInputFormModel, GasSafetyDetailState>() {
     override val formModelClass = NoInputFormModel::class
 
-    override fun getStepSpecificContent(state: GasSafetyState) =
+    override fun getStepSpecificContent(state: GasSafetyDetailState) =
         mapOf(
             "landlordGasSafetyUrl" to LANDLORD_GAS_SAFETY_URL,
             "submitButtonText" to
                 if (state.isOccupied == true) "forms.buttons.continue" else "forms.buttons.saveAndContinue",
         )
 
-    override fun chooseTemplate(state: GasSafetyState) =
+    override fun chooseTemplate(state: GasSafetyDetailState) =
         state.isOccupied?.let { isOccupied ->
             if (isOccupied) {
                 "forms/provideGasCertificateLaterForOccupiedProperty"
@@ -28,13 +28,13 @@ class ProvideGasCertLaterStepConfig : AbstractRequestableStepConfig<Complete, No
             }
         } ?: throw IllegalStateException("ProvideGasCertLaterStep should not be reachable before isOccupied is set")
 
-    override fun mode(state: GasSafetyState) = getFormModelFromStateOrNull(state)?.let { Complete.COMPLETE }
+    override fun mode(state: GasSafetyDetailState) = getFormModelFromStateOrNull(state)?.let { Complete.COMPLETE }
 }
 
 @JourneyFrameworkComponent
 final class ProvideGasCertLaterStep(
     stepConfig: ProvideGasCertLaterStepConfig,
-) : RequestableStep<Complete, NoInputFormModel, GasSafetyState>(stepConfig) {
+) : RequestableStep<Complete, NoInputFormModel, GasSafetyDetailState>(stepConfig) {
     companion object {
         const val ROUTE_SEGMENT = "provide-gas-safety-certificate-later"
     }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/RemoveElectricalCertUploadStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/RemoveElectricalCertUploadStepConfig.kt
@@ -4,7 +4,7 @@ import uk.gov.communities.prsdb.webapp.annotations.webAnnotations.JourneyFramewo
 import uk.gov.communities.prsdb.webapp.journeys.AbstractRequestableStepConfig
 import uk.gov.communities.prsdb.webapp.journeys.JourneyStep.RequestableStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.CertificateUpload
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.ElectricalSafetyState
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.ElectricalSafetyDetailState
 import uk.gov.communities.prsdb.webapp.journeys.shared.AnyMembers
 import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.RemoveFileFormModel
 import uk.gov.communities.prsdb.webapp.models.viewModels.formModels.RadiosViewModel
@@ -17,38 +17,38 @@ import kotlin.collections.remove
 class RemoveElectricalCertUploadStepConfig(
     private val collectionKeyParameterService: CollectionKeyParameterService,
     private val uploadService: UploadService,
-) : AbstractRequestableStepConfig<AnyMembers, RemoveFileFormModel, ElectricalSafetyState>() {
+) : AbstractRequestableStepConfig<AnyMembers, RemoveFileFormModel, ElectricalSafetyDetailState>() {
     override val formModelClass = RemoveFileFormModel::class
 
-    override fun getStepSpecificContent(state: ElectricalSafetyState) =
+    override fun getStepSpecificContent(state: ElectricalSafetyDetailState) =
         mapOf(
             "fieldSetHeading" to "uploads.removeUploads.fieldSetHeading",
             "radioOptions" to RadiosViewModel.yesOrNoRadios(),
             "optionalFieldSetHeadingParam" to getFileToRemove(state)?.fileName,
         )
 
-    override fun chooseTemplate(state: ElectricalSafetyState): String = "forms/areYouSureForm"
+    override fun chooseTemplate(state: ElectricalSafetyDetailState): String = "forms/areYouSureForm"
 
-    override fun mode(state: ElectricalSafetyState) =
+    override fun mode(state: ElectricalSafetyDetailState) =
         if (state.electricalUploadMap.isNotEmpty()) {
             AnyMembers.SOME_MEMBERS
         } else {
             AnyMembers.NO_MEMBERS
         }
 
-    private fun getFileToRemove(state: ElectricalSafetyState): CertificateUpload? {
+    private fun getFileToRemove(state: ElectricalSafetyDetailState): CertificateUpload? {
         val keyToRemove = collectionKeyParameterService.getParameterOrNull()
         return state.electricalUploadMap[keyToRemove]
     }
 
-    override fun beforeAttemptingToReachStep(state: ElectricalSafetyState): Boolean {
+    override fun beforeAttemptingToReachStep(state: ElectricalSafetyDetailState): Boolean {
         val keyToRemove = collectionKeyParameterService.getParameterOrNull()
         val currentMap = state.electricalUploadMap
 
         return keyToRemove != null && keyToRemove in currentMap.keys
     }
 
-    override fun afterStepDataIsAdded(state: ElectricalSafetyState) {
+    override fun afterStepDataIsAdded(state: ElectricalSafetyDetailState) {
         if (getFormModelFromStateOrNull(state)?.wantsToProceed == false) {
             return
         }
@@ -64,7 +64,7 @@ class RemoveElectricalCertUploadStepConfig(
 @JourneyFrameworkComponent
 final class RemoveElectricalCertUploadStep(
     stepConfig: RemoveElectricalCertUploadStepConfig,
-) : RequestableStep<AnyMembers, RemoveFileFormModel, ElectricalSafetyState>(stepConfig) {
+) : RequestableStep<AnyMembers, RemoveFileFormModel, ElectricalSafetyDetailState>(stepConfig) {
     companion object {
         const val ROUTE_SEGMENT = "remove-electrical-safety-certificate-upload"
     }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/RemoveGasCertUploadStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/RemoveGasCertUploadStepConfig.kt
@@ -4,7 +4,7 @@ import uk.gov.communities.prsdb.webapp.annotations.webAnnotations.JourneyFramewo
 import uk.gov.communities.prsdb.webapp.journeys.AbstractRequestableStepConfig
 import uk.gov.communities.prsdb.webapp.journeys.JourneyStep.RequestableStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.CertificateUpload
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.GasSafetyState
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.GasSafetyDetailState
 import uk.gov.communities.prsdb.webapp.journeys.shared.AnyMembers
 import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.RemoveFileFormModel
 import uk.gov.communities.prsdb.webapp.models.viewModels.formModels.RadiosViewModel
@@ -17,38 +17,38 @@ import kotlin.collections.remove
 class RemoveGasCertUploadStepConfig(
     private val collectionKeyParameterService: CollectionKeyParameterService,
     private val uploadService: UploadService,
-) : AbstractRequestableStepConfig<AnyMembers, RemoveFileFormModel, GasSafetyState>() {
+) : AbstractRequestableStepConfig<AnyMembers, RemoveFileFormModel, GasSafetyDetailState>() {
     override val formModelClass = RemoveFileFormModel::class
 
-    override fun getStepSpecificContent(state: GasSafetyState) =
+    override fun getStepSpecificContent(state: GasSafetyDetailState) =
         mapOf(
             "fieldSetHeading" to "uploads.removeUploads.fieldSetHeading",
             "radioOptions" to RadiosViewModel.yesOrNoRadios(),
             "optionalFieldSetHeadingParam" to getFileToRemove(state)?.fileName,
         )
 
-    override fun chooseTemplate(state: GasSafetyState): String = "forms/areYouSureForm"
+    override fun chooseTemplate(state: GasSafetyDetailState): String = "forms/areYouSureForm"
 
-    override fun mode(state: GasSafetyState) =
+    override fun mode(state: GasSafetyDetailState) =
         if (state.gasUploadMap.isNotEmpty()) {
             AnyMembers.SOME_MEMBERS
         } else {
             AnyMembers.NO_MEMBERS
         }
 
-    private fun getFileToRemove(state: GasSafetyState): CertificateUpload? {
+    private fun getFileToRemove(state: GasSafetyDetailState): CertificateUpload? {
         val keyToRemove = collectionKeyParameterService.getParameterOrNull()
         return state.gasUploadMap[keyToRemove]
     }
 
-    override fun beforeAttemptingToReachStep(state: GasSafetyState): Boolean {
+    override fun beforeAttemptingToReachStep(state: GasSafetyDetailState): Boolean {
         val keyToRemove = collectionKeyParameterService.getParameterOrNull()
         val currentMap = state.gasUploadMap
 
         return keyToRemove != null && keyToRemove in currentMap.keys
     }
 
-    override fun afterStepDataIsAdded(state: GasSafetyState) {
+    override fun afterStepDataIsAdded(state: GasSafetyDetailState) {
         if (getFormModelFromStateOrNull(state)?.wantsToProceed == false) {
             return
         }
@@ -64,7 +64,7 @@ class RemoveGasCertUploadStepConfig(
 @JourneyFrameworkComponent
 final class RemoveGasCertUploadStep(
     stepConfig: RemoveGasCertUploadStepConfig,
-) : RequestableStep<AnyMembers, RemoveFileFormModel, GasSafetyState>(stepConfig) {
+) : RequestableStep<AnyMembers, RemoveFileFormModel, GasSafetyDetailState>(stepConfig) {
     companion object {
         const val ROUTE_SEGMENT = "remove-gas-safety-certificate-upload"
     }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/SavePropertyRegistrationDataStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/SavePropertyRegistrationDataStepConfig.kt
@@ -141,24 +141,24 @@ class SavePropertyRegistrationDataStepConfig(
                 state.electricalSafetyTask.electricalSafetyDetailsTask
                     .hasElectricalCertStep.outcome == HasElectricalCertMode.PROVIDE_THIS_LATER,
             epcCertificateUrl =
-                state.epcTask.acceptedEpcIfStillAccepted?.let {
+                state.epcTask.epcDetailsTask.acceptedEpcIfStillAccepted?.let {
                     epcCertificateUrlProvider.getEpcCertificateUrl(it.certificateNumber)
                 },
-            epcExpiryDate = state.epcTask.acceptedEpcIfStillAccepted?.expiryDateAsJavaLocalDate,
-            epcEnergyRating = state.epcTask.acceptedEpcIfStillAccepted?.energyRating,
+            epcExpiryDate = state.epcTask.epcDetailsTask.acceptedEpcIfStillAccepted?.expiryDateAsJavaLocalDate,
+            epcEnergyRating = state.epcTask.epcDetailsTask.acceptedEpcIfStillAccepted?.energyRating,
             tenancyStartedBeforeEpcExpiry =
-                state.epcTask.epcInDateAtStartOfTenancyCheckStep
+                state.epcTask.epcDetailsTask.epcInDateAtStartOfTenancyCheckStep
                     .formModelIfReachableOrNull
                     ?.tenancyStartedBeforeExpiry,
             epcExemptionReason =
-                state.epcTask.epcExemptionStep
+                state.epcTask.epcDetailsTask.epcExemptionStep
                     .formModelIfReachableOrNull
                     ?.exemptionReason,
             epcMeesExemptionReason =
-                state.epcTask.meesExemptionStep
+                state.epcTask.epcDetailsTask.meesExemptionStep
                     .formModelIfReachableOrNull
                     ?.exemptionReason,
-            epcProvideLater = state.epcTask.hasEpcStep.outcome == HasEpcMode.PROVIDE_LATER,
+            epcProvideLater = state.epcTask.epcDetailsTask.hasEpcStep.outcome == HasEpcMode.PROVIDE_LATER,
         )
     }
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/SavePropertyRegistrationDataStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/SavePropertyRegistrationDataStepConfig.kt
@@ -129,10 +129,11 @@ class SavePropertyRegistrationDataStepConfig(
             gasSafetyFileUploadIds = state.gasSafetyTask.gasSafetyDetailsTask.gasUploadIds,
             gasSafetyCertProvideLater =
                 state.gasSafetyTask.gasSafetyDetailsTask.hasGasCertStep.outcome == HasGasCertMode.PROVIDE_THIS_LATER,
-            electricalSafetyFileUploadIds = state.electricalUploadIds,
-            electricalSafetyExpiryDate = state.getElectricalCertificateExpiryDateIfReachable()?.toJavaLocalDate(),
-            electricalCertType = state.mapElectricalCertificateTypeToGlobalCertificateType(),
-            electricalSafetyCertProvideLater = state.hasElectricalCertStep.outcome == HasElectricalCertMode.PROVIDE_THIS_LATER,
+            electricalSafetyFileUploadIds = state.electricalSafetyTask.electricalUploadIds,
+            electricalSafetyExpiryDate = state.electricalSafetyTask.getElectricalCertificateExpiryDateIfReachable()?.toJavaLocalDate(),
+            electricalCertType = state.electricalSafetyTask.mapElectricalCertificateTypeToGlobalCertificateType(),
+            electricalSafetyCertProvideLater =
+                state.electricalSafetyTask.hasElectricalCertStep.outcome == HasElectricalCertMode.PROVIDE_THIS_LATER,
             epcCertificateUrl =
                 state.acceptedEpcIfStillAccepted?.let {
                     epcCertificateUrlProvider.getEpcCertificateUrl(it.certificateNumber)

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/SavePropertyRegistrationDataStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/SavePropertyRegistrationDataStepConfig.kt
@@ -129,11 +129,17 @@ class SavePropertyRegistrationDataStepConfig(
             gasSafetyFileUploadIds = state.gasSafetyTask.gasSafetyDetailsTask.gasUploadIds,
             gasSafetyCertProvideLater =
                 state.gasSafetyTask.gasSafetyDetailsTask.hasGasCertStep.outcome == HasGasCertMode.PROVIDE_THIS_LATER,
-            electricalSafetyFileUploadIds = state.electricalSafetyTask.electricalUploadIds,
-            electricalSafetyExpiryDate = state.electricalSafetyTask.getElectricalCertificateExpiryDateIfReachable()?.toJavaLocalDate(),
-            electricalCertType = state.electricalSafetyTask.mapElectricalCertificateTypeToGlobalCertificateType(),
+            electricalSafetyFileUploadIds = state.electricalSafetyTask.electricalSafetyDetailsTask.electricalUploadIds,
+            electricalSafetyExpiryDate =
+                state.electricalSafetyTask.electricalSafetyDetailsTask
+                    .getElectricalCertificateExpiryDateIfReachable()
+                    ?.toJavaLocalDate(),
+            electricalCertType =
+                state.electricalSafetyTask.electricalSafetyDetailsTask
+                    .mapElectricalCertificateTypeToGlobalCertificateType(),
             electricalSafetyCertProvideLater =
-                state.electricalSafetyTask.hasElectricalCertStep.outcome == HasElectricalCertMode.PROVIDE_THIS_LATER,
+                state.electricalSafetyTask.electricalSafetyDetailsTask
+                    .hasElectricalCertStep.outcome == HasElectricalCertMode.PROVIDE_THIS_LATER,
             epcCertificateUrl =
                 state.acceptedEpcIfStillAccepted?.let {
                     epcCertificateUrlProvider.getEpcCertificateUrl(it.certificateNumber)

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/SavePropertyRegistrationDataStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/SavePropertyRegistrationDataStepConfig.kt
@@ -141,24 +141,24 @@ class SavePropertyRegistrationDataStepConfig(
                 state.electricalSafetyTask.electricalSafetyDetailsTask
                     .hasElectricalCertStep.outcome == HasElectricalCertMode.PROVIDE_THIS_LATER,
             epcCertificateUrl =
-                state.acceptedEpcIfStillAccepted?.let {
+                state.epcTask.acceptedEpcIfStillAccepted?.let {
                     epcCertificateUrlProvider.getEpcCertificateUrl(it.certificateNumber)
                 },
-            epcExpiryDate = state.acceptedEpcIfStillAccepted?.expiryDateAsJavaLocalDate,
-            epcEnergyRating = state.acceptedEpcIfStillAccepted?.energyRating,
+            epcExpiryDate = state.epcTask.acceptedEpcIfStillAccepted?.expiryDateAsJavaLocalDate,
+            epcEnergyRating = state.epcTask.acceptedEpcIfStillAccepted?.energyRating,
             tenancyStartedBeforeEpcExpiry =
-                state.epcInDateAtStartOfTenancyCheckStep
+                state.epcTask.epcInDateAtStartOfTenancyCheckStep
                     .formModelIfReachableOrNull
                     ?.tenancyStartedBeforeExpiry,
             epcExemptionReason =
-                state.epcExemptionStep
+                state.epcTask.epcExemptionStep
                     .formModelIfReachableOrNull
                     ?.exemptionReason,
             epcMeesExemptionReason =
-                state.meesExemptionStep
+                state.epcTask.meesExemptionStep
                     .formModelIfReachableOrNull
                     ?.exemptionReason,
-            epcProvideLater = state.hasEpcStep.outcome == HasEpcMode.PROVIDE_LATER,
+            epcProvideLater = state.epcTask.hasEpcStep.outcome == HasEpcMode.PROVIDE_LATER,
         )
     }
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/SavePropertyRegistrationDataStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/SavePropertyRegistrationDataStepConfig.kt
@@ -121,10 +121,14 @@ class SavePropertyRegistrationDataStepConfig(
             baseUserId = SecurityContextHolder.getContext().authentication.name,
             jointLandlordEmails = jointLandlordEmails,
             markedJointLandlord = markedJointLandlord,
-            hasGasSupply = state.gasSafetyTask.hasGasSupplyStep.outcome == YesOrNo.YES,
-            gasSafetyCertIssueDate = state.gasSafetyTask.getGasSafetyCertificateIssueDateIfReachable()?.toJavaLocalDate(),
-            gasSafetyFileUploadIds = state.gasSafetyTask.gasUploadIds,
-            gasSafetyCertProvideLater = state.gasSafetyTask.hasGasCertStep.outcome == HasGasCertMode.PROVIDE_THIS_LATER,
+            hasGasSupply = state.gasSafetyTask.gasSafetyDetailsTask.hasGasSupplyStep.outcome == YesOrNo.YES,
+            gasSafetyCertIssueDate =
+                state.gasSafetyTask.gasSafetyDetailsTask
+                    .getGasSafetyCertificateIssueDateIfReachable()
+                    ?.toJavaLocalDate(),
+            gasSafetyFileUploadIds = state.gasSafetyTask.gasSafetyDetailsTask.gasUploadIds,
+            gasSafetyCertProvideLater =
+                state.gasSafetyTask.gasSafetyDetailsTask.hasGasCertStep.outcome == HasGasCertMode.PROVIDE_THIS_LATER,
             electricalSafetyFileUploadIds = state.electricalUploadIds,
             electricalSafetyExpiryDate = state.getElectricalCertificateExpiryDateIfReachable()?.toJavaLocalDate(),
             electricalCertType = state.mapElectricalCertificateTypeToGlobalCertificateType(),

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/SavePropertyRegistrationDataStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/SavePropertyRegistrationDataStepConfig.kt
@@ -65,16 +65,22 @@ class SavePropertyRegistrationDataStepConfig(
 
         propertyRegistrationService.registerProperty(
             addressModel = state.propertyDetailsTask.addressTask.getAddress(),
-            propertyType = state.propertyDetailsTask.propertyTypeStep.formModel.notNullValue(PropertyTypeFormModel::propertyType),
+            propertyType =
+                state.propertyDetailsTask.propertyTypeStep.formModel
+                    .notNullValue(PropertyTypeFormModel::propertyType),
             customPropertyType =
                 if (state.propertyDetailsTask.propertyTypeStep.formModel.propertyType == PropertyType.OTHER) {
                     state.propertyDetailsTask.propertyTypeStep.formModel.customPropertyType
                 } else {
                     null
                 },
-            licenseType = state.licensingTask.licensingTypeStep.formModel.notNullValue(LicensingTypeFormModel::licensingType),
+            licenseType =
+                state.licensingTask.licensingTypeStep.formModel
+                    .notNullValue(LicensingTypeFormModel::licensingType),
             licenceNumber = state.licensingTask.getLicenceNumberOrNull() ?: "",
-            ownershipType = state.ownershipAndLandlordsTask.ownershipTypeStep.formModel.notNullValue(OwnershipTypeFormModel::ownershipType),
+            ownershipType =
+                state.ownershipAndLandlordsTask.ownershipTypeStep.formModel
+                    .notNullValue(OwnershipTypeFormModel::ownershipType),
             isOccupied = isOccupied,
             numberOfHouseholds =
                 if (isOccupied) {
@@ -115,10 +121,10 @@ class SavePropertyRegistrationDataStepConfig(
             baseUserId = SecurityContextHolder.getContext().authentication.name,
             jointLandlordEmails = jointLandlordEmails,
             markedJointLandlord = markedJointLandlord,
-            hasGasSupply = state.hasGasSupplyStep.outcome == YesOrNo.YES,
-            gasSafetyCertIssueDate = state.getGasSafetyCertificateIssueDateIfReachable()?.toJavaLocalDate(),
-            gasSafetyFileUploadIds = state.gasUploadIds,
-            gasSafetyCertProvideLater = state.hasGasCertStep.outcome == HasGasCertMode.PROVIDE_THIS_LATER,
+            hasGasSupply = state.gasSafetyTask.hasGasSupplyStep.outcome == YesOrNo.YES,
+            gasSafetyCertIssueDate = state.gasSafetyTask.getGasSafetyCertificateIssueDateIfReachable()?.toJavaLocalDate(),
+            gasSafetyFileUploadIds = state.gasSafetyTask.gasUploadIds,
+            gasSafetyCertProvideLater = state.gasSafetyTask.hasGasCertStep.outcome == HasGasCertMode.PROVIDE_THIS_LATER,
             electricalSafetyFileUploadIds = state.electricalUploadIds,
             electricalSafetyExpiryDate = state.getElectricalCertificateExpiryDateIfReachable()?.toJavaLocalDate(),
             electricalCertType = state.mapElectricalCertificateTypeToGlobalCertificateType(),

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/UploadElectricalCertStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/UploadElectricalCertStepConfig.kt
@@ -8,7 +8,7 @@ import uk.gov.communities.prsdb.webapp.exceptions.PrsdbWebException
 import uk.gov.communities.prsdb.webapp.journeys.AbstractRequestableStepConfig
 import uk.gov.communities.prsdb.webapp.journeys.JourneyStep.RequestableStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.CertificateUpload
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.ElectricalSafetyState
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.ElectricalSafetyDetailState
 import uk.gov.communities.prsdb.webapp.journeys.shared.Complete
 import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.ElectricalUploadCertificateFormModel
 import uk.gov.communities.prsdb.webapp.services.CollectionKeyParameterService
@@ -22,10 +22,10 @@ class UploadElectricalCertStepConfig(
     private val virusScanCallbackService: VirusScanCallbackService,
     private val fileUploadCookieService: FileUploadCookieService,
     private val memberIdService: CollectionKeyParameterService,
-) : AbstractRequestableStepConfig<Complete, ElectricalUploadCertificateFormModel, ElectricalSafetyState>() {
+) : AbstractRequestableStepConfig<Complete, ElectricalUploadCertificateFormModel, ElectricalSafetyDetailState>() {
     override val formModelClass = ElectricalUploadCertificateFormModel::class
 
-    override fun getStepSpecificContent(state: ElectricalSafetyState): Map<String, Any?> {
+    override fun getStepSpecificContent(state: ElectricalSafetyDetailState): Map<String, Any?> {
         fileUploadCookieService.addFileUploadCookieToResponse()
 
         val fieldSetHeading =
@@ -45,11 +45,11 @@ class UploadElectricalCertStepConfig(
         )
     }
 
-    override fun chooseTemplate(state: ElectricalSafetyState): String = "forms/registrationCertificateForm"
+    override fun chooseTemplate(state: ElectricalSafetyDetailState): String = "forms/registrationCertificateForm"
 
-    override fun mode(state: ElectricalSafetyState) = if (state.electricalUploadMap.isNotEmpty()) Complete.COMPLETE else null
+    override fun mode(state: ElectricalSafetyDetailState) = if (state.electricalUploadMap.isNotEmpty()) Complete.COMPLETE else null
 
-    override fun afterStepDataIsAdded(state: ElectricalSafetyState) {
+    override fun afterStepDataIsAdded(state: ElectricalSafetyDetailState) {
         getFormModelFromState(state).fileUploadId?.let { fileUploadId ->
             virusScanCallbackService.saveEmailForJourney(
                 state.journeyId,
@@ -81,7 +81,7 @@ class UploadElectricalCertStepConfig(
 @JourneyFrameworkComponent
 final class UploadElectricalCertStep(
     stepConfig: UploadElectricalCertStepConfig,
-) : RequestableStep<Complete, ElectricalUploadCertificateFormModel, ElectricalSafetyState>(stepConfig) {
+) : RequestableStep<Complete, ElectricalUploadCertificateFormModel, ElectricalSafetyDetailState>(stepConfig) {
     companion object {
         const val ROUTE_SEGMENT = "electrical-safety-certificate-$FILE_UPLOAD_URL_SUBSTRING"
     }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/UploadGasCertStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/UploadGasCertStepConfig.kt
@@ -6,7 +6,7 @@ import uk.gov.communities.prsdb.webapp.constants.enums.CertificateType
 import uk.gov.communities.prsdb.webapp.journeys.AbstractRequestableStepConfig
 import uk.gov.communities.prsdb.webapp.journeys.JourneyStep.RequestableStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.CertificateUpload
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.GasSafetyState
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.GasSafetyDetailState
 import uk.gov.communities.prsdb.webapp.journeys.shared.Complete
 import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.GasSafetyUploadCertificateFormModel
 import uk.gov.communities.prsdb.webapp.services.CollectionKeyParameterService
@@ -20,10 +20,10 @@ class UploadGasCertStepConfig(
     private val virusScanCallbackService: VirusScanCallbackService,
     private val fileUploadCookieService: FileUploadCookieService,
     private val memberIdService: CollectionKeyParameterService,
-) : AbstractRequestableStepConfig<Complete, GasSafetyUploadCertificateFormModel, GasSafetyState>() {
+) : AbstractRequestableStepConfig<Complete, GasSafetyUploadCertificateFormModel, GasSafetyDetailState>() {
     override val formModelClass = GasSafetyUploadCertificateFormModel::class
 
-    override fun getStepSpecificContent(state: GasSafetyState): Map<String, Any?> {
+    override fun getStepSpecificContent(state: GasSafetyDetailState): Map<String, Any?> {
         fileUploadCookieService.addFileUploadCookieToResponse()
 
         return mapOf(
@@ -32,11 +32,11 @@ class UploadGasCertStepConfig(
         )
     }
 
-    override fun chooseTemplate(state: GasSafetyState): String = "forms/registrationCertificateForm"
+    override fun chooseTemplate(state: GasSafetyDetailState): String = "forms/registrationCertificateForm"
 
-    override fun mode(state: GasSafetyState) = if (state.gasUploadMap.isNotEmpty()) Complete.COMPLETE else null
+    override fun mode(state: GasSafetyDetailState) = if (state.gasUploadMap.isNotEmpty()) Complete.COMPLETE else null
 
-    override fun afterStepDataIsAdded(state: GasSafetyState) {
+    override fun afterStepDataIsAdded(state: GasSafetyDetailState) {
         getFormModelFromState(state).fileUploadId?.let { fileUploadId ->
             virusScanCallbackService.saveEmailForJourney(
                 state.journeyId,
@@ -68,7 +68,7 @@ class UploadGasCertStepConfig(
 @JourneyFrameworkComponent
 final class UploadGasCertStep(
     stepConfig: UploadGasCertStepConfig,
-) : RequestableStep<Complete, GasSafetyUploadCertificateFormModel, GasSafetyState>(stepConfig) {
+) : RequestableStep<Complete, GasSafetyUploadCertificateFormModel, GasSafetyDetailState>(stepConfig) {
     companion object {
         const val ROUTE_SEGMENT = "gas-safety-certificate-$FILE_UPLOAD_URL_SUBSTRING"
     }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/tasks/ElectricalSafetyDetailsTask.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/tasks/ElectricalSafetyDetailsTask.kt
@@ -1,16 +1,19 @@
 package uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks
 
 import uk.gov.communities.prsdb.webapp.annotations.webAnnotations.JourneyFrameworkComponent
+import uk.gov.communities.prsdb.webapp.journeys.DuplicableTaskWithDependencies
+import uk.gov.communities.prsdb.webapp.journeys.JourneyStateService
 import uk.gov.communities.prsdb.webapp.journeys.OrParents
-import uk.gov.communities.prsdb.webapp.journeys.Task
 import uk.gov.communities.prsdb.webapp.journeys.hasOutcome
 import uk.gov.communities.prsdb.webapp.journeys.isComplete
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.ElectricalSafetyState
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.CertificateUpload
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.ElectricalSafetyDetailState
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.CheckElectricalCertUploadsStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.ElectricalCertExpiredStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.ElectricalCertExpiryDateMode
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.ElectricalCertExpiryDateStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.ElectricalCertMissingStep
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.HasAnyInCollectionStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.HasAnyInCollectionStepConfig
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.HasElectricalCertMode
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.HasElectricalCertStep
@@ -19,9 +22,32 @@ import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.Remov
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.UploadElectricalCertStep
 import uk.gov.communities.prsdb.webapp.journeys.shared.AnyMembers
 
-@JourneyFrameworkComponent
-class ElectricalSafetyDetailsTask : Task<ElectricalSafetyState>() {
-    override fun makeSubJourney(state: ElectricalSafetyState) =
+@JourneyFrameworkComponent("propertyRegistrationElectricalSafetyDetailsTask")
+class ElectricalSafetyDetailsTask(
+    override val hasUploadedElectricalCert: HasAnyInCollectionStep,
+    override val hasElectricalCertStep: HasElectricalCertStep,
+    override val electricalCertExpiryDateStep: ElectricalCertExpiryDateStep,
+    override val uploadElectricalCertStep: UploadElectricalCertStep,
+    override val checkElectricalCertUploadsStep: CheckElectricalCertUploadsStep,
+    override val removeElectricalCertUploadStep: RemoveElectricalCertUploadStep,
+    override val electricalCertExpiredStep: ElectricalCertExpiredStep,
+    override val electricalCertMissingStep: ElectricalCertMissingStep,
+    override val provideElectricalCertLaterStep: ProvideElectricalCertLaterStep,
+    journeyStateService: JourneyStateService,
+) : DuplicableTaskWithDependencies<ElectricalSafetyDetailState, ElectricalSafetyDependencies>(journeyStateService),
+    ElectricalSafetyDetailState {
+    override val taskState: ElectricalSafetyDetailState
+        get() = this
+
+    override val isOccupied: Boolean
+        get() = dependencies.isOccupied
+    override val allowProvideCertificateLaterRoute: Boolean
+        get() = dependencies.allowProvideCertificateLaterRoute
+
+    override var electricalUploadMap: Map<Int, CertificateUpload> by delegateProvider.requiredDelegate("electricalUploadMap", mapOf())
+    override var highestAssignedElectricalMemberId: Int? by delegateProvider.nullableDelegate("highestAssignedElectricalMemberId")
+
+    override fun makeSubJourney(state: ElectricalSafetyDetailState) =
         subJourney(state) {
             step(journey.hasElectricalCertStep) {
                 routeSegment(HasElectricalCertStep.ROUTE_SEGMENT)

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/tasks/ElectricalSafetyTask.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/tasks/ElectricalSafetyTask.kt
@@ -4,46 +4,20 @@ import uk.gov.communities.prsdb.webapp.annotations.webAnnotations.JourneyFramewo
 import uk.gov.communities.prsdb.webapp.journeys.DuplicableTaskWithDependencies
 import uk.gov.communities.prsdb.webapp.journeys.JourneyStateService
 import uk.gov.communities.prsdb.webapp.journeys.isComplete
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.CertificateUpload
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.ElectricalSafetyState
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.CheckElectricalCertUploadsStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.CheckElectricalSafetyAnswersStep
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.ElectricalCertExpiredStep
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.ElectricalCertExpiryDateStep
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.ElectricalCertMissingStep
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.HasAnyInCollectionStep
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.HasElectricalCertStep
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.ProvideElectricalCertLaterStep
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.RemoveElectricalCertUploadStep
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.UploadElectricalCertStep
 
 @JourneyFrameworkComponent("propertyRegistrationElectricalSafetyTask")
 class ElectricalSafetyTask(
     journeyStateService: JourneyStateService,
     override val electricalSafetyDetailsTask: ElectricalSafetyDetailsTask,
-    override val hasElectricalCertStep: HasElectricalCertStep,
-    override val electricalCertExpiryDateStep: ElectricalCertExpiryDateStep,
-    override val uploadElectricalCertStep: UploadElectricalCertStep,
-    override val hasUploadedElectricalCert: HasAnyInCollectionStep,
-    override val checkElectricalCertUploadsStep: CheckElectricalCertUploadsStep,
-    override val removeElectricalCertUploadStep: RemoveElectricalCertUploadStep,
-    override val electricalCertExpiredStep: ElectricalCertExpiredStep,
-    override val electricalCertMissingStep: ElectricalCertMissingStep,
-    override val provideElectricalCertLaterStep: ProvideElectricalCertLaterStep,
     override val checkElectricalSafetyAnswersStep: CheckElectricalSafetyAnswersStep,
 ) : DuplicableTaskWithDependencies<ElectricalSafetyState, ElectricalSafetyDependencies>(journeyStateService),
     ElectricalSafetyState {
-    override val isOccupied: Boolean
-        get() = dependencies.isOccupied
-    override val allowProvideCertificateLaterRoute: Boolean
-        get() = dependencies.allowProvideCertificateLaterRoute
-
-    override var electricalUploadMap: Map<Int, CertificateUpload> by delegateProvider.requiredDelegate("electricalUploadMap", mapOf())
-    override var highestAssignedElectricalMemberId: Int? by delegateProvider.nullableDelegate("highestAssignedElectricalMemberId")
-
     override fun makeSubJourney(state: ElectricalSafetyState) =
         subJourney(state) {
-            task(journey.electricalSafetyDetailsTask) {
+            duplicableTask(journey.electricalSafetyDetailsTask) {
+                withDependencies { dependencies }
                 nextStep { journey.checkElectricalSafetyAnswersStep }
                 savable()
             }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/tasks/ElectricalSafetyTask.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/tasks/ElectricalSafetyTask.kt
@@ -1,13 +1,46 @@
 package uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks
 
 import uk.gov.communities.prsdb.webapp.annotations.webAnnotations.JourneyFrameworkComponent
-import uk.gov.communities.prsdb.webapp.journeys.Task
+import uk.gov.communities.prsdb.webapp.journeys.DuplicableTaskWithDependencies
+import uk.gov.communities.prsdb.webapp.journeys.JourneyStateService
 import uk.gov.communities.prsdb.webapp.journeys.isComplete
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.CertificateUpload
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.ElectricalSafetyState
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.CheckElectricalCertUploadsStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.CheckElectricalSafetyAnswersStep
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.ElectricalCertExpiredStep
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.ElectricalCertExpiryDateStep
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.ElectricalCertMissingStep
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.HasAnyInCollectionStep
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.HasElectricalCertStep
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.ProvideElectricalCertLaterStep
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.RemoveElectricalCertUploadStep
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.UploadElectricalCertStep
 
-@JourneyFrameworkComponent
-class ElectricalSafetyTask : Task<ElectricalSafetyState>() {
+@JourneyFrameworkComponent("propertyRegistrationElectricalSafetyTask")
+class ElectricalSafetyTask(
+    journeyStateService: JourneyStateService,
+    override val electricalSafetyDetailsTask: ElectricalSafetyDetailsTask,
+    override val hasElectricalCertStep: HasElectricalCertStep,
+    override val electricalCertExpiryDateStep: ElectricalCertExpiryDateStep,
+    override val uploadElectricalCertStep: UploadElectricalCertStep,
+    override val hasUploadedElectricalCert: HasAnyInCollectionStep,
+    override val checkElectricalCertUploadsStep: CheckElectricalCertUploadsStep,
+    override val removeElectricalCertUploadStep: RemoveElectricalCertUploadStep,
+    override val electricalCertExpiredStep: ElectricalCertExpiredStep,
+    override val electricalCertMissingStep: ElectricalCertMissingStep,
+    override val provideElectricalCertLaterStep: ProvideElectricalCertLaterStep,
+    override val checkElectricalSafetyAnswersStep: CheckElectricalSafetyAnswersStep,
+) : DuplicableTaskWithDependencies<ElectricalSafetyState, ElectricalSafetyDependencies>(journeyStateService),
+    ElectricalSafetyState {
+    override val isOccupied: Boolean
+        get() = dependencies.isOccupied
+    override val allowProvideCertificateLaterRoute: Boolean
+        get() = dependencies.allowProvideCertificateLaterRoute
+
+    override var electricalUploadMap: Map<Int, CertificateUpload> by delegateProvider.requiredDelegate("electricalUploadMap", mapOf())
+    override var highestAssignedElectricalMemberId: Int? by delegateProvider.nullableDelegate("highestAssignedElectricalMemberId")
+
     override fun makeSubJourney(state: ElectricalSafetyState) =
         subJourney(state) {
             task(journey.electricalSafetyDetailsTask) {
@@ -24,4 +57,12 @@ class ElectricalSafetyTask : Task<ElectricalSafetyState>() {
                 parents { journey.checkElectricalSafetyAnswersStep.isComplete() }
             }
         }
+
+    override val taskState: ElectricalSafetyState
+        get() = this
+}
+
+interface ElectricalSafetyDependencies {
+    val isOccupied: Boolean
+    val allowProvideCertificateLaterRoute: Boolean
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/tasks/EpcDetailsTask.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/tasks/EpcDetailsTask.kt
@@ -1,23 +1,27 @@
 package uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks
 
 import uk.gov.communities.prsdb.webapp.annotations.webAnnotations.JourneyFrameworkComponent
+import uk.gov.communities.prsdb.webapp.journeys.DuplicableTaskWithDependencies
+import uk.gov.communities.prsdb.webapp.journeys.JourneyStateService
 import uk.gov.communities.prsdb.webapp.journeys.OrParents
-import uk.gov.communities.prsdb.webapp.journeys.Task
 import uk.gov.communities.prsdb.webapp.journeys.always
 import uk.gov.communities.prsdb.webapp.journeys.hasOutcome
 import uk.gov.communities.prsdb.webapp.journeys.isComplete
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.EpcState
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.EpcDetailState
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.ConfirmEpcDetailsRetrievedByCertificateNumberStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.ConfirmEpcDetailsRetrievedByCertificateNumberStepConfig
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.ConfirmEpcRetrievedByUprnStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.ConfirmEpcRetrievedByUprnStepConfig
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.EpcAgeCheckMode
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.EpcAgeCheckStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.EpcEnergyRatingCheckMode
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.EpcEnergyRatingCheckStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.EpcExemptionStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.EpcExpiredStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.EpcInDateAtStartOfTenancyCheckMode
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.EpcInDateAtStartOfTenancyCheckStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.EpcLookupByUprnMode
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.EpcLookupByUprnStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.EpcMissingStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.EpcNotFoundStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.EpcSuperseededStep
@@ -30,13 +34,58 @@ import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.HasMe
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.IsEpcRequiredStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.LowEnergyRatingStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.MeesExemptionStep
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.PropertyOccupiedCheckStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.ProvideEpcLaterStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.StartEpcStep
 import uk.gov.communities.prsdb.webapp.journeys.shared.YesOrNo
+import uk.gov.communities.prsdb.webapp.models.dataModels.EpcDataModel
 
 @JourneyFrameworkComponent("propertyRegistrationEpcDetailsTask")
-class EpcDetailsTask : Task<EpcState>() {
-    override fun makeSubJourney(state: EpcState) =
+class EpcDetailsTask(
+    journeyStateService: JourneyStateService,
+    override val startEpcStep: StartEpcStep,
+    override val epcLookupByUprnStep: EpcLookupByUprnStep,
+    override val hasEpcStep: HasEpcStep,
+    override val checkUprnMatchedEpcStep: ConfirmEpcRetrievedByUprnStep,
+    override val epcAgeCheckStep: EpcAgeCheckStep,
+    override val epcEnergyRatingCheckStep: EpcEnergyRatingCheckStep,
+    override val isPropertyOccupiedCheckStep: PropertyOccupiedCheckStep,
+    override val confirmEpcDetailsRetrievedByCertificateNumberStep: ConfirmEpcDetailsRetrievedByCertificateNumberStep,
+    override val findYourEpcStep: FindYourEpcStep,
+    override val checkSupersededEpcStep: EpcSuperseededStep,
+    override val epcNotFoundStep: EpcNotFoundStep,
+    override val epcInDateAtStartOfTenancyCheckStep: EpcInDateAtStartOfTenancyCheckStep,
+    override val hasMeesExemptionStep: HasMeesExemptionStep,
+    override val meesExemptionStep: MeesExemptionStep,
+    override val lowEnergyRatingStep: LowEnergyRatingStep,
+    override val epcExpiredStep: EpcExpiredStep,
+    override val isEpcRequiredStep: IsEpcRequiredStep,
+    override val epcExemptionStep: EpcExemptionStep,
+    override val epcMissingStep: EpcMissingStep,
+    override val provideEpcLaterStep: ProvideEpcLaterStep,
+) : DuplicableTaskWithDependencies<EpcDetailState, EpcDependencies>(journeyStateService),
+    EpcDetailState {
+    override val taskState: EpcDetailState
+        get() = this
+
+    override val isOccupied: Boolean?
+        get() = dependencies.isOccupied
+    override val uprn: Long?
+        get() = dependencies.uprn
+    override val allowProvideCertificateLaterRoute: Boolean
+        get() = dependencies.allowProvideCertificateLaterRoute
+
+    override var epcRetrievedByUprn: EpcDataModel? by delegateProvider.nullableDelegate("epcRetrievedByUprn")
+    override var epcRetrievedByUprnUpdatedSinceUserReview: Boolean?
+        by delegateProvider.nullableDelegate("epcRetrievedByUprnUpdatedSinceUserReview")
+    override var epcRetrievedByCertificateNumber: EpcDataModel? by delegateProvider.nullableDelegate("epcRetrievedByCertificateNumber")
+    override var epcRetrievedByCertificateNumberUpdatedSinceUserReview: Boolean?
+        by delegateProvider.nullableDelegate("epcRetrievedByCertificateNumberUpdatedSinceUserReview")
+    override var updatedEpcRetrievedByCertificateNumber: EpcDataModel? by delegateProvider
+        .nullableDelegate("updatedEpcRetrievedByCertificateNumber")
+    override var acceptedEpc: EpcDataModel? by delegateProvider.nullableDelegate("acceptedEpc")
+
+    override fun makeSubJourney(state: EpcDetailState) =
         subJourney(state) {
             step(journey.startEpcStep) {
                 routeSegment(StartEpcStep.ROUTE_SEGMENT)

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/tasks/EpcTask.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/tasks/EpcTask.kt
@@ -2,13 +2,77 @@ package uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks
 
 import uk.gov.communities.prsdb.webapp.annotations.webAnnotations.JourneyFrameworkComponent
 import uk.gov.communities.prsdb.webapp.constants.enums.TaskStatus
-import uk.gov.communities.prsdb.webapp.journeys.Task
+import uk.gov.communities.prsdb.webapp.journeys.DuplicableTaskWithDependencies
+import uk.gov.communities.prsdb.webapp.journeys.JourneyStateService
 import uk.gov.communities.prsdb.webapp.journeys.isComplete
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.EpcState
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.CheckEpcAnswersStep
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.ConfirmEpcDetailsRetrievedByCertificateNumberStep
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.ConfirmEpcRetrievedByUprnStep
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.EpcAgeCheckStep
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.EpcEnergyRatingCheckStep
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.EpcExemptionStep
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.EpcExpiredStep
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.EpcInDateAtStartOfTenancyCheckStep
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.EpcLookupByUprnStep
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.EpcMissingStep
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.EpcNotFoundStep
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.EpcSuperseededStep
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.FindYourEpcStep
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.HasEpcStep
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.HasMeesExemptionStep
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.IsEpcRequiredStep
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.LowEnergyRatingStep
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.MeesExemptionStep
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.PropertyOccupiedCheckStep
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.ProvideEpcLaterStep
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.StartEpcStep
+import uk.gov.communities.prsdb.webapp.models.dataModels.EpcDataModel
 
 @JourneyFrameworkComponent("propertyRegistrationEpcTask")
-class EpcTask : Task<EpcState>() {
+class EpcTask(
+    journeyStateService: JourneyStateService,
+    override val epcDetailsTask: EpcDetailsTask,
+    override val startEpcStep: StartEpcStep,
+    override val epcLookupByUprnStep: EpcLookupByUprnStep,
+    override val hasEpcStep: HasEpcStep,
+    override val checkUprnMatchedEpcStep: ConfirmEpcRetrievedByUprnStep,
+    override val epcAgeCheckStep: EpcAgeCheckStep,
+    override val epcEnergyRatingCheckStep: EpcEnergyRatingCheckStep,
+    override val isPropertyOccupiedCheckStep: PropertyOccupiedCheckStep,
+    override val confirmEpcDetailsRetrievedByCertificateNumberStep: ConfirmEpcDetailsRetrievedByCertificateNumberStep,
+    override val findYourEpcStep: FindYourEpcStep,
+    override val checkSupersededEpcStep: EpcSuperseededStep,
+    override val epcNotFoundStep: EpcNotFoundStep,
+    override val epcInDateAtStartOfTenancyCheckStep: EpcInDateAtStartOfTenancyCheckStep,
+    override val hasMeesExemptionStep: HasMeesExemptionStep,
+    override val meesExemptionStep: MeesExemptionStep,
+    override val lowEnergyRatingStep: LowEnergyRatingStep,
+    override val epcExpiredStep: EpcExpiredStep,
+    override val isEpcRequiredStep: IsEpcRequiredStep,
+    override val epcExemptionStep: EpcExemptionStep,
+    override val epcMissingStep: EpcMissingStep,
+    override val provideEpcLaterStep: ProvideEpcLaterStep,
+    override val checkEpcAnswersStep: CheckEpcAnswersStep,
+) : DuplicableTaskWithDependencies<EpcState, EpcDependencies>(journeyStateService),
+    EpcState {
+    override val isOccupied: Boolean?
+        get() = dependencies.isOccupied
+    override val uprn: Long?
+        get() = dependencies.uprn
+    override val allowProvideCertificateLaterRoute: Boolean
+        get() = dependencies.allowProvideCertificateLaterRoute
+
+    override var epcRetrievedByUprn: EpcDataModel? by delegateProvider.nullableDelegate("epcRetrievedByUprn")
+    override var epcRetrievedByUprnUpdatedSinceUserReview: Boolean?
+        by delegateProvider.nullableDelegate("epcRetrievedByUprnUpdatedSinceUserReview")
+    override var epcRetrievedByCertificateNumber: EpcDataModel? by delegateProvider.nullableDelegate("epcRetrievedByCertificateNumber")
+    override var epcRetrievedByCertificateNumberUpdatedSinceUserReview: Boolean?
+        by delegateProvider.nullableDelegate("epcRetrievedByCertificateNumberUpdatedSinceUserReview")
+    override var updatedEpcRetrievedByCertificateNumber: EpcDataModel? by delegateProvider
+        .nullableDelegate("updatedEpcRetrievedByCertificateNumber")
+    override var acceptedEpc: EpcDataModel? by delegateProvider.nullableDelegate("acceptedEpc")
+
     override fun makeSubJourney(state: EpcState) =
         subJourney(state) {
             taskStatus {
@@ -34,4 +98,13 @@ class EpcTask : Task<EpcState>() {
                 parents { journey.checkEpcAnswersStep.isComplete() }
             }
         }
+
+    override val taskState: EpcState
+        get() = this
+}
+
+interface EpcDependencies {
+    val isOccupied: Boolean?
+    val uprn: Long?
+    val allowProvideCertificateLaterRoute: Boolean
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/tasks/EpcTask.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/tasks/EpcTask.kt
@@ -7,84 +7,27 @@ import uk.gov.communities.prsdb.webapp.journeys.JourneyStateService
 import uk.gov.communities.prsdb.webapp.journeys.isComplete
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.EpcState
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.CheckEpcAnswersStep
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.ConfirmEpcDetailsRetrievedByCertificateNumberStep
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.ConfirmEpcRetrievedByUprnStep
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.EpcAgeCheckStep
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.EpcEnergyRatingCheckStep
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.EpcExemptionStep
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.EpcExpiredStep
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.EpcInDateAtStartOfTenancyCheckStep
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.EpcLookupByUprnStep
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.EpcMissingStep
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.EpcNotFoundStep
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.EpcSuperseededStep
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.FindYourEpcStep
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.HasEpcStep
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.HasMeesExemptionStep
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.IsEpcRequiredStep
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.LowEnergyRatingStep
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.MeesExemptionStep
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.PropertyOccupiedCheckStep
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.ProvideEpcLaterStep
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.StartEpcStep
-import uk.gov.communities.prsdb.webapp.models.dataModels.EpcDataModel
 
 @JourneyFrameworkComponent("propertyRegistrationEpcTask")
 class EpcTask(
     journeyStateService: JourneyStateService,
     override val epcDetailsTask: EpcDetailsTask,
-    override val startEpcStep: StartEpcStep,
-    override val epcLookupByUprnStep: EpcLookupByUprnStep,
-    override val hasEpcStep: HasEpcStep,
-    override val checkUprnMatchedEpcStep: ConfirmEpcRetrievedByUprnStep,
-    override val epcAgeCheckStep: EpcAgeCheckStep,
-    override val epcEnergyRatingCheckStep: EpcEnergyRatingCheckStep,
-    override val isPropertyOccupiedCheckStep: PropertyOccupiedCheckStep,
-    override val confirmEpcDetailsRetrievedByCertificateNumberStep: ConfirmEpcDetailsRetrievedByCertificateNumberStep,
-    override val findYourEpcStep: FindYourEpcStep,
-    override val checkSupersededEpcStep: EpcSuperseededStep,
-    override val epcNotFoundStep: EpcNotFoundStep,
-    override val epcInDateAtStartOfTenancyCheckStep: EpcInDateAtStartOfTenancyCheckStep,
-    override val hasMeesExemptionStep: HasMeesExemptionStep,
-    override val meesExemptionStep: MeesExemptionStep,
-    override val lowEnergyRatingStep: LowEnergyRatingStep,
-    override val epcExpiredStep: EpcExpiredStep,
-    override val isEpcRequiredStep: IsEpcRequiredStep,
-    override val epcExemptionStep: EpcExemptionStep,
-    override val epcMissingStep: EpcMissingStep,
-    override val provideEpcLaterStep: ProvideEpcLaterStep,
     override val checkEpcAnswersStep: CheckEpcAnswersStep,
 ) : DuplicableTaskWithDependencies<EpcState, EpcDependencies>(journeyStateService),
     EpcState {
-    override val isOccupied: Boolean?
-        get() = dependencies.isOccupied
-    override val uprn: Long?
-        get() = dependencies.uprn
-    override val allowProvideCertificateLaterRoute: Boolean
-        get() = dependencies.allowProvideCertificateLaterRoute
-
-    override var epcRetrievedByUprn: EpcDataModel? by delegateProvider.nullableDelegate("epcRetrievedByUprn")
-    override var epcRetrievedByUprnUpdatedSinceUserReview: Boolean?
-        by delegateProvider.nullableDelegate("epcRetrievedByUprnUpdatedSinceUserReview")
-    override var epcRetrievedByCertificateNumber: EpcDataModel? by delegateProvider.nullableDelegate("epcRetrievedByCertificateNumber")
-    override var epcRetrievedByCertificateNumberUpdatedSinceUserReview: Boolean?
-        by delegateProvider.nullableDelegate("epcRetrievedByCertificateNumberUpdatedSinceUserReview")
-    override var updatedEpcRetrievedByCertificateNumber: EpcDataModel? by delegateProvider
-        .nullableDelegate("updatedEpcRetrievedByCertificateNumber")
-    override var acceptedEpc: EpcDataModel? by delegateProvider.nullableDelegate("acceptedEpc")
-
     override fun makeSubJourney(state: EpcState) =
         subJourney(state) {
             taskStatus {
                 when {
                     exitStep.isStepReachable -> TaskStatus.COMPLETED
-                    journey.checkUprnMatchedEpcStep.outcome != null -> TaskStatus.IN_PROGRESS
-                    journey.hasEpcStep.outcome != null -> TaskStatus.IN_PROGRESS
-                    journey.startEpcStep.isStepReachable -> TaskStatus.NOT_STARTED
+                    journey.epcDetailsTask.checkUprnMatchedEpcStep.outcome != null -> TaskStatus.IN_PROGRESS
+                    journey.epcDetailsTask.hasEpcStep.outcome != null -> TaskStatus.IN_PROGRESS
+                    journey.epcDetailsTask.startEpcStep.isStepReachable -> TaskStatus.NOT_STARTED
                     else -> TaskStatus.CANNOT_START
                 }
             }
-            task(journey.epcDetailsTask) {
+            duplicableTask(journey.epcDetailsTask) {
+                withDependencies { dependencies }
                 nextStep { journey.checkEpcAnswersStep }
                 savable()
             }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/tasks/GasSafetyDetailsTask.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/tasks/GasSafetyDetailsTask.kt
@@ -1,16 +1,19 @@
 package uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks
 
 import uk.gov.communities.prsdb.webapp.annotations.webAnnotations.JourneyFrameworkComponent
+import uk.gov.communities.prsdb.webapp.journeys.DuplicableTaskWithDependencies
+import uk.gov.communities.prsdb.webapp.journeys.JourneyStateService
 import uk.gov.communities.prsdb.webapp.journeys.OrParents
-import uk.gov.communities.prsdb.webapp.journeys.Task
 import uk.gov.communities.prsdb.webapp.journeys.hasOutcome
 import uk.gov.communities.prsdb.webapp.journeys.isComplete
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.GasSafetyState
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.CertificateUpload
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.GasSafetyDetailState
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.CheckGasCertUploadsStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.GasCertExpiredStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.GasCertIssueDateMode
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.GasCertIssueDateStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.GasCertMissingStep
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.HasAnyInCollectionStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.HasAnyInCollectionStepConfig
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.HasGasCertMode
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.HasGasCertStep
@@ -22,8 +25,32 @@ import uk.gov.communities.prsdb.webapp.journeys.shared.AnyMembers
 import uk.gov.communities.prsdb.webapp.journeys.shared.YesOrNo
 
 @JourneyFrameworkComponent("propertyRegistrationGasSafetyDetailsTask")
-class GasSafetyDetailsTask : Task<GasSafetyState>() {
-    override fun makeSubJourney(state: GasSafetyState) =
+class GasSafetyDetailsTask(
+    override val hasUploadedCert: HasAnyInCollectionStep,
+    override val hasGasSupplyStep: HasGasSupplyStep,
+    override val hasGasCertStep: HasGasCertStep,
+    override val gasCertIssueDateStep: GasCertIssueDateStep,
+    override val uploadGasCertStep: UploadGasCertStep,
+    override val checkGasCertUploadsStep: CheckGasCertUploadsStep,
+    override val removeGasCertUploadStep: RemoveGasCertUploadStep,
+    override val gasCertExpiredStep: GasCertExpiredStep,
+    override val gasCertMissingStep: GasCertMissingStep,
+    override val provideGasCertLaterStep: ProvideGasCertLaterStep,
+    journeyStateService: JourneyStateService,
+) : DuplicableTaskWithDependencies<GasSafetyDetailState, GasSafetyDependencies>(journeyStateService),
+    GasSafetyDetailState {
+    override val taskState: GasSafetyDetailState
+        get() = this
+
+    override val isOccupied: Boolean
+        get() = dependencies.isOccupied
+    override val allowProvideCertificateLaterRoute: Boolean
+        get() = dependencies.allowProvideCertificateLaterRoute
+
+    override var gasUploadMap: Map<Int, CertificateUpload> by delegateProvider.requiredDelegate("gasUploadMap", mapOf())
+    override var highestAssignedGasMemberId: Int? by delegateProvider.nullableDelegate("highestGasUploadMemberId")
+
+    override fun makeSubJourney(state: GasSafetyDetailState) =
         subJourney(state) {
             step(journey.hasGasSupplyStep) {
                 routeSegment(HasGasSupplyStep.ROUTE_SEGMENT)

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/tasks/GasSafetyTask.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/tasks/GasSafetyTask.kt
@@ -4,48 +4,20 @@ import uk.gov.communities.prsdb.webapp.annotations.webAnnotations.JourneyFramewo
 import uk.gov.communities.prsdb.webapp.journeys.DuplicableTaskWithDependencies
 import uk.gov.communities.prsdb.webapp.journeys.JourneyStateService
 import uk.gov.communities.prsdb.webapp.journeys.isComplete
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.CertificateUpload
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.GasSafetyState
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.CheckGasCertUploadsStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.CheckGasSafetyAnswersStep
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.GasCertExpiredStep
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.GasCertIssueDateStep
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.GasCertMissingStep
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.HasAnyInCollectionStep
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.HasGasCertStep
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.HasGasSupplyStep
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.ProvideGasCertLaterStep
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.RemoveGasCertUploadStep
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.UploadGasCertStep
 
 @JourneyFrameworkComponent("propertyRegistrationGasSafetyTask")
 class GasSafetyTask(
     journeyStateService: JourneyStateService,
     override val gasSafetyDetailsTask: GasSafetyDetailsTask,
-    override val hasUploadedCert: HasAnyInCollectionStep,
-    override val hasGasSupplyStep: HasGasSupplyStep,
-    override val hasGasCertStep: HasGasCertStep,
-    override val gasCertIssueDateStep: GasCertIssueDateStep,
-    override val uploadGasCertStep: UploadGasCertStep,
-    override val checkGasCertUploadsStep: CheckGasCertUploadsStep,
-    override val removeGasCertUploadStep: RemoveGasCertUploadStep,
-    override val gasCertExpiredStep: GasCertExpiredStep,
-    override val gasCertMissingStep: GasCertMissingStep,
-    override val provideGasCertLaterStep: ProvideGasCertLaterStep,
     override val checkGasSafetyAnswersStep: CheckGasSafetyAnswersStep,
 ) : DuplicableTaskWithDependencies<GasSafetyState, GasSafetyDependencies>(journeyStateService),
     GasSafetyState {
-    override val isOccupied: Boolean
-        get() = dependencies.isOccupied
-    override val allowProvideCertificateLaterRoute: Boolean
-        get() = dependencies.allowProvideCertificateLaterRoute
-
-    override var gasUploadMap: Map<Int, CertificateUpload> by delegateProvider.requiredDelegate("gasUploadMap", mapOf())
-    override var highestAssignedGasMemberId: Int? by delegateProvider.nullableDelegate("highestGasUploadMemberId")
-
     override fun makeSubJourney(state: GasSafetyState) =
         subJourney(state) {
-            task(journey.gasSafetyDetailsTask) {
+            duplicableTask(journey.gasSafetyDetailsTask) {
+                withDependencies { dependencies }
                 nextStep { journey.checkGasSafetyAnswersStep }
                 savable()
             }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/tasks/GasSafetyTask.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/tasks/GasSafetyTask.kt
@@ -1,13 +1,48 @@
 package uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks
 
 import uk.gov.communities.prsdb.webapp.annotations.webAnnotations.JourneyFrameworkComponent
-import uk.gov.communities.prsdb.webapp.journeys.Task
+import uk.gov.communities.prsdb.webapp.journeys.DuplicableTaskWithDependencies
+import uk.gov.communities.prsdb.webapp.journeys.JourneyStateService
 import uk.gov.communities.prsdb.webapp.journeys.isComplete
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.CertificateUpload
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.GasSafetyState
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.CheckGasCertUploadsStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.CheckGasSafetyAnswersStep
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.GasCertExpiredStep
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.GasCertIssueDateStep
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.GasCertMissingStep
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.HasAnyInCollectionStep
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.HasGasCertStep
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.HasGasSupplyStep
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.ProvideGasCertLaterStep
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.RemoveGasCertUploadStep
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.UploadGasCertStep
 
 @JourneyFrameworkComponent("propertyRegistrationGasSafetyTask")
-class GasSafetyTask : Task<GasSafetyState>() {
+class GasSafetyTask(
+    journeyStateService: JourneyStateService,
+    override val gasSafetyDetailsTask: GasSafetyDetailsTask,
+    override val hasUploadedCert: HasAnyInCollectionStep,
+    override val hasGasSupplyStep: HasGasSupplyStep,
+    override val hasGasCertStep: HasGasCertStep,
+    override val gasCertIssueDateStep: GasCertIssueDateStep,
+    override val uploadGasCertStep: UploadGasCertStep,
+    override val checkGasCertUploadsStep: CheckGasCertUploadsStep,
+    override val removeGasCertUploadStep: RemoveGasCertUploadStep,
+    override val gasCertExpiredStep: GasCertExpiredStep,
+    override val gasCertMissingStep: GasCertMissingStep,
+    override val provideGasCertLaterStep: ProvideGasCertLaterStep,
+    override val checkGasSafetyAnswersStep: CheckGasSafetyAnswersStep,
+) : DuplicableTaskWithDependencies<GasSafetyState, GasSafetyDependencies>(journeyStateService),
+    GasSafetyState {
+    override val isOccupied: Boolean
+        get() = dependencies.isOccupied
+    override val allowProvideCertificateLaterRoute: Boolean
+        get() = dependencies.allowProvideCertificateLaterRoute
+
+    override var gasUploadMap: Map<Int, CertificateUpload> by delegateProvider.requiredDelegate("gasUploadMap", mapOf())
+    override var highestAssignedGasMemberId: Int? by delegateProvider.nullableDelegate("highestGasUploadMemberId")
+
     override fun makeSubJourney(state: GasSafetyState) =
         subJourney(state) {
             task(journey.gasSafetyDetailsTask) {
@@ -24,4 +59,12 @@ class GasSafetyTask : Task<GasSafetyState>() {
                 parents { journey.checkGasSafetyAnswersStep.isComplete() }
             }
         }
+
+    override val taskState: GasSafetyState
+        get() = this
+}
+
+interface GasSafetyDependencies {
+    val isOccupied: Boolean
+    val allowProvideCertificateLaterRoute: Boolean
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/update/electricalSafety/CompleteElectricalSafetyUpdateStep.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/update/electricalSafety/CompleteElectricalSafetyUpdateStep.kt
@@ -24,9 +24,11 @@ class CompleteElectricalSafetyUpdateStepConfig(
             propertyComplianceService.updateElectricalSafety(
                 propertyOwnershipId = state.propertyId,
                 initialLastModifiedDate = Instant.parse(state.lastModifiedDate).toJavaInstant(),
-                electricalCertType = state.mapElectricalCertificateTypeToGlobalCertificateType(),
-                electricalSafetyExpiryDate = state.getElectricalCertificateExpiryDateIfReachable()?.toJavaLocalDate(),
-                electricalSafetyCertUploadIds = state.electricalUploadIds,
+                electricalCertType = state.electricalSafetyDetailsTask.mapElectricalCertificateTypeToGlobalCertificateType(),
+                electricalSafetyExpiryDate =
+                    state.electricalSafetyDetailsTask.getElectricalCertificateExpiryDateIfReachable()
+                        ?.toJavaLocalDate(),
+                electricalSafetyCertUploadIds = state.electricalSafetyDetailsTask.electricalUploadIds,
             )
         } catch (ex: UpdateConflictException) {
             state.deleteJourney()

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/update/electricalSafety/UpdateCheckElectricalSafetyAnswersStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/update/electricalSafety/UpdateCheckElectricalSafetyAnswersStepConfig.kt
@@ -17,7 +17,7 @@ class UpdateCheckElectricalSafetyAnswersStepConfig(
 
     override fun getStepSpecificContent(state: UpdateElectricalSafetyJourneyState): Map<String, Any?> {
         val factory =
-            ElectricalSafetyRegistrationCyaSummaryRowsFactory(state, uploadService) { step ->
+            ElectricalSafetyRegistrationCyaSummaryRowsFactory(state.electricalSafetyDetailsTask, uploadService) { step ->
                 Destination.VisitableStep(step, state.getCyaJourneyId(step))
             }
         return mapOf(

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/update/electricalSafety/UpdateElectricalSafetyJourneyFactory.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/update/electricalSafety/UpdateElectricalSafetyJourneyFactory.kt
@@ -27,7 +27,6 @@ import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.Provi
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.RemoveElectricalCertUploadStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.UploadElectricalCertStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.ElectricalSafetyDetailsTask
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.ElectricalSafetyTask
 import uk.gov.communities.prsdb.webapp.journeys.shared.states.CheckYourAnswersJourneyState
 import uk.gov.communities.prsdb.webapp.journeys.shared.states.CheckYourAnswersJourneyState.Companion.checkAnswerTask
 import uk.gov.communities.prsdb.webapp.services.PropertyOwnershipService
@@ -137,7 +136,6 @@ class UpdateElectricalSafetyJourneyFactory(
 class UpdateElectricalSafetyJourney(
     journeyStateService: JourneyStateService,
     journeyName: String = "electricalSafety",
-    override val electricalSafetyTask: ElectricalSafetyTask,
     override val hasElectricalCertStep: HasElectricalCertStep,
     override val electricalCertExpiryDateStep: ElectricalCertExpiryDateStep,
     override val uploadElectricalCertStep: UploadElectricalCertStep,
@@ -180,6 +178,5 @@ interface UpdateElectricalSafetyJourneyState :
     val propertyId: Long
     val lastModifiedDate: String
     val previousUploadIds: List<Long>
-    val electricalSafetyTask: ElectricalSafetyTask
     val completeElectricalSafetyUpdateStep: CompleteElectricalSafetyUpdateStep
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/update/electricalSafety/UpdateElectricalSafetyJourneyFactory.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/update/electricalSafety/UpdateElectricalSafetyJourneyFactory.kt
@@ -13,22 +13,11 @@ import uk.gov.communities.prsdb.webapp.journeys.JourneyStateService
 import uk.gov.communities.prsdb.webapp.journeys.StepLifecycleOrchestrator
 import uk.gov.communities.prsdb.webapp.journeys.builders.JourneyBuilder.Companion.journey
 import uk.gov.communities.prsdb.webapp.journeys.isComplete
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.CertificateUpload
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.ElectricalSafetyState
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.CheckElectricalCertUploadsStep
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.CheckElectricalSafetyAnswersStep
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.ElectricalCertExpiredStep
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.ElectricalCertExpiryDateStep
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.ElectricalCertMissingStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.FinishCyaJourneyStep
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.HasAnyInCollectionStep
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.HasElectricalCertStep
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.ProvideElectricalCertLaterStep
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.RemoveElectricalCertUploadStep
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.UploadElectricalCertStep
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.ElectricalSafetyDependencies
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.ElectricalSafetyDetailsTask
 import uk.gov.communities.prsdb.webapp.journeys.shared.states.CheckYourAnswersJourneyState
-import uk.gov.communities.prsdb.webapp.journeys.shared.states.CheckYourAnswersJourneyState.Companion.checkAnswerTask
+import uk.gov.communities.prsdb.webapp.journeys.shared.states.CheckYourAnswersJourneyState.Companion.duplicableCheckAnswerTask
 import uk.gov.communities.prsdb.webapp.services.PropertyOwnershipService
 import java.security.Principal
 
@@ -73,7 +62,8 @@ class UpdateElectricalSafetyJourneyFactory(
 
         return journey(state) {
             unreachableStepUrl { propertyComplianceRoute }
-            task(journey.electricalSafetyDetailsTask) {
+            duplicableTask(journey.electricalSafetyDetailsTask) {
+                withDependencies { journey }
                 initialStep()
                 backUrl { propertyComplianceRoute }
                 nextStep { journey.updateCheckElectricalSafetyAnswersStep }
@@ -118,7 +108,11 @@ class UpdateElectricalSafetyJourneyFactory(
                 }
             }
             configureFirst { backDestination { journey.returnToCyaPageDestination } }
-            checkAnswerTask(journey.electricalSafetyDetailsTask)
+            duplicableCheckAnswerTask(
+                journey.electricalSafetyDetailsTask,
+                { journey },
+            )
+
             step(journey.finishCyaStep) {
                 initialStep()
                 nextDestination { Destination.Nowhere() }
@@ -136,16 +130,6 @@ class UpdateElectricalSafetyJourneyFactory(
 class UpdateElectricalSafetyJourney(
     journeyStateService: JourneyStateService,
     journeyName: String = "electricalSafety",
-    override val hasElectricalCertStep: HasElectricalCertStep,
-    override val electricalCertExpiryDateStep: ElectricalCertExpiryDateStep,
-    override val uploadElectricalCertStep: UploadElectricalCertStep,
-    override val hasUploadedElectricalCert: HasAnyInCollectionStep,
-    override val checkElectricalCertUploadsStep: CheckElectricalCertUploadsStep,
-    override val removeElectricalCertUploadStep: RemoveElectricalCertUploadStep,
-    override val electricalCertExpiredStep: ElectricalCertExpiredStep,
-    override val electricalCertMissingStep: ElectricalCertMissingStep,
-    override val provideElectricalCertLaterStep: ProvideElectricalCertLaterStep,
-    override val checkElectricalSafetyAnswersStep: CheckElectricalSafetyAnswersStep,
     val updateCheckElectricalSafetyAnswersStep: UpdateCheckElectricalSafetyAnswersStep,
     override val completeElectricalSafetyUpdateStep: CompleteElectricalSafetyUpdateStep,
     override val electricalSafetyDetailsTask: ElectricalSafetyDetailsTask,
@@ -156,12 +140,6 @@ class UpdateElectricalSafetyJourney(
     override var propertyId: Long by delegateProvider.requiredImmutableDelegate("propertyId")
     override var lastModifiedDate: String by delegateProvider.requiredImmutableDelegate("lastModifiedDate")
     override var previousUploadIds: List<Long> by delegateProvider.requiredImmutableDelegate("previousUploads")
-    override var isOccupied: Boolean by delegateProvider.requiredImmutableDelegate("isOccupied")
-
-    override var electricalUploadMap: Map<Int, CertificateUpload> by delegateProvider.requiredDelegate("electricalUploadMap", mapOf())
-    override var highestAssignedElectricalMemberId: Int? by delegateProvider.nullableDelegate("highestElectricalUploadMemberId")
-
-    override val allowProvideCertificateLaterRoute: Boolean = false
 
     override var originalJourneyUpdated: Instant? by delegateProvider.nullableDelegate("originalJourneyUpdated")
     override var checkingAnswersFor: String? by delegateProvider.nullableDelegate("checkingAnswersFor")
@@ -169,12 +147,16 @@ class UpdateElectricalSafetyJourney(
     override var cyaUrlPath: String? by delegateProvider.nullableDelegate("cyaRouteSegment")
 
     override val cyaStep get() = updateCheckElectricalSafetyAnswersStep
+
+    override var isOccupied: Boolean by delegateProvider.requiredImmutableDelegate("isOccupied")
+    override val allowProvideCertificateLaterRoute: Boolean = false
 }
 
 interface UpdateElectricalSafetyJourneyState :
     JourneyState,
-    ElectricalSafetyState,
+    ElectricalSafetyDependencies,
     CheckYourAnswersJourneyState {
+    val electricalSafetyDetailsTask: ElectricalSafetyDetailsTask
     val propertyId: Long
     val lastModifiedDate: String
     val previousUploadIds: List<Long>

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/update/epc/CompleteEpcUpdateStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/update/epc/CompleteEpcUpdateStepConfig.kt
@@ -20,7 +20,7 @@ class CompleteEpcUpdateStepConfig(
     override fun mode(state: UpdateEpcJourneyState): Complete = Complete.COMPLETE
 
     override fun afterStepIsReached(state: UpdateEpcJourneyState) {
-        val acceptedEpc = state.acceptedEpcIfStillAccepted
+        val acceptedEpc = state.epcDetailsTask.acceptedEpcIfStillAccepted
 
         try {
             propertyComplianceService.updateEpc(
@@ -30,9 +30,9 @@ class CompleteEpcUpdateStepConfig(
                 epcExpiryDate = acceptedEpc?.expiryDate?.toJavaLocalDate(),
                 epcEnergyRating = acceptedEpc?.energyRating,
                 tenancyStartedBeforeEpcExpiry =
-                    state.epcInDateAtStartOfTenancyCheckStep.formModelIfReachableOrNull?.tenancyStartedBeforeExpiry,
-                epcExemptionReason = state.epcExemptionStep.formModelIfReachableOrNull?.exemptionReason,
-                epcMeesExemptionReason = state.meesExemptionStep.formModelIfReachableOrNull?.exemptionReason,
+                    state.epcDetailsTask.epcInDateAtStartOfTenancyCheckStep.formModelIfReachableOrNull?.tenancyStartedBeforeExpiry,
+                epcExemptionReason = state.epcDetailsTask.epcExemptionStep.formModelIfReachableOrNull?.exemptionReason,
+                epcMeesExemptionReason = state.epcDetailsTask.meesExemptionStep.formModelIfReachableOrNull?.exemptionReason,
             )
         } catch (ex: UpdateConflictException) {
             state.deleteJourney()

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/update/epc/UpdateCheckEpcAnswersStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/update/epc/UpdateCheckEpcAnswersStepConfig.kt
@@ -17,7 +17,7 @@ class UpdateCheckEpcAnswersStepConfig(
 
     override fun getStepSpecificContent(state: UpdateEpcJourneyState): Map<String, Any?> {
         val factory =
-            EpcRegistrationCyaSummaryRowsFactory(epcCertificateUrlProvider, state) { step ->
+            EpcRegistrationCyaSummaryRowsFactory(epcCertificateUrlProvider, state.epcDetailsTask) { step ->
                 Destination.VisitableStep(step, state.getCyaJourneyId(step))
             }
         return mapOf(

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/update/epc/UpdateEpcJourneyFactory.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/update/epc/UpdateEpcJourneyFactory.kt
@@ -13,33 +13,11 @@ import uk.gov.communities.prsdb.webapp.journeys.JourneyStateService
 import uk.gov.communities.prsdb.webapp.journeys.StepLifecycleOrchestrator
 import uk.gov.communities.prsdb.webapp.journeys.builders.JourneyBuilder.Companion.journey
 import uk.gov.communities.prsdb.webapp.journeys.isComplete
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.EpcState
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.CheckEpcAnswersStep
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.ConfirmEpcDetailsRetrievedByCertificateNumberStep
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.ConfirmEpcRetrievedByUprnStep
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.EpcAgeCheckStep
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.EpcEnergyRatingCheckStep
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.EpcExemptionStep
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.EpcExpiredStep
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.EpcInDateAtStartOfTenancyCheckStep
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.EpcLookupByUprnStep
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.EpcMissingStep
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.EpcNotFoundStep
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.EpcSuperseededStep
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.FindYourEpcStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.FinishCyaJourneyStep
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.HasEpcStep
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.HasMeesExemptionStep
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.IsEpcRequiredStep
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.LowEnergyRatingStep
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.MeesExemptionStep
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.PropertyOccupiedCheckStep
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.ProvideEpcLaterStep
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.StartEpcStep
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.EpcDependencies
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.EpcDetailsTask
 import uk.gov.communities.prsdb.webapp.journeys.shared.states.CheckYourAnswersJourneyState
-import uk.gov.communities.prsdb.webapp.journeys.shared.states.CheckYourAnswersJourneyState.Companion.checkAnswerTask
-import uk.gov.communities.prsdb.webapp.models.dataModels.EpcDataModel
+import uk.gov.communities.prsdb.webapp.journeys.shared.states.CheckYourAnswersJourneyState.Companion.duplicableCheckAnswerTask
 import uk.gov.communities.prsdb.webapp.services.PropertyOwnershipService
 import java.security.Principal
 
@@ -84,7 +62,8 @@ class UpdateEpcJourneyFactory(
 
         return journey(state) {
             unreachableStepUrl { propertyComplianceRoute }
-            task(journey.epcDetailsTask) {
+            duplicableTask(journey.epcDetailsTask) {
+                withDependencies { journey }
                 initialStep()
                 backUrl { propertyComplianceRoute }
                 nextStep { journey.updateCheckEpcAnswersStep }
@@ -129,7 +108,11 @@ class UpdateEpcJourneyFactory(
                 }
             }
             configureFirst { backDestination { journey.returnToCyaPageDestination } }
-            checkAnswerTask(journey.epcDetailsTask)
+            duplicableCheckAnswerTask(
+                journey.epcDetailsTask,
+                { journey },
+            )
+
             step(journey.finishCyaStep) {
                 initialStep()
                 nextDestination { Destination.Nowhere() }
@@ -147,30 +130,9 @@ class UpdateEpcJourneyFactory(
 class UpdateEpcJourney(
     journeyStateService: JourneyStateService,
     journeyName: String = "updateEpc",
-    override val epcLookupByUprnStep: EpcLookupByUprnStep,
-    override val hasEpcStep: HasEpcStep,
-    override val checkUprnMatchedEpcStep: ConfirmEpcRetrievedByUprnStep,
-    override val epcAgeCheckStep: EpcAgeCheckStep,
-    override val epcEnergyRatingCheckStep: EpcEnergyRatingCheckStep,
-    override val isPropertyOccupiedCheckStep: PropertyOccupiedCheckStep,
-    override val confirmEpcDetailsRetrievedByCertificateNumberStep: ConfirmEpcDetailsRetrievedByCertificateNumberStep,
-    override val findYourEpcStep: FindYourEpcStep,
-    override val checkSupersededEpcStep: EpcSuperseededStep,
-    override val epcNotFoundStep: EpcNotFoundStep,
-    override val epcInDateAtStartOfTenancyCheckStep: EpcInDateAtStartOfTenancyCheckStep,
-    override val hasMeesExemptionStep: HasMeesExemptionStep,
-    override val meesExemptionStep: MeesExemptionStep,
-    override val lowEnergyRatingStep: LowEnergyRatingStep,
-    override val epcExpiredStep: EpcExpiredStep,
-    override val isEpcRequiredStep: IsEpcRequiredStep,
-    override val epcExemptionStep: EpcExemptionStep,
-    override val epcMissingStep: EpcMissingStep,
-    override val provideEpcLaterStep: ProvideEpcLaterStep,
-    override val checkEpcAnswersStep: CheckEpcAnswersStep,
     val updateCheckEpcAnswersStep: UpdateCheckEpcAnswersStep,
     override val epcDetailsTask: EpcDetailsTask,
     override val completeEpcUpdateStep: CompleteEpcUpdateStep,
-    override val startEpcStep: StartEpcStep,
     override val finishCyaStep: FinishCyaJourneyStep,
     override val stateFactory: ObjectFactory<UpdateEpcJourneyState>,
 ) : AbstractPropertyOwnershipUpdateJourneyState(journeyStateService, journeyName),
@@ -179,16 +141,6 @@ class UpdateEpcJourney(
     override var lastModifiedDate: String by delegateProvider.requiredImmutableDelegate("lastModifiedDate")
     override var isOccupied: Boolean by delegateProvider.requiredImmutableDelegate("isOccupied")
     override var uprn: Long? by delegateProvider.nullableDelegate("uprn")
-
-    override var epcRetrievedByUprn: EpcDataModel? by delegateProvider.nullableDelegate("epcRetrievedByUprn")
-    override var epcRetrievedByUprnUpdatedSinceUserReview: Boolean?
-        by delegateProvider.nullableDelegate("epcRetrievedByUprnUpdatedSinceUserReview")
-    override var epcRetrievedByCertificateNumber: EpcDataModel? by delegateProvider.nullableDelegate("epcRetrievedByCertificateNumber")
-    override var epcRetrievedByCertificateNumberUpdatedSinceUserReview: Boolean?
-        by delegateProvider.nullableDelegate("epcRetrievedByCertificateNumberUpdatedSinceUserReview")
-    override var updatedEpcRetrievedByCertificateNumber: EpcDataModel? by delegateProvider
-        .nullableDelegate("updatedEpcRetrievedByCertificateNumber")
-    override var acceptedEpc: EpcDataModel? by delegateProvider.nullableDelegate("acceptedEpc")
 
     override val allowProvideCertificateLaterRoute: Boolean = false
 
@@ -202,9 +154,11 @@ class UpdateEpcJourney(
 
 interface UpdateEpcJourneyState :
     JourneyState,
-    EpcState,
+    EpcDependencies,
     CheckYourAnswersJourneyState {
+    val epcDetailsTask: EpcDetailsTask
     val propertyId: Long
     val lastModifiedDate: String
+    override var isOccupied: Boolean
     val completeEpcUpdateStep: CompleteEpcUpdateStep
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/update/epc/UpdateEpcJourneyFactory.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/update/epc/UpdateEpcJourneyFactory.kt
@@ -37,7 +37,6 @@ import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.Prope
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.ProvideEpcLaterStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.StartEpcStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.EpcDetailsTask
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.EpcTask
 import uk.gov.communities.prsdb.webapp.journeys.shared.states.CheckYourAnswersJourneyState
 import uk.gov.communities.prsdb.webapp.journeys.shared.states.CheckYourAnswersJourneyState.Companion.checkAnswerTask
 import uk.gov.communities.prsdb.webapp.models.dataModels.EpcDataModel
@@ -148,7 +147,6 @@ class UpdateEpcJourneyFactory(
 class UpdateEpcJourney(
     journeyStateService: JourneyStateService,
     journeyName: String = "updateEpc",
-    override val epcTask: EpcTask,
     override val epcLookupByUprnStep: EpcLookupByUprnStep,
     override val hasEpcStep: HasEpcStep,
     override val checkUprnMatchedEpcStep: ConfirmEpcRetrievedByUprnStep,
@@ -208,6 +206,5 @@ interface UpdateEpcJourneyState :
     CheckYourAnswersJourneyState {
     val propertyId: Long
     val lastModifiedDate: String
-    val epcTask: EpcTask
     val completeEpcUpdateStep: CompleteEpcUpdateStep
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/update/gasSafety/CompleteGasSafetyUpdateStep.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/update/gasSafety/CompleteGasSafetyUpdateStep.kt
@@ -26,10 +26,10 @@ class CompleteGasSafetyUpdateStepConfig(
                 propertyOwnershipId = state.propertyId,
                 initialLastModifiedDate = Instant.parse(state.lastModifiedDate).toJavaInstant(),
                 hasGasSupply =
-                    state.hasGasSupplyStep.formModel.hasGasSupply
+                    state.gasSafetyDetailsTask.hasGasSupplyStep.formModel.hasGasSupply
                         ?: throw NotNullFormModelValueIsNullException("hasGasSupply is null"),
-                gasSafetyCertIssueDate = state.getGasSafetyCertificateIssueDateIfReachable()?.toJavaLocalDate(),
-                gasSafetyCertUploadIds = state.gasUploadIds,
+                gasSafetyCertIssueDate = state.gasSafetyDetailsTask.getGasSafetyCertificateIssueDateIfReachable()?.toJavaLocalDate(),
+                gasSafetyCertUploadIds = state.gasSafetyDetailsTask.gasUploadIds,
             )
         } catch (ex: UpdateConflictException) {
             state.deleteJourney()

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/update/gasSafety/UpdateCheckGasSafetyAnswersStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/update/gasSafety/UpdateCheckGasSafetyAnswersStepConfig.kt
@@ -17,7 +17,7 @@ class UpdateCheckGasSafetyAnswersStepConfig(
 
     override fun getStepSpecificContent(state: UpdateGasSafetyJourneyState): Map<String, Any?> {
         val factory =
-            GasSafetyRegistrationCyaSummaryRowsFactory(state, uploadService) { step ->
+            GasSafetyRegistrationCyaSummaryRowsFactory(state.gasSafetyDetailsTask, uploadService) { step ->
                 Destination.VisitableStep(step, state.getCyaJourneyId(step))
             }
         return mapOf(

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/update/gasSafety/UpdateGasSafetyJourneyFactory.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/update/gasSafety/UpdateGasSafetyJourneyFactory.kt
@@ -28,7 +28,6 @@ import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.Provi
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.RemoveGasCertUploadStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.UploadGasCertStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.GasSafetyDetailsTask
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.GasSafetyTask
 import uk.gov.communities.prsdb.webapp.journeys.shared.states.CheckYourAnswersJourneyState
 import uk.gov.communities.prsdb.webapp.journeys.shared.states.CheckYourAnswersJourneyState.Companion.checkAnswerTask
 import uk.gov.communities.prsdb.webapp.services.PropertyOwnershipService
@@ -138,7 +137,6 @@ class UpdateGasSafetyJourneyFactory(
 class UpdateGasSafetyJourney(
     journeyStateService: JourneyStateService,
     journeyName: String = "gasSafety",
-    override val gasSafetyTask: GasSafetyTask,
     override val gasSafetyDetailsTask: GasSafetyDetailsTask,
     override val hasGasSupplyStep: HasGasSupplyStep,
     override val hasGasCertStep: HasGasCertStep,
@@ -182,6 +180,5 @@ interface UpdateGasSafetyJourneyState :
     val propertyId: Long
     val lastModifiedDate: String
     val previousUploadIds: List<Long>
-    val gasSafetyTask: GasSafetyTask
     val completeGasSafetyUpdateStep: CompleteGasSafetyUpdateStep
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/update/gasSafety/UpdateGasSafetyJourneyFactory.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/update/gasSafety/UpdateGasSafetyJourneyFactory.kt
@@ -13,23 +13,11 @@ import uk.gov.communities.prsdb.webapp.journeys.JourneyStateService
 import uk.gov.communities.prsdb.webapp.journeys.StepLifecycleOrchestrator
 import uk.gov.communities.prsdb.webapp.journeys.builders.JourneyBuilder.Companion.journey
 import uk.gov.communities.prsdb.webapp.journeys.isComplete
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.CertificateUpload
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.GasSafetyState
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.CheckGasCertUploadsStep
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.CheckGasSafetyAnswersStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.FinishCyaJourneyStep
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.GasCertExpiredStep
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.GasCertIssueDateStep
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.GasCertMissingStep
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.HasAnyInCollectionStep
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.HasGasCertStep
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.HasGasSupplyStep
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.ProvideGasCertLaterStep
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.RemoveGasCertUploadStep
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.UploadGasCertStep
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.GasSafetyDependencies
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.GasSafetyDetailsTask
 import uk.gov.communities.prsdb.webapp.journeys.shared.states.CheckYourAnswersJourneyState
-import uk.gov.communities.prsdb.webapp.journeys.shared.states.CheckYourAnswersJourneyState.Companion.checkAnswerTask
+import uk.gov.communities.prsdb.webapp.journeys.shared.states.CheckYourAnswersJourneyState.Companion.duplicableCheckAnswerTask
 import uk.gov.communities.prsdb.webapp.services.PropertyOwnershipService
 import java.security.Principal
 
@@ -74,7 +62,8 @@ class UpdateGasSafetyJourneyFactory(
 
         return journey(state) {
             unreachableStepUrl { propertyComplianceRoute }
-            task(journey.gasSafetyDetailsTask) {
+            duplicableTask(journey.gasSafetyDetailsTask) {
+                withDependencies { journey }
                 initialStep()
                 backUrl { propertyComplianceRoute }
                 nextStep { journey.updateCheckGasSafetyAnswersStep }
@@ -119,7 +108,11 @@ class UpdateGasSafetyJourneyFactory(
                 }
             }
             configureFirst { backDestination { journey.returnToCyaPageDestination } }
-            checkAnswerTask(journey.gasSafetyDetailsTask)
+            duplicableCheckAnswerTask(
+                journey.gasSafetyDetailsTask,
+                { journey },
+            )
+
             step(journey.finishCyaStep) {
                 initialStep()
                 nextDestination { Destination.Nowhere() }
@@ -138,19 +131,8 @@ class UpdateGasSafetyJourney(
     journeyStateService: JourneyStateService,
     journeyName: String = "gasSafety",
     override val gasSafetyDetailsTask: GasSafetyDetailsTask,
-    override val hasGasSupplyStep: HasGasSupplyStep,
-    override val hasGasCertStep: HasGasCertStep,
-    override val gasCertIssueDateStep: GasCertIssueDateStep,
-    override val uploadGasCertStep: UploadGasCertStep,
-    override val checkGasCertUploadsStep: CheckGasCertUploadsStep,
-    override val removeGasCertUploadStep: RemoveGasCertUploadStep,
-    override val gasCertExpiredStep: GasCertExpiredStep,
-    override val gasCertMissingStep: GasCertMissingStep,
-    override val provideGasCertLaterStep: ProvideGasCertLaterStep,
-    override val checkGasSafetyAnswersStep: CheckGasSafetyAnswersStep,
     val updateCheckGasSafetyAnswersStep: UpdateCheckGasSafetyAnswersStep,
     override val completeGasSafetyUpdateStep: CompleteGasSafetyUpdateStep,
-    override val hasUploadedCert: HasAnyInCollectionStep,
     override val finishCyaStep: FinishCyaJourneyStep,
     override val stateFactory: ObjectFactory<UpdateGasSafetyJourneyState>,
 ) : AbstractPropertyOwnershipUpdateJourneyState(journeyStateService, journeyName),
@@ -158,12 +140,6 @@ class UpdateGasSafetyJourney(
     override var propertyId: Long by delegateProvider.requiredImmutableDelegate("propertyId")
     override var lastModifiedDate: String by delegateProvider.requiredImmutableDelegate("lastModifiedDate")
     override var previousUploadIds: List<Long> by delegateProvider.requiredImmutableDelegate("previousUploads")
-    override var isOccupied: Boolean by delegateProvider.requiredImmutableDelegate("isOccupied")
-
-    override var gasUploadMap: Map<Int, CertificateUpload> by delegateProvider.requiredDelegate("gasUploadMap", mapOf())
-    override var highestAssignedGasMemberId: Int? by delegateProvider.nullableDelegate("highestGasUploadMemberId")
-
-    override val allowProvideCertificateLaterRoute: Boolean = false
 
     override var originalJourneyUpdated: Instant? by delegateProvider.nullableDelegate("originalJourneyUpdated")
     override var checkingAnswersFor: String? by delegateProvider.nullableDelegate("checkingAnswersFor")
@@ -171,12 +147,16 @@ class UpdateGasSafetyJourney(
     override var cyaUrlPath: String? by delegateProvider.nullableDelegate("cyaRouteSegment")
 
     override val cyaStep get() = updateCheckGasSafetyAnswersStep
+
+    override var isOccupied: Boolean by delegateProvider.requiredImmutableDelegate("isOccupied")
+    override val allowProvideCertificateLaterRoute: Boolean = false
 }
 
 interface UpdateGasSafetyJourneyState :
     JourneyState,
-    GasSafetyState,
+    GasSafetyDependencies,
     CheckYourAnswersJourneyState {
+    val gasSafetyDetailsTask: GasSafetyDetailsTask
     val propertyId: Long
     val lastModifiedDate: String
     val previousUploadIds: List<Long>

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/shared/helpers/ComplianceDetailsHelper.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/shared/helpers/ComplianceDetailsHelper.kt
@@ -17,10 +17,13 @@ class ComplianceDetailsHelper(
     private val epcCertificateUrlProvider: EpcCertificateUrlProvider,
     private val uploadService: UploadService,
 ) {
-    fun <T> getGasSafetyCyaContent(state: T): Map<String, Any?> where T : GasSafetyState, T : CheckYourAnswersJourneyState {
+    fun getGasSafetyCyaContent(
+        cyaState: CheckYourAnswersJourneyState,
+        gasSafetyState: GasSafetyState,
+    ): Map<String, Any?> {
         val factory =
-            GasSafetyRegistrationCyaSummaryRowsFactory(state, uploadService) { step ->
-                Destination.VisitableStep(step, state.getCyaJourneyId(step))
+            GasSafetyRegistrationCyaSummaryRowsFactory(gasSafetyState, uploadService) { step ->
+                Destination.VisitableStep(step, cyaState.getCyaJourneyId(step))
             }
         return mapOf(
             "gasSupplyRows" to factory.createGasSupplyRows(),

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/shared/helpers/ComplianceDetailsHelper.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/shared/helpers/ComplianceDetailsHelper.kt
@@ -46,10 +46,13 @@ class ComplianceDetailsHelper(
         )
     }
 
-    fun <T> getEpcCyaContent(state: T): Map<String, Any?> where T : EpcState, T : CheckYourAnswersJourneyState {
+    fun getEpcCyaContent(
+        cyaState: CheckYourAnswersJourneyState,
+        epcState: EpcState,
+    ): Map<String, Any?> {
         val factory =
-            EpcRegistrationCyaSummaryRowsFactory(epcCertificateUrlProvider, state) { step ->
-                Destination.VisitableStep(step, state.getCyaJourneyId(step))
+            EpcRegistrationCyaSummaryRowsFactory(epcCertificateUrlProvider, epcState) { step ->
+                Destination.VisitableStep(step, cyaState.getCyaJourneyId(step))
             }
         return mapOf(
             "epcCardTitle" to factory.createEpcCardTitle(),

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/shared/helpers/ComplianceDetailsHelper.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/shared/helpers/ComplianceDetailsHelper.kt
@@ -51,7 +51,7 @@ class ComplianceDetailsHelper(
         epcState: EpcState,
     ): Map<String, Any?> {
         val factory =
-            EpcRegistrationCyaSummaryRowsFactory(epcCertificateUrlProvider, epcState) { step ->
+            EpcRegistrationCyaSummaryRowsFactory(epcCertificateUrlProvider, epcState.epcDetailsTask) { step ->
                 Destination.VisitableStep(step, cyaState.getCyaJourneyId(step))
             }
         return mapOf(

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/shared/helpers/ComplianceDetailsHelper.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/shared/helpers/ComplianceDetailsHelper.kt
@@ -32,10 +32,13 @@ class ComplianceDetailsHelper(
         )
     }
 
-    fun <T> getElectricalSafetyCyaContent(state: T): Map<String, Any?> where T : ElectricalSafetyState, T : CheckYourAnswersJourneyState {
+    fun getElectricalSafetyCyaContent(
+        cyaState: CheckYourAnswersJourneyState,
+        electricalSafetyState: ElectricalSafetyState,
+    ): Map<String, Any?> {
         val factory =
-            ElectricalSafetyRegistrationCyaSummaryRowsFactory(state, uploadService) { step ->
-                Destination.VisitableStep(step, state.getCyaJourneyId(step))
+            ElectricalSafetyRegistrationCyaSummaryRowsFactory(electricalSafetyState, uploadService) { step ->
+                Destination.VisitableStep(step, cyaState.getCyaJourneyId(step))
             }
         return mapOf(
             "electricalRows" to factory.createRows(),

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/shared/helpers/ComplianceDetailsHelper.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/shared/helpers/ComplianceDetailsHelper.kt
@@ -22,7 +22,7 @@ class ComplianceDetailsHelper(
         gasSafetyState: GasSafetyState,
     ): Map<String, Any?> {
         val factory =
-            GasSafetyRegistrationCyaSummaryRowsFactory(gasSafetyState, uploadService) { step ->
+            GasSafetyRegistrationCyaSummaryRowsFactory(gasSafetyState.gasSafetyDetailsTask, uploadService) { step ->
                 Destination.VisitableStep(step, cyaState.getCyaJourneyId(step))
             }
         return mapOf(

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/shared/helpers/ComplianceDetailsHelper.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/shared/helpers/ComplianceDetailsHelper.kt
@@ -37,7 +37,7 @@ class ComplianceDetailsHelper(
         electricalSafetyState: ElectricalSafetyState,
     ): Map<String, Any?> {
         val factory =
-            ElectricalSafetyRegistrationCyaSummaryRowsFactory(electricalSafetyState, uploadService) { step ->
+            ElectricalSafetyRegistrationCyaSummaryRowsFactory(electricalSafetyState.electricalSafetyDetailsTask, uploadService) { step ->
                 Destination.VisitableStep(step, cyaState.getCyaJourneyId(step))
             }
         return mapOf(

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/shared/states/CheckYourAnswersJourneyState.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/shared/states/CheckYourAnswersJourneyState.kt
@@ -93,19 +93,6 @@ interface CheckYourAnswersJourneyState : JourneyState {
         }
 
         @Suppress("ktlint:standard:max-line-length")
-        fun <TEmbeddedState : JourneyState, TOuterState : CheckYourAnswersJourneyState, TMode : Enum<TMode>> EmbedBuilder<TEmbeddedState, TOuterState>.checkAnswerTask(
-            task: Task<TEmbeddedState>,
-            route: String? = null,
-        ) {
-            task(task) {
-                route?.let { routeSegment(it) }
-                initialStep()
-                backDestination { journey.returnToCyaPageDestination }
-                nextStep { journey.finishCyaStep }
-            }
-        }
-
-        @Suppress("ktlint:standard:max-line-length")
         fun <TJourneyState : CheckYourAnswersJourneyState, TTaskState : JourneyState> JourneyBuilder<TJourneyState>.duplicableCheckAnswerTask(
             task: DuplicableTaskWithDependencies<TTaskState, *>,
             route: String? = null,

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/shared/states/CheckYourAnswersJourneyState.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/shared/states/CheckYourAnswersJourneyState.kt
@@ -93,6 +93,19 @@ interface CheckYourAnswersJourneyState : JourneyState {
         }
 
         @Suppress("ktlint:standard:max-line-length")
+        fun <TEmbeddedState : JourneyState, TOuterState : CheckYourAnswersJourneyState, TMode : Enum<TMode>> EmbedBuilder<TEmbeddedState, TOuterState>.checkAnswerTask(
+            task: Task<TEmbeddedState>,
+            route: String? = null,
+        ) {
+            task(task) {
+                route?.let { routeSegment(it) }
+                initialStep()
+                backDestination { journey.returnToCyaPageDestination }
+                nextStep { journey.finishCyaStep }
+            }
+        }
+
+        @Suppress("ktlint:standard:max-line-length")
         fun <TJourneyState : CheckYourAnswersJourneyState, TTaskState : JourneyState> JourneyBuilder<TJourneyState>.duplicableCheckAnswerTask(
             task: DuplicableTaskWithDependencies<TTaskState, *>,
             route: String? = null,

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/shared/states/CheckYourAnswersJourneyState.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/shared/states/CheckYourAnswersJourneyState.kt
@@ -93,6 +93,19 @@ interface CheckYourAnswersJourneyState : JourneyState {
         }
 
         @Suppress("ktlint:standard:max-line-length")
+        fun <TEmbeddedState : JourneyState, TOuterState : CheckYourAnswersJourneyState> EmbedBuilder<TEmbeddedState, TOuterState>.checkAnswerTask(
+            task: Task<TEmbeddedState>,
+            route: String? = null,
+        ) {
+            task(task) {
+                route?.let { routeSegment(it) }
+                initialStep()
+                backDestination { journey.returnToCyaPageDestination }
+                nextStep { journey.finishCyaStep }
+            }
+        }
+
+        @Suppress("ktlint:standard:max-line-length")
         fun <TJourneyState : CheckYourAnswersJourneyState, TTaskState : JourneyState> JourneyBuilder<TJourneyState>.duplicableCheckAnswerTask(
             task: DuplicableTaskWithDependencies<TTaskState, *>,
             route: String? = null,

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/shared/states/CheckYourAnswersJourneyState.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/shared/states/CheckYourAnswersJourneyState.kt
@@ -93,19 +93,6 @@ interface CheckYourAnswersJourneyState : JourneyState {
         }
 
         @Suppress("ktlint:standard:max-line-length")
-        fun <TEmbeddedState : JourneyState, TOuterState : CheckYourAnswersJourneyState> EmbedBuilder<TEmbeddedState, TOuterState>.checkAnswerTask(
-            task: Task<TEmbeddedState>,
-            route: String? = null,
-        ) {
-            task(task) {
-                route?.let { routeSegment(it) }
-                initialStep()
-                backDestination { journey.returnToCyaPageDestination }
-                nextStep { journey.finishCyaStep }
-            }
-        }
-
-        @Suppress("ktlint:standard:max-line-length")
         fun <TJourneyState : CheckYourAnswersJourneyState, TTaskState : JourneyState> JourneyBuilder<TJourneyState>.duplicableCheckAnswerTask(
             task: DuplicableTaskWithDependencies<TTaskState, *>,
             route: String? = null,

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/CompleteElectricalSafetyUpdateStepConfigTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/CompleteElectricalSafetyUpdateStepConfigTests.kt
@@ -16,6 +16,7 @@ import org.mockito.kotlin.whenever
 import uk.gov.communities.prsdb.webapp.constants.enums.CertificateType
 import uk.gov.communities.prsdb.webapp.exceptions.UpdateConflictException
 import uk.gov.communities.prsdb.webapp.journeys.Destination
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.ElectricalSafetyDetailsTask
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.update.electricalSafety.CompleteElectricalSafetyUpdateStepConfig
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.update.electricalSafety.UpdateElectricalSafetyJourneyState
 import uk.gov.communities.prsdb.webapp.services.PropertyComplianceService
@@ -28,6 +29,9 @@ class CompleteElectricalSafetyUpdateStepConfigTests {
 
     @Mock
     private lateinit var mockState: UpdateElectricalSafetyJourneyState
+
+    @Mock
+    private lateinit var mockElectricalSafetyDetailsTask: ElectricalSafetyDetailsTask
 
     @Mock
     private lateinit var mockUploadService: UploadService
@@ -47,6 +51,7 @@ class CompleteElectricalSafetyUpdateStepConfigTests {
         @BeforeEach
         fun setUp() {
             whenever(mockState.propertyId).thenReturn(propertyId)
+            whenever(mockState.electricalSafetyDetailsTask).thenReturn(mockElectricalSafetyDetailsTask)
         }
 
         @Test
@@ -56,9 +61,9 @@ class CompleteElectricalSafetyUpdateStepConfigTests {
 
             whenever(mockState.previousUploadIds).thenReturn(emptyList())
             whenever(mockState.lastModifiedDate).thenReturn(initialLastModifiedDate.toString())
-            whenever(mockState.mapElectricalCertificateTypeToGlobalCertificateType()).thenReturn(CertificateType.Eicr)
-            whenever(mockState.getElectricalCertificateExpiryDateIfReachable()).thenReturn(expiryDate)
-            whenever(mockState.electricalUploadIds).thenReturn(uploadIds)
+            whenever(mockElectricalSafetyDetailsTask.mapElectricalCertificateTypeToGlobalCertificateType()).thenReturn(CertificateType.Eicr)
+            whenever(mockElectricalSafetyDetailsTask.getElectricalCertificateExpiryDateIfReachable()).thenReturn(expiryDate)
+            whenever(mockElectricalSafetyDetailsTask.electricalUploadIds).thenReturn(uploadIds)
 
             stepConfig.afterStepIsReached(mockState)
 
@@ -75,9 +80,9 @@ class CompleteElectricalSafetyUpdateStepConfigTests {
         fun `calls updateElectricalSafety with null expiry date and empty uploads`() {
             whenever(mockState.previousUploadIds).thenReturn(emptyList())
             whenever(mockState.lastModifiedDate).thenReturn(initialLastModifiedDate.toString())
-            whenever(mockState.mapElectricalCertificateTypeToGlobalCertificateType()).thenReturn(null)
-            whenever(mockState.getElectricalCertificateExpiryDateIfReachable()).thenReturn(null)
-            whenever(mockState.electricalUploadIds).thenReturn(emptyList())
+            whenever(mockElectricalSafetyDetailsTask.mapElectricalCertificateTypeToGlobalCertificateType()).thenReturn(null)
+            whenever(mockElectricalSafetyDetailsTask.getElectricalCertificateExpiryDateIfReachable()).thenReturn(null)
+            whenever(mockElectricalSafetyDetailsTask.electricalUploadIds).thenReturn(emptyList())
 
             stepConfig.afterStepIsReached(mockState)
 
@@ -115,9 +120,9 @@ class CompleteElectricalSafetyUpdateStepConfigTests {
             whenever(mockState.previousUploadIds).thenReturn(mutableListOf(10L, 20L))
 
             whenever(mockState.lastModifiedDate).thenReturn(initialLastModifiedDate.toString())
-            whenever(mockState.mapElectricalCertificateTypeToGlobalCertificateType()).thenReturn(null)
-            whenever(mockState.getElectricalCertificateExpiryDateIfReachable()).thenReturn(null)
-            whenever(mockState.electricalUploadIds).thenReturn(emptyList())
+            whenever(mockElectricalSafetyDetailsTask.mapElectricalCertificateTypeToGlobalCertificateType()).thenReturn(null)
+            whenever(mockElectricalSafetyDetailsTask.getElectricalCertificateExpiryDateIfReachable()).thenReturn(null)
+            whenever(mockElectricalSafetyDetailsTask.electricalUploadIds).thenReturn(emptyList())
 
             stepConfig.afterStepIsReached(mockState)
 

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/CompleteEpcUpdateStepConfigTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/CompleteEpcUpdateStepConfigTests.kt
@@ -21,6 +21,7 @@ import uk.gov.communities.prsdb.webapp.journeys.Destination
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.EpcExemptionStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.EpcInDateAtStartOfTenancyCheckStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.MeesExemptionStep
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.EpcDetailsTask
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.update.epc.CompleteEpcUpdateStepConfig
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.update.epc.UpdateEpcJourneyState
 import uk.gov.communities.prsdb.webapp.models.dataModels.EpcDataModel
@@ -41,6 +42,9 @@ class CompleteEpcUpdateStepConfigTests {
 
     @Mock
     private lateinit var mockState: UpdateEpcJourneyState
+
+    @Mock
+    private lateinit var mockEpcDetailsTask: EpcDetailsTask
 
     @Mock
     private lateinit var mockEpcExemptionStep: EpcExemptionStep
@@ -181,10 +185,11 @@ class CompleteEpcUpdateStepConfigTests {
 
         whenever(mockState.propertyId).thenReturn(propertyId)
         whenever(mockState.lastModifiedDate).thenReturn(initialLastModifiedDate.toString())
-        whenever(mockState.acceptedEpcIfStillAccepted).thenReturn(acceptedEpc)
-        whenever(mockState.epcExemptionStep).thenReturn(mockEpcExemptionStep)
-        whenever(mockState.meesExemptionStep).thenReturn(mockMeesExemptionStep)
-        whenever(mockState.epcInDateAtStartOfTenancyCheckStep).thenReturn(mockEpcInDateAtStartOfTenancyCheckStep)
+        whenever(mockState.epcDetailsTask).thenReturn(mockEpcDetailsTask)
+        whenever(mockEpcDetailsTask.acceptedEpcIfStillAccepted).thenReturn(acceptedEpc)
+        whenever(mockEpcDetailsTask.epcExemptionStep).thenReturn(mockEpcExemptionStep)
+        whenever(mockEpcDetailsTask.meesExemptionStep).thenReturn(mockMeesExemptionStep)
+        whenever(mockEpcDetailsTask.epcInDateAtStartOfTenancyCheckStep).thenReturn(mockEpcInDateAtStartOfTenancyCheckStep)
         whenever(mockEpcExemptionStep.formModelIfReachableOrNull).thenReturn(epcExemptionFormModel)
         whenever(mockMeesExemptionStep.formModelIfReachableOrNull).thenReturn(meesExemptionFormModel)
         whenever(mockEpcInDateAtStartOfTenancyCheckStep.formModelIfReachableOrNull).thenReturn(tenancyFormModel)

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/CompleteGasSafetyUpdateStepConfigTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/CompleteGasSafetyUpdateStepConfigTests.kt
@@ -17,6 +17,7 @@ import uk.gov.communities.prsdb.webapp.exceptions.NotNullFormModelValueIsNullExc
 import uk.gov.communities.prsdb.webapp.exceptions.UpdateConflictException
 import uk.gov.communities.prsdb.webapp.journeys.Destination
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.HasGasSupplyStep
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.GasSafetyDetailsTask
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.update.gasSafety.CompleteGasSafetyUpdateStepConfig
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.update.gasSafety.UpdateGasSafetyJourneyState
 import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.GasSupplyFormModel
@@ -52,9 +53,13 @@ class CompleteGasSafetyUpdateStepConfigTests {
 
     @Nested
     inner class AfterStepIsReached {
+        @Mock
+        private lateinit var mockDetailTask: GasSafetyDetailsTask
+
         @BeforeEach
         fun setUp() {
             whenever(mockState.propertyId).thenReturn(propertyId)
+            whenever(mockState.gasSafetyDetailsTask).thenReturn(mockDetailTask)
         }
 
         @Test
@@ -64,11 +69,11 @@ class CompleteGasSafetyUpdateStepConfigTests {
 
             whenever(mockState.previousUploadIds).thenReturn(emptyList())
             whenever(mockState.lastModifiedDate).thenReturn(initialLastModifiedDate.toString())
-            whenever(mockState.hasGasSupplyStep).thenReturn(mockHasGasSupplyStep)
+            whenever(mockDetailTask.hasGasSupplyStep).thenReturn(mockHasGasSupplyStep)
             whenever(mockHasGasSupplyStep.formModel).thenReturn(mockGasSupplyFormModel)
             whenever(mockGasSupplyFormModel.hasGasSupply).thenReturn(true)
-            whenever(mockState.getGasSafetyCertificateIssueDateIfReachable()).thenReturn(issueDate)
-            whenever(mockState.gasUploadIds).thenReturn(uploadIds)
+            whenever(mockDetailTask.getGasSafetyCertificateIssueDateIfReachable()).thenReturn(issueDate)
+            whenever(mockDetailTask.gasUploadIds).thenReturn(uploadIds)
 
             stepConfig.afterStepIsReached(mockState)
 
@@ -85,11 +90,11 @@ class CompleteGasSafetyUpdateStepConfigTests {
         fun `calls updateGasSafety with no gas supply and null issue date`() {
             whenever(mockState.previousUploadIds).thenReturn(emptyList())
             whenever(mockState.lastModifiedDate).thenReturn(initialLastModifiedDate.toString())
-            whenever(mockState.hasGasSupplyStep).thenReturn(mockHasGasSupplyStep)
+            whenever(mockDetailTask.hasGasSupplyStep).thenReturn(mockHasGasSupplyStep)
             whenever(mockHasGasSupplyStep.formModel).thenReturn(mockGasSupplyFormModel)
             whenever(mockGasSupplyFormModel.hasGasSupply).thenReturn(false)
-            whenever(mockState.getGasSafetyCertificateIssueDateIfReachable()).thenReturn(null)
-            whenever(mockState.gasUploadIds).thenReturn(emptyList())
+            whenever(mockDetailTask.getGasSafetyCertificateIssueDateIfReachable()).thenReturn(null)
+            whenever(mockDetailTask.gasUploadIds).thenReturn(emptyList())
 
             stepConfig.afterStepIsReached(mockState)
 
@@ -105,7 +110,7 @@ class CompleteGasSafetyUpdateStepConfigTests {
         @Test
         fun `throws NotNullFormModelValueIsNullException when hasGasSupply is null`() {
             whenever(mockState.lastModifiedDate).thenReturn(initialLastModifiedDate.toString())
-            whenever(mockState.hasGasSupplyStep).thenReturn(mockHasGasSupplyStep)
+            whenever(mockDetailTask.hasGasSupplyStep).thenReturn(mockHasGasSupplyStep)
             whenever(mockHasGasSupplyStep.formModel).thenReturn(mockGasSupplyFormModel)
             whenever(mockGasSupplyFormModel.hasGasSupply).thenReturn(null)
 
@@ -118,7 +123,7 @@ class CompleteGasSafetyUpdateStepConfigTests {
         fun `deletes the journey then rethrows when it gets an UpdateConflictException`() {
             // Arrange
             whenever(mockState.lastModifiedDate).thenReturn(initialLastModifiedDate.toString())
-            whenever(mockState.hasGasSupplyStep).thenReturn(mockHasGasSupplyStep)
+            whenever(mockDetailTask.hasGasSupplyStep).thenReturn(mockHasGasSupplyStep)
             whenever(mockHasGasSupplyStep.formModel).thenReturn(mockGasSupplyFormModel)
             whenever(mockGasSupplyFormModel.hasGasSupply).thenReturn(false)
 
@@ -143,11 +148,11 @@ class CompleteGasSafetyUpdateStepConfigTests {
             whenever(mockState.previousUploadIds).thenReturn(mutableListOf(10L, 20L))
 
             whenever(mockState.lastModifiedDate).thenReturn(initialLastModifiedDate.toString())
-            whenever(mockState.hasGasSupplyStep).thenReturn(mockHasGasSupplyStep)
+            whenever(mockDetailTask.hasGasSupplyStep).thenReturn(mockHasGasSupplyStep)
             whenever(mockHasGasSupplyStep.formModel).thenReturn(mockGasSupplyFormModel)
             whenever(mockGasSupplyFormModel.hasGasSupply).thenReturn(false)
-            whenever(mockState.getGasSafetyCertificateIssueDateIfReachable()).thenReturn(null)
-            whenever(mockState.gasUploadIds).thenReturn(emptyList())
+            whenever(mockDetailTask.getGasSafetyCertificateIssueDateIfReachable()).thenReturn(null)
+            whenever(mockDetailTask.gasUploadIds).thenReturn(emptyList())
 
             stepConfig.afterStepIsReached(mockState)
 

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/ElectricalSafetyRegistrationCyaSummaryRowsFactoryTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/ElectricalSafetyRegistrationCyaSummaryRowsFactoryTests.kt
@@ -16,7 +16,7 @@ import uk.gov.communities.prsdb.webapp.constants.enums.FileUploadStatus
 import uk.gov.communities.prsdb.webapp.constants.enums.HasElectricalSafetyCertificate
 import uk.gov.communities.prsdb.webapp.database.entity.FileUpload
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.CertificateUpload
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.ElectricalSafetyState
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.ElectricalSafetyDetailState
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.CheckElectricalCertUploadsStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.ElectricalCertExpiryDateStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.HasElectricalCertMode
@@ -27,7 +27,7 @@ import uk.gov.communities.prsdb.webapp.services.UploadService
 @ExtendWith(MockitoExtension::class)
 class ElectricalSafetyRegistrationCyaSummaryRowsFactoryTests {
     @Mock
-    lateinit var mockState: ElectricalSafetyState
+    lateinit var mockState: ElectricalSafetyDetailState
 
     private val mockHasElectricalCertStep: HasElectricalCertStep = mock()
     private val mockElectricalCertExpiryDateStep: ElectricalCertExpiryDateStep = mock()

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/EpcRegistrationCyaSummaryRowsFactoryTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/EpcRegistrationCyaSummaryRowsFactoryTests.kt
@@ -7,7 +7,7 @@ import org.mockito.kotlin.whenever
 import uk.gov.communities.prsdb.webapp.constants.enums.EpcExemptionReason
 import uk.gov.communities.prsdb.webapp.constants.enums.MeesExemptionReason
 import uk.gov.communities.prsdb.webapp.journeys.Destination
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.EpcState
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.EpcDetailState
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.EpcAgeCheckMode
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.EpcAgeCheckStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.EpcEnergyRatingCheckMode
@@ -48,7 +48,7 @@ class EpcRegistrationCyaSummaryRowsFactoryTests {
     private val mockIsEpcRequiredStep: IsEpcRequiredStep = mock()
     private val mockEpcExemptionStep: EpcExemptionStep = mock()
     private val mockStartEpcStep: StartEpcStep = mock()
-    private val mockState: EpcState = mock()
+    private val mockState: EpcDetailState = mock()
 
     private val epcUrl = "https://find-energy-certificate.service.gov.uk/energy-certificate/0000-0000-0000-0892-1563"
     private val validEpc = MockEpcData.createEpcDataModel(energyRating = "C")

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/GasSafetyRegistrationCyaSummaryRowsFactoryTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/GasSafetyRegistrationCyaSummaryRowsFactoryTests.kt
@@ -15,7 +15,7 @@ import org.mockito.kotlin.whenever
 import uk.gov.communities.prsdb.webapp.constants.enums.FileUploadStatus
 import uk.gov.communities.prsdb.webapp.database.entity.FileUpload
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.CertificateUpload
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.GasSafetyState
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.GasSafetyDetailState
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.CheckGasCertUploadsStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.GasCertIssueDateStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.HasGasCertMode
@@ -29,7 +29,7 @@ import uk.gov.communities.prsdb.webapp.services.UploadService
 @ExtendWith(MockitoExtension::class)
 class GasSafetyRegistrationCyaSummaryRowsFactoryTests {
     @Mock
-    lateinit var mockState: GasSafetyState
+    lateinit var mockState: GasSafetyDetailState
 
     private val mockHasGasSupplyStep: HasGasSupplyStep = mock()
     private val mockHasGasCertStep: HasGasCertStep = mock()

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/states/ElectricalSafetyDetailsStateTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/states/ElectricalSafetyDetailsStateTests.kt
@@ -12,7 +12,6 @@ import uk.gov.communities.prsdb.webapp.constants.enums.CertificateType
 import uk.gov.communities.prsdb.webapp.constants.enums.HasElectricalSafetyCertificate
 import uk.gov.communities.prsdb.webapp.journeys.AbstractJourneyState
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.CheckElectricalCertUploadsStep
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.CheckElectricalSafetyAnswersStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.ElectricalCertExpiredStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.ElectricalCertExpiryDateStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.ElectricalCertMissingStep
@@ -21,18 +20,17 @@ import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.HasEl
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.ProvideElectricalCertLaterStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.RemoveElectricalCertUploadStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.UploadElectricalCertStep
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.ElectricalSafetyDetailsTask
 import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.AnyDateFormModel
 import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.HasElectricalCertFormModel
 import java.time.LocalDate
 
-class ElectricalSafetyStateTests {
+class ElectricalSafetyDetailsStateTests {
     @Test
     fun `getElectricalCertificateExpiryDateIfReachable returns the expiry date from state as a LocalDate`() {
         // Arrange
         val expiryDate = LocalDate.of(2030, 1, 1)
         val expiryDateFormModel = AnyDateFormModel().applyFromDate(expiryDate)
-        val state = buildTestElectricalSafetyState(expiryDateFormModel = expiryDateFormModel)
+        val state = buildTestElectricalSafetyDetailState(expiryDateFormModel = expiryDateFormModel)
 
         // Act
         val retrievedExpiryDate = state.getElectricalCertificateExpiryDateIfReachable()
@@ -43,13 +41,13 @@ class ElectricalSafetyStateTests {
 
     @Test
     fun `getElectricalCertificateExpiryDateIfReachable returns null if the expiry date is not set`() {
-        val state = buildTestElectricalSafetyState(expiryDateStepShouldBeReachable = true)
+        val state = buildTestElectricalSafetyDetailState(expiryDateStepShouldBeReachable = true)
         assertNull(state.getElectricalCertificateExpiryDateIfReachable())
     }
 
     @Test
     fun `getElectricalCertificateExpiryDateIfReachable returns null if formModelIfReachableOrNull is null`() {
-        val state = buildTestElectricalSafetyState(expiryDateStepShouldBeReachable = false)
+        val state = buildTestElectricalSafetyDetailState(expiryDateStepShouldBeReachable = false)
         assertNull(state.getElectricalCertificateExpiryDateIfReachable())
     }
 
@@ -58,7 +56,7 @@ class ElectricalSafetyStateTests {
         // Arrange
         val expiryDate = LocalDate.now().minusDays(5)
         val expiryDateFormModel = AnyDateFormModel().applyFromDate(expiryDate)
-        val state = buildTestElectricalSafetyState(expiryDateFormModel = expiryDateFormModel)
+        val state = buildTestElectricalSafetyDetailState(expiryDateFormModel = expiryDateFormModel)
 
         // Act, Assert
         assertTrue(state.getElectricalCertificateIsOutdated()!!)
@@ -69,7 +67,7 @@ class ElectricalSafetyStateTests {
         // Arrange
         val expiryDate = LocalDate.now().plusDays(5)
         val expiryDateFormModel = AnyDateFormModel().applyFromDate(expiryDate)
-        val state = buildTestElectricalSafetyState(expiryDateFormModel = expiryDateFormModel)
+        val state = buildTestElectricalSafetyDetailState(expiryDateFormModel = expiryDateFormModel)
 
         // Act, Assert
         assertFalse(state.getElectricalCertificateIsOutdated()!!)
@@ -80,7 +78,7 @@ class ElectricalSafetyStateTests {
         // Arrange
         val expiryDate = LocalDate.now()
         val expiryDateFormModel = AnyDateFormModel().applyFromDate(expiryDate)
-        val state = buildTestElectricalSafetyState(expiryDateFormModel = expiryDateFormModel)
+        val state = buildTestElectricalSafetyDetailState(expiryDateFormModel = expiryDateFormModel)
 
         // Act, Assert
         assertTrue(state.getElectricalCertificateIsOutdated()!!)
@@ -88,64 +86,64 @@ class ElectricalSafetyStateTests {
 
     @Test
     fun `getElectricalCertificateIsOutdated returns null if the expiryDate is null`() {
-        val state = buildTestElectricalSafetyState()
+        val state = buildTestElectricalSafetyDetailState()
         assertNull(state.getElectricalCertificateIsOutdated())
     }
 
     @Test
     fun `getElectricalCertificateType returns HAS_EIC when EIC is selected`() {
         val formModel = HasElectricalCertFormModel().apply { electricalCertType = HasElectricalSafetyCertificate.HAS_EIC }
-        val state = buildTestElectricalSafetyState(hasElectricalCertFormModel = formModel)
+        val state = buildTestElectricalSafetyDetailState(hasElectricalCertFormModel = formModel)
         assertEquals(HasElectricalSafetyCertificate.HAS_EIC, state.getElectricalCertificateType())
     }
 
     @Test
     fun `getElectricalCertificateType returns HAS_EICR when EICR is selected`() {
         val formModel = HasElectricalCertFormModel().apply { electricalCertType = HasElectricalSafetyCertificate.HAS_EICR }
-        val state = buildTestElectricalSafetyState(hasElectricalCertFormModel = formModel)
+        val state = buildTestElectricalSafetyDetailState(hasElectricalCertFormModel = formModel)
         assertEquals(HasElectricalSafetyCertificate.HAS_EICR, state.getElectricalCertificateType())
     }
 
     @Test
     fun `getElectricalCertificateType returns null when step is not reachable`() {
-        val state = buildTestElectricalSafetyState(hasElectricalCertStepShouldBeReachable = false)
+        val state = buildTestElectricalSafetyDetailState(hasElectricalCertStepShouldBeReachable = false)
         assertNull(state.getElectricalCertificateType())
     }
 
     @Test
     fun `mapElectricalCertificateTypeToGlobalCertificateType returns Eic when HAS_EIC is selected`() {
         val formModel = HasElectricalCertFormModel().apply { electricalCertType = HasElectricalSafetyCertificate.HAS_EIC }
-        val state = buildTestElectricalSafetyState(hasElectricalCertFormModel = formModel)
+        val state = buildTestElectricalSafetyDetailState(hasElectricalCertFormModel = formModel)
         assertEquals(CertificateType.Eic, state.mapElectricalCertificateTypeToGlobalCertificateType())
     }
 
     @Test
     fun `mapElectricalCertificateTypeToGlobalCertificateType returns Eicr when HAS_EICR is selected`() {
         val formModel = HasElectricalCertFormModel().apply { electricalCertType = HasElectricalSafetyCertificate.HAS_EICR }
-        val state = buildTestElectricalSafetyState(hasElectricalCertFormModel = formModel)
+        val state = buildTestElectricalSafetyDetailState(hasElectricalCertFormModel = formModel)
         assertEquals(CertificateType.Eicr, state.mapElectricalCertificateTypeToGlobalCertificateType())
     }
 
     @Test
     fun `mapElectricalCertificateTypeToGlobalCertificateType returns null when NO_CERTIFICATE is selected`() {
-        val state = buildTestElectricalSafetyState(hasElectricalCertStepShouldBeReachable = false)
+        val state = buildTestElectricalSafetyDetailState(hasElectricalCertStepShouldBeReachable = false)
         assertNull(state.mapElectricalCertificateTypeToGlobalCertificateType())
     }
 
     @Test
     fun `mapElectricalCertificateTypeToGlobalCertificateType returns null when step is not reachable`() {
         val formModel = HasElectricalCertFormModel().apply { electricalCertType = HasElectricalSafetyCertificate.NO_CERTIFICATE }
-        val state = buildTestElectricalSafetyState(hasElectricalCertFormModel = formModel)
+        val state = buildTestElectricalSafetyDetailState(hasElectricalCertFormModel = formModel)
         assertNull(state.mapElectricalCertificateTypeToGlobalCertificateType())
     }
 
-    private fun buildTestElectricalSafetyState(
+    private fun buildTestElectricalSafetyDetailState(
         expiryDateFormModel: AnyDateFormModel = AnyDateFormModel(),
         expiryDateStepShouldBeReachable: Boolean = true,
         hasElectricalCertFormModel: HasElectricalCertFormModel? = null,
         hasElectricalCertStepShouldBeReachable: Boolean = true,
-    ): ElectricalSafetyState =
-        object : AbstractJourneyState(journeyStateService = mock()), ElectricalSafetyState {
+    ): ElectricalSafetyDetailState =
+        object : AbstractJourneyState(journeyStateService = mock()), ElectricalSafetyDetailState {
             override val isOccupied: Boolean = true
             override var electricalUploadMap: Map<Int, CertificateUpload> = mapOf()
             override var highestAssignedElectricalMemberId: Int? = null
@@ -157,9 +155,6 @@ class ElectricalSafetyStateTests {
             override val electricalCertMissingStep = mock<ElectricalCertMissingStep>()
             override val allowProvideCertificateLaterRoute: Boolean = true
             override val provideElectricalCertLaterStep = mock<ProvideElectricalCertLaterStep>()
-            override val checkElectricalSafetyAnswersStep = mock<CheckElectricalSafetyAnswersStep>()
-            override val electricalSafetyDetailsTask =
-                mock<ElectricalSafetyDetailsTask>()
 
             override val hasElectricalCertStep =
                 mock<HasElectricalCertStep>().apply {

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/states/EpcDetailsStateTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/states/EpcDetailsStateTests.kt
@@ -8,7 +8,6 @@ import org.mockito.Mockito.mock
 import org.mockito.kotlin.whenever
 import uk.gov.communities.prsdb.webapp.exceptions.PrsdbWebException
 import uk.gov.communities.prsdb.webapp.journeys.AbstractJourneyState
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.CheckEpcAnswersStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.ConfirmEpcDetailsRetrievedByCertificateNumberStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.ConfirmEpcRetrievedByUprnStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.EpcAgeCheckStep
@@ -29,16 +28,15 @@ import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.MeesE
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.PropertyOccupiedCheckStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.ProvideEpcLaterStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.StartEpcStep
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.EpcDetailsTask
 import uk.gov.communities.prsdb.webapp.journeys.shared.Complete
 import uk.gov.communities.prsdb.webapp.journeys.shared.YesOrNo
 import uk.gov.communities.prsdb.webapp.models.dataModels.EpcDataModel
 
-class EpcStateTests {
+class EpcDetailsStateTests {
     @Test
     fun `acceptedEpcIfStillAccepted returns acceptedEpc when checkUprnMatchedEpcStep has outcome YES`() {
         val epc = mock<EpcDataModel>()
-        val state = buildTestEpcState(acceptedEpc = epc, uprnStepOutcome = YesOrNo.YES)
+        val state = buildTestEpcDetailsState(acceptedEpc = epc, uprnStepOutcome = YesOrNo.YES)
 
         assertEquals(epc, state.acceptedEpcIfStillAccepted)
     }
@@ -46,7 +44,7 @@ class EpcStateTests {
     @Test
     fun `acceptedEpcIfStillAccepted returns acceptedEpc when confirmEpcDetailsRetrievedByCertificateNumberStep has outcome YES`() {
         val epc = mock<EpcDataModel>()
-        val state = buildTestEpcState(acceptedEpc = epc, certStepOutcome = YesOrNo.YES)
+        val state = buildTestEpcDetailsState(acceptedEpc = epc, certStepOutcome = YesOrNo.YES)
 
         assertEquals(epc, state.acceptedEpcIfStillAccepted)
     }
@@ -54,7 +52,7 @@ class EpcStateTests {
     @Test
     fun `acceptedEpcIfStillAccepted returns acceptedEpc when checkSuperseededEpcStep has outcome COMPLETE`() {
         val epc = mock<EpcDataModel>()
-        val state = buildTestEpcState(acceptedEpc = epc, supersededStepOutcome = Complete.COMPLETE)
+        val state = buildTestEpcDetailsState(acceptedEpc = epc, supersededStepOutcome = Complete.COMPLETE)
 
         assertEquals(epc, state.acceptedEpcIfStillAccepted)
     }
@@ -62,25 +60,25 @@ class EpcStateTests {
     @Test
     fun `acceptedEpcIfStillAccepted returns null when no confirm step has a positive outcome`() {
         val epc = mock<EpcDataModel>()
-        val state = buildTestEpcState(acceptedEpc = epc)
+        val state = buildTestEpcDetailsState(acceptedEpc = epc)
 
         assertNull(state.acceptedEpcIfStillAccepted)
     }
 
     @Test
     fun `acceptedEpcIfStillAccepted throws when acceptedEpc is null and a confirm step has positive outcome`() {
-        val state = buildTestEpcState(acceptedEpc = null, uprnStepOutcome = YesOrNo.YES)
+        val state = buildTestEpcDetailsState(acceptedEpc = null, uprnStepOutcome = YesOrNo.YES)
 
         assertThrows<PrsdbWebException> { state.acceptedEpcIfStillAccepted }
     }
 
-    private fun buildTestEpcState(
+    private fun buildTestEpcDetailsState(
         acceptedEpc: EpcDataModel? = null,
         uprnStepOutcome: YesOrNo? = null,
         certStepOutcome: YesOrNo? = null,
         supersededStepOutcome: Complete? = null,
-    ): EpcState =
-        object : AbstractJourneyState(journeyStateService = mock()), EpcState {
+    ): EpcDetailState =
+        object : AbstractJourneyState(journeyStateService = mock()), EpcDetailState {
             override val isOccupied: Boolean? = null
             override val uprn: Long? = null
             override val allowProvideCertificateLaterRoute: Boolean = true
@@ -127,7 +125,5 @@ class EpcStateTests {
             override val epcExemptionStep = mock<EpcExemptionStep>()
             override val epcMissingStep = mock<EpcMissingStep>()
             override val provideEpcLaterStep = mock<ProvideEpcLaterStep>()
-            override val checkEpcAnswersStep = mock<CheckEpcAnswersStep>()
-            override val epcDetailsTask = mock<EpcDetailsTask>()
         }
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/states/GasSafetyDetailsStateTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/states/GasSafetyDetailsStateTests.kt
@@ -11,7 +11,6 @@ import org.mockito.kotlin.whenever
 import uk.gov.communities.prsdb.webapp.constants.GAS_SAFETY_CERT_VALIDITY_YEARS
 import uk.gov.communities.prsdb.webapp.journeys.AbstractJourneyState
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.CheckGasCertUploadsStep
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.CheckGasSafetyAnswersStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.GasCertExpiredStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.GasCertIssueDateStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.GasCertMissingStep
@@ -21,11 +20,10 @@ import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.HasGa
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.ProvideGasCertLaterStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.RemoveGasCertUploadStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.UploadGasCertStep
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.GasSafetyDetailsTask
 import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.TodayOrPastDateFormModel
 import java.time.LocalDate
 
-class GasSafetyStateTests {
+class GasSafetyDetailsStateTests {
     @Test
     fun `getGasSafetyCertificateIssueDateIfReachable returns the issue date from state as a LocalDate`() {
         // Arrange
@@ -94,8 +92,8 @@ class GasSafetyStateTests {
     private fun buildTestGasSafetyState(
         issueDateFormModel: TodayOrPastDateFormModel = TodayOrPastDateFormModel(),
         issueDateStepShouldBeReachable: Boolean = true,
-    ): GasSafetyState =
-        object : AbstractJourneyState(journeyStateService = mock()), GasSafetyState {
+    ): GasSafetyDetailState =
+        object : AbstractJourneyState(journeyStateService = mock()), GasSafetyDetailState {
             override val allowProvideCertificateLaterRoute: Boolean = true
             override val isOccupied: Boolean = false
             override var gasUploadMap: Map<Int, CertificateUpload> = emptyMap()
@@ -108,9 +106,7 @@ class GasSafetyStateTests {
             override val gasCertExpiredStep = mock<GasCertExpiredStep>()
             override val gasCertMissingStep = mock<GasCertMissingStep>()
             override val provideGasCertLaterStep = mock<ProvideGasCertLaterStep>()
-            override val checkGasSafetyAnswersStep = mock<CheckGasSafetyAnswersStep>()
-            override val gasSafetyDetailsTask = mock<GasSafetyDetailsTask>()
-            override val hasUploadedCert: HasAnyInCollectionStep = mock<HasAnyInCollectionStep>()
+            override val hasUploadedCert: HasAnyInCollectionStep = mock()
 
             override val gasCertIssueDateStep =
                 mock<GasCertIssueDateStep>().apply {

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/AbstractConfirmEpcDetailsStepConfigTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/AbstractConfirmEpcDetailsStepConfigTests.kt
@@ -11,7 +11,7 @@ import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.EpcState
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.EpcDetailState
 import uk.gov.communities.prsdb.webapp.journeys.shared.YesOrNo
 import uk.gov.communities.prsdb.webapp.models.dataModels.EpcDataModel
 import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.ConfirmEpcDetailsFromUprnFormModel
@@ -21,7 +21,7 @@ import uk.gov.communities.prsdb.webapp.testHelpers.mockObjects.MockEpcData
 @ExtendWith(MockitoExtension::class)
 class AbstractConfirmEpcDetailsStepConfigTests {
     @Mock
-    lateinit var mockState: EpcState
+    lateinit var mockState: EpcDetailState
 
     private val routeSegment = "test-route-segment"
 
@@ -30,9 +30,9 @@ class AbstractConfirmEpcDetailsStepConfigTests {
             object : AbstractConfirmEpcDetailsStepConfig<ConfirmEpcDetailsFromUprnFormModel>() {
                 override val formModelClass = ConfirmEpcDetailsFromUprnFormModel::class
 
-                override fun getStepSpecificContent(state: EpcState) = emptyMap<String, Any?>()
+                override fun getStepSpecificContent(state: EpcDetailState) = emptyMap<String, Any?>()
 
-                override fun chooseTemplate(state: EpcState) = ""
+                override fun chooseTemplate(state: EpcDetailState) = ""
             }
         stepConfig.usingEpc { usingEpc }
         stepConfig.routeSegment = routeSegment

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/CheckElectricalCertUploadsStepConfigTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/CheckElectricalCertUploadsStepConfigTests.kt
@@ -15,7 +15,7 @@ import org.mockito.kotlin.whenever
 import uk.gov.communities.prsdb.webapp.constants.enums.FileUploadStatus
 import uk.gov.communities.prsdb.webapp.database.entity.FileUpload
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.CertificateUpload
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.ElectricalSafetyState
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.ElectricalSafetyDetailState
 import uk.gov.communities.prsdb.webapp.journeys.shared.Complete
 import uk.gov.communities.prsdb.webapp.services.CollectionKeyParameterService
 import uk.gov.communities.prsdb.webapp.services.UploadService
@@ -24,7 +24,7 @@ import uk.gov.communities.prsdb.webapp.testHelpers.mockObjects.AlwaysTrueValidat
 @ExtendWith(MockitoExtension::class)
 class CheckElectricalCertUploadsStepConfigTests {
     @Mock
-    lateinit var mockState: ElectricalSafetyState
+    lateinit var mockState: ElectricalSafetyDetailState
 
     @Mock
     lateinit var mockMemberIdService: CollectionKeyParameterService

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/ConfirmEpcDetailsRetrievedByCertificateNumberStepConfigTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/ConfirmEpcDetailsRetrievedByCertificateNumberStepConfigTests.kt
@@ -7,7 +7,7 @@ import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.EpcState
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.EpcDetailState
 import uk.gov.communities.prsdb.webapp.services.EpcCertificateUrlProvider
 import uk.gov.communities.prsdb.webapp.testHelpers.mockObjects.AlwaysTrueValidator
 
@@ -17,7 +17,7 @@ class ConfirmEpcDetailsRetrievedByCertificateNumberStepConfigTests {
     lateinit var mockEpcCertificateUrlProvider: EpcCertificateUrlProvider
 
     @Mock
-    lateinit var mockState: EpcState
+    lateinit var mockState: EpcDetailState
 
     private val routeSegment = ConfirmEpcDetailsRetrievedByCertificateNumberStep.ROUTE_SEGMENT
 

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/ConfirmEpcRetrievedByUprnStepConfigTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/ConfirmEpcRetrievedByUprnStepConfigTests.kt
@@ -7,7 +7,7 @@ import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.EpcState
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.EpcDetailState
 import uk.gov.communities.prsdb.webapp.services.EpcCertificateUrlProvider
 import uk.gov.communities.prsdb.webapp.testHelpers.mockObjects.AlwaysTrueValidator
 
@@ -17,7 +17,7 @@ class ConfirmEpcRetrievedByUprnStepConfigTests {
     lateinit var mockEpcCertificateUrlProvider: EpcCertificateUrlProvider
 
     @Mock
-    lateinit var mockState: EpcState
+    lateinit var mockState: EpcDetailState
 
     private val routeSegment = ConfirmEpcRetrievedByUprnStep.ROUTE_SEGMENT
 

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/ElectricalCertExpiredStepConfigTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/ElectricalCertExpiredStepConfigTests.kt
@@ -6,13 +6,13 @@ import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.whenever
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.ElectricalSafetyState
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.ElectricalSafetyDetailState
 import uk.gov.communities.prsdb.webapp.testHelpers.mockObjects.AlwaysTrueValidator
 
 @ExtendWith(MockitoExtension::class)
 class ElectricalCertExpiredStepConfigTests {
     @Mock
-    lateinit var mockState: ElectricalSafetyState
+    lateinit var mockState: ElectricalSafetyDetailState
 
     @Test
     fun `chooseTemplate returns occupied template when isOccupied is true`() {

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/ElectricalCertExpiryDateStepConfigTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/ElectricalCertExpiryDateStepConfigTests.kt
@@ -7,13 +7,13 @@ import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.whenever
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.ElectricalSafetyState
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.ElectricalSafetyDetailState
 import uk.gov.communities.prsdb.webapp.testHelpers.mockObjects.AlwaysTrueValidator
 
 @ExtendWith(MockitoExtension::class)
 class ElectricalCertExpiryDateStepConfigTests {
     @Mock
-    lateinit var mockState: ElectricalSafetyState
+    lateinit var mockState: ElectricalSafetyDetailState
 
     @Test
     fun `mode returns null when getElectricalCertificateIsOutdated returns null`() {

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/ElectricalCertMissingStepConfigTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/ElectricalCertMissingStepConfigTests.kt
@@ -6,13 +6,13 @@ import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.whenever
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.ElectricalSafetyState
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.ElectricalSafetyDetailState
 import uk.gov.communities.prsdb.webapp.testHelpers.mockObjects.AlwaysTrueValidator
 
 @ExtendWith(MockitoExtension::class)
 class ElectricalCertMissingStepConfigTests {
     @Mock
-    lateinit var mockState: ElectricalSafetyState
+    lateinit var mockState: ElectricalSafetyDetailState
 
     @Test
     fun `chooseTemplate returns occupied template when isOccupied is true`() {

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/EpcAgeCheckStepConfigTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/EpcAgeCheckStepConfigTests.kt
@@ -9,14 +9,14 @@ import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.whenever
 import uk.gov.communities.prsdb.webapp.exceptions.NotNullFormModelValueIsNullException
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.EpcState
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.EpcDetailState
 import uk.gov.communities.prsdb.webapp.testHelpers.mockObjects.MockEpcData
 import java.time.LocalDate
 
 @ExtendWith(MockitoExtension::class)
 class EpcAgeCheckStepConfigTests {
     @Mock
-    lateinit var mockState: EpcState
+    lateinit var mockState: EpcDetailState
 
     @Test
     fun `mode throws exception when acceptedEpc is null`() {

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/EpcEnergyRatingCheckStepConfigTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/EpcEnergyRatingCheckStepConfigTests.kt
@@ -8,13 +8,13 @@ import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.whenever
 import uk.gov.communities.prsdb.webapp.exceptions.NotNullFormModelValueIsNullException
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.EpcState
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.EpcDetailState
 import uk.gov.communities.prsdb.webapp.testHelpers.mockObjects.MockEpcData
 
 @ExtendWith(MockitoExtension::class)
 class EpcEnergyRatingCheckStepConfigTests {
     @Mock
-    lateinit var mockState: EpcState
+    lateinit var mockState: EpcDetailState
 
     @Test
     fun `mode throws exception when acceptedEpc is null`() {

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/EpcExpiredStepConfigTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/EpcExpiredStepConfigTests.kt
@@ -7,13 +7,13 @@ import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.whenever
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.EpcState
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.EpcDetailState
 import uk.gov.communities.prsdb.webapp.testHelpers.mockObjects.AlwaysTrueValidator
 
 @ExtendWith(MockitoExtension::class)
 class EpcExpiredStepConfigTests {
     @Mock
-    lateinit var mockState: EpcState
+    lateinit var mockState: EpcDetailState
 
     @Test
     fun `chooseTemplate returns occupied template when isOccupied is true`() {

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/EpcInDateAtStartOfTenancyCheckStepConfigTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/EpcInDateAtStartOfTenancyCheckStepConfigTests.kt
@@ -7,13 +7,13 @@ import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.whenever
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.EpcState
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.EpcDetailState
 import uk.gov.communities.prsdb.webapp.testHelpers.mockObjects.AlwaysTrueValidator
 
 @ExtendWith(MockitoExtension::class)
 class EpcInDateAtStartOfTenancyCheckStepConfigTests {
     @Mock
-    lateinit var mockState: EpcState
+    lateinit var mockState: EpcDetailState
 
     private val routeSegment = EpcInDateAtStartOfTenancyCheckStep.ROUTE_SEGMENT
 

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/EpcLookupByUprnStepConfigTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/EpcLookupByUprnStepConfigTests.kt
@@ -10,7 +10,7 @@ import org.mockito.kotlin.any
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.EpcState
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.EpcDetailState
 import uk.gov.communities.prsdb.webapp.models.dataModels.EpcDataModel
 import uk.gov.communities.prsdb.webapp.services.EpcLookupService
 import uk.gov.communities.prsdb.webapp.testHelpers.mockObjects.MockEpcData
@@ -21,7 +21,7 @@ class EpcLookupByUprnStepConfigTests {
     lateinit var mockEpcLookupService: EpcLookupService
 
     @Mock
-    lateinit var mockState: EpcState
+    lateinit var mockState: EpcDetailState
 
     val epcDataModel: EpcDataModel = MockEpcData.createEpcDataModel()
 

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/EpcMissingStepConfigTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/EpcMissingStepConfigTests.kt
@@ -7,13 +7,13 @@ import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.whenever
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.EpcState
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.EpcDetailState
 import uk.gov.communities.prsdb.webapp.testHelpers.mockObjects.AlwaysTrueValidator
 
 @ExtendWith(MockitoExtension::class)
 class EpcMissingStepConfigTests {
     @Mock
-    lateinit var mockState: EpcState
+    lateinit var mockState: EpcDetailState
 
     @Test
     fun `chooseTemplate returns occupied template when isOccupied is true`() {

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/EpcNotFoundStepConfigTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/EpcNotFoundStepConfigTests.kt
@@ -7,7 +7,7 @@ import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.whenever
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.EpcState
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.EpcDetailState
 import uk.gov.communities.prsdb.webapp.journeys.shared.Complete
 import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.FindEpcByCertificateNumberFormModel
 import uk.gov.communities.prsdb.webapp.testHelpers.mockObjects.AlwaysTrueValidator
@@ -15,7 +15,7 @@ import uk.gov.communities.prsdb.webapp.testHelpers.mockObjects.AlwaysTrueValidat
 @ExtendWith(MockitoExtension::class)
 class EpcNotFoundStepConfigTests {
     @Mock
-    lateinit var mockState: EpcState
+    lateinit var mockState: EpcDetailState
 
     @Mock
     lateinit var mockFindYourEpcStep: FindYourEpcStep

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/EpcSuperseededStepConfigTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/EpcSuperseededStepConfigTests.kt
@@ -7,7 +7,7 @@ import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.EpcState
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.EpcDetailState
 import uk.gov.communities.prsdb.webapp.services.EpcCertificateUrlProvider
 import uk.gov.communities.prsdb.webapp.testHelpers.mockObjects.AlwaysTrueValidator
 import uk.gov.communities.prsdb.webapp.testHelpers.mockObjects.MockEpcData
@@ -18,7 +18,7 @@ class EpcSuperseededStepConfigTests {
     lateinit var mockEpcCertificateUrlProvider: EpcCertificateUrlProvider
 
     @Mock
-    lateinit var mockState: EpcState
+    lateinit var mockState: EpcDetailState
 
     val routeSegment = EpcSuperseededStep.ROUTE_SEGMENT
 

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/FindYourEpcStepConfigTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/FindYourEpcStepConfigTests.kt
@@ -9,7 +9,7 @@ import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.EpcState
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.EpcDetailState
 import uk.gov.communities.prsdb.webapp.services.EpcLookupService
 import uk.gov.communities.prsdb.webapp.testHelpers.mockObjects.AlwaysTrueValidator
 import uk.gov.communities.prsdb.webapp.testHelpers.mockObjects.MockEpcData
@@ -20,7 +20,7 @@ class FindYourEpcStepConfigTests {
     lateinit var mockEpcLookupService: EpcLookupService
 
     @Mock
-    lateinit var mockState: EpcState
+    lateinit var mockState: EpcDetailState
 
     val routeSegment = FindYourEpcStep.ROUTE_SEGMENT
 

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/GasCertExpiredStepConfigTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/GasCertExpiredStepConfigTests.kt
@@ -6,13 +6,13 @@ import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.whenever
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.GasSafetyState
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.GasSafetyDetailState
 import uk.gov.communities.prsdb.webapp.testHelpers.mockObjects.AlwaysTrueValidator
 
 @ExtendWith(MockitoExtension::class)
 class GasCertExpiredStepConfigTests {
     @Mock
-    lateinit var mockState: GasSafetyState
+    lateinit var mockState: GasSafetyDetailState
 
     @Test
     fun `chooseTemplate returns occupied template when isOccupied is true`() {

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/GasCertIssueDateStepConfigTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/GasCertIssueDateStepConfigTests.kt
@@ -7,13 +7,13 @@ import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.whenever
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.GasSafetyState
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.GasSafetyDetailState
 import uk.gov.communities.prsdb.webapp.testHelpers.mockObjects.AlwaysTrueValidator
 
 @ExtendWith(MockitoExtension::class)
 class GasCertIssueDateStepConfigTests {
     @Mock
-    lateinit var mockState: GasSafetyState
+    lateinit var mockState: GasSafetyDetailState
 
     @Test
     fun `mode returns null when getGasSafetyCertificateIsOutdated returns null`() {

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/GasCertMissingStepConfigTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/GasCertMissingStepConfigTests.kt
@@ -6,13 +6,13 @@ import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.whenever
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.GasSafetyState
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.GasSafetyDetailState
 import uk.gov.communities.prsdb.webapp.testHelpers.mockObjects.AlwaysTrueValidator
 
 @ExtendWith(MockitoExtension::class)
 class GasCertMissingStepConfigTests {
     @Mock
-    lateinit var mockState: GasSafetyState
+    lateinit var mockState: GasSafetyDetailState
 
     @Test
     fun `chooseTemplate returns occupied template when isOccupied is true`() {

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/HasElectricalCertStepConfigTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/HasElectricalCertStepConfigTests.kt
@@ -15,13 +15,13 @@ import uk.gov.communities.prsdb.webapp.constants.CONTINUE_BUTTON_ACTION_NAME
 import uk.gov.communities.prsdb.webapp.constants.PROVIDE_THIS_LATER_BUTTON_ACTION_NAME
 import uk.gov.communities.prsdb.webapp.constants.enums.HasElectricalSafetyCertificate
 import uk.gov.communities.prsdb.webapp.journeys.UnrecoverableJourneyStateException
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.ElectricalSafetyState
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.ElectricalSafetyDetailState
 import uk.gov.communities.prsdb.webapp.testHelpers.mockObjects.AlwaysTrueValidator
 
 @ExtendWith(MockitoExtension::class)
 class HasElectricalCertStepConfigTests {
     @Mock
-    lateinit var mockJourneyState: ElectricalSafetyState
+    lateinit var mockJourneyState: ElectricalSafetyDetailState
 
     val routeSegment = HasElectricalCertStep.ROUTE_SEGMENT
 

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/HasEpcStepConfigTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/HasEpcStepConfigTests.kt
@@ -11,13 +11,13 @@ import org.mockito.kotlin.whenever
 import uk.gov.communities.prsdb.webapp.constants.CONTINUE_BUTTON_ACTION_NAME
 import uk.gov.communities.prsdb.webapp.constants.PROVIDE_THIS_LATER_BUTTON_ACTION_NAME
 import uk.gov.communities.prsdb.webapp.journeys.UnrecoverableJourneyStateException
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.EpcState
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.EpcDetailState
 import uk.gov.communities.prsdb.webapp.testHelpers.mockObjects.AlwaysTrueValidator
 
 @ExtendWith(MockitoExtension::class)
 class HasEpcStepConfigTests {
     @Mock
-    lateinit var mockJourneyState: EpcState
+    lateinit var mockJourneyState: EpcDetailState
 
     val routeSegment = HasEpcStep.ROUTE_SEGMENT
 

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/HasGasCertStepConfigTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/HasGasCertStepConfigTests.kt
@@ -13,13 +13,13 @@ import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.whenever
 import uk.gov.communities.prsdb.webapp.constants.PROVIDE_THIS_LATER_BUTTON_ACTION_NAME
 import uk.gov.communities.prsdb.webapp.journeys.UnrecoverableJourneyStateException
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.GasSafetyState
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.GasSafetyDetailState
 import uk.gov.communities.prsdb.webapp.testHelpers.mockObjects.AlwaysTrueValidator
 
 @ExtendWith(MockitoExtension::class)
 class HasGasCertStepConfigTests {
     @Mock
-    lateinit var mockJourneyState: GasSafetyState
+    lateinit var mockJourneyState: GasSafetyDetailState
 
     val routeSegment = HasGasCertStep.ROUTE_SEGMENT
 

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/HasMissingComplianceStepConfigTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/HasMissingComplianceStepConfigTests.kt
@@ -14,6 +14,7 @@ import org.mockito.kotlin.whenever
 import uk.gov.communities.prsdb.webapp.constants.enums.EpcExemptionReason
 import uk.gov.communities.prsdb.webapp.constants.enums.MeesExemptionReason
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.CombinedComplianceCheckState
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.ElectricalSafetyDetailsTask
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.ElectricalSafetyTask
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.GasSafetyDetailsTask
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.GasSafetyTask
@@ -145,16 +146,22 @@ class HasMissingComplianceStepConfigTests {
         }
 
         private fun setupElectricalCertMissing() {
+            val mockDetailsTask: ElectricalSafetyDetailsTask = mock()
+            whenever(mockDetailsTask.hasElectricalCertStep).thenReturn(mock<HasElectricalCertStep>())
+            whenever(mockDetailsTask.getElectricalCertificateIsOutdated()).thenReturn(null)
+
             val mockElectricalSafetyTask: ElectricalSafetyTask = mock()
-            whenever(mockElectricalSafetyTask.hasElectricalCertStep).thenReturn(mock<HasElectricalCertStep>())
-            whenever(mockElectricalSafetyTask.getElectricalCertificateIsOutdated()).thenReturn(null)
+            whenever(mockElectricalSafetyTask.electricalSafetyDetailsTask).thenReturn(mockDetailsTask)
             whenever(mockState.electricalSafetyTask).thenReturn(mockElectricalSafetyTask)
         }
 
         private fun setupElectricalCertPresent() {
+            val mockDetailsTask: ElectricalSafetyDetailsTask = mock()
+            whenever(mockDetailsTask.hasElectricalCertStep).thenReturn(mock<HasElectricalCertStep>())
+            whenever(mockDetailsTask.getElectricalCertificateIsOutdated()).thenReturn(false)
+
             val mockElectricalSafetyTask: ElectricalSafetyTask = mock()
-            whenever(mockElectricalSafetyTask.hasElectricalCertStep).thenReturn(mock<HasElectricalCertStep>())
-            whenever(mockElectricalSafetyTask.getElectricalCertificateIsOutdated()).thenReturn(false)
+            whenever(mockElectricalSafetyTask.electricalSafetyDetailsTask).thenReturn(mockDetailsTask)
             whenever(mockState.electricalSafetyTask).thenReturn(mockElectricalSafetyTask)
         }
 
@@ -190,10 +197,13 @@ class HasMissingComplianceStepConfigTests {
         }
 
         private fun setupElectricalCertProvideLater() {
-            val mockElectricalSafetyTask: ElectricalSafetyTask = mock()
+            val mockDetailsTask: ElectricalSafetyDetailsTask = mock()
             val mockHasElectricalCertStep = mock<HasElectricalCertStep>()
             whenever(mockHasElectricalCertStep.outcome).thenReturn(HasElectricalCertMode.PROVIDE_THIS_LATER)
-            whenever(mockElectricalSafetyTask.hasElectricalCertStep).thenReturn(mockHasElectricalCertStep)
+            whenever(mockDetailsTask.hasElectricalCertStep).thenReturn(mockHasElectricalCertStep)
+
+            val mockElectricalSafetyTask: ElectricalSafetyTask = mock()
+            whenever(mockElectricalSafetyTask.electricalSafetyDetailsTask).thenReturn(mockDetailsTask)
             whenever(mockState.electricalSafetyTask).thenReturn(mockElectricalSafetyTask)
         }
 
@@ -291,35 +301,43 @@ class HasMissingComplianceStepConfigTests {
         @Mock
         lateinit var mockElectricalSafetyTask: ElectricalSafetyTask
 
+        @Mock
+        lateinit var mockElectricalSafetyDetailTask: ElectricalSafetyDetailsTask
+
+        @BeforeEach
+        fun setUp() {
+            whenever(mockElectricalSafetyTask.electricalSafetyDetailsTask).thenReturn(mockElectricalSafetyDetailTask)
+        }
+
         @Test
         fun `returns false when user chose provide this later`() {
             val mockHasElectricalCertStep = mock<HasElectricalCertStep>()
             whenever(mockHasElectricalCertStep.outcome).thenReturn(HasElectricalCertMode.PROVIDE_THIS_LATER)
-            whenever(mockElectricalSafetyTask.hasElectricalCertStep).thenReturn(mockHasElectricalCertStep)
+            whenever(mockElectricalSafetyDetailTask.hasElectricalCertStep).thenReturn(mockHasElectricalCertStep)
 
             assertFalse(HasMissingComplianceStepConfig.isElectricalCertInvalid(mockElectricalSafetyTask))
         }
 
         @Test
         fun `returns true when cert is missing`() {
-            whenever(mockElectricalSafetyTask.hasElectricalCertStep).thenReturn(mock<HasElectricalCertStep>())
-            whenever(mockElectricalSafetyTask.getElectricalCertificateIsOutdated()).thenReturn(null)
+            whenever(mockElectricalSafetyDetailTask.hasElectricalCertStep).thenReturn(mock<HasElectricalCertStep>())
+            whenever(mockElectricalSafetyDetailTask.getElectricalCertificateIsOutdated()).thenReturn(null)
 
             assertTrue(HasMissingComplianceStepConfig.isElectricalCertInvalid(mockElectricalSafetyTask))
         }
 
         @Test
         fun `returns true when cert is outdated`() {
-            whenever(mockElectricalSafetyTask.hasElectricalCertStep).thenReturn(mock<HasElectricalCertStep>())
-            whenever(mockElectricalSafetyTask.getElectricalCertificateIsOutdated()).thenReturn(true)
+            whenever(mockElectricalSafetyDetailTask.hasElectricalCertStep).thenReturn(mock<HasElectricalCertStep>())
+            whenever(mockElectricalSafetyDetailTask.getElectricalCertificateIsOutdated()).thenReturn(true)
 
             assertTrue(HasMissingComplianceStepConfig.isElectricalCertInvalid(mockElectricalSafetyTask))
         }
 
         @Test
         fun `returns false when cert is valid`() {
-            whenever(mockElectricalSafetyTask.hasElectricalCertStep).thenReturn(mock<HasElectricalCertStep>())
-            whenever(mockElectricalSafetyTask.getElectricalCertificateIsOutdated()).thenReturn(false)
+            whenever(mockElectricalSafetyDetailTask.hasElectricalCertStep).thenReturn(mock<HasElectricalCertStep>())
+            whenever(mockElectricalSafetyDetailTask.getElectricalCertificateIsOutdated()).thenReturn(false)
 
             assertFalse(HasMissingComplianceStepConfig.isElectricalCertInvalid(mockElectricalSafetyTask))
         }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/HasMissingComplianceStepConfigTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/HasMissingComplianceStepConfigTests.kt
@@ -16,6 +16,7 @@ import uk.gov.communities.prsdb.webapp.constants.enums.MeesExemptionReason
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.CombinedComplianceCheckState
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.ElectricalSafetyDetailsTask
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.ElectricalSafetyTask
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.EpcDetailsTask
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.EpcTask
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.GasSafetyDetailsTask
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.GasSafetyTask
@@ -167,22 +168,28 @@ class HasMissingComplianceStepConfigTests {
         }
 
         private fun setupEpcMissing() {
-            val mockEpcTask: EpcTask = mock()
-            whenever(mockEpcTask.hasEpcStep).thenReturn(mock<HasEpcStep>())
-            whenever(mockEpcTask.acceptedEpcIfStillAccepted).thenReturn(null)
+            val mockDetailsTask: EpcDetailsTask = mock()
+            whenever(mockDetailsTask.hasEpcStep).thenReturn(mock<HasEpcStep>())
+            whenever(mockDetailsTask.acceptedEpcIfStillAccepted).thenReturn(null)
             val mockEpcExemptionStep = mock<EpcExemptionStep>()
             whenever(mockEpcExemptionStep.formModelIfReachableOrNull).thenReturn(null)
-            whenever(mockEpcTask.epcExemptionStep).thenReturn(mockEpcExemptionStep)
+            whenever(mockDetailsTask.epcExemptionStep).thenReturn(mockEpcExemptionStep)
+
+            val mockEpcTask: EpcTask = mock()
+            whenever(mockEpcTask.epcDetailsTask).thenReturn(mockDetailsTask)
             whenever(mockState.epcTask).thenReturn(mockEpcTask)
         }
 
         private fun setupEpcPresent() {
-            val mockEpcTask: EpcTask = mock()
-            whenever(mockEpcTask.hasEpcStep).thenReturn(mock<HasEpcStep>())
+            val mockDetailsTask: EpcDetailsTask = mock()
+            whenever(mockDetailsTask.hasEpcStep).thenReturn(mock<HasEpcStep>())
             val mockEpc = mock<EpcDataModel>()
             whenever(mockEpc.isPastExpiryDate()).thenReturn(false)
             whenever(mockEpc.isEnergyRatingEOrBetter()).thenReturn(true)
-            whenever(mockEpcTask.acceptedEpcIfStillAccepted).thenReturn(mockEpc)
+            whenever(mockDetailsTask.acceptedEpcIfStillAccepted).thenReturn(mockEpc)
+
+            val mockEpcTask: EpcTask = mock()
+            whenever(mockEpcTask.epcDetailsTask).thenReturn(mockDetailsTask)
             whenever(mockState.epcTask).thenReturn(mockEpcTask)
         }
 
@@ -213,10 +220,13 @@ class HasMissingComplianceStepConfigTests {
         }
 
         private fun setupEpcProvideLater() {
-            val mockEpcTask: EpcTask = mock()
+            val mockDetailsTask: EpcDetailsTask = mock()
             val mockHasEpcStep = mock<HasEpcStep>()
             whenever(mockHasEpcStep.outcome).thenReturn(HasEpcMode.PROVIDE_LATER)
-            whenever(mockEpcTask.hasEpcStep).thenReturn(mockHasEpcStep)
+            whenever(mockDetailsTask.hasEpcStep).thenReturn(mockHasEpcStep)
+
+            val mockEpcTask: EpcTask = mock()
+            whenever(mockEpcTask.epcDetailsTask).thenReturn(mockDetailsTask)
             whenever(mockState.epcTask).thenReturn(mockEpcTask)
         }
     }
@@ -355,136 +365,144 @@ class HasMissingComplianceStepConfigTests {
         @Mock
         lateinit var mockEpcTask: EpcTask
 
+        @Mock
+        lateinit var mockEpcDetailsTask: EpcDetailsTask
+
+        @BeforeEach
+        fun setUp() {
+            whenever(mockEpcTask.epcDetailsTask).thenReturn(mockEpcDetailsTask)
+        }
+
         @Test
         fun `returns false when user chose provide later`() {
             val mockHasEpcStep = mock<HasEpcStep>()
             whenever(mockHasEpcStep.outcome).thenReturn(HasEpcMode.PROVIDE_LATER)
-            whenever(mockEpcTask.hasEpcStep).thenReturn(mockHasEpcStep)
+            whenever(mockEpcDetailsTask.hasEpcStep).thenReturn(mockHasEpcStep)
 
             assertFalse(HasMissingComplianceStepConfig.isEpcInvalid(mockEpcTask))
         }
 
         @Test
         fun `returns false when accepted epc present and not expired and good rating`() {
-            whenever(mockEpcTask.hasEpcStep).thenReturn(mock<HasEpcStep>())
+            whenever(mockEpcDetailsTask.hasEpcStep).thenReturn(mock<HasEpcStep>())
             val mockEpc = mock<EpcDataModel>()
             whenever(mockEpc.isPastExpiryDate()).thenReturn(false)
             whenever(mockEpc.isEnergyRatingEOrBetter()).thenReturn(true)
-            whenever(mockEpcTask.acceptedEpcIfStillAccepted).thenReturn(mockEpc)
+            whenever(mockEpcDetailsTask.acceptedEpcIfStillAccepted).thenReturn(mockEpc)
 
             assertFalse(HasMissingComplianceStepConfig.isEpcInvalid(mockEpcTask))
         }
 
         @Test
         fun `returns true when accepted epc present but expired and tenancy did not start before expiry`() {
-            whenever(mockEpcTask.hasEpcStep).thenReturn(mock<HasEpcStep>())
+            whenever(mockEpcDetailsTask.hasEpcStep).thenReturn(mock<HasEpcStep>())
             val mockEpc = mock<EpcDataModel>()
             whenever(mockEpc.isPastExpiryDate()).thenReturn(true)
-            whenever(mockEpcTask.acceptedEpcIfStillAccepted).thenReturn(mockEpc)
+            whenever(mockEpcDetailsTask.acceptedEpcIfStillAccepted).thenReturn(mockEpc)
             val mockTenancyStep = mock<EpcInDateAtStartOfTenancyCheckStep>()
             whenever(mockTenancyStep.outcome).thenReturn(EpcInDateAtStartOfTenancyCheckMode.NOT_IN_DATE)
-            whenever(mockEpcTask.epcInDateAtStartOfTenancyCheckStep).thenReturn(mockTenancyStep)
+            whenever(mockEpcDetailsTask.epcInDateAtStartOfTenancyCheckStep).thenReturn(mockTenancyStep)
 
             assertTrue(HasMissingComplianceStepConfig.isEpcInvalid(mockEpcTask))
         }
 
         @Test
         fun `returns false when accepted epc present but expired and tenancy started before expiry`() {
-            whenever(mockEpcTask.hasEpcStep).thenReturn(mock<HasEpcStep>())
+            whenever(mockEpcDetailsTask.hasEpcStep).thenReturn(mock<HasEpcStep>())
             val mockEpc = mock<EpcDataModel>()
             whenever(mockEpc.isPastExpiryDate()).thenReturn(true)
             whenever(mockEpc.isEnergyRatingEOrBetter()).thenReturn(true)
-            whenever(mockEpcTask.acceptedEpcIfStillAccepted).thenReturn(mockEpc)
+            whenever(mockEpcDetailsTask.acceptedEpcIfStillAccepted).thenReturn(mockEpc)
             val mockTenancyStep = mock<EpcInDateAtStartOfTenancyCheckStep>()
             whenever(mockTenancyStep.outcome).thenReturn(EpcInDateAtStartOfTenancyCheckMode.IN_DATE)
-            whenever(mockEpcTask.epcInDateAtStartOfTenancyCheckStep).thenReturn(mockTenancyStep)
+            whenever(mockEpcDetailsTask.epcInDateAtStartOfTenancyCheckStep).thenReturn(mockTenancyStep)
 
             assertFalse(HasMissingComplianceStepConfig.isEpcInvalid(mockEpcTask))
         }
 
         @Test
         fun `returns true when accepted epc is expired with tenancy started before expiry but has low rating and no mees exemption`() {
-            whenever(mockEpcTask.hasEpcStep).thenReturn(mock<HasEpcStep>())
+            whenever(mockEpcDetailsTask.hasEpcStep).thenReturn(mock<HasEpcStep>())
             val mockEpc = mock<EpcDataModel>()
             whenever(mockEpc.isPastExpiryDate()).thenReturn(true)
             whenever(mockEpc.isEnergyRatingEOrBetter()).thenReturn(false)
-            whenever(mockEpcTask.acceptedEpcIfStillAccepted).thenReturn(mockEpc)
+            whenever(mockEpcDetailsTask.acceptedEpcIfStillAccepted).thenReturn(mockEpc)
             val mockTenancyStep = mock<EpcInDateAtStartOfTenancyCheckStep>()
             whenever(mockTenancyStep.outcome).thenReturn(EpcInDateAtStartOfTenancyCheckMode.IN_DATE)
-            whenever(mockEpcTask.epcInDateAtStartOfTenancyCheckStep).thenReturn(mockTenancyStep)
+            whenever(mockEpcDetailsTask.epcInDateAtStartOfTenancyCheckStep).thenReturn(mockTenancyStep)
             val mockMeesExemptionStep = mock<MeesExemptionStep>()
             whenever(mockMeesExemptionStep.formModelIfReachableOrNull).thenReturn(null)
-            whenever(mockEpcTask.meesExemptionStep).thenReturn(mockMeesExemptionStep)
+            whenever(mockEpcDetailsTask.meesExemptionStep).thenReturn(mockMeesExemptionStep)
 
             assertTrue(HasMissingComplianceStepConfig.isEpcInvalid(mockEpcTask))
         }
 
         @Test
         fun `returns true when accepted epc has low rating and no mees exemption`() {
-            whenever(mockEpcTask.hasEpcStep).thenReturn(mock<HasEpcStep>())
+            whenever(mockEpcDetailsTask.hasEpcStep).thenReturn(mock<HasEpcStep>())
             val mockEpc = mock<EpcDataModel>()
             whenever(mockEpc.isPastExpiryDate()).thenReturn(false)
             whenever(mockEpc.isEnergyRatingEOrBetter()).thenReturn(false)
-            whenever(mockEpcTask.acceptedEpcIfStillAccepted).thenReturn(mockEpc)
+            whenever(mockEpcDetailsTask.acceptedEpcIfStillAccepted).thenReturn(mockEpc)
             val mockMeesExemptionStep = mock<MeesExemptionStep>()
             whenever(mockMeesExemptionStep.formModelIfReachableOrNull).thenReturn(null)
-            whenever(mockEpcTask.meesExemptionStep).thenReturn(mockMeesExemptionStep)
+            whenever(mockEpcDetailsTask.meesExemptionStep).thenReturn(mockMeesExemptionStep)
 
             assertTrue(HasMissingComplianceStepConfig.isEpcInvalid(mockEpcTask))
         }
 
         @Test
         fun `returns false when accepted epc has low rating but has mees exemption`() {
-            whenever(mockEpcTask.hasEpcStep).thenReturn(mock<HasEpcStep>())
+            whenever(mockEpcDetailsTask.hasEpcStep).thenReturn(mock<HasEpcStep>())
             val mockEpc = mock<EpcDataModel>()
             whenever(mockEpc.isPastExpiryDate()).thenReturn(false)
             whenever(mockEpc.isEnergyRatingEOrBetter()).thenReturn(false)
-            whenever(mockEpcTask.acceptedEpcIfStillAccepted).thenReturn(mockEpc)
+            whenever(mockEpcDetailsTask.acceptedEpcIfStillAccepted).thenReturn(mockEpc)
             val mockMeesExemptionStep = mock<MeesExemptionStep>()
             val formModel =
                 MeesExemptionReasonFormModel().apply {
                     exemptionReason = MeesExemptionReason.ALL_IMPROVEMENTS_MADE
                 }
             whenever(mockMeesExemptionStep.formModelIfReachableOrNull).thenReturn(formModel)
-            whenever(mockEpcTask.meesExemptionStep).thenReturn(mockMeesExemptionStep)
+            whenever(mockEpcDetailsTask.meesExemptionStep).thenReturn(mockMeesExemptionStep)
 
             assertFalse(HasMissingComplianceStepConfig.isEpcInvalid(mockEpcTask))
         }
 
         @Test
         fun `returns true when no accepted epc and no exemption`() {
-            whenever(mockEpcTask.hasEpcStep).thenReturn(mock<HasEpcStep>())
-            whenever(mockEpcTask.acceptedEpcIfStillAccepted).thenReturn(null)
+            whenever(mockEpcDetailsTask.hasEpcStep).thenReturn(mock<HasEpcStep>())
+            whenever(mockEpcDetailsTask.acceptedEpcIfStillAccepted).thenReturn(null)
             val mockEpcExemptionStep = mock<EpcExemptionStep>()
             whenever(mockEpcExemptionStep.formModelIfReachableOrNull).thenReturn(null)
-            whenever(mockEpcTask.epcExemptionStep).thenReturn(mockEpcExemptionStep)
+            whenever(mockEpcDetailsTask.epcExemptionStep).thenReturn(mockEpcExemptionStep)
 
             assertTrue(HasMissingComplianceStepConfig.isEpcInvalid(mockEpcTask))
         }
 
         @Test
         fun `returns false when no accepted epc but exemption present`() {
-            whenever(mockEpcTask.hasEpcStep).thenReturn(mock<HasEpcStep>())
-            whenever(mockEpcTask.acceptedEpcIfStillAccepted).thenReturn(null)
+            whenever(mockEpcDetailsTask.hasEpcStep).thenReturn(mock<HasEpcStep>())
+            whenever(mockEpcDetailsTask.acceptedEpcIfStillAccepted).thenReturn(null)
             val mockEpcExemptionStep = mock<EpcExemptionStep>()
             val formModel =
                 EpcExemptionFormModel().apply {
                     exemptionReason = EpcExemptionReason.PROTECTED_ARCHITECTURAL_OR_HISTORICAL_MERIT
                 }
             whenever(mockEpcExemptionStep.formModelIfReachableOrNull).thenReturn(formModel)
-            whenever(mockEpcTask.epcExemptionStep).thenReturn(mockEpcExemptionStep)
+            whenever(mockEpcDetailsTask.epcExemptionStep).thenReturn(mockEpcExemptionStep)
 
             assertFalse(HasMissingComplianceStepConfig.isEpcInvalid(mockEpcTask))
         }
 
         @Test
         fun `returns true when no accepted epc and exemption reason is null`() {
-            whenever(mockEpcTask.hasEpcStep).thenReturn(mock<HasEpcStep>())
-            whenever(mockEpcTask.acceptedEpcIfStillAccepted).thenReturn(null)
+            whenever(mockEpcDetailsTask.hasEpcStep).thenReturn(mock<HasEpcStep>())
+            whenever(mockEpcDetailsTask.acceptedEpcIfStillAccepted).thenReturn(null)
             val mockEpcExemptionStep = mock<EpcExemptionStep>()
             val formModel = EpcExemptionFormModel()
             whenever(mockEpcExemptionStep.formModelIfReachableOrNull).thenReturn(formModel)
-            whenever(mockEpcTask.epcExemptionStep).thenReturn(mockEpcExemptionStep)
+            whenever(mockEpcDetailsTask.epcExemptionStep).thenReturn(mockEpcExemptionStep)
 
             assertTrue(HasMissingComplianceStepConfig.isEpcInvalid(mockEpcTask))
         }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/HasMissingComplianceStepConfigTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/HasMissingComplianceStepConfigTests.kt
@@ -3,6 +3,7 @@ package uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
@@ -13,6 +14,7 @@ import org.mockito.kotlin.whenever
 import uk.gov.communities.prsdb.webapp.constants.enums.EpcExemptionReason
 import uk.gov.communities.prsdb.webapp.constants.enums.MeesExemptionReason
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.CombinedComplianceCheckState
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.GasSafetyDetailsTask
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.GasSafetyTask
 import uk.gov.communities.prsdb.webapp.models.dataModels.EpcDataModel
 import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.EpcExemptionFormModel
@@ -114,24 +116,30 @@ class HasMissingComplianceStepConfigTests {
         }
 
         private fun setupGasCertMissing() {
-            val mockGasSafetyTask: GasSafetyTask = mock()
+            val mockDetailsTask: GasSafetyDetailsTask = mock()
             val mockHasGasSupplyStep = mock<HasGasSupplyStep>()
             val gasFormModel = GasSupplyFormModel().apply { hasGasSupply = true }
             whenever(mockHasGasSupplyStep.formModelIfReachableOrNull).thenReturn(gasFormModel)
-            whenever(mockGasSafetyTask.hasGasSupplyStep).thenReturn(mockHasGasSupplyStep)
-            whenever(mockGasSafetyTask.hasGasCertStep).thenReturn(mock<HasGasCertStep>())
-            whenever(mockGasSafetyTask.getGasSafetyCertificateIsOutdated()).thenReturn(null)
+            whenever(mockDetailsTask.hasGasSupplyStep).thenReturn(mockHasGasSupplyStep)
+            whenever(mockDetailsTask.hasGasCertStep).thenReturn(mock<HasGasCertStep>())
+            whenever(mockDetailsTask.getGasSafetyCertificateIsOutdated()).thenReturn(null)
+
+            val mockGasSafetyTask: GasSafetyTask = mock()
+            whenever(mockGasSafetyTask.gasSafetyDetailsTask).thenReturn(mockDetailsTask)
             whenever(mockState.gasSafetyTask).thenReturn(mockGasSafetyTask)
         }
 
         private fun setupGasCertPresent() {
-            val mockGasSafetyTask: GasSafetyTask = mock()
+            val mockDetailsTask: GasSafetyDetailsTask = mock()
             val mockHasGasSupplyStep = mock<HasGasSupplyStep>()
             val gasFormModel = GasSupplyFormModel().apply { hasGasSupply = true }
             whenever(mockHasGasSupplyStep.formModelIfReachableOrNull).thenReturn(gasFormModel)
-            whenever(mockGasSafetyTask.hasGasSupplyStep).thenReturn(mockHasGasSupplyStep)
-            whenever(mockGasSafetyTask.hasGasCertStep).thenReturn(mock<HasGasCertStep>())
-            whenever(mockGasSafetyTask.getGasSafetyCertificateIsOutdated()).thenReturn(false)
+            whenever(mockDetailsTask.hasGasSupplyStep).thenReturn(mockHasGasSupplyStep)
+            whenever(mockDetailsTask.hasGasCertStep).thenReturn(mock<HasGasCertStep>())
+            whenever(mockDetailsTask.getGasSafetyCertificateIsOutdated()).thenReturn(false)
+
+            val mockGasSafetyTask: GasSafetyTask = mock()
+            whenever(mockGasSafetyTask.gasSafetyDetailsTask).thenReturn(mockDetailsTask)
             whenever(mockState.gasSafetyTask).thenReturn(mockGasSafetyTask)
         }
 
@@ -162,14 +170,17 @@ class HasMissingComplianceStepConfigTests {
         }
 
         private fun setupGasCertProvideLater() {
-            val mockGasSafetyTask: GasSafetyTask = mock()
+            val mockDetailsTask: GasSafetyDetailsTask = mock()
             val mockHasGasSupplyStep = mock<HasGasSupplyStep>()
             val gasFormModel = GasSupplyFormModel().apply { hasGasSupply = true }
             whenever(mockHasGasSupplyStep.formModelIfReachableOrNull).thenReturn(gasFormModel)
-            whenever(mockGasSafetyTask.hasGasSupplyStep).thenReturn(mockHasGasSupplyStep)
+            whenever(mockDetailsTask.hasGasSupplyStep).thenReturn(mockHasGasSupplyStep)
             val mockHasGasCertStep = mock<HasGasCertStep>()
             whenever(mockHasGasCertStep.outcome).thenReturn(HasGasCertMode.PROVIDE_THIS_LATER)
-            whenever(mockGasSafetyTask.hasGasCertStep).thenReturn(mockHasGasCertStep)
+            whenever(mockDetailsTask.hasGasCertStep).thenReturn(mockHasGasCertStep)
+
+            val mockGasSafetyTask: GasSafetyTask = mock()
+            whenever(mockGasSafetyTask.gasSafetyDetailsTask).thenReturn(mockDetailsTask)
             whenever(mockState.gasSafetyTask).thenReturn(mockGasSafetyTask)
         }
 
@@ -191,15 +202,23 @@ class HasMissingComplianceStepConfigTests {
         @Mock
         lateinit var mockGasSafetyTask: GasSafetyTask
 
+        @Mock
+        lateinit var mockGasSafetyDetailTask: GasSafetyDetailsTask
+
+        @BeforeEach
+        fun setUp() {
+            whenever(mockGasSafetyTask.gasSafetyDetailsTask).thenReturn(mockGasSafetyDetailTask)
+        }
+
         @Test
         fun `returns false when user chose provide this later`() {
             val mockHasGasSupplyStep = mock<HasGasSupplyStep>()
             val formModel = GasSupplyFormModel().apply { hasGasSupply = true }
             whenever(mockHasGasSupplyStep.formModelIfReachableOrNull).thenReturn(formModel)
-            whenever(mockGasSafetyTask.hasGasSupplyStep).thenReturn(mockHasGasSupplyStep)
+            whenever(mockGasSafetyDetailTask.hasGasSupplyStep).thenReturn(mockHasGasSupplyStep)
             val mockHasGasCertStep = mock<HasGasCertStep>()
             whenever(mockHasGasCertStep.outcome).thenReturn(HasGasCertMode.PROVIDE_THIS_LATER)
-            whenever(mockGasSafetyTask.hasGasCertStep).thenReturn(mockHasGasCertStep)
+            whenever(mockGasSafetyDetailTask.hasGasCertStep).thenReturn(mockHasGasCertStep)
 
             assertFalse(HasMissingComplianceStepConfig.isGasCertInvalid(mockGasSafetyTask))
         }
@@ -208,7 +227,7 @@ class HasMissingComplianceStepConfigTests {
         fun `returns false when gas supply step not reachable`() {
             val mockHasGasSupplyStep = mock<HasGasSupplyStep>()
             whenever(mockHasGasSupplyStep.formModelIfReachableOrNull).thenReturn(null)
-            whenever(mockGasSafetyTask.hasGasSupplyStep).thenReturn(mockHasGasSupplyStep)
+            whenever(mockGasSafetyDetailTask.hasGasSupplyStep).thenReturn(mockHasGasSupplyStep)
 
             assertFalse(HasMissingComplianceStepConfig.isGasCertInvalid(mockGasSafetyTask))
         }
@@ -218,7 +237,7 @@ class HasMissingComplianceStepConfigTests {
             val mockHasGasSupplyStep = mock<HasGasSupplyStep>()
             val formModel = GasSupplyFormModel().apply { hasGasSupply = false }
             whenever(mockHasGasSupplyStep.formModelIfReachableOrNull).thenReturn(formModel)
-            whenever(mockGasSafetyTask.hasGasSupplyStep).thenReturn(mockHasGasSupplyStep)
+            whenever(mockGasSafetyDetailTask.hasGasSupplyStep).thenReturn(mockHasGasSupplyStep)
 
             assertFalse(HasMissingComplianceStepConfig.isGasCertInvalid(mockGasSafetyTask))
         }
@@ -228,9 +247,9 @@ class HasMissingComplianceStepConfigTests {
             val mockHasGasSupplyStep = mock<HasGasSupplyStep>()
             val formModel = GasSupplyFormModel().apply { hasGasSupply = true }
             whenever(mockHasGasSupplyStep.formModelIfReachableOrNull).thenReturn(formModel)
-            whenever(mockGasSafetyTask.hasGasSupplyStep).thenReturn(mockHasGasSupplyStep)
-            whenever(mockGasSafetyTask.hasGasCertStep).thenReturn(mock<HasGasCertStep>())
-            whenever(mockGasSafetyTask.getGasSafetyCertificateIsOutdated()).thenReturn(null)
+            whenever(mockGasSafetyDetailTask.hasGasSupplyStep).thenReturn(mockHasGasSupplyStep)
+            whenever(mockGasSafetyDetailTask.hasGasCertStep).thenReturn(mock<HasGasCertStep>())
+            whenever(mockGasSafetyDetailTask.getGasSafetyCertificateIsOutdated()).thenReturn(null)
 
             assertTrue(HasMissingComplianceStepConfig.isGasCertInvalid(mockGasSafetyTask))
         }
@@ -240,9 +259,9 @@ class HasMissingComplianceStepConfigTests {
             val mockHasGasSupplyStep = mock<HasGasSupplyStep>()
             val formModel = GasSupplyFormModel().apply { hasGasSupply = true }
             whenever(mockHasGasSupplyStep.formModelIfReachableOrNull).thenReturn(formModel)
-            whenever(mockGasSafetyTask.hasGasSupplyStep).thenReturn(mockHasGasSupplyStep)
-            whenever(mockGasSafetyTask.hasGasCertStep).thenReturn(mock<HasGasCertStep>())
-            whenever(mockGasSafetyTask.getGasSafetyCertificateIsOutdated()).thenReturn(true)
+            whenever(mockGasSafetyDetailTask.hasGasSupplyStep).thenReturn(mockHasGasSupplyStep)
+            whenever(mockGasSafetyDetailTask.hasGasCertStep).thenReturn(mock<HasGasCertStep>())
+            whenever(mockGasSafetyDetailTask.getGasSafetyCertificateIsOutdated()).thenReturn(true)
 
             assertTrue(HasMissingComplianceStepConfig.isGasCertInvalid(mockGasSafetyTask))
         }
@@ -252,9 +271,9 @@ class HasMissingComplianceStepConfigTests {
             val mockHasGasSupplyStep = mock<HasGasSupplyStep>()
             val formModel = GasSupplyFormModel().apply { hasGasSupply = true }
             whenever(mockHasGasSupplyStep.formModelIfReachableOrNull).thenReturn(formModel)
-            whenever(mockGasSafetyTask.hasGasSupplyStep).thenReturn(mockHasGasSupplyStep)
-            whenever(mockGasSafetyTask.hasGasCertStep).thenReturn(mock<HasGasCertStep>())
-            whenever(mockGasSafetyTask.getGasSafetyCertificateIsOutdated()).thenReturn(false)
+            whenever(mockGasSafetyDetailTask.hasGasSupplyStep).thenReturn(mockHasGasSupplyStep)
+            whenever(mockGasSafetyDetailTask.hasGasCertStep).thenReturn(mock<HasGasCertStep>())
+            whenever(mockGasSafetyDetailTask.getGasSafetyCertificateIsOutdated()).thenReturn(false)
 
             assertFalse(HasMissingComplianceStepConfig.isGasCertInvalid(mockGasSafetyTask))
         }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/HasMissingComplianceStepConfigTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/HasMissingComplianceStepConfigTests.kt
@@ -14,6 +14,7 @@ import org.mockito.kotlin.whenever
 import uk.gov.communities.prsdb.webapp.constants.enums.EpcExemptionReason
 import uk.gov.communities.prsdb.webapp.constants.enums.MeesExemptionReason
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.CombinedComplianceCheckState
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.ElectricalSafetyTask
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.GasSafetyDetailsTask
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.GasSafetyTask
 import uk.gov.communities.prsdb.webapp.models.dataModels.EpcDataModel
@@ -144,13 +145,17 @@ class HasMissingComplianceStepConfigTests {
         }
 
         private fun setupElectricalCertMissing() {
-            whenever(mockState.hasElectricalCertStep).thenReturn(mock<HasElectricalCertStep>())
-            whenever(mockState.getElectricalCertificateIsOutdated()).thenReturn(null)
+            val mockElectricalSafetyTask: ElectricalSafetyTask = mock()
+            whenever(mockElectricalSafetyTask.hasElectricalCertStep).thenReturn(mock<HasElectricalCertStep>())
+            whenever(mockElectricalSafetyTask.getElectricalCertificateIsOutdated()).thenReturn(null)
+            whenever(mockState.electricalSafetyTask).thenReturn(mockElectricalSafetyTask)
         }
 
         private fun setupElectricalCertPresent() {
-            whenever(mockState.hasElectricalCertStep).thenReturn(mock<HasElectricalCertStep>())
-            whenever(mockState.getElectricalCertificateIsOutdated()).thenReturn(false)
+            val mockElectricalSafetyTask: ElectricalSafetyTask = mock()
+            whenever(mockElectricalSafetyTask.hasElectricalCertStep).thenReturn(mock<HasElectricalCertStep>())
+            whenever(mockElectricalSafetyTask.getElectricalCertificateIsOutdated()).thenReturn(false)
+            whenever(mockState.electricalSafetyTask).thenReturn(mockElectricalSafetyTask)
         }
 
         private fun setupEpcMissing() {
@@ -185,9 +190,11 @@ class HasMissingComplianceStepConfigTests {
         }
 
         private fun setupElectricalCertProvideLater() {
+            val mockElectricalSafetyTask: ElectricalSafetyTask = mock()
             val mockHasElectricalCertStep = mock<HasElectricalCertStep>()
             whenever(mockHasElectricalCertStep.outcome).thenReturn(HasElectricalCertMode.PROVIDE_THIS_LATER)
-            whenever(mockState.hasElectricalCertStep).thenReturn(mockHasElectricalCertStep)
+            whenever(mockElectricalSafetyTask.hasElectricalCertStep).thenReturn(mockHasElectricalCertStep)
+            whenever(mockState.electricalSafetyTask).thenReturn(mockElectricalSafetyTask)
         }
 
         private fun setupEpcProvideLater() {
@@ -281,37 +288,40 @@ class HasMissingComplianceStepConfigTests {
 
     @Nested
     inner class IsElectricalCertMissingOrExpired {
+        @Mock
+        lateinit var mockElectricalSafetyTask: ElectricalSafetyTask
+
         @Test
         fun `returns false when user chose provide this later`() {
             val mockHasElectricalCertStep = mock<HasElectricalCertStep>()
             whenever(mockHasElectricalCertStep.outcome).thenReturn(HasElectricalCertMode.PROVIDE_THIS_LATER)
-            whenever(mockState.hasElectricalCertStep).thenReturn(mockHasElectricalCertStep)
+            whenever(mockElectricalSafetyTask.hasElectricalCertStep).thenReturn(mockHasElectricalCertStep)
 
-            assertFalse(HasMissingComplianceStepConfig.isElectricalCertInvalid(mockState))
+            assertFalse(HasMissingComplianceStepConfig.isElectricalCertInvalid(mockElectricalSafetyTask))
         }
 
         @Test
         fun `returns true when cert is missing`() {
-            whenever(mockState.hasElectricalCertStep).thenReturn(mock<HasElectricalCertStep>())
-            whenever(mockState.getElectricalCertificateIsOutdated()).thenReturn(null)
+            whenever(mockElectricalSafetyTask.hasElectricalCertStep).thenReturn(mock<HasElectricalCertStep>())
+            whenever(mockElectricalSafetyTask.getElectricalCertificateIsOutdated()).thenReturn(null)
 
-            assertTrue(HasMissingComplianceStepConfig.isElectricalCertInvalid(mockState))
+            assertTrue(HasMissingComplianceStepConfig.isElectricalCertInvalid(mockElectricalSafetyTask))
         }
 
         @Test
         fun `returns true when cert is outdated`() {
-            whenever(mockState.hasElectricalCertStep).thenReturn(mock<HasElectricalCertStep>())
-            whenever(mockState.getElectricalCertificateIsOutdated()).thenReturn(true)
+            whenever(mockElectricalSafetyTask.hasElectricalCertStep).thenReturn(mock<HasElectricalCertStep>())
+            whenever(mockElectricalSafetyTask.getElectricalCertificateIsOutdated()).thenReturn(true)
 
-            assertTrue(HasMissingComplianceStepConfig.isElectricalCertInvalid(mockState))
+            assertTrue(HasMissingComplianceStepConfig.isElectricalCertInvalid(mockElectricalSafetyTask))
         }
 
         @Test
         fun `returns false when cert is valid`() {
-            whenever(mockState.hasElectricalCertStep).thenReturn(mock<HasElectricalCertStep>())
-            whenever(mockState.getElectricalCertificateIsOutdated()).thenReturn(false)
+            whenever(mockElectricalSafetyTask.hasElectricalCertStep).thenReturn(mock<HasElectricalCertStep>())
+            whenever(mockElectricalSafetyTask.getElectricalCertificateIsOutdated()).thenReturn(false)
 
-            assertFalse(HasMissingComplianceStepConfig.isElectricalCertInvalid(mockState))
+            assertFalse(HasMissingComplianceStepConfig.isElectricalCertInvalid(mockElectricalSafetyTask))
         }
     }
 

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/HasMissingComplianceStepConfigTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/HasMissingComplianceStepConfigTests.kt
@@ -16,6 +16,7 @@ import uk.gov.communities.prsdb.webapp.constants.enums.MeesExemptionReason
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.CombinedComplianceCheckState
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.ElectricalSafetyDetailsTask
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.ElectricalSafetyTask
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.EpcTask
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.GasSafetyDetailsTask
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.GasSafetyTask
 import uk.gov.communities.prsdb.webapp.models.dataModels.EpcDataModel
@@ -166,19 +167,23 @@ class HasMissingComplianceStepConfigTests {
         }
 
         private fun setupEpcMissing() {
-            whenever(mockState.hasEpcStep).thenReturn(mock<HasEpcStep>())
-            whenever(mockState.acceptedEpcIfStillAccepted).thenReturn(null)
+            val mockEpcTask: EpcTask = mock()
+            whenever(mockEpcTask.hasEpcStep).thenReturn(mock<HasEpcStep>())
+            whenever(mockEpcTask.acceptedEpcIfStillAccepted).thenReturn(null)
             val mockEpcExemptionStep = mock<EpcExemptionStep>()
             whenever(mockEpcExemptionStep.formModelIfReachableOrNull).thenReturn(null)
-            whenever(mockState.epcExemptionStep).thenReturn(mockEpcExemptionStep)
+            whenever(mockEpcTask.epcExemptionStep).thenReturn(mockEpcExemptionStep)
+            whenever(mockState.epcTask).thenReturn(mockEpcTask)
         }
 
         private fun setupEpcPresent() {
-            whenever(mockState.hasEpcStep).thenReturn(mock<HasEpcStep>())
+            val mockEpcTask: EpcTask = mock()
+            whenever(mockEpcTask.hasEpcStep).thenReturn(mock<HasEpcStep>())
             val mockEpc = mock<EpcDataModel>()
             whenever(mockEpc.isPastExpiryDate()).thenReturn(false)
             whenever(mockEpc.isEnergyRatingEOrBetter()).thenReturn(true)
-            whenever(mockState.acceptedEpcIfStillAccepted).thenReturn(mockEpc)
+            whenever(mockEpcTask.acceptedEpcIfStillAccepted).thenReturn(mockEpc)
+            whenever(mockState.epcTask).thenReturn(mockEpcTask)
         }
 
         private fun setupGasCertProvideLater() {
@@ -208,9 +213,11 @@ class HasMissingComplianceStepConfigTests {
         }
 
         private fun setupEpcProvideLater() {
+            val mockEpcTask: EpcTask = mock()
             val mockHasEpcStep = mock<HasEpcStep>()
             whenever(mockHasEpcStep.outcome).thenReturn(HasEpcMode.PROVIDE_LATER)
-            whenever(mockState.hasEpcStep).thenReturn(mockHasEpcStep)
+            whenever(mockEpcTask.hasEpcStep).thenReturn(mockHasEpcStep)
+            whenever(mockState.epcTask).thenReturn(mockEpcTask)
         }
     }
 
@@ -345,138 +352,141 @@ class HasMissingComplianceStepConfigTests {
 
     @Nested
     inner class IsEpcMissingOrExpired {
+        @Mock
+        lateinit var mockEpcTask: EpcTask
+
         @Test
         fun `returns false when user chose provide later`() {
             val mockHasEpcStep = mock<HasEpcStep>()
             whenever(mockHasEpcStep.outcome).thenReturn(HasEpcMode.PROVIDE_LATER)
-            whenever(mockState.hasEpcStep).thenReturn(mockHasEpcStep)
+            whenever(mockEpcTask.hasEpcStep).thenReturn(mockHasEpcStep)
 
-            assertFalse(HasMissingComplianceStepConfig.isEpcInvalid(mockState))
+            assertFalse(HasMissingComplianceStepConfig.isEpcInvalid(mockEpcTask))
         }
 
         @Test
         fun `returns false when accepted epc present and not expired and good rating`() {
-            whenever(mockState.hasEpcStep).thenReturn(mock<HasEpcStep>())
+            whenever(mockEpcTask.hasEpcStep).thenReturn(mock<HasEpcStep>())
             val mockEpc = mock<EpcDataModel>()
             whenever(mockEpc.isPastExpiryDate()).thenReturn(false)
             whenever(mockEpc.isEnergyRatingEOrBetter()).thenReturn(true)
-            whenever(mockState.acceptedEpcIfStillAccepted).thenReturn(mockEpc)
+            whenever(mockEpcTask.acceptedEpcIfStillAccepted).thenReturn(mockEpc)
 
-            assertFalse(HasMissingComplianceStepConfig.isEpcInvalid(mockState))
+            assertFalse(HasMissingComplianceStepConfig.isEpcInvalid(mockEpcTask))
         }
 
         @Test
         fun `returns true when accepted epc present but expired and tenancy did not start before expiry`() {
-            whenever(mockState.hasEpcStep).thenReturn(mock<HasEpcStep>())
+            whenever(mockEpcTask.hasEpcStep).thenReturn(mock<HasEpcStep>())
             val mockEpc = mock<EpcDataModel>()
             whenever(mockEpc.isPastExpiryDate()).thenReturn(true)
-            whenever(mockState.acceptedEpcIfStillAccepted).thenReturn(mockEpc)
+            whenever(mockEpcTask.acceptedEpcIfStillAccepted).thenReturn(mockEpc)
             val mockTenancyStep = mock<EpcInDateAtStartOfTenancyCheckStep>()
             whenever(mockTenancyStep.outcome).thenReturn(EpcInDateAtStartOfTenancyCheckMode.NOT_IN_DATE)
-            whenever(mockState.epcInDateAtStartOfTenancyCheckStep).thenReturn(mockTenancyStep)
+            whenever(mockEpcTask.epcInDateAtStartOfTenancyCheckStep).thenReturn(mockTenancyStep)
 
-            assertTrue(HasMissingComplianceStepConfig.isEpcInvalid(mockState))
+            assertTrue(HasMissingComplianceStepConfig.isEpcInvalid(mockEpcTask))
         }
 
         @Test
         fun `returns false when accepted epc present but expired and tenancy started before expiry`() {
-            whenever(mockState.hasEpcStep).thenReturn(mock<HasEpcStep>())
+            whenever(mockEpcTask.hasEpcStep).thenReturn(mock<HasEpcStep>())
             val mockEpc = mock<EpcDataModel>()
             whenever(mockEpc.isPastExpiryDate()).thenReturn(true)
             whenever(mockEpc.isEnergyRatingEOrBetter()).thenReturn(true)
-            whenever(mockState.acceptedEpcIfStillAccepted).thenReturn(mockEpc)
+            whenever(mockEpcTask.acceptedEpcIfStillAccepted).thenReturn(mockEpc)
             val mockTenancyStep = mock<EpcInDateAtStartOfTenancyCheckStep>()
             whenever(mockTenancyStep.outcome).thenReturn(EpcInDateAtStartOfTenancyCheckMode.IN_DATE)
-            whenever(mockState.epcInDateAtStartOfTenancyCheckStep).thenReturn(mockTenancyStep)
+            whenever(mockEpcTask.epcInDateAtStartOfTenancyCheckStep).thenReturn(mockTenancyStep)
 
-            assertFalse(HasMissingComplianceStepConfig.isEpcInvalid(mockState))
+            assertFalse(HasMissingComplianceStepConfig.isEpcInvalid(mockEpcTask))
         }
 
         @Test
         fun `returns true when accepted epc is expired with tenancy started before expiry but has low rating and no mees exemption`() {
-            whenever(mockState.hasEpcStep).thenReturn(mock<HasEpcStep>())
+            whenever(mockEpcTask.hasEpcStep).thenReturn(mock<HasEpcStep>())
             val mockEpc = mock<EpcDataModel>()
             whenever(mockEpc.isPastExpiryDate()).thenReturn(true)
             whenever(mockEpc.isEnergyRatingEOrBetter()).thenReturn(false)
-            whenever(mockState.acceptedEpcIfStillAccepted).thenReturn(mockEpc)
+            whenever(mockEpcTask.acceptedEpcIfStillAccepted).thenReturn(mockEpc)
             val mockTenancyStep = mock<EpcInDateAtStartOfTenancyCheckStep>()
             whenever(mockTenancyStep.outcome).thenReturn(EpcInDateAtStartOfTenancyCheckMode.IN_DATE)
-            whenever(mockState.epcInDateAtStartOfTenancyCheckStep).thenReturn(mockTenancyStep)
+            whenever(mockEpcTask.epcInDateAtStartOfTenancyCheckStep).thenReturn(mockTenancyStep)
             val mockMeesExemptionStep = mock<MeesExemptionStep>()
             whenever(mockMeesExemptionStep.formModelIfReachableOrNull).thenReturn(null)
-            whenever(mockState.meesExemptionStep).thenReturn(mockMeesExemptionStep)
+            whenever(mockEpcTask.meesExemptionStep).thenReturn(mockMeesExemptionStep)
 
-            assertTrue(HasMissingComplianceStepConfig.isEpcInvalid(mockState))
+            assertTrue(HasMissingComplianceStepConfig.isEpcInvalid(mockEpcTask))
         }
 
         @Test
         fun `returns true when accepted epc has low rating and no mees exemption`() {
-            whenever(mockState.hasEpcStep).thenReturn(mock<HasEpcStep>())
+            whenever(mockEpcTask.hasEpcStep).thenReturn(mock<HasEpcStep>())
             val mockEpc = mock<EpcDataModel>()
             whenever(mockEpc.isPastExpiryDate()).thenReturn(false)
             whenever(mockEpc.isEnergyRatingEOrBetter()).thenReturn(false)
-            whenever(mockState.acceptedEpcIfStillAccepted).thenReturn(mockEpc)
+            whenever(mockEpcTask.acceptedEpcIfStillAccepted).thenReturn(mockEpc)
             val mockMeesExemptionStep = mock<MeesExemptionStep>()
             whenever(mockMeesExemptionStep.formModelIfReachableOrNull).thenReturn(null)
-            whenever(mockState.meesExemptionStep).thenReturn(mockMeesExemptionStep)
+            whenever(mockEpcTask.meesExemptionStep).thenReturn(mockMeesExemptionStep)
 
-            assertTrue(HasMissingComplianceStepConfig.isEpcInvalid(mockState))
+            assertTrue(HasMissingComplianceStepConfig.isEpcInvalid(mockEpcTask))
         }
 
         @Test
         fun `returns false when accepted epc has low rating but has mees exemption`() {
-            whenever(mockState.hasEpcStep).thenReturn(mock<HasEpcStep>())
+            whenever(mockEpcTask.hasEpcStep).thenReturn(mock<HasEpcStep>())
             val mockEpc = mock<EpcDataModel>()
             whenever(mockEpc.isPastExpiryDate()).thenReturn(false)
             whenever(mockEpc.isEnergyRatingEOrBetter()).thenReturn(false)
-            whenever(mockState.acceptedEpcIfStillAccepted).thenReturn(mockEpc)
+            whenever(mockEpcTask.acceptedEpcIfStillAccepted).thenReturn(mockEpc)
             val mockMeesExemptionStep = mock<MeesExemptionStep>()
             val formModel =
                 MeesExemptionReasonFormModel().apply {
                     exemptionReason = MeesExemptionReason.ALL_IMPROVEMENTS_MADE
                 }
             whenever(mockMeesExemptionStep.formModelIfReachableOrNull).thenReturn(formModel)
-            whenever(mockState.meesExemptionStep).thenReturn(mockMeesExemptionStep)
+            whenever(mockEpcTask.meesExemptionStep).thenReturn(mockMeesExemptionStep)
 
-            assertFalse(HasMissingComplianceStepConfig.isEpcInvalid(mockState))
+            assertFalse(HasMissingComplianceStepConfig.isEpcInvalid(mockEpcTask))
         }
 
         @Test
         fun `returns true when no accepted epc and no exemption`() {
-            whenever(mockState.hasEpcStep).thenReturn(mock<HasEpcStep>())
-            whenever(mockState.acceptedEpcIfStillAccepted).thenReturn(null)
+            whenever(mockEpcTask.hasEpcStep).thenReturn(mock<HasEpcStep>())
+            whenever(mockEpcTask.acceptedEpcIfStillAccepted).thenReturn(null)
             val mockEpcExemptionStep = mock<EpcExemptionStep>()
             whenever(mockEpcExemptionStep.formModelIfReachableOrNull).thenReturn(null)
-            whenever(mockState.epcExemptionStep).thenReturn(mockEpcExemptionStep)
+            whenever(mockEpcTask.epcExemptionStep).thenReturn(mockEpcExemptionStep)
 
-            assertTrue(HasMissingComplianceStepConfig.isEpcInvalid(mockState))
+            assertTrue(HasMissingComplianceStepConfig.isEpcInvalid(mockEpcTask))
         }
 
         @Test
         fun `returns false when no accepted epc but exemption present`() {
-            whenever(mockState.hasEpcStep).thenReturn(mock<HasEpcStep>())
-            whenever(mockState.acceptedEpcIfStillAccepted).thenReturn(null)
+            whenever(mockEpcTask.hasEpcStep).thenReturn(mock<HasEpcStep>())
+            whenever(mockEpcTask.acceptedEpcIfStillAccepted).thenReturn(null)
             val mockEpcExemptionStep = mock<EpcExemptionStep>()
             val formModel =
                 EpcExemptionFormModel().apply {
                     exemptionReason = EpcExemptionReason.PROTECTED_ARCHITECTURAL_OR_HISTORICAL_MERIT
                 }
             whenever(mockEpcExemptionStep.formModelIfReachableOrNull).thenReturn(formModel)
-            whenever(mockState.epcExemptionStep).thenReturn(mockEpcExemptionStep)
+            whenever(mockEpcTask.epcExemptionStep).thenReturn(mockEpcExemptionStep)
 
-            assertFalse(HasMissingComplianceStepConfig.isEpcInvalid(mockState))
+            assertFalse(HasMissingComplianceStepConfig.isEpcInvalid(mockEpcTask))
         }
 
         @Test
         fun `returns true when no accepted epc and exemption reason is null`() {
-            whenever(mockState.hasEpcStep).thenReturn(mock<HasEpcStep>())
-            whenever(mockState.acceptedEpcIfStillAccepted).thenReturn(null)
+            whenever(mockEpcTask.hasEpcStep).thenReturn(mock<HasEpcStep>())
+            whenever(mockEpcTask.acceptedEpcIfStillAccepted).thenReturn(null)
             val mockEpcExemptionStep = mock<EpcExemptionStep>()
             val formModel = EpcExemptionFormModel()
             whenever(mockEpcExemptionStep.formModelIfReachableOrNull).thenReturn(formModel)
-            whenever(mockState.epcExemptionStep).thenReturn(mockEpcExemptionStep)
+            whenever(mockEpcTask.epcExemptionStep).thenReturn(mockEpcExemptionStep)
 
-            assertTrue(HasMissingComplianceStepConfig.isEpcInvalid(mockState))
+            assertTrue(HasMissingComplianceStepConfig.isEpcInvalid(mockEpcTask))
         }
     }
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/HasMissingComplianceStepConfigTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/HasMissingComplianceStepConfigTests.kt
@@ -13,6 +13,7 @@ import org.mockito.kotlin.whenever
 import uk.gov.communities.prsdb.webapp.constants.enums.EpcExemptionReason
 import uk.gov.communities.prsdb.webapp.constants.enums.MeesExemptionReason
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.CombinedComplianceCheckState
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.GasSafetyTask
 import uk.gov.communities.prsdb.webapp.models.dataModels.EpcDataModel
 import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.EpcExemptionFormModel
 import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.GasSupplyFormModel
@@ -113,21 +114,25 @@ class HasMissingComplianceStepConfigTests {
         }
 
         private fun setupGasCertMissing() {
+            val mockGasSafetyTask: GasSafetyTask = mock()
             val mockHasGasSupplyStep = mock<HasGasSupplyStep>()
             val gasFormModel = GasSupplyFormModel().apply { hasGasSupply = true }
             whenever(mockHasGasSupplyStep.formModelIfReachableOrNull).thenReturn(gasFormModel)
-            whenever(mockState.hasGasSupplyStep).thenReturn(mockHasGasSupplyStep)
-            whenever(mockState.hasGasCertStep).thenReturn(mock<HasGasCertStep>())
-            whenever(mockState.getGasSafetyCertificateIsOutdated()).thenReturn(null)
+            whenever(mockGasSafetyTask.hasGasSupplyStep).thenReturn(mockHasGasSupplyStep)
+            whenever(mockGasSafetyTask.hasGasCertStep).thenReturn(mock<HasGasCertStep>())
+            whenever(mockGasSafetyTask.getGasSafetyCertificateIsOutdated()).thenReturn(null)
+            whenever(mockState.gasSafetyTask).thenReturn(mockGasSafetyTask)
         }
 
         private fun setupGasCertPresent() {
+            val mockGasSafetyTask: GasSafetyTask = mock()
             val mockHasGasSupplyStep = mock<HasGasSupplyStep>()
             val gasFormModel = GasSupplyFormModel().apply { hasGasSupply = true }
             whenever(mockHasGasSupplyStep.formModelIfReachableOrNull).thenReturn(gasFormModel)
-            whenever(mockState.hasGasSupplyStep).thenReturn(mockHasGasSupplyStep)
-            whenever(mockState.hasGasCertStep).thenReturn(mock<HasGasCertStep>())
-            whenever(mockState.getGasSafetyCertificateIsOutdated()).thenReturn(false)
+            whenever(mockGasSafetyTask.hasGasSupplyStep).thenReturn(mockHasGasSupplyStep)
+            whenever(mockGasSafetyTask.hasGasCertStep).thenReturn(mock<HasGasCertStep>())
+            whenever(mockGasSafetyTask.getGasSafetyCertificateIsOutdated()).thenReturn(false)
+            whenever(mockState.gasSafetyTask).thenReturn(mockGasSafetyTask)
         }
 
         private fun setupElectricalCertMissing() {
@@ -157,13 +162,15 @@ class HasMissingComplianceStepConfigTests {
         }
 
         private fun setupGasCertProvideLater() {
+            val mockGasSafetyTask: GasSafetyTask = mock()
             val mockHasGasSupplyStep = mock<HasGasSupplyStep>()
             val gasFormModel = GasSupplyFormModel().apply { hasGasSupply = true }
             whenever(mockHasGasSupplyStep.formModelIfReachableOrNull).thenReturn(gasFormModel)
-            whenever(mockState.hasGasSupplyStep).thenReturn(mockHasGasSupplyStep)
+            whenever(mockGasSafetyTask.hasGasSupplyStep).thenReturn(mockHasGasSupplyStep)
             val mockHasGasCertStep = mock<HasGasCertStep>()
             whenever(mockHasGasCertStep.outcome).thenReturn(HasGasCertMode.PROVIDE_THIS_LATER)
-            whenever(mockState.hasGasCertStep).thenReturn(mockHasGasCertStep)
+            whenever(mockGasSafetyTask.hasGasCertStep).thenReturn(mockHasGasCertStep)
+            whenever(mockState.gasSafetyTask).thenReturn(mockGasSafetyTask)
         }
 
         private fun setupElectricalCertProvideLater() {
@@ -181,26 +188,29 @@ class HasMissingComplianceStepConfigTests {
 
     @Nested
     inner class IsGasCertMissingOrExpired {
+        @Mock
+        lateinit var mockGasSafetyTask: GasSafetyTask
+
         @Test
         fun `returns false when user chose provide this later`() {
             val mockHasGasSupplyStep = mock<HasGasSupplyStep>()
             val formModel = GasSupplyFormModel().apply { hasGasSupply = true }
             whenever(mockHasGasSupplyStep.formModelIfReachableOrNull).thenReturn(formModel)
-            whenever(mockState.hasGasSupplyStep).thenReturn(mockHasGasSupplyStep)
+            whenever(mockGasSafetyTask.hasGasSupplyStep).thenReturn(mockHasGasSupplyStep)
             val mockHasGasCertStep = mock<HasGasCertStep>()
             whenever(mockHasGasCertStep.outcome).thenReturn(HasGasCertMode.PROVIDE_THIS_LATER)
-            whenever(mockState.hasGasCertStep).thenReturn(mockHasGasCertStep)
+            whenever(mockGasSafetyTask.hasGasCertStep).thenReturn(mockHasGasCertStep)
 
-            assertFalse(HasMissingComplianceStepConfig.isGasCertInvalid(mockState))
+            assertFalse(HasMissingComplianceStepConfig.isGasCertInvalid(mockGasSafetyTask))
         }
 
         @Test
         fun `returns false when gas supply step not reachable`() {
             val mockHasGasSupplyStep = mock<HasGasSupplyStep>()
             whenever(mockHasGasSupplyStep.formModelIfReachableOrNull).thenReturn(null)
-            whenever(mockState.hasGasSupplyStep).thenReturn(mockHasGasSupplyStep)
+            whenever(mockGasSafetyTask.hasGasSupplyStep).thenReturn(mockHasGasSupplyStep)
 
-            assertFalse(HasMissingComplianceStepConfig.isGasCertInvalid(mockState))
+            assertFalse(HasMissingComplianceStepConfig.isGasCertInvalid(mockGasSafetyTask))
         }
 
         @Test
@@ -208,9 +218,9 @@ class HasMissingComplianceStepConfigTests {
             val mockHasGasSupplyStep = mock<HasGasSupplyStep>()
             val formModel = GasSupplyFormModel().apply { hasGasSupply = false }
             whenever(mockHasGasSupplyStep.formModelIfReachableOrNull).thenReturn(formModel)
-            whenever(mockState.hasGasSupplyStep).thenReturn(mockHasGasSupplyStep)
+            whenever(mockGasSafetyTask.hasGasSupplyStep).thenReturn(mockHasGasSupplyStep)
 
-            assertFalse(HasMissingComplianceStepConfig.isGasCertInvalid(mockState))
+            assertFalse(HasMissingComplianceStepConfig.isGasCertInvalid(mockGasSafetyTask))
         }
 
         @Test
@@ -218,11 +228,11 @@ class HasMissingComplianceStepConfigTests {
             val mockHasGasSupplyStep = mock<HasGasSupplyStep>()
             val formModel = GasSupplyFormModel().apply { hasGasSupply = true }
             whenever(mockHasGasSupplyStep.formModelIfReachableOrNull).thenReturn(formModel)
-            whenever(mockState.hasGasSupplyStep).thenReturn(mockHasGasSupplyStep)
-            whenever(mockState.hasGasCertStep).thenReturn(mock<HasGasCertStep>())
-            whenever(mockState.getGasSafetyCertificateIsOutdated()).thenReturn(null)
+            whenever(mockGasSafetyTask.hasGasSupplyStep).thenReturn(mockHasGasSupplyStep)
+            whenever(mockGasSafetyTask.hasGasCertStep).thenReturn(mock<HasGasCertStep>())
+            whenever(mockGasSafetyTask.getGasSafetyCertificateIsOutdated()).thenReturn(null)
 
-            assertTrue(HasMissingComplianceStepConfig.isGasCertInvalid(mockState))
+            assertTrue(HasMissingComplianceStepConfig.isGasCertInvalid(mockGasSafetyTask))
         }
 
         @Test
@@ -230,11 +240,11 @@ class HasMissingComplianceStepConfigTests {
             val mockHasGasSupplyStep = mock<HasGasSupplyStep>()
             val formModel = GasSupplyFormModel().apply { hasGasSupply = true }
             whenever(mockHasGasSupplyStep.formModelIfReachableOrNull).thenReturn(formModel)
-            whenever(mockState.hasGasSupplyStep).thenReturn(mockHasGasSupplyStep)
-            whenever(mockState.hasGasCertStep).thenReturn(mock<HasGasCertStep>())
-            whenever(mockState.getGasSafetyCertificateIsOutdated()).thenReturn(true)
+            whenever(mockGasSafetyTask.hasGasSupplyStep).thenReturn(mockHasGasSupplyStep)
+            whenever(mockGasSafetyTask.hasGasCertStep).thenReturn(mock<HasGasCertStep>())
+            whenever(mockGasSafetyTask.getGasSafetyCertificateIsOutdated()).thenReturn(true)
 
-            assertTrue(HasMissingComplianceStepConfig.isGasCertInvalid(mockState))
+            assertTrue(HasMissingComplianceStepConfig.isGasCertInvalid(mockGasSafetyTask))
         }
 
         @Test
@@ -242,11 +252,11 @@ class HasMissingComplianceStepConfigTests {
             val mockHasGasSupplyStep = mock<HasGasSupplyStep>()
             val formModel = GasSupplyFormModel().apply { hasGasSupply = true }
             whenever(mockHasGasSupplyStep.formModelIfReachableOrNull).thenReturn(formModel)
-            whenever(mockState.hasGasSupplyStep).thenReturn(mockHasGasSupplyStep)
-            whenever(mockState.hasGasCertStep).thenReturn(mock<HasGasCertStep>())
-            whenever(mockState.getGasSafetyCertificateIsOutdated()).thenReturn(false)
+            whenever(mockGasSafetyTask.hasGasSupplyStep).thenReturn(mockHasGasSupplyStep)
+            whenever(mockGasSafetyTask.hasGasCertStep).thenReturn(mock<HasGasCertStep>())
+            whenever(mockGasSafetyTask.getGasSafetyCertificateIsOutdated()).thenReturn(false)
 
-            assertFalse(HasMissingComplianceStepConfig.isGasCertInvalid(mockState))
+            assertFalse(HasMissingComplianceStepConfig.isGasCertInvalid(mockGasSafetyTask))
         }
     }
 

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/LowEnergyRatingStepConfigTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/LowEnergyRatingStepConfigTests.kt
@@ -7,13 +7,13 @@ import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.whenever
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.EpcState
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.EpcDetailState
 import uk.gov.communities.prsdb.webapp.testHelpers.mockObjects.AlwaysTrueValidator
 
 @ExtendWith(MockitoExtension::class)
 class LowEnergyRatingStepConfigTests {
     @Mock
-    lateinit var mockState: EpcState
+    lateinit var mockState: EpcDetailState
 
     @Test
     fun `chooseTemplate returns occupied template when isOccupied is true`() {

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/PropertyOccupiedCheckStepConfigTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/PropertyOccupiedCheckStepConfigTests.kt
@@ -6,13 +6,13 @@ import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.whenever
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.EpcState
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.EpcDetailState
 import uk.gov.communities.prsdb.webapp.journeys.shared.YesOrNo
 
 @ExtendWith(MockitoExtension::class)
 class PropertyOccupiedCheckStepConfigTests {
     @Mock
-    lateinit var mockState: EpcState
+    lateinit var mockState: EpcDetailState
 
     @Test
     fun `mode returns YES when the property is occupied`() {

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/ProvideElectricalCertLaterStepConfigTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/ProvideElectricalCertLaterStepConfigTests.kt
@@ -6,13 +6,13 @@ import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.whenever
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.ElectricalSafetyState
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.ElectricalSafetyDetailState
 import uk.gov.communities.prsdb.webapp.testHelpers.mockObjects.AlwaysTrueValidator
 
 @ExtendWith(MockitoExtension::class)
 class ProvideElectricalCertLaterStepConfigTests {
     @Mock
-    lateinit var mockState: ElectricalSafetyState
+    lateinit var mockState: ElectricalSafetyDetailState
 
     @Test
     fun `chooseTemplate returns occupied template when isOccupied is true`() {

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/ProvideEpcLaterStepConfigTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/ProvideEpcLaterStepConfigTests.kt
@@ -7,13 +7,13 @@ import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.whenever
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.EpcState
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.EpcDetailState
 import uk.gov.communities.prsdb.webapp.testHelpers.mockObjects.AlwaysTrueValidator
 
 @ExtendWith(MockitoExtension::class)
 class ProvideEpcLaterStepConfigTests {
     @Mock
-    lateinit var mockState: EpcState
+    lateinit var mockState: EpcDetailState
 
     @Test
     fun `chooseTemplate returns occupied template when isOccupied is true`() {

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/ProvideGasCertLaterStepConfigTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/ProvideGasCertLaterStepConfigTests.kt
@@ -6,13 +6,13 @@ import org.junit.jupiter.api.extension.ExtendWith
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.kotlin.whenever
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.GasSafetyState
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.GasSafetyDetailState
 import uk.gov.communities.prsdb.webapp.testHelpers.mockObjects.AlwaysTrueValidator
 
 @ExtendWith(MockitoExtension::class)
 class ProvideGasCertLaterStepConfigTests {
     @Mock
-    lateinit var mockState: GasSafetyState
+    lateinit var mockState: GasSafetyDetailState
 
     @Test
     fun `chooseTemplate returns occupied template when isOccupied is true`() {

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/SavePropertyRegistrationDataStepConfigTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/SavePropertyRegistrationDataStepConfigTests.kt
@@ -28,6 +28,7 @@ import uk.gov.communities.prsdb.webapp.constants.enums.OwnershipType
 import uk.gov.communities.prsdb.webapp.constants.enums.PropertyType
 import uk.gov.communities.prsdb.webapp.journeys.Destination
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.PropertyRegistrationJourneyState
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.ElectricalSafetyDetailsTask
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.ElectricalSafetyTask
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.GasSafetyDetailsTask
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.GasSafetyTask
@@ -186,8 +187,10 @@ class SavePropertyRegistrationDataStepConfigTests {
         setupStateForPropertyRegistration()
         setupStateForComplianceData()
         whenever(mockState.gasSafetyTask.gasSafetyDetailsTask.gasUploadIds).thenReturn(emptyList())
-        whenever(mockState.electricalSafetyTask.electricalUploadIds).thenReturn(emptyList())
-        whenever(mockState.electricalSafetyTask.mapElectricalCertificateTypeToGlobalCertificateType()).thenReturn(null)
+        whenever(mockState.electricalSafetyTask.electricalSafetyDetailsTask.electricalUploadIds).thenReturn(emptyList())
+        whenever(
+            mockState.electricalSafetyTask.electricalSafetyDetailsTask.mapElectricalCertificateTypeToGlobalCertificateType(),
+        ).thenReturn(null)
         whenever(
             mockPropertyRegistrationService.registerProperty(
                 addressModel = any(),
@@ -380,11 +383,11 @@ class SavePropertyRegistrationDataStepConfigTests {
         meesExemptionReason: MeesExemptionReason = MeesExemptionReason.HIGH_COST,
     ) {
         val gasSafetyTask: GasSafetyDetailsTask = mock()
-        val electricalSafetyTask: ElectricalSafetyTask = mock()
+        val electricalSafetyDetailsTask: ElectricalSafetyDetailsTask = mock()
 
         whenever(gasSafetyTask.gasUploadIds).thenReturn(gasUploadIds)
-        whenever(electricalSafetyTask.electricalUploadIds).thenReturn(electricalUploadIds)
-        whenever(electricalSafetyTask.mapElectricalCertificateTypeToGlobalCertificateType()).thenReturn(electricalCertType)
+        whenever(electricalSafetyDetailsTask.electricalUploadIds).thenReturn(electricalUploadIds)
+        whenever(electricalSafetyDetailsTask.mapElectricalCertificateTypeToGlobalCertificateType()).thenReturn(electricalCertType)
 
         val mockHasGasSupplyStep = mock<HasGasSupplyStep>()
         whenever(gasSafetyTask.hasGasSupplyStep).thenReturn(mockHasGasSupplyStep)
@@ -395,7 +398,7 @@ class SavePropertyRegistrationDataStepConfigTests {
         whenever(mockHasGasCertStep.outcome).thenReturn(HasGasCertMode.HAS_CERTIFICATE)
 
         val mockHasElectricalCertStep = mock<HasElectricalCertStep>()
-        whenever(electricalSafetyTask.hasElectricalCertStep).thenReturn(mockHasElectricalCertStep)
+        whenever(electricalSafetyDetailsTask.hasElectricalCertStep).thenReturn(mockHasElectricalCertStep)
         whenever(mockHasElectricalCertStep.outcome).thenReturn(HasElectricalCertMode.HAS_EIC)
 
         val mockHasEpcStep = mock<HasEpcStep>()
@@ -403,7 +406,7 @@ class SavePropertyRegistrationDataStepConfigTests {
         whenever(mockHasEpcStep.outcome).thenReturn(HasEpcMode.HAS_EPC)
 
         whenever(gasSafetyTask.getGasSafetyCertificateIssueDateIfReachable()).thenReturn(gasCertIssueDate)
-        whenever(electricalSafetyTask.getElectricalCertificateExpiryDateIfReachable()).thenReturn(electricalCertExpiryDate)
+        whenever(electricalSafetyDetailsTask.getElectricalCertificateExpiryDateIfReachable()).thenReturn(electricalCertExpiryDate)
 
         if (acceptedEpc != null) {
             whenever(mockEpcCertificateUrlProvider.getEpcCertificateUrl(acceptedEpc.certificateNumber)).thenReturn(epcUrl)
@@ -436,16 +439,18 @@ class SavePropertyRegistrationDataStepConfigTests {
         val mockGasTask: GasSafetyTask = mock()
         whenever(mockGasTask.gasSafetyDetailsTask).thenReturn(gasSafetyTask)
         whenever(mockState.gasSafetyTask).thenReturn(mockGasTask)
-        whenever(mockState.electricalSafetyTask).thenReturn(electricalSafetyTask)
+        val mockElectricalSafetyTask: ElectricalSafetyTask = mock()
+        whenever(mockElectricalSafetyTask.electricalSafetyDetailsTask).thenReturn(electricalSafetyDetailsTask)
+        whenever(mockState.electricalSafetyTask).thenReturn(mockElectricalSafetyTask)
     }
 
     private fun setupStateForComplianceDataWithNullValues() {
         val gasSafetyDetailsTask: GasSafetyDetailsTask = mock()
-        val electricalSafetyTask: ElectricalSafetyTask = mock()
+        val electricalSafetyDetailsTask: ElectricalSafetyDetailsTask = mock()
 
         whenever(gasSafetyDetailsTask.gasUploadIds).thenReturn(emptyList())
-        whenever(electricalSafetyTask.electricalUploadIds).thenReturn(emptyList())
-        whenever(electricalSafetyTask.mapElectricalCertificateTypeToGlobalCertificateType()).thenReturn(null)
+        whenever(electricalSafetyDetailsTask.electricalUploadIds).thenReturn(emptyList())
+        whenever(electricalSafetyDetailsTask.mapElectricalCertificateTypeToGlobalCertificateType()).thenReturn(null)
 
         val mockHasGasSupplyStep = mock<HasGasSupplyStep>()
         whenever(gasSafetyDetailsTask.hasGasSupplyStep).thenReturn(mockHasGasSupplyStep)
@@ -456,7 +461,7 @@ class SavePropertyRegistrationDataStepConfigTests {
         whenever(mockHasGasCertStep.outcome).thenReturn(null)
 
         val mockHasElectricalCertStep = mock<HasElectricalCertStep>()
-        whenever(electricalSafetyTask.hasElectricalCertStep).thenReturn(mockHasElectricalCertStep)
+        whenever(electricalSafetyDetailsTask.hasElectricalCertStep).thenReturn(mockHasElectricalCertStep)
         whenever(mockHasElectricalCertStep.outcome).thenReturn(null)
 
         val mockHasEpcStep = mock<HasEpcStep>()
@@ -464,13 +469,15 @@ class SavePropertyRegistrationDataStepConfigTests {
         whenever(mockHasEpcStep.outcome).thenReturn(null)
 
         whenever(gasSafetyDetailsTask.getGasSafetyCertificateIssueDateIfReachable()).thenReturn(null)
-        whenever(electricalSafetyTask.getElectricalCertificateExpiryDateIfReachable()).thenReturn(null)
+        whenever(electricalSafetyDetailsTask.getElectricalCertificateExpiryDateIfReachable()).thenReturn(null)
         whenever(mockState.acceptedEpcIfStillAccepted).thenReturn(null)
 
         val mockGasTask: GasSafetyTask = mock()
         whenever(mockGasTask.gasSafetyDetailsTask).thenReturn(gasSafetyDetailsTask)
         whenever(mockState.gasSafetyTask).thenReturn(mockGasTask)
-        whenever(mockState.electricalSafetyTask).thenReturn(electricalSafetyTask)
+        val mockElectricalSafetyTask: ElectricalSafetyTask = mock()
+        whenever(mockElectricalSafetyTask.electricalSafetyDetailsTask).thenReturn(electricalSafetyDetailsTask)
+        whenever(mockState.electricalSafetyTask).thenReturn(mockElectricalSafetyTask)
 
         val mockTenancyStep = mock<EpcInDateAtStartOfTenancyCheckStep>()
         val mockEpcExemptionStep = mock<EpcExemptionStep>()

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/SavePropertyRegistrationDataStepConfigTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/SavePropertyRegistrationDataStepConfigTests.kt
@@ -28,6 +28,7 @@ import uk.gov.communities.prsdb.webapp.constants.enums.OwnershipType
 import uk.gov.communities.prsdb.webapp.constants.enums.PropertyType
 import uk.gov.communities.prsdb.webapp.journeys.Destination
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.PropertyRegistrationJourneyState
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.ElectricalSafetyTask
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.GasSafetyDetailsTask
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.GasSafetyTask
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.JointLandlordsPropertyRegistrationTask
@@ -185,8 +186,8 @@ class SavePropertyRegistrationDataStepConfigTests {
         setupStateForPropertyRegistration()
         setupStateForComplianceData()
         whenever(mockState.gasSafetyTask.gasSafetyDetailsTask.gasUploadIds).thenReturn(emptyList())
-        whenever(mockState.electricalUploadIds).thenReturn(emptyList())
-        whenever(mockState.mapElectricalCertificateTypeToGlobalCertificateType()).thenReturn(null)
+        whenever(mockState.electricalSafetyTask.electricalUploadIds).thenReturn(emptyList())
+        whenever(mockState.electricalSafetyTask.mapElectricalCertificateTypeToGlobalCertificateType()).thenReturn(null)
         whenever(
             mockPropertyRegistrationService.registerProperty(
                 addressModel = any(),
@@ -379,10 +380,11 @@ class SavePropertyRegistrationDataStepConfigTests {
         meesExemptionReason: MeesExemptionReason = MeesExemptionReason.HIGH_COST,
     ) {
         val gasSafetyTask: GasSafetyDetailsTask = mock()
+        val electricalSafetyTask: ElectricalSafetyTask = mock()
 
         whenever(gasSafetyTask.gasUploadIds).thenReturn(gasUploadIds)
-        whenever(mockState.electricalUploadIds).thenReturn(electricalUploadIds)
-        whenever(mockState.mapElectricalCertificateTypeToGlobalCertificateType()).thenReturn(electricalCertType)
+        whenever(electricalSafetyTask.electricalUploadIds).thenReturn(electricalUploadIds)
+        whenever(electricalSafetyTask.mapElectricalCertificateTypeToGlobalCertificateType()).thenReturn(electricalCertType)
 
         val mockHasGasSupplyStep = mock<HasGasSupplyStep>()
         whenever(gasSafetyTask.hasGasSupplyStep).thenReturn(mockHasGasSupplyStep)
@@ -393,7 +395,7 @@ class SavePropertyRegistrationDataStepConfigTests {
         whenever(mockHasGasCertStep.outcome).thenReturn(HasGasCertMode.HAS_CERTIFICATE)
 
         val mockHasElectricalCertStep = mock<HasElectricalCertStep>()
-        whenever(mockState.hasElectricalCertStep).thenReturn(mockHasElectricalCertStep)
+        whenever(electricalSafetyTask.hasElectricalCertStep).thenReturn(mockHasElectricalCertStep)
         whenever(mockHasElectricalCertStep.outcome).thenReturn(HasElectricalCertMode.HAS_EIC)
 
         val mockHasEpcStep = mock<HasEpcStep>()
@@ -401,7 +403,7 @@ class SavePropertyRegistrationDataStepConfigTests {
         whenever(mockHasEpcStep.outcome).thenReturn(HasEpcMode.HAS_EPC)
 
         whenever(gasSafetyTask.getGasSafetyCertificateIssueDateIfReachable()).thenReturn(gasCertIssueDate)
-        whenever(mockState.getElectricalCertificateExpiryDateIfReachable()).thenReturn(electricalCertExpiryDate)
+        whenever(electricalSafetyTask.getElectricalCertificateExpiryDateIfReachable()).thenReturn(electricalCertExpiryDate)
 
         if (acceptedEpc != null) {
             whenever(mockEpcCertificateUrlProvider.getEpcCertificateUrl(acceptedEpc.certificateNumber)).thenReturn(epcUrl)
@@ -434,14 +436,16 @@ class SavePropertyRegistrationDataStepConfigTests {
         val mockGasTask: GasSafetyTask = mock()
         whenever(mockGasTask.gasSafetyDetailsTask).thenReturn(gasSafetyTask)
         whenever(mockState.gasSafetyTask).thenReturn(mockGasTask)
+        whenever(mockState.electricalSafetyTask).thenReturn(electricalSafetyTask)
     }
 
     private fun setupStateForComplianceDataWithNullValues() {
         val gasSafetyDetailsTask: GasSafetyDetailsTask = mock()
+        val electricalSafetyTask: ElectricalSafetyTask = mock()
 
         whenever(gasSafetyDetailsTask.gasUploadIds).thenReturn(emptyList())
-        whenever(mockState.electricalUploadIds).thenReturn(emptyList())
-        whenever(mockState.mapElectricalCertificateTypeToGlobalCertificateType()).thenReturn(null)
+        whenever(electricalSafetyTask.electricalUploadIds).thenReturn(emptyList())
+        whenever(electricalSafetyTask.mapElectricalCertificateTypeToGlobalCertificateType()).thenReturn(null)
 
         val mockHasGasSupplyStep = mock<HasGasSupplyStep>()
         whenever(gasSafetyDetailsTask.hasGasSupplyStep).thenReturn(mockHasGasSupplyStep)
@@ -452,7 +456,7 @@ class SavePropertyRegistrationDataStepConfigTests {
         whenever(mockHasGasCertStep.outcome).thenReturn(null)
 
         val mockHasElectricalCertStep = mock<HasElectricalCertStep>()
-        whenever(mockState.hasElectricalCertStep).thenReturn(mockHasElectricalCertStep)
+        whenever(electricalSafetyTask.hasElectricalCertStep).thenReturn(mockHasElectricalCertStep)
         whenever(mockHasElectricalCertStep.outcome).thenReturn(null)
 
         val mockHasEpcStep = mock<HasEpcStep>()
@@ -460,12 +464,13 @@ class SavePropertyRegistrationDataStepConfigTests {
         whenever(mockHasEpcStep.outcome).thenReturn(null)
 
         whenever(gasSafetyDetailsTask.getGasSafetyCertificateIssueDateIfReachable()).thenReturn(null)
-        whenever(mockState.getElectricalCertificateExpiryDateIfReachable()).thenReturn(null)
+        whenever(electricalSafetyTask.getElectricalCertificateExpiryDateIfReachable()).thenReturn(null)
         whenever(mockState.acceptedEpcIfStillAccepted).thenReturn(null)
 
         val mockGasTask: GasSafetyTask = mock()
         whenever(mockGasTask.gasSafetyDetailsTask).thenReturn(gasSafetyDetailsTask)
         whenever(mockState.gasSafetyTask).thenReturn(mockGasTask)
+        whenever(mockState.electricalSafetyTask).thenReturn(electricalSafetyTask)
 
         val mockTenancyStep = mock<EpcInDateAtStartOfTenancyCheckStep>()
         val mockEpcExemptionStep = mock<EpcExemptionStep>()

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/SavePropertyRegistrationDataStepConfigTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/SavePropertyRegistrationDataStepConfigTests.kt
@@ -28,6 +28,7 @@ import uk.gov.communities.prsdb.webapp.constants.enums.OwnershipType
 import uk.gov.communities.prsdb.webapp.constants.enums.PropertyType
 import uk.gov.communities.prsdb.webapp.journeys.Destination
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.PropertyRegistrationJourneyState
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.GasSafetyDetailsTask
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.GasSafetyTask
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.JointLandlordsPropertyRegistrationTask
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.LicensingTask
@@ -183,7 +184,7 @@ class SavePropertyRegistrationDataStepConfigTests {
         // Arrange
         setupStateForPropertyRegistration()
         setupStateForComplianceData()
-        whenever(mockState.gasSafetyTask.gasUploadIds).thenReturn(emptyList())
+        whenever(mockState.gasSafetyTask.gasSafetyDetailsTask.gasUploadIds).thenReturn(emptyList())
         whenever(mockState.electricalUploadIds).thenReturn(emptyList())
         whenever(mockState.mapElectricalCertificateTypeToGlobalCertificateType()).thenReturn(null)
         whenever(
@@ -377,7 +378,7 @@ class SavePropertyRegistrationDataStepConfigTests {
         epcExemptionReason: EpcExemptionReason = EpcExemptionReason.PROTECTED_ARCHITECTURAL_OR_HISTORICAL_MERIT,
         meesExemptionReason: MeesExemptionReason = MeesExemptionReason.HIGH_COST,
     ) {
-        val gasSafetyTask: GasSafetyTask = mock()
+        val gasSafetyTask: GasSafetyDetailsTask = mock()
 
         whenever(gasSafetyTask.gasUploadIds).thenReturn(gasUploadIds)
         whenever(mockState.electricalUploadIds).thenReturn(electricalUploadIds)
@@ -429,22 +430,25 @@ class SavePropertyRegistrationDataStepConfigTests {
                 exemptionReason = meesExemptionReason
             },
         )
-        whenever(mockState.gasSafetyTask).thenReturn(gasSafetyTask)
+
+        val mockGasTask: GasSafetyTask = mock()
+        whenever(mockGasTask.gasSafetyDetailsTask).thenReturn(gasSafetyTask)
+        whenever(mockState.gasSafetyTask).thenReturn(mockGasTask)
     }
 
     private fun setupStateForComplianceDataWithNullValues() {
-        val gasSafetyTask: GasSafetyTask = mock()
+        val gasSafetyDetailsTask: GasSafetyDetailsTask = mock()
 
-        whenever(gasSafetyTask.gasUploadIds).thenReturn(emptyList())
+        whenever(gasSafetyDetailsTask.gasUploadIds).thenReturn(emptyList())
         whenever(mockState.electricalUploadIds).thenReturn(emptyList())
         whenever(mockState.mapElectricalCertificateTypeToGlobalCertificateType()).thenReturn(null)
 
         val mockHasGasSupplyStep = mock<HasGasSupplyStep>()
-        whenever(gasSafetyTask.hasGasSupplyStep).thenReturn(mockHasGasSupplyStep)
+        whenever(gasSafetyDetailsTask.hasGasSupplyStep).thenReturn(mockHasGasSupplyStep)
         whenever(mockHasGasSupplyStep.outcome).thenReturn(YesOrNo.YES)
 
         val mockHasGasCertStep = mock<HasGasCertStep>()
-        whenever(gasSafetyTask.hasGasCertStep).thenReturn(mockHasGasCertStep)
+        whenever(gasSafetyDetailsTask.hasGasCertStep).thenReturn(mockHasGasCertStep)
         whenever(mockHasGasCertStep.outcome).thenReturn(null)
 
         val mockHasElectricalCertStep = mock<HasElectricalCertStep>()
@@ -455,11 +459,13 @@ class SavePropertyRegistrationDataStepConfigTests {
         whenever(mockState.hasEpcStep).thenReturn(mockHasEpcStep)
         whenever(mockHasEpcStep.outcome).thenReturn(null)
 
-        whenever(gasSafetyTask.getGasSafetyCertificateIssueDateIfReachable()).thenReturn(null)
+        whenever(gasSafetyDetailsTask.getGasSafetyCertificateIssueDateIfReachable()).thenReturn(null)
         whenever(mockState.getElectricalCertificateExpiryDateIfReachable()).thenReturn(null)
         whenever(mockState.acceptedEpcIfStillAccepted).thenReturn(null)
 
-        whenever(mockState.gasSafetyTask).thenReturn(gasSafetyTask)
+        val mockGasTask: GasSafetyTask = mock()
+        whenever(mockGasTask.gasSafetyDetailsTask).thenReturn(gasSafetyDetailsTask)
+        whenever(mockState.gasSafetyTask).thenReturn(mockGasTask)
 
         val mockTenancyStep = mock<EpcInDateAtStartOfTenancyCheckStep>()
         val mockEpcExemptionStep = mock<EpcExemptionStep>()

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/SavePropertyRegistrationDataStepConfigTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/SavePropertyRegistrationDataStepConfigTests.kt
@@ -28,6 +28,7 @@ import uk.gov.communities.prsdb.webapp.constants.enums.OwnershipType
 import uk.gov.communities.prsdb.webapp.constants.enums.PropertyType
 import uk.gov.communities.prsdb.webapp.journeys.Destination
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.PropertyRegistrationJourneyState
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.GasSafetyTask
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.JointLandlordsPropertyRegistrationTask
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.LicensingTask
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.OwnershipAndLandlordsTask
@@ -182,7 +183,7 @@ class SavePropertyRegistrationDataStepConfigTests {
         // Arrange
         setupStateForPropertyRegistration()
         setupStateForComplianceData()
-        whenever(mockState.gasUploadIds).thenReturn(emptyList())
+        whenever(mockState.gasSafetyTask.gasUploadIds).thenReturn(emptyList())
         whenever(mockState.electricalUploadIds).thenReturn(emptyList())
         whenever(mockState.mapElectricalCertificateTypeToGlobalCertificateType()).thenReturn(null)
         whenever(
@@ -376,16 +377,18 @@ class SavePropertyRegistrationDataStepConfigTests {
         epcExemptionReason: EpcExemptionReason = EpcExemptionReason.PROTECTED_ARCHITECTURAL_OR_HISTORICAL_MERIT,
         meesExemptionReason: MeesExemptionReason = MeesExemptionReason.HIGH_COST,
     ) {
-        whenever(mockState.gasUploadIds).thenReturn(gasUploadIds)
+        val gasSafetyTask: GasSafetyTask = mock()
+
+        whenever(gasSafetyTask.gasUploadIds).thenReturn(gasUploadIds)
         whenever(mockState.electricalUploadIds).thenReturn(electricalUploadIds)
         whenever(mockState.mapElectricalCertificateTypeToGlobalCertificateType()).thenReturn(electricalCertType)
 
         val mockHasGasSupplyStep = mock<HasGasSupplyStep>()
-        whenever(mockState.hasGasSupplyStep).thenReturn(mockHasGasSupplyStep)
+        whenever(gasSafetyTask.hasGasSupplyStep).thenReturn(mockHasGasSupplyStep)
         whenever(mockHasGasSupplyStep.outcome).thenReturn(YesOrNo.YES)
 
         val mockHasGasCertStep = mock<HasGasCertStep>()
-        whenever(mockState.hasGasCertStep).thenReturn(mockHasGasCertStep)
+        whenever(gasSafetyTask.hasGasCertStep).thenReturn(mockHasGasCertStep)
         whenever(mockHasGasCertStep.outcome).thenReturn(HasGasCertMode.HAS_CERTIFICATE)
 
         val mockHasElectricalCertStep = mock<HasElectricalCertStep>()
@@ -396,7 +399,7 @@ class SavePropertyRegistrationDataStepConfigTests {
         whenever(mockState.hasEpcStep).thenReturn(mockHasEpcStep)
         whenever(mockHasEpcStep.outcome).thenReturn(HasEpcMode.HAS_EPC)
 
-        whenever(mockState.getGasSafetyCertificateIssueDateIfReachable()).thenReturn(gasCertIssueDate)
+        whenever(gasSafetyTask.getGasSafetyCertificateIssueDateIfReachable()).thenReturn(gasCertIssueDate)
         whenever(mockState.getElectricalCertificateExpiryDateIfReachable()).thenReturn(electricalCertExpiryDate)
 
         if (acceptedEpc != null) {
@@ -426,19 +429,22 @@ class SavePropertyRegistrationDataStepConfigTests {
                 exemptionReason = meesExemptionReason
             },
         )
+        whenever(mockState.gasSafetyTask).thenReturn(gasSafetyTask)
     }
 
     private fun setupStateForComplianceDataWithNullValues() {
-        whenever(mockState.gasUploadIds).thenReturn(emptyList())
+        val gasSafetyTask: GasSafetyTask = mock()
+
+        whenever(gasSafetyTask.gasUploadIds).thenReturn(emptyList())
         whenever(mockState.electricalUploadIds).thenReturn(emptyList())
         whenever(mockState.mapElectricalCertificateTypeToGlobalCertificateType()).thenReturn(null)
 
         val mockHasGasSupplyStep = mock<HasGasSupplyStep>()
-        whenever(mockState.hasGasSupplyStep).thenReturn(mockHasGasSupplyStep)
+        whenever(gasSafetyTask.hasGasSupplyStep).thenReturn(mockHasGasSupplyStep)
         whenever(mockHasGasSupplyStep.outcome).thenReturn(YesOrNo.YES)
 
         val mockHasGasCertStep = mock<HasGasCertStep>()
-        whenever(mockState.hasGasCertStep).thenReturn(mockHasGasCertStep)
+        whenever(gasSafetyTask.hasGasCertStep).thenReturn(mockHasGasCertStep)
         whenever(mockHasGasCertStep.outcome).thenReturn(null)
 
         val mockHasElectricalCertStep = mock<HasElectricalCertStep>()
@@ -449,9 +455,11 @@ class SavePropertyRegistrationDataStepConfigTests {
         whenever(mockState.hasEpcStep).thenReturn(mockHasEpcStep)
         whenever(mockHasEpcStep.outcome).thenReturn(null)
 
-        whenever(mockState.getGasSafetyCertificateIssueDateIfReachable()).thenReturn(null)
+        whenever(gasSafetyTask.getGasSafetyCertificateIssueDateIfReachable()).thenReturn(null)
         whenever(mockState.getElectricalCertificateExpiryDateIfReachable()).thenReturn(null)
         whenever(mockState.acceptedEpcIfStillAccepted).thenReturn(null)
+
+        whenever(mockState.gasSafetyTask).thenReturn(gasSafetyTask)
 
         val mockTenancyStep = mock<EpcInDateAtStartOfTenancyCheckStep>()
         val mockEpcExemptionStep = mock<EpcExemptionStep>()

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/SavePropertyRegistrationDataStepConfigTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/SavePropertyRegistrationDataStepConfigTests.kt
@@ -30,6 +30,7 @@ import uk.gov.communities.prsdb.webapp.journeys.Destination
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.PropertyRegistrationJourneyState
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.ElectricalSafetyDetailsTask
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.ElectricalSafetyTask
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.EpcDetailsTask
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.EpcTask
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.GasSafetyDetailsTask
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.GasSafetyTask
@@ -404,7 +405,9 @@ class SavePropertyRegistrationDataStepConfigTests {
 
         val mockHasEpcStep = mock<HasEpcStep>()
         val mockEpcTask: EpcTask = mock()
-        whenever(mockEpcTask.hasEpcStep).thenReturn(mockHasEpcStep)
+        val mockEpcDetailsTask: EpcDetailsTask = mock()
+        whenever(mockEpcTask.epcDetailsTask).thenReturn(mockEpcDetailsTask)
+        whenever(mockEpcDetailsTask.hasEpcStep).thenReturn(mockHasEpcStep)
         whenever(mockHasEpcStep.outcome).thenReturn(HasEpcMode.HAS_EPC)
 
         whenever(gasSafetyTask.getGasSafetyCertificateIssueDateIfReachable()).thenReturn(gasCertIssueDate)
@@ -414,24 +417,24 @@ class SavePropertyRegistrationDataStepConfigTests {
             whenever(mockEpcCertificateUrlProvider.getEpcCertificateUrl(acceptedEpc.certificateNumber)).thenReturn(epcUrl)
         }
 
-        whenever(mockEpcTask.acceptedEpcIfStillAccepted).thenReturn(acceptedEpc)
+        whenever(mockEpcDetailsTask.acceptedEpcIfStillAccepted).thenReturn(acceptedEpc)
 
         val mockTenancyStep = mock<EpcInDateAtStartOfTenancyCheckStep>()
         val mockEpcExemptionStep = mock<EpcExemptionStep>()
         val mockMeesExemptionStep = mock<MeesExemptionStep>()
-        whenever(mockEpcTask.epcInDateAtStartOfTenancyCheckStep).thenReturn(mockTenancyStep)
+        whenever(mockEpcDetailsTask.epcInDateAtStartOfTenancyCheckStep).thenReturn(mockTenancyStep)
         whenever(mockTenancyStep.formModelIfReachableOrNull).thenReturn(
             EpcInDateAtStartOfTenancyCheckFormModel().apply {
                 tenancyStartedBeforeExpiry = tenancyStartedBeforeEpcExpiry
             },
         )
-        whenever(mockEpcTask.epcExemptionStep).thenReturn(mockEpcExemptionStep)
+        whenever(mockEpcDetailsTask.epcExemptionStep).thenReturn(mockEpcExemptionStep)
         whenever(mockEpcExemptionStep.formModelIfReachableOrNull).thenReturn(
             EpcExemptionFormModel().apply {
                 exemptionReason = epcExemptionReason
             },
         )
-        whenever(mockEpcTask.meesExemptionStep).thenReturn(mockMeesExemptionStep)
+        whenever(mockEpcDetailsTask.meesExemptionStep).thenReturn(mockMeesExemptionStep)
         whenever(mockMeesExemptionStep.formModelIfReachableOrNull).thenReturn(
             MeesExemptionReasonFormModel().apply {
                 exemptionReason = meesExemptionReason
@@ -451,6 +454,8 @@ class SavePropertyRegistrationDataStepConfigTests {
         val gasSafetyDetailsTask: GasSafetyDetailsTask = mock()
         val electricalSafetyDetailsTask: ElectricalSafetyDetailsTask = mock()
         val mockEpcTask: EpcTask = mock()
+        val mockEpcDetailsTask: EpcDetailsTask = mock()
+        whenever(mockEpcTask.epcDetailsTask).thenReturn(mockEpcDetailsTask)
 
         whenever(gasSafetyDetailsTask.gasUploadIds).thenReturn(emptyList())
         whenever(electricalSafetyDetailsTask.electricalUploadIds).thenReturn(emptyList())
@@ -469,12 +474,12 @@ class SavePropertyRegistrationDataStepConfigTests {
         whenever(mockHasElectricalCertStep.outcome).thenReturn(null)
 
         val mockHasEpcStep = mock<HasEpcStep>()
-        whenever(mockEpcTask.hasEpcStep).thenReturn(mockHasEpcStep)
+        whenever(mockEpcDetailsTask.hasEpcStep).thenReturn(mockHasEpcStep)
         whenever(mockHasEpcStep.outcome).thenReturn(null)
 
         whenever(gasSafetyDetailsTask.getGasSafetyCertificateIssueDateIfReachable()).thenReturn(null)
         whenever(electricalSafetyDetailsTask.getElectricalCertificateExpiryDateIfReachable()).thenReturn(null)
-        whenever(mockEpcTask.acceptedEpcIfStillAccepted).thenReturn(null)
+        whenever(mockEpcDetailsTask.acceptedEpcIfStillAccepted).thenReturn(null)
 
         val mockGasTask: GasSafetyTask = mock()
         whenever(mockGasTask.gasSafetyDetailsTask).thenReturn(gasSafetyDetailsTask)
@@ -487,11 +492,11 @@ class SavePropertyRegistrationDataStepConfigTests {
         val mockTenancyStep = mock<EpcInDateAtStartOfTenancyCheckStep>()
         val mockEpcExemptionStep = mock<EpcExemptionStep>()
         val mockMeesExemptionStep = mock<MeesExemptionStep>()
-        whenever(mockEpcTask.epcInDateAtStartOfTenancyCheckStep).thenReturn(mockTenancyStep)
+        whenever(mockEpcDetailsTask.epcInDateAtStartOfTenancyCheckStep).thenReturn(mockTenancyStep)
         whenever(mockTenancyStep.formModelIfReachableOrNull).thenReturn(null)
-        whenever(mockEpcTask.epcExemptionStep).thenReturn(mockEpcExemptionStep)
+        whenever(mockEpcDetailsTask.epcExemptionStep).thenReturn(mockEpcExemptionStep)
         whenever(mockEpcExemptionStep.formModelIfReachableOrNull).thenReturn(null)
-        whenever(mockEpcTask.meesExemptionStep).thenReturn(mockMeesExemptionStep)
+        whenever(mockEpcDetailsTask.meesExemptionStep).thenReturn(mockMeesExemptionStep)
         whenever(mockMeesExemptionStep.formModelIfReachableOrNull).thenReturn(null)
     }
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/SavePropertyRegistrationDataStepConfigTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/SavePropertyRegistrationDataStepConfigTests.kt
@@ -30,6 +30,7 @@ import uk.gov.communities.prsdb.webapp.journeys.Destination
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.PropertyRegistrationJourneyState
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.ElectricalSafetyDetailsTask
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.ElectricalSafetyTask
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.EpcTask
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.GasSafetyDetailsTask
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.GasSafetyTask
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.JointLandlordsPropertyRegistrationTask
@@ -402,7 +403,8 @@ class SavePropertyRegistrationDataStepConfigTests {
         whenever(mockHasElectricalCertStep.outcome).thenReturn(HasElectricalCertMode.HAS_EIC)
 
         val mockHasEpcStep = mock<HasEpcStep>()
-        whenever(mockState.hasEpcStep).thenReturn(mockHasEpcStep)
+        val mockEpcTask: EpcTask = mock()
+        whenever(mockEpcTask.hasEpcStep).thenReturn(mockHasEpcStep)
         whenever(mockHasEpcStep.outcome).thenReturn(HasEpcMode.HAS_EPC)
 
         whenever(gasSafetyTask.getGasSafetyCertificateIssueDateIfReachable()).thenReturn(gasCertIssueDate)
@@ -412,24 +414,24 @@ class SavePropertyRegistrationDataStepConfigTests {
             whenever(mockEpcCertificateUrlProvider.getEpcCertificateUrl(acceptedEpc.certificateNumber)).thenReturn(epcUrl)
         }
 
-        whenever(mockState.acceptedEpcIfStillAccepted).thenReturn(acceptedEpc)
+        whenever(mockEpcTask.acceptedEpcIfStillAccepted).thenReturn(acceptedEpc)
 
         val mockTenancyStep = mock<EpcInDateAtStartOfTenancyCheckStep>()
         val mockEpcExemptionStep = mock<EpcExemptionStep>()
         val mockMeesExemptionStep = mock<MeesExemptionStep>()
-        whenever(mockState.epcInDateAtStartOfTenancyCheckStep).thenReturn(mockTenancyStep)
+        whenever(mockEpcTask.epcInDateAtStartOfTenancyCheckStep).thenReturn(mockTenancyStep)
         whenever(mockTenancyStep.formModelIfReachableOrNull).thenReturn(
             EpcInDateAtStartOfTenancyCheckFormModel().apply {
                 tenancyStartedBeforeExpiry = tenancyStartedBeforeEpcExpiry
             },
         )
-        whenever(mockState.epcExemptionStep).thenReturn(mockEpcExemptionStep)
+        whenever(mockEpcTask.epcExemptionStep).thenReturn(mockEpcExemptionStep)
         whenever(mockEpcExemptionStep.formModelIfReachableOrNull).thenReturn(
             EpcExemptionFormModel().apply {
                 exemptionReason = epcExemptionReason
             },
         )
-        whenever(mockState.meesExemptionStep).thenReturn(mockMeesExemptionStep)
+        whenever(mockEpcTask.meesExemptionStep).thenReturn(mockMeesExemptionStep)
         whenever(mockMeesExemptionStep.formModelIfReachableOrNull).thenReturn(
             MeesExemptionReasonFormModel().apply {
                 exemptionReason = meesExemptionReason
@@ -442,11 +444,13 @@ class SavePropertyRegistrationDataStepConfigTests {
         val mockElectricalSafetyTask: ElectricalSafetyTask = mock()
         whenever(mockElectricalSafetyTask.electricalSafetyDetailsTask).thenReturn(electricalSafetyDetailsTask)
         whenever(mockState.electricalSafetyTask).thenReturn(mockElectricalSafetyTask)
+        whenever(mockState.epcTask).thenReturn(mockEpcTask)
     }
 
     private fun setupStateForComplianceDataWithNullValues() {
         val gasSafetyDetailsTask: GasSafetyDetailsTask = mock()
         val electricalSafetyDetailsTask: ElectricalSafetyDetailsTask = mock()
+        val mockEpcTask: EpcTask = mock()
 
         whenever(gasSafetyDetailsTask.gasUploadIds).thenReturn(emptyList())
         whenever(electricalSafetyDetailsTask.electricalUploadIds).thenReturn(emptyList())
@@ -465,12 +469,12 @@ class SavePropertyRegistrationDataStepConfigTests {
         whenever(mockHasElectricalCertStep.outcome).thenReturn(null)
 
         val mockHasEpcStep = mock<HasEpcStep>()
-        whenever(mockState.hasEpcStep).thenReturn(mockHasEpcStep)
+        whenever(mockEpcTask.hasEpcStep).thenReturn(mockHasEpcStep)
         whenever(mockHasEpcStep.outcome).thenReturn(null)
 
         whenever(gasSafetyDetailsTask.getGasSafetyCertificateIssueDateIfReachable()).thenReturn(null)
         whenever(electricalSafetyDetailsTask.getElectricalCertificateExpiryDateIfReachable()).thenReturn(null)
-        whenever(mockState.acceptedEpcIfStillAccepted).thenReturn(null)
+        whenever(mockEpcTask.acceptedEpcIfStillAccepted).thenReturn(null)
 
         val mockGasTask: GasSafetyTask = mock()
         whenever(mockGasTask.gasSafetyDetailsTask).thenReturn(gasSafetyDetailsTask)
@@ -478,15 +482,16 @@ class SavePropertyRegistrationDataStepConfigTests {
         val mockElectricalSafetyTask: ElectricalSafetyTask = mock()
         whenever(mockElectricalSafetyTask.electricalSafetyDetailsTask).thenReturn(electricalSafetyDetailsTask)
         whenever(mockState.electricalSafetyTask).thenReturn(mockElectricalSafetyTask)
+        whenever(mockState.epcTask).thenReturn(mockEpcTask)
 
         val mockTenancyStep = mock<EpcInDateAtStartOfTenancyCheckStep>()
         val mockEpcExemptionStep = mock<EpcExemptionStep>()
         val mockMeesExemptionStep = mock<MeesExemptionStep>()
-        whenever(mockState.epcInDateAtStartOfTenancyCheckStep).thenReturn(mockTenancyStep)
+        whenever(mockEpcTask.epcInDateAtStartOfTenancyCheckStep).thenReturn(mockTenancyStep)
         whenever(mockTenancyStep.formModelIfReachableOrNull).thenReturn(null)
-        whenever(mockState.epcExemptionStep).thenReturn(mockEpcExemptionStep)
+        whenever(mockEpcTask.epcExemptionStep).thenReturn(mockEpcExemptionStep)
         whenever(mockEpcExemptionStep.formModelIfReachableOrNull).thenReturn(null)
-        whenever(mockState.meesExemptionStep).thenReturn(mockMeesExemptionStep)
+        whenever(mockEpcTask.meesExemptionStep).thenReturn(mockMeesExemptionStep)
         whenever(mockMeesExemptionStep.formModelIfReachableOrNull).thenReturn(null)
     }
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/UploadElectricalCertStepConfigTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/propertyRegistration/steps/UploadElectricalCertStepConfigTests.kt
@@ -14,7 +14,7 @@ import uk.gov.communities.prsdb.webapp.constants.enums.CertificateType
 import uk.gov.communities.prsdb.webapp.constants.enums.HasElectricalSafetyCertificate
 import uk.gov.communities.prsdb.webapp.exceptions.PrsdbWebException
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.CertificateUpload
-import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.ElectricalSafetyState
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.states.ElectricalSafetyDetailState
 import uk.gov.communities.prsdb.webapp.journeys.shared.Complete
 import uk.gov.communities.prsdb.webapp.services.CollectionKeyParameterService
 import uk.gov.communities.prsdb.webapp.services.FileUploadCookieService
@@ -24,7 +24,7 @@ import uk.gov.communities.prsdb.webapp.testHelpers.mockObjects.AlwaysTrueValidat
 @ExtendWith(MockitoExtension::class)
 class UploadElectricalCertStepConfigTests {
     @Mock
-    lateinit var mockState: ElectricalSafetyState
+    lateinit var mockState: ElectricalSafetyDetailState
 
     @Mock
     lateinit var virusScanCallbackService: VirusScanCallbackService

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/shared/helpers/ComplianceDetailsHelperTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/shared/helpers/ComplianceDetailsHelperTests.kt
@@ -180,7 +180,10 @@ class ComplianceDetailsHelperTests {
     @Nested
     inner class GetEpcCyaContent {
         @Mock
-        internal lateinit var mockState: TestableEpcState
+        internal lateinit var mockCyaState: CheckYourAnswersJourneyState
+
+        @Mock
+        internal lateinit var mockState: EpcState
 
         private val mockHasEpcStep: HasEpcStep = mock()
 
@@ -190,11 +193,11 @@ class ComplianceDetailsHelperTests {
         fun `skipped occupied returns all expected keys with null epcCardTitle and non-empty nonEpcRows`() {
             whenever(mockState.startEpcStep).thenReturn(mockStartEpcStep)
             whenever(mockState.hasEpcStep).thenReturn(mockHasEpcStep)
-            whenever(mockState.getCyaJourneyId(any())).thenReturn("test-journey-id")
+            whenever(mockCyaState.getCyaJourneyId(any())).thenReturn("test-journey-id")
             whenever(mockHasEpcStep.outcome).thenReturn(HasEpcMode.PROVIDE_LATER)
             whenever(mockState.isOccupied).thenReturn(true)
 
-            val content = helper.getEpcCyaContent(mockState)
+            val content = helper.getEpcCyaContent(mockCyaState, mockState)
 
             assertEquals(
                 setOf(

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/shared/helpers/ComplianceDetailsHelperTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/shared/helpers/ComplianceDetailsHelperTests.kt
@@ -4,6 +4,7 @@ import kotlinx.datetime.LocalDate
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
@@ -28,15 +29,12 @@ import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.HasGa
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.HasGasCertStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.HasGasSupplyStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.StartEpcStep
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.GasSafetyDetailsTask
 import uk.gov.communities.prsdb.webapp.journeys.shared.YesOrNo
 import uk.gov.communities.prsdb.webapp.journeys.shared.states.CheckYourAnswersJourneyState
 import uk.gov.communities.prsdb.webapp.models.viewModels.summaryModels.SummaryListRowViewModel
 import uk.gov.communities.prsdb.webapp.services.EpcCertificateUrlProvider
 import uk.gov.communities.prsdb.webapp.services.UploadService
-
-internal interface TestableGasSafetyState :
-    GasSafetyState,
-    CheckYourAnswersJourneyState
 
 internal interface TestableElectricalSafetyState :
     ElectricalSafetyState,
@@ -58,18 +56,29 @@ class ComplianceDetailsHelperTests {
     @Nested
     inner class GetGasSafetyCyaContent {
         @Mock
-        internal lateinit var mockState: TestableGasSafetyState
+        internal lateinit var mockCyaState: CheckYourAnswersJourneyState
+
+        @Mock
+        internal lateinit var mockGasState: GasSafetyState
+
+        @Mock
+        internal lateinit var mockGasDetailsTask: GasSafetyDetailsTask
 
         private val mockHasGasSupplyStep: HasGasSupplyStep = mock()
         private val mockHasGasCertStep: HasGasCertStep = mock()
 
+        @BeforeEach
+        fun setUp() {
+            whenever(mockGasState.gasSafetyDetailsTask).thenReturn(mockGasDetailsTask)
+        }
+
         @Test
         fun `no gas supply returns gasSupplyRows with 1 row, empty certRows, and noGasSupply inset text key`() {
-            whenever(mockState.hasGasSupplyStep).thenReturn(mockHasGasSupplyStep)
-            whenever(mockState.getCyaJourneyId(any())).thenReturn("test-journey-id")
+            whenever(mockGasDetailsTask.hasGasSupplyStep).thenReturn(mockHasGasSupplyStep)
+            whenever(mockCyaState.getCyaJourneyId(any())).thenReturn("test-journey-id")
             whenever(mockHasGasSupplyStep.outcome).thenReturn(YesOrNo.NO)
 
-            val content = helper.getGasSafetyCyaContent(mockState, mockState)
+            val content = helper.getGasSafetyCyaContent(mockCyaState, mockGasState)
 
             @Suppress("UNCHECKED_CAST")
             val gasSupplyRows = content["gasSupplyRows"] as List<SummaryListRowViewModel>
@@ -88,22 +97,22 @@ class ComplianceDetailsHelperTests {
             val mockGasCertIssueDateStep: GasCertIssueDateStep = mock()
             val mockCheckGasCertUploadsStep: CheckGasCertUploadsStep = mock()
 
-            whenever(mockState.hasGasSupplyStep).thenReturn(mockHasGasSupplyStep)
-            whenever(mockState.hasGasCertStep).thenReturn(mockHasGasCertStep)
-            whenever(mockState.getCyaJourneyId(any())).thenReturn("test-journey-id")
+            whenever(mockGasDetailsTask.hasGasSupplyStep).thenReturn(mockHasGasSupplyStep)
+            whenever(mockGasDetailsTask.hasGasCertStep).thenReturn(mockHasGasCertStep)
+            whenever(mockCyaState.getCyaJourneyId(any())).thenReturn("test-journey-id")
             whenever(mockHasGasSupplyStep.outcome).thenReturn(YesOrNo.YES)
             whenever(mockHasGasCertStep.outcome).thenReturn(HasGasCertMode.HAS_CERTIFICATE)
-            whenever(mockState.getGasSafetyCertificateIsOutdated()).thenReturn(false)
-            whenever(mockState.getGasSafetyCertificateIssueDateIfReachable()).thenReturn(LocalDate(2024, 1, 15))
-            whenever(mockState.gasCertIssueDateStep).thenReturn(mockGasCertIssueDateStep)
-            whenever(mockState.checkGasCertUploadsStep).thenReturn(mockCheckGasCertUploadsStep)
-            whenever(mockState.gasUploadMap).thenReturn(mapOf(1 to CertificateUpload(1L, "cert.pdf")))
+            whenever(mockGasDetailsTask.getGasSafetyCertificateIsOutdated()).thenReturn(false)
+            whenever(mockGasDetailsTask.getGasSafetyCertificateIssueDateIfReachable()).thenReturn(LocalDate(2024, 1, 15))
+            whenever(mockGasDetailsTask.gasCertIssueDateStep).thenReturn(mockGasCertIssueDateStep)
+            whenever(mockGasDetailsTask.checkGasCertUploadsStep).thenReturn(mockCheckGasCertUploadsStep)
+            whenever(mockGasDetailsTask.gasUploadMap).thenReturn(mapOf(1 to CertificateUpload(1L, "cert.pdf")))
             val mockFileUpload: FileUpload = mock()
             whenever(mockFileUpload.status).thenReturn(FileUploadStatus.SCANNED)
             whenever(mockUploadService.getFileUploadById(1L)).thenReturn(mockFileUpload)
             whenever(mockUploadService.getDownloadUrlOrNull(any(), any())).thenReturn("/download/cert.pdf")
 
-            val content = helper.getGasSafetyCyaContent(mockState, mockState)
+            val content = helper.getGasSafetyCyaContent(mockCyaState, mockGasState)
 
             @Suppress("UNCHECKED_CAST")
             val gasSupplyRows = content["gasSupplyRows"] as List<SummaryListRowViewModel>

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/shared/helpers/ComplianceDetailsHelperTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/shared/helpers/ComplianceDetailsHelperTests.kt
@@ -141,7 +141,7 @@ class ComplianceDetailsHelperTests {
             whenever(mockHasElectricalCertStep.outcome).thenReturn(HasElectricalCertMode.PROVIDE_THIS_LATER)
             whenever(mockState.isOccupied).thenReturn(true)
 
-            val content = helper.getElectricalSafetyCyaContent(mockState)
+            val content = helper.getElectricalSafetyCyaContent(mockState, mockState)
 
             @Suppress("UNCHECKED_CAST")
             val rows = content["electricalRows"] as List<SummaryListRowViewModel>
@@ -158,7 +158,7 @@ class ComplianceDetailsHelperTests {
             whenever(mockHasElectricalCertStep.outcome).thenReturn(HasElectricalCertMode.NO_CERTIFICATE)
             whenever(mockState.isOccupied).thenReturn(true)
 
-            val content = helper.getElectricalSafetyCyaContent(mockState)
+            val content = helper.getElectricalSafetyCyaContent(mockState, mockState)
 
             @Suppress("UNCHECKED_CAST")
             val rows = content["electricalRows"] as List<SummaryListRowViewModel>

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/shared/helpers/ComplianceDetailsHelperTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/shared/helpers/ComplianceDetailsHelperTests.kt
@@ -29,16 +29,13 @@ import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.HasGa
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.HasGasCertStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.HasGasSupplyStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.StartEpcStep
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.ElectricalSafetyDetailsTask
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.GasSafetyDetailsTask
 import uk.gov.communities.prsdb.webapp.journeys.shared.YesOrNo
 import uk.gov.communities.prsdb.webapp.journeys.shared.states.CheckYourAnswersJourneyState
 import uk.gov.communities.prsdb.webapp.models.viewModels.summaryModels.SummaryListRowViewModel
 import uk.gov.communities.prsdb.webapp.services.EpcCertificateUrlProvider
 import uk.gov.communities.prsdb.webapp.services.UploadService
-
-internal interface TestableElectricalSafetyState :
-    ElectricalSafetyState,
-    CheckYourAnswersJourneyState
 
 internal interface TestableEpcState :
     EpcState,
@@ -130,18 +127,29 @@ class ComplianceDetailsHelperTests {
     @Nested
     inner class GetElectricalSafetyCyaContent {
         @Mock
-        internal lateinit var mockState: TestableElectricalSafetyState
+        internal lateinit var mockCyaState: CheckYourAnswersJourneyState
+
+        @Mock
+        internal lateinit var mockState: ElectricalSafetyState
+
+        @Mock
+        internal lateinit var mockElectricalDetailsTask: ElectricalSafetyDetailsTask
 
         private val mockHasElectricalCertStep: HasElectricalCertStep = mock()
 
+        @BeforeEach
+        fun setUp() {
+            whenever(mockState.electricalSafetyDetailsTask).thenReturn(mockElectricalDetailsTask)
+        }
+
         @Test
         fun `provide later for occupied property returns 1 row and null inset text key`() {
-            whenever(mockState.hasElectricalCertStep).thenReturn(mockHasElectricalCertStep)
-            whenever(mockState.getCyaJourneyId(any())).thenReturn("test-journey-id")
+            whenever(mockElectricalDetailsTask.hasElectricalCertStep).thenReturn(mockHasElectricalCertStep)
+            whenever(mockCyaState.getCyaJourneyId(any())).thenReturn("test-journey-id")
             whenever(mockHasElectricalCertStep.outcome).thenReturn(HasElectricalCertMode.PROVIDE_THIS_LATER)
-            whenever(mockState.isOccupied).thenReturn(true)
+            whenever(mockElectricalDetailsTask.isOccupied).thenReturn(true)
 
-            val content = helper.getElectricalSafetyCyaContent(mockState, mockState)
+            val content = helper.getElectricalSafetyCyaContent(mockCyaState, mockState)
 
             @Suppress("UNCHECKED_CAST")
             val rows = content["electricalRows"] as List<SummaryListRowViewModel>
@@ -153,12 +161,12 @@ class ComplianceDetailsHelperTests {
 
         @Test
         fun `no cert for occupied property returns 1 row and occupiedNoCert inset text key`() {
-            whenever(mockState.hasElectricalCertStep).thenReturn(mockHasElectricalCertStep)
-            whenever(mockState.getCyaJourneyId(any())).thenReturn("test-journey-id")
+            whenever(mockElectricalDetailsTask.hasElectricalCertStep).thenReturn(mockHasElectricalCertStep)
+            whenever(mockCyaState.getCyaJourneyId(any())).thenReturn("test-journey-id")
             whenever(mockHasElectricalCertStep.outcome).thenReturn(HasElectricalCertMode.NO_CERTIFICATE)
-            whenever(mockState.isOccupied).thenReturn(true)
+            whenever(mockElectricalDetailsTask.isOccupied).thenReturn(true)
 
-            val content = helper.getElectricalSafetyCyaContent(mockState, mockState)
+            val content = helper.getElectricalSafetyCyaContent(mockCyaState, mockState)
 
             @Suppress("UNCHECKED_CAST")
             val rows = content["electricalRows"] as List<SummaryListRowViewModel>

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/shared/helpers/ComplianceDetailsHelperTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/shared/helpers/ComplianceDetailsHelperTests.kt
@@ -30,6 +30,7 @@ import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.HasGa
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.HasGasSupplyStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.StartEpcStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.ElectricalSafetyDetailsTask
+import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.EpcDetailsTask
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.tasks.GasSafetyDetailsTask
 import uk.gov.communities.prsdb.webapp.journeys.shared.YesOrNo
 import uk.gov.communities.prsdb.webapp.journeys.shared.states.CheckYourAnswersJourneyState
@@ -185,17 +186,25 @@ class ComplianceDetailsHelperTests {
         @Mock
         internal lateinit var mockState: EpcState
 
+        @Mock
+        internal lateinit var mockEpcDetailsTask: EpcDetailsTask
+
         private val mockHasEpcStep: HasEpcStep = mock()
 
         private val mockStartEpcStep: StartEpcStep = mock()
 
+        @BeforeEach
+        fun setUp() {
+            whenever(mockState.epcDetailsTask).thenReturn(mockEpcDetailsTask)
+        }
+
         @Test
         fun `skipped occupied returns all expected keys with null epcCardTitle and non-empty nonEpcRows`() {
-            whenever(mockState.startEpcStep).thenReturn(mockStartEpcStep)
-            whenever(mockState.hasEpcStep).thenReturn(mockHasEpcStep)
+            whenever(mockEpcDetailsTask.startEpcStep).thenReturn(mockStartEpcStep)
+            whenever(mockEpcDetailsTask.hasEpcStep).thenReturn(mockHasEpcStep)
             whenever(mockCyaState.getCyaJourneyId(any())).thenReturn("test-journey-id")
             whenever(mockHasEpcStep.outcome).thenReturn(HasEpcMode.PROVIDE_LATER)
-            whenever(mockState.isOccupied).thenReturn(true)
+            whenever(mockEpcDetailsTask.isOccupied).thenReturn(true)
 
             val content = helper.getEpcCyaContent(mockCyaState, mockState)
 

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/shared/helpers/ComplianceDetailsHelperTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/shared/helpers/ComplianceDetailsHelperTests.kt
@@ -69,7 +69,7 @@ class ComplianceDetailsHelperTests {
             whenever(mockState.getCyaJourneyId(any())).thenReturn("test-journey-id")
             whenever(mockHasGasSupplyStep.outcome).thenReturn(YesOrNo.NO)
 
-            val content = helper.getGasSafetyCyaContent(mockState)
+            val content = helper.getGasSafetyCyaContent(mockState, mockState)
 
             @Suppress("UNCHECKED_CAST")
             val gasSupplyRows = content["gasSupplyRows"] as List<SummaryListRowViewModel>
@@ -103,7 +103,7 @@ class ComplianceDetailsHelperTests {
             whenever(mockUploadService.getFileUploadById(1L)).thenReturn(mockFileUpload)
             whenever(mockUploadService.getDownloadUrlOrNull(any(), any())).thenReturn("/download/cert.pdf")
 
-            val content = helper.getGasSafetyCyaContent(mockState)
+            val content = helper.getGasSafetyCyaContent(mockState, mockState)
 
             @Suppress("UNCHECKED_CAST")
             val gasSupplyRows = content["gasSupplyRows"] as List<SummaryListRowViewModel>


### PR DESCRIPTION
## Ticket number

PDJB-896

## Goal of change

Migrate the three property-registration compliance sections (gas safety, electrical safety, EPC) — both container tasks and their inner details tasks — onto the `DuplicableTaskWithDependencies` composition model already used elsewhere in this ticket.

## Description of main change(s)

Six commits, one per task, applied in the same pattern for each section:

- **Container migration** (`GasSafetyTask`, `ElectricalSafetyTask`, `EpcTask`) — converts each container `Task` to a `DuplicableTaskWithDependencies<XxxState, XxxDependencies>`. Steps and delegates that used to live on `PropertyRegistrationJourney` (and on the update-journey concrete class) are pulled into the task's constructor and delegate storage. Journey factories now wire the task with `duplicableTask { withDependencies { journey } }`, and CYA sub-journeys use `fromTask(...) { checkAnswerTask(task.xxxDetailsTask) }`.
- **Details migration** (`GasSafetyDetailsTask`, `ElectricalSafetyDetailsTask`, `EpcDetailsTask`) — splits each state interface into a small container state (`XxxState`) and a wide detail state (`XxxDetailState`) and moves all step overrides, upload maps / EPC data-model delegates, and `isOccupied` / `allowProvideCertificateLaterRoute` overrides onto the details task. Step configs are re-typed against the new detail state, and the container's inner call switches to `duplicableTask(...) { withDependencies { dependencies } }`. Update journeys drop their per-step constructor params and instead extend `XxxDependencies`.
- Shared helpers (`ComplianceDetailsHelper.getXxxCyaContent`) now take an explicit `(cyaState, xxxState)` pair rather than a self-typed generic, mirroring the split-state design.
- `CombinedComplianceCheckState` no longer inherits the compliance states directly; it exposes `gasSafetyTask`, `electricalSafetyTask`, and `epcTask`, and `HasMissingComplianceStepConfig` reads through those.

Behaviour is unchanged; all existing tests were updated in place (routing stubs through the new `.xxxDetailsTask.*` accessors) and pass.

## Anything you''d like to highlight to the reviewer?

- The migration is best reviewed one commit at a time — each commit is a mechanical mirror of the previous section''s pattern.
- The `EmbedBuilder.checkAnswerTask` extension in `CheckYourAnswersJourneyState` is added and removed several times through the commit series as each pair of tasks changes; the final state (HEAD) is that it is removed, because once every compliance details task is duplicable the extension has no callers.

## Checklist

- [x] Unit tests for new logic (e.g. new service methods) have been added
- [x] Test suite has been run in full locally and is passing
