### PR TITLE
PDJB-1252: Add skeleton page for landlord details

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/LandlordDetailsController.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/LandlordDetailsController.kt
@@ -16,13 +16,16 @@ import uk.gov.communities.prsdb.webapp.constants.LANDLORD_PATH_SEGMENT
 import uk.gov.communities.prsdb.webapp.constants.LOCAL_COUNCIL_PATH_SEGMENT
 import uk.gov.communities.prsdb.webapp.constants.REGISTERED_PROPERTIES_FRAGMENT
 import uk.gov.communities.prsdb.webapp.constants.UPDATE_PATH_SEGMENT
+import uk.gov.communities.prsdb.webapp.constants.enums.LandlordType
 import uk.gov.communities.prsdb.webapp.controllers.LandlordController.Companion.LANDLORD_DASHBOARD_URL
-import uk.gov.communities.prsdb.webapp.exceptions.PrsdbWebException
+import uk.gov.communities.prsdb.webapp.database.entity.OrganisationLandlord
 import uk.gov.communities.prsdb.webapp.helpers.DateTimeHelper
 import uk.gov.communities.prsdb.webapp.models.viewModels.summaryModels.LandlordViewModel
 import uk.gov.communities.prsdb.webapp.services.BackUrlStorageService
 import uk.gov.communities.prsdb.webapp.services.LandlordService
+import uk.gov.communities.prsdb.webapp.services.OrganisationGoverningBodyMemberService
 import uk.gov.communities.prsdb.webapp.services.PropertyOwnershipService
+import uk.gov.communities.prsdb.webapp.services.UserToLandlordService
 import java.security.Principal
 
 @PrsdbController
