### PR TITLE
PDJB-NONE: Speed up integration tests with a truncate-based database reset

### DIFF
--- a/.github/instructions/database.instructions.md
+++ b/.github/instructions/database.instructions.md
@@ -101,6 +101,13 @@ CREATE TABLE example_table (
 CREATE INDEX idx_example_name ON example_table(name);
 ```
 
+### Reference Data in Migrations
+
+Integration tests reset the database by truncating every table except `flyway_schema_history` and `local_council`.
+If a migration inserts reference data that tests rely on, add that table to `PRESERVED_TABLES` in
+`src/test/kotlin/uk/gov/communities/prsdb/webapp/testHelpers/IntegrationTestHelper.kt`. Otherwise the data will be
+deleted before every test that resets the database.
+
 ## Search with Trigrams
 - Use `pg_trgm` extension for fuzzy text search
 - See existing search implementations for patterns

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,5 +1,6 @@
 import org.gradle.internal.os.OperatingSystem
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+import java.util.concurrent.ConcurrentLinkedQueue
 
 plugins {
     kotlin("jvm") version "1.9.25"
@@ -163,12 +164,46 @@ tasks.withType<KotlinCompile> {
 // integration tests is a JUnit @Nested inner class, and PropertyRegistrationSinglePageTests alone is a
 // single scheduling unit worth ~5 minutes. Use -PtestForks=1 to fall back to serial execution.
 val testForks = (project.findProperty("testForks") as String?)?.toInt() ?: 3
+val slowTestCount = (project.findProperty("slowTestCount") as String?)?.toInt() ?: 15
 
 tasks.withType<Test> {
     useJUnitPlatform()
     dependsOn("copyBuiltAssets")
     maxHeapSize = "2g"
     maxParallelForks = testForks
+
+    val taskLogger = logger
+    val testDurations = ConcurrentLinkedQueue<Pair<String, Long>>()
+
+    addTestListener(
+        object : TestListener {
+            override fun beforeSuite(suite: TestDescriptor) = Unit
+
+            override fun beforeTest(testDescriptor: TestDescriptor) = Unit
+
+            override fun afterTest(
+                testDescriptor: TestDescriptor,
+                result: TestResult,
+            ) {
+                val name = "${testDescriptor.className}.${testDescriptor.name}"
+                testDurations.add(name to (result.endTime - result.startTime))
+            }
+
+            override fun afterSuite(
+                suite: TestDescriptor,
+                result: TestResult,
+            ) {
+                if (suite.parent != null) return
+                val slowest = testDurations.sortedByDescending { it.second }.take(slowTestCount)
+                if (slowest.isEmpty()) return
+                taskLogger.lifecycle("")
+                taskLogger.lifecycle("Slowest ${slowest.size} tests:")
+                slowest.forEach { (name, durationMs) ->
+                    taskLogger.lifecycle(String.format("  %8.2fs  %s", durationMs / 1000.0, name))
+                }
+            }
+        },
+    )
 }
 
 tasks.register<JavaExec>("playwright") {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -159,10 +159,16 @@ tasks.withType<KotlinCompile> {
     dependsOn("copyBuiltAssets")
 }
 
+// Three forks is the useful maximum: Gradle schedules by top-level class, every nested grouping in the
+// integration tests is a JUnit @Nested inner class, and PropertyRegistrationSinglePageTests alone is a
+// single scheduling unit worth ~5 minutes. Use -PtestForks=1 to fall back to serial execution.
+val testForks = (project.findProperty("testForks") as String?)?.toInt() ?: 3
+
 tasks.withType<Test> {
     useJUnitPlatform()
     dependsOn("copyBuiltAssets")
     maxHeapSize = "2g"
+    maxParallelForks = testForks
 }
 
 tasks.register<JavaExec>("playwright") {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -160,17 +160,12 @@ tasks.withType<KotlinCompile> {
     dependsOn("copyBuiltAssets")
 }
 
-// Three forks is the useful maximum: Gradle schedules by top-level class, every nested grouping in the
-// integration tests is a JUnit @Nested inner class, and PropertyRegistrationSinglePageTests alone is a
-// single scheduling unit worth ~5 minutes. Use -PtestForks=1 to fall back to serial execution.
-val testForks = (project.findProperty("testForks") as String?)?.toInt() ?: 3
 val slowTestCount = (project.findProperty("slowTestCount") as String?)?.toInt() ?: 15
 
 tasks.withType<Test> {
     useJUnitPlatform()
     dependsOn("copyBuiltAssets")
     maxHeapSize = "2g"
-    maxParallelForks = testForks
 
     val taskLogger = logger
     val testDurations = ConcurrentLinkedQueue<Pair<String, Long>>()

--- a/docs/IntegrationTestReadMe.md
+++ b/docs/IntegrationTestReadMe.md
@@ -24,17 +24,15 @@ These are the only two tables with rows after a bare migrate. If you add a migra
 its table to `PRESERVED_TABLES` in `IntegrationTestHelper`, or the data will be wiped before every test. You can check
 which tables hold reference data by migrating an empty database and looking for non-empty tables.
 
-## Parallel Execution
+## Test Timing
 
-Tests run across three forked JVMs. Each fork is completely isolated: its own Spring contexts, its own Postgres and
-Redis containers, its own database and its own browser. No test needs to be aware of this.
+Every run ends with a table of the slowest tests, so that suite speed stays visible as scenarios are added. Change
+its length with `-PslowTestCount=N`.
 
-Three is the useful maximum because Gradle schedules by top-level class, every nested grouping is a JUnit
-`@Nested inner class`, and `PropertyRegistrationSinglePageTests` alone is a single scheduling unit worth about five
-minutes.
-
-Override the fork count with `-PtestForks=N`. Use `-PtestForks=1` for fully serial execution when debugging. Every run
-ends with a table of the slowest tests; change its length with `-PslowTestCount=N`.
+Running the suite across parallel Gradle forks was measured and rejected. Each fork needs its own Spring contexts,
+Postgres and Redis containers, application instance and browser, and Playwright tests are latency-sensitive, so the
+contention inflates per-test time faster than the parallelism recovers it: summed test time rose 32% at two forks and
+84% at three, making wall clock no better than serial while introducing timeout and Docker-discovery flakes.
 
 ## Page Objects (and Components)
 

--- a/docs/IntegrationTestReadMe.md
+++ b/docs/IntegrationTestReadMe.md
@@ -13,6 +13,29 @@ We set seed data by passing SQL script names into integration test class constru
 Tests that require different seed data to the rest of the class must be put in nested classes that inherit from 
 `NestedIntegrationTestWithMutableData` or `NestedIntegrationTestWithImmutableData` depending on the outer class.
 
+Resetting the database means truncating every table in the `public` schema with `RESTART IDENTITY CASCADE`, then
+running the seed scripts. Two tables are deliberately preserved:
+
+* `flyway_schema_history` - Flyway's own bookkeeping. Dropping it would make every migration re-run.
+* `local_council` - reference data inserted by `V1_0_0__la_and_address_tables.sql` (as `local_authority`, renamed by
+  `V1_6_0`). No seed script writes to it.
+
+These are the only two tables with rows after a bare migrate. If you add a migration that inserts reference data, add
+its table to `PRESERVED_TABLES` in `IntegrationTestHelper`, or the data will be wiped before every test. You can check
+which tables hold reference data by migrating an empty database and looking for non-empty tables.
+
+## Parallel Execution
+
+Tests run across three forked JVMs. Each fork is completely isolated: its own Spring contexts, its own Postgres and
+Redis containers, its own database and its own browser. No test needs to be aware of this.
+
+Three is the useful maximum because Gradle schedules by top-level class, every nested grouping is a JUnit
+`@Nested inner class`, and `PropertyRegistrationSinglePageTests` alone is a single scheduling unit worth about five
+minutes.
+
+Override the fork count with `-PtestForks=N`. Use `-PtestForks=1` for fully serial execution when debugging. Every run
+ends with a table of the slowest tests; change its length with `-PslowTestCount=N`.
+
 ## Page Objects (and Components)
 
 We encapsulate logic for interacting with our pages into page objects (as described by [Martin Fowler](https://martinfowler.com/bliki/PageObject.html) and

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/IntegrationTest.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/IntegrationTest.kt
@@ -34,10 +34,7 @@ import uk.gov.service.notify.NotificationClient
 import kotlin.reflect.full.isSubclassOf
 
 @Import(TestcontainersConfiguration::class)
-@SpringBootTest(
-    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
-    properties = ["spring.flyway.clean-disabled=false"],
-)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @UsePlaywright
 @ActiveProfiles(profiles = ["local", "local-no-auth"])

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/IntegrationTestHelperTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/IntegrationTestHelperTests.kt
@@ -1,0 +1,59 @@
+package uk.gov.communities.prsdb.webapp.integration
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.jdbc.core.JdbcTemplate
+import uk.gov.communities.prsdb.webapp.testHelpers.IntegrationTestHelper
+
+class IntegrationTestHelperTests : IntegrationTestWithMutableData("data-local.sql") {
+    @Autowired
+    lateinit var jdbcTemplate: JdbcTemplate
+
+    private fun countRowsIn(table: String) = jdbcTemplate.queryForObject("SELECT COUNT(*) FROM $table", Int::class.java)!!
+
+    @Test
+    fun `resetDatabase clears seeded data`() {
+        assertTrue(countRowsIn("prsdb_user") > 0, "seed data should have been loaded")
+
+        IntegrationTestHelper.resetDatabase(jdbcTemplate)
+
+        assertEquals(0, countRowsIn("prsdb_user"))
+        assertEquals(0, countRowsIn("landlord"))
+        assertEquals(0, countRowsIn("property_ownership"))
+    }
+
+    @Test
+    fun `resetDatabase preserves local council reference data`() {
+        val localCouncilsBefore = countRowsIn("local_council")
+        assertTrue(localCouncilsBefore > 0, "migrations should have inserted local councils")
+
+        IntegrationTestHelper.resetDatabase(jdbcTemplate)
+
+        assertEquals(localCouncilsBefore, countRowsIn("local_council"))
+    }
+
+    @Test
+    fun `resetDatabase preserves the flyway schema history`() {
+        val migrationsBefore = countRowsIn("flyway_schema_history")
+        assertTrue(migrationsBefore > 0, "migrations should have been recorded")
+
+        IntegrationTestHelper.resetDatabase(jdbcTemplate)
+
+        assertEquals(migrationsBefore, countRowsIn("flyway_schema_history"))
+    }
+
+    @Test
+    fun `resetDatabase restarts identity sequences`() {
+        IntegrationTestHelper.resetDatabase(jdbcTemplate)
+
+        val id =
+            jdbcTemplate.queryForObject(
+                "INSERT INTO address (single_line_address, postcode) VALUES ('1 Test Street, EG1 2AB', 'EG1 2AB') RETURNING id",
+                Long::class.java,
+            )
+
+        assertEquals(1L, id)
+    }
+}

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/IntegrationTestWithImmutableData.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/IntegrationTestWithImmutableData.kt
@@ -1,6 +1,5 @@
 package uk.gov.communities.prsdb.webapp.integration
 
-import org.flywaydb.core.Flyway
 import org.junit.jupiter.api.BeforeAll
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.jdbc.core.JdbcTemplate
@@ -13,10 +12,9 @@ abstract class IntegrationTestWithImmutableData(
 
     @BeforeAll
     fun setUpBeforeAll(
-        @Autowired flyway: Flyway,
         @Autowired jdbcTemplate: JdbcTemplate,
     ) {
-        IntegrationTestHelper.resetAndSeedDatabase(flyway, seedDataScripts, jdbcTemplate)
+        IntegrationTestHelper.resetAndSeedDatabase(seedDataScripts, jdbcTemplate)
     }
 
     abstract class NestedIntegrationTestWithImmutableData(
@@ -26,10 +24,9 @@ abstract class IntegrationTestWithImmutableData(
 
         @BeforeAll
         fun setUpBeforeAll(
-            @Autowired flyway: Flyway,
             @Autowired jdbcTemplate: JdbcTemplate,
         ) {
-            IntegrationTestHelper.resetAndSeedDatabase(flyway, seedDataScripts, jdbcTemplate)
+            IntegrationTestHelper.resetAndSeedDatabase(seedDataScripts, jdbcTemplate)
         }
     }
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/IntegrationTestWithMutableData.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/IntegrationTestWithMutableData.kt
@@ -1,6 +1,5 @@
 package uk.gov.communities.prsdb.webapp.integration
 
-import org.flywaydb.core.Flyway
 import org.junit.jupiter.api.BeforeEach
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.jdbc.core.JdbcTemplate
@@ -13,10 +12,9 @@ abstract class IntegrationTestWithMutableData(
 
     @BeforeEach
     fun setUpBeforeEach(
-        @Autowired flyway: Flyway,
         @Autowired jdbcTemplate: JdbcTemplate,
     ) {
-        IntegrationTestHelper.resetAndSeedDatabase(flyway, seedDataScripts, jdbcTemplate)
+        IntegrationTestHelper.resetAndSeedDatabase(seedDataScripts, jdbcTemplate)
     }
 
     abstract class NestedIntegrationTestWithMutableData(
@@ -26,10 +24,9 @@ abstract class IntegrationTestWithMutableData(
 
         @BeforeEach
         fun setUpBeforeEach(
-            @Autowired flyway: Flyway,
             @Autowired jdbcTemplate: JdbcTemplate,
         ) {
-            IntegrationTestHelper.resetAndSeedDatabase(flyway, seedDataScripts, jdbcTemplate)
+            IntegrationTestHelper.resetAndSeedDatabase(seedDataScripts, jdbcTemplate)
         }
     }
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/testHelpers/IntegrationTestHelper.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/testHelpers/IntegrationTestHelper.kt
@@ -6,6 +6,13 @@ import org.springframework.util.ResourceUtils
 
 class IntegrationTestHelper {
     companion object {
+        // Tables that must survive a reset. flyway_schema_history is Flyway's own bookkeeping - dropping it
+        // would cause every migration to re-run on the next context start. local_council holds reference
+        // data inserted by V1_0_0__la_and_address_tables.sql (as local_authority, renamed by V1_6_0) and is
+        // never written to by a seed script. These are the only two tables with rows after a bare migrate.
+        // Any future migration that inserts reference data must add its table to this set.
+        private val PRESERVED_TABLES = setOf("flyway_schema_history", "local_council")
+
         fun resetAndSeedDatabase(
             flyway: Flyway,
             scripts: List<String>,
@@ -13,6 +20,20 @@ class IntegrationTestHelper {
         ) {
             resetDatabase(flyway)
             seedDatabase(scripts, jdbcTemplate)
+        }
+
+        fun resetDatabase(jdbcTemplate: JdbcTemplate) {
+            val tablesToTruncate =
+                jdbcTemplate
+                    .queryForList("SELECT tablename FROM pg_tables WHERE schemaname = 'public'", String::class.java)
+                    .filterNot { it in PRESERVED_TABLES }
+
+            check(tablesToTruncate.isNotEmpty()) {
+                "No truncatable tables found in the public schema - have the Flyway migrations run?"
+            }
+
+            val quotedTables = tablesToTruncate.joinToString(", ") { "\"$it\"" }
+            jdbcTemplate.execute("TRUNCATE TABLE $quotedTables RESTART IDENTITY CASCADE")
         }
 
         private fun resetDatabase(flyway: Flyway) {

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/testHelpers/IntegrationTestHelper.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/testHelpers/IntegrationTestHelper.kt
@@ -1,6 +1,5 @@
 package uk.gov.communities.prsdb.webapp.testHelpers
 
-import org.flywaydb.core.Flyway
 import org.springframework.jdbc.core.JdbcTemplate
 import org.springframework.util.ResourceUtils
 
@@ -14,11 +13,10 @@ class IntegrationTestHelper {
         private val PRESERVED_TABLES = setOf("flyway_schema_history", "local_council")
 
         fun resetAndSeedDatabase(
-            flyway: Flyway,
             scripts: List<String>,
             jdbcTemplate: JdbcTemplate,
         ) {
-            resetDatabase(flyway)
+            resetDatabase(jdbcTemplate)
             seedDatabase(scripts, jdbcTemplate)
         }
 
@@ -34,11 +32,6 @@ class IntegrationTestHelper {
 
             val quotedTables = tablesToTruncate.joinToString(", ") { "\"$it\"" }
             jdbcTemplate.execute("TRUNCATE TABLE $quotedTables RESTART IDENTITY CASCADE")
-        }
-
-        private fun resetDatabase(flyway: Flyway) {
-            flyway.clean()
-            flyway.migrate()
         }
 
         private fun seedDatabase(


### PR DESCRIPTION
## Ticket number

PDJB-NONE

## Goal of change

Speed up the integration test suite without losing any test coverage.

## Description of main change(s)

- Integration tests now reset the database by truncating every table in the `public` schema with `RESTART IDENTITY CASCADE`, rather than running `flyway.clean()` + `flyway.migrate()`. The old reset re-ran all 47 migrations (~1.3s) and happened roughly 263 times per suite run; the new one takes ~30ms. Migrations still run once per JVM at Spring context startup.
- `flyway_schema_history` and `local_council` are preserved, as the only two tables holding rows after a bare migrate. `PRESERVED_TABLES` and a note in `database.instructions.md` record that any future migration inserting reference data must be added there.
- Every test run now ends with a table of the slowest tests, so suite speed stays visible as we add scenarios. Length is configurable with `-PslowTestCount=N`.

Full local suite: 32.8 min before, 19.6–22.3 min across three runs after. The set of test names is identical before and after, verified by diffing the JUnit XML, plus four new tests covering the reset itself.

## Checklist

- [x] Unit tests for new logic (e.g. new service methods) have been added
- [x] Test suite has been run in full locally and is passing
- [x] Branch has been rebased onto main and run locally, with everything working as expected (both for your new feature and any related functionality)
