### PR TITLE
PDJB-NONE: Stop deployed seed data scanning the address table

### DIFF
--- a/src/main/resources/data-integration.sql
+++ b/src/main/resources/data-integration.sql
@@ -1,16 +1,35 @@
 -- =============================================================================
--- available_addresses(n): returns the first n existing active addresses not already
--- used by an active property, ranked 1..n (rn). Like the rest of this seed, the
--- cohorts below reference the AddressBase/NGD addresses already present rather than
--- inserting their own; each claims distinct free addresses by joining this function
--- on rn. The inner LIMIT n keeps callers from ranking the whole address table.
--- Defined with a single-quoted SQL body (no dollar-quoting) because the spring.sql.init
--- runner splits scripts on ';' and cannot parse dollar-quoted function blocks.
+-- Addresses for the QA and metrics cohorts below, at reserved ids far above the range
+-- the AddressBase/NGD loader allocates from. The cohorts used to claim whichever
+-- existing addresses were not yet used by an active property, which meant an unbounded
+-- scan of the 35m-row address table on every boot and left each property in whichever
+-- council happened to own the address it claimed.
+--
+--   9000000001-9000000009  provide-later property record QA cohort (properties 49-57)
+--   9000001001-9000001101  metrics test cohort 1 (properties 1201-1301)
+--   9000002001-9000002100  metrics test cohort 2 (properties 1601-1700)
+--
+-- These rows are inert to the NGD loader, which is delta-based and keyed on uprn:
+--   * uprn IS NULL, so its ON CONFLICT (uprn) DO UPDATE never matches them, and its
+--     property_ownership refresh (WHERE a.uprn IN (...)) never overwrites them
+--   * is_active, so its "delete unused inactive addresses" pass never considers them
+--   * the address id sequence is deliberately NOT bumped past these ids, so the loader
+--     carries on allocating from where it left off
+-- A NULL uprn also keeps them out of the address lookup, which requires uprn IS NOT NULL.
 -- =============================================================================
-CREATE OR REPLACE FUNCTION available_addresses(n integer)
-    RETURNS TABLE (address_id bigint, rn bigint)
-    LANGUAGE sql
-AS 'SELECT id, ROW_NUMBER() OVER (ORDER BY id) FROM (SELECT a.id FROM address a WHERE a.is_active AND NOT EXISTS (SELECT 1 FROM property_ownership po WHERE po.is_active AND po.address_id = a.id) ORDER BY a.id LIMIT $1) limited';
+INSERT INTO address (id, created_date, uprn, single_line_address, postcode, building_number, local_council_id)
+SELECT 9000000000 + i, current_timestamp, null::bigint,
+       i || ' Provide Later Road, Testville, QA1 1AA', 'QA1 1AA', i || '', 2
+FROM generate_series(1, 9) AS s(i)
+UNION ALL
+SELECT 9000001000 + i, current_timestamp, null::bigint,
+       i || ' Metrics Property Street, MT2 2BB', 'MT2 2BB', i || '', 2
+FROM generate_series(1, 101) AS s(i)
+UNION ALL
+SELECT 9000002000 + i, current_timestamp, null::bigint,
+       i || ' Realistic Metrics Street, MT3 3CC', 'MT3 3CC', i || '', 2
+FROM generate_series(1, 100) AS s(i)
+ON CONFLICT DO NOTHING;
 
 INSERT INTO prsdb_user (id, created_date)
 VALUES ('urn:fdc:gov.uk:2022:n93slCXHsxJ9rU6-AFM0jFIctYQjYf0KN9YVuJT-cao', '2024-10-15 00:00:00+00'),
@@ -298,10 +317,8 @@ UPDATE property_ownership SET marked_joint_landlord = true WHERE id = 1;
 -- =============================================================================
 -- PDJB-1048 provide-later property record QA properties (landlord 1), ids 49-56.
 -- For manual QA of the new-layout notification banners and "Provide this later"
