### PR TITLE
PDJB-NONE: Shard CI tests across four parallel jobs

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -5,8 +5,12 @@ on:
 
 jobs:
   test:
-    name: Build and test
+    name: Test shard
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [0, 1, 2, 3]
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -47,11 +51,47 @@ jobs:
           openssl genrsa -out src/main/resources/private_key.pem 2048
           openssl rsa -in src/main/resources/private_key.pem -pubout -out src/main/resources/public_key.pem
 
-      - name: Run gradle `check` to run linting and tests
+      - name: Run tests for shard ${{ matrix.shard }}
         env:
           EMAILNOTIFICATIONS_APIKEY: ${{ secrets.NOTIFY_KEY }}
           EMAILNOTIFICATIONS_USE_PRODUCTION_NOTIFY: ${{ github.base_ref == 'production' || github.merge_group.base_ref == 'refs/head/production' }}
-        run: ./gradlew clean check --no-daemon
+        run: ./gradlew clean test --no-daemon -PshardIndex=${{ matrix.shard }} -PshardCount=4
+
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'corretto'
+          java-version: 21
+          cache: 'gradle'
+
+      - name: Install node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: 'npm'
+
+      - run: npm ci
+
+      - run: npm run build
+
+      - name: Run ktlintCheck
+        run: ./gradlew ktlintCheck --no-daemon
 
       - name: Run ktlintFormat
         run: ./gradlew ktlintFormat --no-daemon
+
+  # Named to match the existing required status check, so branch protection needs no change and the shard
+  # count can be tuned without touching it. The individual shards report as "Test shard (0)" etc.
+  all-tests:
+    name: Build and test
+    needs: [test, lint]
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "All shards and lint passed"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -159,10 +159,35 @@ tasks.withType<KotlinCompile> {
     dependsOn("copyBuiltAssets")
 }
 
+// CI runs the test suite as several parallel jobs, each taking a slice of the test classes. Nested
+// classes must execute with their enclosing class, so the slice is chosen from the top-level class name
+// and every nested class follows it.
+val shardIndex = (project.findProperty("shardIndex") as String?)?.toInt()
+val shardCount = (project.findProperty("shardCount") as String?)?.toInt()
+
+require(shardCount == null || (shardIndex != null && shardIndex in 0 until shardCount)) {
+    "shardIndex must be set and within 0..<shardCount when shardCount is given"
+}
+
 tasks.withType<Test> {
     useJUnitPlatform()
     dependsOn("copyBuiltAssets")
     maxHeapSize = "2g"
+
+    if (shardIndex != null && shardCount != null) {
+        exclude { element ->
+            if (element.isDirectory) {
+                false
+            } else {
+                val path = element.path
+                if (!path.endsWith(".class")) {
+                    false
+                } else {
+                    Math.floorMod(path.substringBefore('$').hashCode(), shardCount) != shardIndex
+                }
+            }
+        }
+    }
 }
 
 tasks.register<JavaExec>("playwright") {


### PR DESCRIPTION
## Ticket number

PDJB-NONE

## Goal of change

Reduces the time the test suite takes on CI

## Description of main change(s)

- Runs the test suite as 4 parallel CI jobs instead of 1, each taking a quarter of the test classes
- Runs ktlint in its own job rather than repeating it in every shard
- Adds an aggregating job for the shards to report through, named `Build and test` to match the existing required status check
- Makes sharding opt-in via `-PshardIndex` and `-PshardCount`, so a local `./gradlew test` is unaffected

Takes CI from ~22 min to 12.0 min, and to 9.7 min with #1676 and #1677 on top. Coverage is unchanged: the shards run the same 2,869 tests as an unsharded run.

## Anything you'd like to highlight to the reviewer?

No branch protection change is needed, as the aggregating job keeps the existing `Build and test` name.

## Checklist

Delete any that are not applicable, and add explanation below for any that are applicable but haven't been done

- [x] Test suite has been run in full locally and is passing
- [X] Branch has been rebased onto main and run locally, with everything working as expected (both for your new feature
  and any related functionality)
