### PR TITLE
PDJB-NONE: Fail the build when a test shard fails

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -92,6 +92,14 @@ jobs:
   all-tests:
     name: Build and test
     needs: [test, lint]
+    # Without always() this job is skipped when a shard fails, and a skipped required check does not block
+    # merging, so the result of the jobs it depends on has to be asserted explicitly.
+    if: always()
     runs-on: ubuntu-latest
     steps:
-      - run: echo "All shards and lint passed"
+      - name: Check shard and lint results
+        run: |
+          echo "test=${{ needs.test.result }} lint=${{ needs.lint.result }}"
+          if [ "${{ needs.test.result }}" != "success" ] || [ "${{ needs.lint.result }}" != "success" ]; then
+            exit 1
+          fi


### PR DESCRIPTION
## Ticket number

PDJB-NONE

## Goal of change

Stops a pull request with failing tests from satisfying branch protection

## Description of main change(s)

When a test shard fails, the `Build and test` job that depends on it is skipped rather than failed. A skipped required check does not block merging, so a pull request with failing tests can enter the merge queue.

- Adds `if: always()` to the `Build and test` job so it still runs when a shard fails
- Asserts the results of the jobs it depends on, so it fails unless every shard and the lint job succeeded

Introduced by the sharding change in #1675, so main is affected until this merges.

## Anything you'd like to highlight to the reviewer?

Verified on CI rather than reasoned about. A deliberately failing test was pushed to this branch, and the jobs reported:

```
Lint: success
Test shard (0): success
Test shard (1): success
Test shard (2): success
Test shard (3): failure
Build and test: failure
```

Before this change the same situation left `Build and test` skipped. The temporary failing test has been removed.

## Checklist

Delete any that are not applicable, and add explanation below for any that are applicable but haven't been done

- [X] Branch has been rebased onto main and run locally, with everything working as expected (both for your new feature
  and any related functionality)