### PR TITLE
PDJB-NONE: Force jackson-bom 2.21.5 on the Gradle build classpath

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -264,6 +264,10 @@ buildscript {
             // spring-boot-buildpack-platform pulls a vulnerable commons-lang3 transitively onto the
             // build classpath; GitHub's dependency submission reports it even though it is build-time only.
             force("org.apache.commons:commons-lang3:3.18.0")
+            // The Flyway and Spring Boot plugins pull jackson 2.21.4 onto the build classpath. The
+            // extra["jackson-bom.version"] override above only applies to the project's dependency
+            // management, not here, so GHSA-5gvw-p9qm-jgwh / GHSA-mhm7-754m-9p8w are reported against it.
+            force("com.fasterxml.jackson:jackson-bom:2.21.5")
         }
     }
 }


### PR DESCRIPTION
## Ticket number

PDJB-NONE

## Goal of change

Clear two open Dependabot alerts (GHSA-5gvw-p9qm-jgwh, GHSA-mhm7-754m-9p8w) reporting `jackson-databind` 2.21.4 without dismissing them as false positives.

## Description of main change(s)

- Forces `com.fasterxml.jackson:jackson-bom:2.21.5` on the Gradle `buildscript` classpath, alongside the existing `commons-lang3` force.

The application itself was never affected — `extra["jackson-bom.version"] = "2.21.5"` already pins every jackson artifact on all project configurations, including `productionRuntimeClasspath`. That override only drives `io.spring.dependency-management`, which does not apply to the build classpath, where the Flyway and Spring Boot plugins pulled jackson 2.21.4. GitHub's dependency submission reports build-time dependencies too, hence the alerts.

## Anything you'd like to highlight to the reviewer?

Build-time only — no application dependency changes. Verified before and after:

| Classpath | Before | After |
| --- | --- | --- |
| `buildscript` classpath | jackson 2.21.4 | jackson 2.21.5 |
| All project configurations (incl. `productionRuntimeClasspath`) | jackson 2.21.5 | jackson 2.21.5, unchanged |

Forcing the BOM alone cascades to all five affected artifacts (`jackson-core`, `jackson-databind`, `jackson-dataformat-toml`, `jackson-datatype-jsr310`, `jackson-module-parameter-names`), so no per-artifact forces are needed. `jackson-annotations` correctly stays at `2.21` — that line has no patch releases and is not covered by either advisory.

The alerts should auto-close on the next dependency submission after merge.

## Checklist

- [ ] Test suite has been run in full locally and is passing — not run locally; the change touches only the Gradle build classpath and leaves every resolved application dependency identical, so CI coverage is sufficient