--- rows behind PROPERTY_REGISTRATION_RESTRUCTURE_AND_SKIPPING. Like the rest of
--- this seed, addresses are NOT inserted: each property claims a distinct existing
--- active AddressBase/NGD address not already used by an active property (the
--- combined insert below picks them via the available_addresses(n) function). Occupied
+-- rows behind PROPERTY_REGISTRATION_RESTRUCTURE_AND_SKIPPING. Each property takes one
+-- of the reserved QA addresses seeded at the top of this file, selected by rn. Occupied
 -- properties set last_occupied_date so the "within 28 days" deadline renders.
 -- Fixed ids + ON CONFLICT DO NOTHING keep this idempotent under sql.init mode: always.
 --   49  occupied, licensing + tenancy skipped, compliance all provide-later -> COMBINED banner
@@ -322,8 +339,8 @@ VALUES (1, 1, 'LQA0000050'),
 
 SELECT setval(pg_get_serial_sequence('license', 'id'), (SELECT MAX(id) FROM license));
 
--- Each QA property claims a distinct existing active address not already used by an active property.
--- available_addresses(9) returns 9 free addresses ranked 1..9 so every row below picks a different one.
+-- rn doubles as the reserved QA address selector (9000000000 + rn), so every row below
+-- gets a distinct address.
 WITH new_properties (rn, id, registration_number_id, license_id, current_num_households, current_num_tenants,
                      furnished_status, rent_frequency, rent_amount, is_occupied, last_occupied_date,
                      license_provide_later, tenancy_provide_later) AS (
@@ -342,12 +359,11 @@ INSERT INTO property_ownership (id, is_active, ownership_type, current_num_house
                                 rent_amount, custom_property_type, marked_joint_landlord, is_occupied, last_occupied_date,
                                 license_provide_later, tenancy_provide_later)
 SELECT np.id, true, 1, np.current_num_households, np.current_num_tenants, np.registration_number_id,
-       aa.address_id, current_date, current_date, np.license_id, 1, 1,
+       9000000000 + np.rn, current_date, current_date, np.license_id, 1, 1,
        null, null, np.furnished_status, np.rent_frequency, null,
        np.rent_amount, null, false, np.is_occupied, np.last_occupied_date,
        np.license_provide_later, np.tenancy_provide_later
 FROM new_properties np
-         JOIN available_addresses(9) aa ON aa.rn = np.rn
 ON CONFLICT DO NOTHING;
 
 SELECT setval(pg_get_serial_sequence('property_ownership', 'id'), (SELECT MAX(id) FROM property_ownership));
@@ -567,11 +583,9 @@ VALUES ('PRSD22', current_date, null, 'urn:fdc:gov.uk:2022:mGHDySEVfCsvfvc6lVWf6
 -- The day offset is added as absolute SECONDS (not a `days` interval) so it stays
 -- exact across the Europe/London DST boundary on 2030-03-31.
 --
--- No addresses are inserted: like the rest of this seed, the cohort references the
--- AddressBase/NGD addresses already present in the environment. Landlords all share an
--- existing address (address_id 1, as the other seeded landlords do), and each property
--- takes a distinct existing active address not already used by an active property
--- (property_ownership.address_id is unique among active rows).
+-- Landlords all share an existing address (address_id 1, as the other seeded landlords
+-- do), and each property takes a distinct reserved metrics address seeded at the top of
+-- this file (9000001001 onwards).
 -- =============================================================================
 INSERT INTO prsdb_user (id, created_date)
 SELECT 'metrics-test-user-' || i, TIMESTAMPTZ '2030-01-01 09:00:00+00'
@@ -598,11 +612,10 @@ ON CONFLICT DO NOTHING;
 INSERT INTO property_ownership (id, is_active, ownership_type, current_num_households, current_num_tenants,
                                registration_number_id, address_id, created_date, last_modified_date, license_id,
                                property_build_type, num_bedrooms, marked_joint_landlord, is_occupied)
-SELECT 1200 + i, true, 1, 1, 2, 1200 + i, fa.address_id,
+SELECT 1200 + i, true, 1, 1, 2, 1200 + i, 9000001000 + i,
        TIMESTAMPTZ '2030-01-01 09:00:00+00' + make_interval(secs => (i - 1) * 86400),
        TIMESTAMPTZ '2030-01-01 09:00:00+00' + make_interval(secs => (i - 1) * 86400), NULL, 1, 2, false, true
 FROM generate_series(1, 101) AS s(i)
-JOIN available_addresses(101) fa ON fa.rn = i
 ON CONFLICT DO NOTHING;
 
 INSERT INTO ownership_link (landlord_id, landlordship_id, created_date)
@@ -624,9 +637,9 @@ ON CONFLICT DO NOTHING;
 -- p90/p95 hours and minutes show too. Fixed sequential ids continuing above the existing
 -- seed (landlords 14xx, properties 16xx) plus ON CONFLICT DO NOTHING keep it idempotent
 -- under mode: always; the setval calls after all metrics inserts bump the sequences past
--- them (matching the rest of this file). Addresses are referenced, not inserted (as in
--- cohort 1): landlords share address_id 1 and each property takes a distinct existing
--- active address not already used by an active property.
+-- them (matching the rest of this file). Addresses come from the reserved block seeded at
+-- the top of this file (as in cohort 1): landlords share address_id 1 and each property
+-- takes a distinct reserved metrics address (9000002001 onwards).
 --
 -- Query the 2028 reporting period (From 1/1/2028 To 31/12/2028) to see only this cohort:
 -- expect 120 registrations, 72 verified, 100 properties, 100 landlords with a property,
@@ -679,9 +692,8 @@ WITH p AS (
                  END)::int) AS created
     FROM generate_series(1, 100) AS s(i)
 )