@@ -31,6 +34,8 @@ class LandlordDetailsController(
     private val landlordService: LandlordService,
     private val propertyOwnershipService: PropertyOwnershipService,
     private val backUrlStorageService: BackUrlStorageService,
+    private val userToLandlordService: UserToLandlordService,
+    private val organisationGoverningBodyMemberService: OrganisationGoverningBodyMemberService,
 ) {
     @PreAuthorize("hasRole('LANDLORD')")
     @GetMapping(LANDLORD_DETAILS_FOR_LANDLORD_ROUTE)
@@ -38,9 +43,11 @@ class LandlordDetailsController(
         model: Model,
         principal: Principal,
     ): String {
-        val landlord =
-            landlordService.retrieveLandlordByBaseUserId(principal.name)
-                ?: throw PrsdbWebException("User ${principal.name} is not registered as a landlord")
+        val landlord = userToLandlordService.getCurrentLandlordForUser()
+
+        if (landlord.landlordType == LandlordType.ORGANISATION) {
+            return getOrgLandlordDetails(landlord as OrganisationLandlord, model)
+        }
 
         val landlordViewModel = LandlordViewModel(landlord, withChangeLinks = true)
 
@@ -65,6 +72,21 @@ class LandlordDetailsController(
         model.addAttribute("deleteLandlordRecordUrl", DeregisterLandlordController.LANDLORD_DEREGISTRATION_PATH)
 
         return "landlordDetailsView"
+    }
+
+    // TODO: PDJB-1276: Update skeleton page
+    private fun getOrgLandlordDetails(
+        orgLandlord: OrganisationLandlord,
+        model: Model,
+    ): String {
+        val governingBodyMembers =
+            organisationGoverningBodyMemberService.getGoverningBodyMembers(orgLandlord)
+
+        model.addAttribute("orgLandlord", orgLandlord)
+        model.addAttribute("governingBodyMembers", governingBodyMembers)
+        model.addAttribute("backUrl", LANDLORD_DASHBOARD_URL)
+
+        return "orgLandlordDetailsView"
     }
 
     @PreAuthorize("hasAnyRole('LOCAL_COUNCIL_USER', 'LOCAL_COUNCIL_ADMIN')")

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/OrganisationGoverningBodyMemberService.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/OrganisationGoverningBodyMemberService.kt
@@ -13,6 +13,9 @@ class OrganisationGoverningBodyMemberService(
     private val organisationGoverningBodyMemberRepository: OrganisationGoverningBodyMemberRepository,
     private val addressService: AddressService,
 ) {
+    fun getGoverningBodyMembers(organisationLandlord: OrganisationLandlord): List<OrganisationGoverningBodyMember> =
+        organisationGoverningBodyMemberRepository.findAllByOrganisationLandlord_Id(organisationLandlord.id)
+
     @Transactional
     fun createGoverningBodyMembers(
         organisationLandlord: OrganisationLandlord,

--- a/src/main/resources/messages/landlordDetails.yml
+++ b/src/main/resources/messages/landlordDetails.yml
@@ -31,3 +31,26 @@ registeredProperties:
     link: Register a property
 update:
   title: Update Landlord record
+org:
+  title: Organisation landlord record
+  heading: Organisation landlord record
+  organisationDetails: Organisation details
+  name: Organisation name
+  address: Organisation address
+  email: Organisation email
+  phone: Organisation phone number
+  organisationType: Organisation type
+  isCompany: Company
+  companyNumber: Companies House number
+  isCharity: Charity
+  isTrust: Trust
+  charityNumber: Charity number
+  mainContactHeading: Main contact
+  mainContactName: Name
+  mainContactEmail: Email
+  mainContactPhone: Phone number
+  leadTrusteeHeading: Lead trustee
+  leadTrusteeName: Name
+  leadTrusteeEmail: Email
+  leadTrusteePhone: Phone number
+  governingBodyHeading: Governing body members

--- a/src/main/resources/messages/landlordDetails.yml
+++ b/src/main/resources/messages/landlordDetails.yml
@@ -33,7 +33,7 @@ update:
   title: Update Landlord record
 org:
   title: Organisation landlord record
-  heading: Organisation landlord record
+  heading: 'TODO PDJB-1276: Organisation landlord record'
   organisationDetails: Organisation details
   name: Organisation name
   address: Organisation address

--- a/src/main/resources/templates/orgLandlordDetailsView.html
+++ b/src/main/resources/templates/orgLandlordDetailsView.html
@@ -1,0 +1,107 @@
+<!DOCTYPE html>
+<html id="page" th:replace="~{fragments/layout :: layout(#{landlordDetails.org.title},~{::#page/content()}, false)}">
+    <a th:replace="~{fragments/forms/backLink :: backLink(${backUrl})}">Back link</a>
+    <main class="govuk-main-wrapper" id="main-content">
+        <h1 class="govuk-heading-l" th:text="#{landlordDetails.org.heading}">landlordDetails.org.heading</h1>
+
+        <h2 class="govuk-heading-m" th:text="#{landlordDetails.org.organisationDetails}">landlordDetails.org.organisationDetails</h2>
+
+        <p class="govuk-body">
+            <strong th:text="#{landlordDetails.org.name}">landlordDetails.org.name</strong><br/>
+            <span th:text="${orgLandlord.name}">Organisation name</span><br/>
+            <a class="govuk-link" href="#">Change</a> <!-- TODO: PDJB-1234: Add update journey -->
+        </p>
+
+        <p class="govuk-body">
+            <strong th:text="#{landlordDetails.org.address}">landlordDetails.org.address</strong><br/>
+            <span th:text="${orgLandlord.address?.singleLineAddress}">Organisation address</span><br/>
+            <a class="govuk-link" href="#">Change</a> <!-- TODO: PDJB-1444: Add update journey -->
+        </p>
+
+        <p class="govuk-body">
+            <strong th:text="#{landlordDetails.org.email}">landlordDetails.org.email</strong><br/>
+            <span th:text="${orgLandlord.email}">Organisation email</span><br/>
+            <a class="govuk-link" href="#">Change</a> <!-- TODO: PDJB-1235: Add update journey -->
+        </p>
+
+        <p class="govuk-body">
+            <strong th:text="#{landlordDetails.org.phone}">landlordDetails.org.phone</strong><br/>
+            <span th:text="${orgLandlord.phoneNumber}">Organisation phone</span><br/>
+            <a class="govuk-link" href="#">Change</a> <!-- TODO: PDJB-1236: Add update journey -->
+        </p>
+
+        <h2 class="govuk-heading-m" th:text="#{landlordDetails.org.organisationType}">landlordDetails.org.organisationType</h2>
+
+        <p class="govuk-body">
+            <strong th:text="#{landlordDetails.org.organisationType}">landlordDetails.org.organisationType</strong><br/>
+            <span th:if="${orgLandlord.isCompany}" th:text="#{landlordDetails.org.isCompany}">Company</span>
+            <span th:if="${orgLandlord.isCharity}" th:text="#{landlordDetails.org.isCharity}">Charity</span>
+            <span th:if="${orgLandlord.isTrust}" th:text="#{landlordDetails.org.isTrust}">Trust</span><br/>
+            <a class="govuk-link" href="#">Change</a> <!-- TODO: PDJB-1237: Add update journey -->
+        </p>
+
+        <p class="govuk-body">
+            <strong th:text="#{landlordDetails.org.isCompany}">landlordDetails.org.isCompany</strong><br/>
+            <span th:text="${orgLandlord.isCompany}">Is company</span><br/>
+            <th:block th:if="${orgLandlord.companyNumber != null}">
+                <strong th:text="#{landlordDetails.org.companyNumber}">landlordDetails.org.companyNumber</strong><br/>
+                <span th:text="${orgLandlord.companyNumber}">Company number</span><br/>
+            </th:block>
+            <a class="govuk-link" href="#">Change</a> <!-- TODO: PDJB-1238: Add update journey -->
+        </p>
+
+        <p class="govuk-body">
+            <strong th:text="#{landlordDetails.org.isCharity}">landlordDetails.org.isCharity</strong><br/>
+            <span th:text="${orgLandlord.isCharity}">Is charity</span><br/>
+            <th:block th:if="${orgLandlord.charityNumber != null}">
+                <strong th:text="#{landlordDetails.org.charityNumber}">landlordDetails.org.charityNumber</strong><br/>
+                <span th:text="${orgLandlord.charityNumber}">Charity number</span><br/>
+            </th:block>
+            <a class="govuk-link" href="#">Change</a> <!-- TODO: PDJB-1239: Add update journey -->
+        </p>
+
+        <h2 class="govuk-heading-m" th:text="#{landlordDetails.org.mainContactHeading}">landlordDetails.org.mainContactHeading</h2>
+
+        <p class="govuk-body">
+            <strong th:text="#{landlordDetails.org.mainContactName}">landlordDetails.org.mainContactName</strong><br/>
+            <span th:text="${orgLandlord.mainContactName}">Main contact name</span><br/>
+            <strong th:text="#{landlordDetails.org.mainContactEmail}">landlordDetails.org.mainContactEmail</strong><br/>
+            <span th:text="${orgLandlord.mainContactEmail}">Main contact email</span><br/>
+            <strong th:text="#{landlordDetails.org.mainContactPhone}">landlordDetails.org.mainContactPhone</strong><br/>
+            <span th:text="${orgLandlord.mainContactPhone}">Main contact phone</span><br/>
+            <a class="govuk-link" href="#">Change</a> <!-- TODO: PDJB-1244: Add update journey -->
+        </p>
+
+        <th:block th:if="${orgLandlord.leadTrusteeName != null}">
+            <h2 class="govuk-heading-m" th:text="#{landlordDetails.org.leadTrusteeHeading}">landlordDetails.org.leadTrusteeHeading</h2>
+
+            <p class="govuk-body">
+                <strong th:text="#{landlordDetails.org.leadTrusteeName}">landlordDetails.org.leadTrusteeName</strong><br/>
+                <span th:text="${orgLandlord.leadTrusteeName}">Lead trustee name</span><br/>
+                <th:block th:if="${orgLandlord.leadTrusteeEmail != null}">
+                    <strong th:text="#{landlordDetails.org.leadTrusteeEmail}">landlordDetails.org.leadTrusteeEmail</strong><br/>
+                    <span th:text="${orgLandlord.leadTrusteeEmail}">Lead trustee email</span><br/>
+                </th:block>
+                <th:block th:if="${orgLandlord.leadTrusteePhone != null}">
+                    <strong th:text="#{landlordDetails.org.leadTrusteePhone}">landlordDetails.org.leadTrusteePhone</strong><br/>
+                    <span th:text="${orgLandlord.leadTrusteePhone}">Lead trustee phone</span><br/>
+                </th:block>
+                <a class="govuk-link" href="#">Change</a> <!-- TODO: PDJB-1469: Add update journey -->
+            </p>
+        </th:block>
+
+        <th:block th:unless="${#lists.isEmpty(governingBodyMembers)}">
+            <h2 class="govuk-heading-m" th:text="#{landlordDetails.org.governingBodyHeading}">landlordDetails.org.governingBodyHeading</h2>
+
+            <th:block th:each="member : ${governingBodyMembers}">
+                <p class="govuk-body">
+                    <strong th:text="${member.name}">Member name</strong><br/>
+                    <span th:text="${member.type}">Member type</span><br/>
+                    <span th:text="${member.dateOfBirth}">Date of birth</span><br/>
+                    <span th:text="${member.address.singleLineAddress}">Contact address</span>
+                </p>
+            </th:block>
+            <a class="govuk-link" href="#">Add, change or remove members of your governing body</a> <!-- TODO: PDJB-1471: Add update journey -->
+        </th:block>
+    </main>
+</html>

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/controllers/LandlordDetailsControllerTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/controllers/LandlordDetailsControllerTests.kt
@@ -11,7 +11,9 @@ import org.springframework.test.web.servlet.get
 import org.springframework.web.context.WebApplicationContext
 import uk.gov.communities.prsdb.webapp.constants.REGISTERED_PROPERTIES_FRAGMENT
 import uk.gov.communities.prsdb.webapp.services.LandlordService
+import uk.gov.communities.prsdb.webapp.services.OrganisationGoverningBodyMemberService
 import uk.gov.communities.prsdb.webapp.services.PropertyOwnershipService
+import uk.gov.communities.prsdb.webapp.services.UserToLandlordService
 import uk.gov.communities.prsdb.webapp.testHelpers.mockObjects.MockLandlordData
 import kotlin.test.Test
 
@@ -24,6 +26,12 @@ class LandlordDetailsControllerTests(
 
     @MockitoBean
     private lateinit var propertyOwnershipService: PropertyOwnershipService
+
+    @MockitoBean
+    private lateinit var userToLandlordService: UserToLandlordService
+
+    @MockitoBean
+    private lateinit var organisationGoverningBodyMemberService: OrganisationGoverningBodyMemberService
 
     @Nested
     inner class GetUserLandlordDetailsTests {
@@ -46,7 +54,7 @@ class LandlordDetailsControllerTests(
         @WithMockUser(roles = ["LANDLORD"])
         fun `getUserLandlordDetails returns 200 for a valid request from a landlord`() {
             val landlord = MockLandlordData.createIndividualLandlord()
-            whenever(landlordService.retrieveLandlordByBaseUserId("user")).thenReturn(landlord)
+            whenever(userToLandlordService.getCurrentLandlordForUser()).thenReturn(landlord)
             whenever(
                 propertyOwnershipService.getRegisteredPropertiesForLandlordUser(
                     "user",


### PR DESCRIPTION
## Ticket number

[PDJB-1252](https://mhclgdigital.atlassian.net/browse/PDJB-1252)

## Goal of change

<img alt="skeleton view" src="https://github.com/user-attachments/assets/9f28c481-e3e0-42c4-bd91-ac2e692c6d2d" />

## Description of main change(s)

adds the page and a handler for it in the controller

the page just pulls everything directly from the org landlord object

this can be improved lots but for showing the change links and showing the info it should be fine

TODOs to the relevant journey update tickets are in place

## Checklist

Delete any that are not applicable, and add explanation below for any that are applicable but haven't been done

- [x] Screenshots of any UI changes have been added
- Controller tests for any new endpoints, including testing the relevant permissions **will leave tests of this nature for when the update journeys are implemented / we implement the actual design for this page**
- [x] Test suite has been run in full locally and is passing
- [x] Branch has been rebased onto main and run locally, with everything working as expected (both for your new feature
  and any related functionality)
- [x] TODO comments referencing this JIRA ticket have been searched for and removed - if a future PR will address them,
  mention that here
- [ ] QA instructions have been added to the ticket (particularly if this is the last PR required to complete the ticket)
- [x] This feature is not behind a feature flag. I've checked that this is appropriate and we're happy with this code becoming live as soon as we release
