### PR TITLE
PDJB-NONE: Cache CI builds instead of rebuilding in every shard

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -31,7 +31,9 @@ jobs:
         with:
           distribution: 'corretto'
           java-version: 21
-          cache: 'gradle'
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
 
       - name: Install node
         uses: actions/setup-node@v4
@@ -40,8 +42,6 @@ jobs:
           cache: 'npm'
 
       - run: npm ci
-
-      - run: npm run build
 
       - name: Run npm tests
         run: npm test
@@ -55,7 +55,7 @@ jobs:
         env:
           EMAILNOTIFICATIONS_APIKEY: ${{ secrets.NOTIFY_KEY }}
           EMAILNOTIFICATIONS_USE_PRODUCTION_NOTIFY: ${{ github.base_ref == 'production' || github.merge_group.base_ref == 'refs/head/production' }}
-        run: ./gradlew clean test --no-daemon -PshardIndex=${{ matrix.shard }} -PshardCount=4
+        run: ./gradlew test --no-daemon -PshardIndex=${{ matrix.shard }} -PshardCount=4
 
   lint:
     name: Lint
@@ -69,7 +69,9 @@ jobs:
         with:
           distribution: 'corretto'
           java-version: 21
-          cache: 'gradle'
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
 
       - name: Install node
         uses: actions/setup-node@v4
@@ -78,8 +80,6 @@ jobs:
           cache: 'npm'
 
       - run: npm ci
-
-      - run: npm run build
 
       - name: Run ktlintCheck
         run: ./gradlew ktlintCheck --no-daemon

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -141,6 +141,13 @@ val frontendAssetsSpec: CopySpec =
 tasks.register<Exec>("buildFrontendAssets") {
     group = "build"
     description = "Build frontend JavaScript and CSS assets using npm"
+    // Declared so Gradle can skip this when nothing has changed, and so the build cache can restore
+    // dist/ on a fresh CI runner rather than re-running rollup in every shard.
+    inputs.dir("src/main/js").withPathSensitivity(PathSensitivity.RELATIVE)
+    inputs.dir("src/main/resources/css").withPathSensitivity(PathSensitivity.RELATIVE)
+    inputs.files("rollup.config.mjs", "package.json", "package-lock.json").withPathSensitivity(PathSensitivity.RELATIVE)
+    outputs.dir("dist")
+    outputs.cacheIf { true }
     if (OperatingSystem.current().isWindows) {
         commandLine("cmd", "/c", "npm", "run", "build")
     } else {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,5 @@
 org.gradle.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=512m -XX:+HeapDumpOnOutOfMemoryError
 kotlin.daemon.jvmargs=-Xmx2g -XX:MaxMetaspaceSize=512m
+
+# Lets CI shards restore compiled classes and frontend assets instead of rebuilding them each run.
+org.gradle.caching=true


### PR DESCRIPTION
## Ticket number

PDJB-NONE

## Goal of change

Stop every CI shard rebuilding from scratch, now that build overhead is a significant share of a much shorter job.

Stacked on #1677, #1676 and #1675 — review those first.

## Description of main change(s)

Measured breakdown of a shard job before this change (9.5 min total):

| Phase | Time |
|---|---|
| Checkout, JDK, node, npm ci | 0.33 min |
| `buildFrontendAssets` (npm build, again, inside Gradle) | 0.52 min |
| `compileKotlin` | 0.81 min |
| `compileTestKotlin` | 0.61 min |
| `test` | 7.04 min |

So ~1.9 min per shard is build work, repeated in all four shards. This PR:

- **Enables the Gradle build cache** (`org.gradle.caching=true`) and swaps `actions/setup-java`'s Gradle caching for `gradle/actions/setup-gradle`, which handles build-cache save and restore properly.
- **Declares inputs and outputs on `buildFrontendAssets`.** It was an `Exec` task with neither, so Gradle could never mark it up-to-date or cache it, and rollup ran on every build. Locally it now goes from 10s to 1s on a repeat run.
- **Drops `clean` from the shard command.** Runners start empty, so it only guaranteed a cold build and prevented the cache from being used.
- **Removes the duplicate `npm run build` workflow step.** Gradle already runs it via `copyBuiltAssets`, so it was building the frontend twice per job.

## Anything you'd like to highlight to the reviewer?

**The two main changes only work together.** A fresh runner has no `dist/`, so declaring outputs on `buildFrontendAssets` achieves nothing on its own — it is the build cache that restores the directory. Verified locally: with `dist/` deleted, the task reports `FROM-CACHE` and completes in 1s instead of 10s.

**The saving is variable, unlike the other PRs in this stack.** Cache hits depend on what changed. A PR touching Kotlin source will still recompile that source; one touching only tests or config should restore most of the build. So expect somewhere between ~0.5 and ~1.9 min per shard rather than a fixed figure. I have not tried to predict a single number, because the last few estimates in this area were wrong until measured.

**Dropping `clean` is the one judgement call.** It trades a guaranteed-clean build for speed. Kotlin incremental compilation is reliable, but if a strange failure ever appears, "does it reproduce with `clean`?" becomes the first question. Easy to revert on its own if that ever bites.

This also helps local development: `buildFrontendAssets` currently re-runs on every `./gradlew test`, and will now be skipped when the frontend has not changed.

## Checklist

- [x] Branch has been rebased onto main and run locally, with everything working as expected (both for your new feature and any related functionality)