-SELECT 1600 + i, true, 1, 1, 2, 1600 + i, fa.address_id, created, created, NULL, 1, 2, false, true
+SELECT 1600 + i, true, 1, 1, 2, 1600 + i, 9000002000 + i, created, created, NULL, 1, 2, false, true
 FROM p
-JOIN available_addresses(100) fa ON fa.rn = p.i
 ON CONFLICT DO NOTHING;
 
 INSERT INTO ownership_link (landlord_id, landlordship_id, created_date)

--- a/src/main/resources/data-metrics-local.sql
+++ b/src/main/resources/data-metrics-local.sql
@@ -42,9 +42,9 @@ ON CONFLICT (subject_identifier) DO NOTHING;
 -- The day offset is added as absolute SECONDS (not a `days` interval) so it stays
 -- exact across the Europe/London DST boundary on 2030-03-31.
 --
--- Unlike data-integration.sql, this local seed inserts its own addresses (ids 10xx for
--- landlords, 12xx for properties): the local database has no AddressBase/NGD addresses to
--- reference, so the cohort cannot claim existing free addresses and must supply them.
+-- Like data-integration.sql, this seed inserts its own addresses (ids 10xx for landlords,
+-- 12xx for properties) rather than referencing AddressBase/NGD data, which the local
+-- database does not have.
 -- =============================================================================
 INSERT INTO prsdb_user (id, created_date)
 SELECT 'metrics-test-user-' || i, TIMESTAMPTZ '2030-01-01 09:00:00+00'

--- a/src/main/resources/data-test.sql
+++ b/src/main/resources/data-test.sql
@@ -1,16 +1,23 @@
 -- =============================================================================
--- available_addresses(n): returns the first n existing active addresses not already
--- used by an active property, ranked 1..n (rn). Like the rest of this seed, the
--- cohorts below reference the AddressBase/NGD addresses already present rather than
--- inserting their own; each claims distinct free addresses by joining this function
--- on rn. The inner LIMIT n keeps callers from ranking the whole address table.
--- Defined with a single-quoted SQL body (no dollar-quoting) because the spring.sql.init
--- runner splits scripts on ';' and cannot parse dollar-quoted function blocks.
+-- Addresses for the QA cohort below, at reserved ids far above the range the
+-- AddressBase/NGD loader allocates from. The cohort used to claim whichever existing
+-- addresses were not yet used by an active property, which meant an unbounded scan of
+-- the 35m-row address table on every boot and left each property in whichever council
+-- happened to own the address it claimed.
+--
+-- These rows are inert to the NGD loader, which is delta-based and keyed on uprn:
+--   * uprn IS NULL, so its ON CONFLICT (uprn) DO UPDATE never matches them, and its
+--     property_ownership refresh (WHERE a.uprn IN (...)) never overwrites them
+--   * is_active, so its "delete unused inactive addresses" pass never considers them
+--   * the address id sequence is deliberately NOT bumped past these ids, so the loader
+--     carries on allocating from where it left off
+-- A NULL uprn also keeps them out of the address lookup, which requires uprn IS NOT NULL.
 -- =============================================================================
-CREATE OR REPLACE FUNCTION available_addresses(n integer)
-    RETURNS TABLE (address_id bigint, rn bigint)
-    LANGUAGE sql
-AS 'SELECT id, ROW_NUMBER() OVER (ORDER BY id) FROM (SELECT a.id FROM address a WHERE a.is_active AND NOT EXISTS (SELECT 1 FROM property_ownership po WHERE po.is_active AND po.address_id = a.id) ORDER BY a.id LIMIT $1) limited';
+INSERT INTO address (id, created_date, uprn, single_line_address, postcode, building_number, local_council_id)
+SELECT 9000000000 + i, current_timestamp, null::bigint,
+       i || ' Provide Later Road, Testville, QA1 1AA', 'QA1 1AA', i || '', 2
+FROM generate_series(1, 9) AS s(i)
+ON CONFLICT DO NOTHING;
 
 INSERT INTO prsdb_user (id, created_date)
 VALUES ('urn:fdc:gov.uk:2022:n93slCXHsxJ9rU6-AFM0jFIctYQjYf0KN9YVuJT-cao', '2024-10-15 00:00:00+00'),        -- Team-PRSDB+laadmin@softwire.com
@@ -333,10 +340,8 @@ UPDATE property_ownership SET marked_joint_landlord = true WHERE id = 1;
 -- =============================================================================
 -- PDJB-1048 provide-later property record QA properties (landlord 1), ids 18-25.
 -- For manual QA of the new-layout notification banners and "Provide this later"
--- rows behind PROPERTY_REGISTRATION_RESTRUCTURE_AND_SKIPPING. Like the rest of
--- this seed, addresses are NOT inserted: each property claims a distinct existing
--- active AddressBase/NGD address not already used by an active property (the
--- combined insert below picks them via the available_addresses(n) function). Occupied
+-- rows behind PROPERTY_REGISTRATION_RESTRUCTURE_AND_SKIPPING. Each property takes one
+-- of the reserved QA addresses seeded at the top of this file, selected by rn. Occupied
 -- properties set last_occupied_date so the "within 28 days" deadline renders.
 -- Fixed ids + ON CONFLICT DO NOTHING keep this idempotent under sql.init mode: always.
 --   18  occupied, licensing + tenancy skipped, compliance all provide-later -> COMBINED banner
@@ -357,8 +362,8 @@ VALUES (1, 1, 'LQA0000019'),
 
 SELECT setval(pg_get_serial_sequence('license', 'id'), (SELECT MAX(id) FROM license));
 
--- Each QA property claims a distinct existing active address not already used by an active property.
--- available_addresses(9) returns 9 free addresses ranked 1..9 so every row below picks a different one.
+-- rn doubles as the reserved QA address selector (9000000000 + rn), so every row below
+-- gets a distinct address.
 WITH new_properties (rn, id, registration_number_id, license_id, current_num_households, current_num_tenants,
                      furnished_status, rent_frequency, rent_amount, is_occupied, last_occupied_date,
                      license_provide_later, tenancy_provide_later) AS (
@@ -377,12 +382,11 @@ INSERT INTO property_ownership (id, is_active, ownership_type, current_num_house
                                 rent_amount, custom_property_type, marked_joint_landlord, is_occupied, last_occupied_date,
                                 license_provide_later, tenancy_provide_later)
 SELECT np.id, true, 1, np.current_num_households, np.current_num_tenants, np.registration_number_id,
-       aa.address_id, current_date, current_date, np.license_id, 1, 1,
+       9000000000 + np.rn, current_date, current_date, np.license_id, 1, 1,
        null, null, np.furnished_status, np.rent_frequency, null,
        np.rent_amount, null, false, np.is_occupied, np.last_occupied_date,
        np.license_provide_later, np.tenancy_provide_later
 FROM new_properties np
-         JOIN available_addresses(9) aa ON aa.rn = np.rn
 ON CONFLICT DO NOTHING;
 
 SELECT setval(pg_get_serial_sequence('property_ownership', 'id'), (SELECT MAX(id) FROM property_ownership));


### PR DESCRIPTION
## Ticket number

PDJB-NONE (follow-up to PDJB-1048)

## Goal of change

The `available_addresses(n)` function added to the deployed seeds in #1568 scans the 35m-row `address` table on every boot, which takes too long.

## Description of main change(s)

- Removes `available_addresses(n)` from `data-test.sql` and `data-integration.sql`. The QA and metrics cohorts now use dedicated seed addresses at reserved ids (`9000000001` onwards) instead of claiming whichever AddressBase/NGD addresses were not yet used by an active property. This is the approach `data-local.sql` and `data-metrics-local.sql` already take.
- Pins the seeded properties to `local_council_id = 2`. Previously each property inherited the council of whichever address it happened to claim, so the cohorts landed in a different council in every environment and were not reliably visible to the seeded LC users.

Why the old approach was slow:

- `LIMIT $1` is a parameter, so it is never folded to a constant. The planner falls back to assuming 10% of the table will be returned — 3.5m rows at production size — and costs every join choice on that basis.
- The function has no volatility marker, so it is `VOLATILE` and can never be inlined. Inlining is what would have substituted the literal `9`/`101`/`100`.
- The cost is unbounded regardless of plan: it is an anti-join walking `address` in id order until it finds N unused active rows.

Measured end-to-end seed time (full `data-integration.sql`, Postgres restarted between runs to clear `shared_buffers`):

| `address` state | before | after |
|---|---|---|
| 2m rows, all active | 397 ms | 469 ms |
| 20m rows, all active | 542 ms | 420 ms |
| 20m rows, 5m inactive at low ids | 6,546 ms | 372 ms |
| 20m rows, 10m inactive at low ids | 7,477 ms | 404 ms |

A large inactive population is a normal state rather than an edge case: the data package is GB-wide (`add_gb_builtaddress`) and `NgdAddressLoader` marks anything outside England/Wales/Unassigned as `is_active = false`, with those rows only removed at the end of a full load. In that state a single `available_addresses(101)` call discards 10m rows and touches 20.1m buffers to return 101, and `data-integration.sql` called it three times per boot.

Note the before/after at 2m rows: in the best case the old version was fine and the new one is marginally slower, since it inserts 210 rows. The point of the change is that the new cost does not vary with the size or state of the address table.

## Anything you'd like to highlight to the reviewer?

**Interaction with the NGD loader.** The seeded addresses are inert to it, because it is delta-based and keyed on `uprn`:

- `uprn IS NULL`, so `ON CONFLICT (uprn) DO UPDATE` never matches them, and `updatePropertyOwnershipAddresses` (`WHERE a.uprn IN (...)`) never overwrites their properties
- `is_active = true`, so `deleteUnusedInactiveAddresses` (`WHERE a.is_active = false`) never considers them
- a NULL `uprn` also keeps them out of the address lookup, which requires `uprn IS NOT NULL`

I checked this by replaying the loader's own statements against the seeded data: all 210 addresses survived with `last_modified_date` still NULL, while 1,685 surrounding NGD rows were deleted.

**The seed must not `setval` the address sequence.** Deliberately omitted, otherwise the loader would start allocating ids above the reserved block. `data-local.sql` does call it, which is fine locally but would not be here.

**These two files have no automated test coverage.** They are selected by `spring.sql.init.platform: ${ENVIRONMENT_NAME}`, which is only set in deployed environments, so nothing in `src/test` loads them. I verified manually against a real Postgres: 47 Flyway migrations applied, each seed run twice to confirm idempotency under `mode: always`, then cohort addresses and trigger population asserted. Worth considering a smoke test that runs these seeds against a migrated testcontainer — it would have caught both #1657 and a `null::bigint` type bug I hit while writing this.

## Checklist

- [x] Seed data has been updated as needed for your feature to be tested without having to e.g. register a new property
- [x] Branch is based on current `main` (`8a73da7d5`). The seeds were exercised directly against a migrated Postgres rather than by booting the app, since these files only load in deployed environments.
- [ ] Test suite has been run in full locally and is passing — ran `ktlintCheck` (passing) and `MetricsSinglePageTests` (10/10), the only test that loads any file changed here. The full suite was not run as no other test touches these seeds.
