### PR TITLE
PDJB-1474: Add organisation details tab to org landlord record page

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/LandlordDetailsController.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/LandlordDetailsController.kt
@@ -81,7 +81,6 @@ class LandlordDetailsController(
         }
     }
 
-    // TODO: PDJB-1474 (details tab) & PDJB-1475 (contacts tab): Replace this skeleton page with proper summary list content
     private fun getOrgLandlordDetails(
         orgLandlord: OrganisationalLandlord,
         model: Model,

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/database/entity/OrganisationalLandlord.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/database/entity/OrganisationalLandlord.kt
@@ -174,7 +174,7 @@ class OrganisationalLandlord() : Landlord() {
 
     @get:Transient
     val isRegisteredCharity: Boolean
-        get() = charityNumber != null
+        get() = charityRegisteredWith != null
 
     @get:Transient
     val hasLeadTrustee: Boolean

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/database/entity/OrganisationalLandlord.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/database/entity/OrganisationalLandlord.kt
@@ -177,6 +177,10 @@ class OrganisationalLandlord() : Landlord() {
         get() = charityRegisteredWith != null
 
     @get:Transient
+    val hasCharityNumber: Boolean
+        get() = charityNumber != null
+
+    @get:Transient
     val hasLeadTrustee: Boolean
         get() = isTrust == true
 

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/helpers/converters/MessageKeyConverter.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/helpers/converters/MessageKeyConverter.kt
@@ -68,7 +68,7 @@ class MessageKeyConverter {
                 OrgType.COMPANY -> "registerAsALandlord.orgType.checkbox.company"
                 OrgType.CHARITY -> "registerAsALandlord.orgType.checkbox.charity"
                 OrgType.TRUST -> "registerAsALandlord.orgType.checkbox.trust"
-                OrgType.NONE -> "commonText.other"
+                OrgType.NONE -> "registerAsALandlord.orgType.checkbox.none"
             }
 
         private fun convertCharityRegulator(charityRegulator: CharityRegulator): String =
@@ -76,7 +76,7 @@ class MessageKeyConverter {
                 CharityRegulator.ENGLAND_AND_WALES -> "forms.orgCharityRegisteredWith.radios.option.englandAndWales"
                 CharityRegulator.NORTHERN_IRELAND -> "forms.orgCharityRegisteredWith.radios.option.northernIreland"
                 CharityRegulator.SCOTLAND -> "forms.orgCharityRegisteredWith.radios.option.scotland"
-                CharityRegulator.NONE -> "commonText.other"
+                CharityRegulator.NONE -> "forms.orgCharityRegisteredWith.radios.option.none"
             }
 
         private fun convertBillsIncluded(billsIncluded: BillsIncluded): String =

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/helpers/converters/MessageKeyConverter.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/helpers/converters/MessageKeyConverter.kt
@@ -1,6 +1,7 @@
 package uk.gov.communities.prsdb.webapp.helpers.converters
 
 import uk.gov.communities.prsdb.webapp.constants.enums.BillsIncluded
+import uk.gov.communities.prsdb.webapp.constants.enums.CharityRegulator
 import uk.gov.communities.prsdb.webapp.constants.enums.ComplianceCertStatus
 import uk.gov.communities.prsdb.webapp.constants.enums.EpcExemptionReason
 import uk.gov.communities.prsdb.webapp.constants.enums.FileUploadStatus
@@ -8,6 +9,7 @@ import uk.gov.communities.prsdb.webapp.constants.enums.FurnishedStatus
 import uk.gov.communities.prsdb.webapp.constants.enums.GoverningBodyMemberType
 import uk.gov.communities.prsdb.webapp.constants.enums.LicensingType
 import uk.gov.communities.prsdb.webapp.constants.enums.MeesExemptionReason
+import uk.gov.communities.prsdb.webapp.constants.enums.OrgType
 import uk.gov.communities.prsdb.webapp.constants.enums.OwnershipType
 import uk.gov.communities.prsdb.webapp.constants.enums.PropertyType
 import uk.gov.communities.prsdb.webapp.constants.enums.RentFrequency
@@ -44,6 +46,10 @@ class MessageKeyConverter {
 
                 is FileUploadStatus -> convertUploadStatus(enum)
 
+                is OrgType -> convertOrgType(enum)
+
+                is CharityRegulator -> convertCharityRegulator(enum)
+
                 else -> throw NotImplementedError(
                     "Was not able to convert Enum as ${this::class.simpleName} does not have a conversion for ${enum::class.simpleName}",
                 )
@@ -55,6 +61,22 @@ class MessageKeyConverter {
                 GoverningBodyMemberType.TRUSTEE -> "landlordDetails.org.governingBody.type.trustee"
                 GoverningBodyMemberType.PARTNER -> "landlordDetails.org.governingBody.type.partner"
                 GoverningBodyMemberType.OTHER -> "landlordDetails.org.governingBody.type.other"
+            }
+
+        private fun convertOrgType(orgType: OrgType): String =
+            when (orgType) {
+                OrgType.COMPANY -> "registerAsALandlord.orgType.checkbox.company"
+                OrgType.CHARITY -> "registerAsALandlord.orgType.checkbox.charity"
+                OrgType.TRUST -> "registerAsALandlord.orgType.checkbox.trust"
+                OrgType.NONE -> "commonText.other"
+            }
+
+        private fun convertCharityRegulator(charityRegulator: CharityRegulator): String =
+            when (charityRegulator) {
+                CharityRegulator.ENGLAND_AND_WALES -> "forms.orgCharityRegisteredWith.radios.option.englandAndWales"
+                CharityRegulator.NORTHERN_IRELAND -> "forms.orgCharityRegisteredWith.radios.option.northernIreland"
+                CharityRegulator.SCOTLAND -> "forms.orgCharityRegisteredWith.radios.option.scotland"
+                CharityRegulator.NONE -> "commonText.other"
             }
 
         private fun convertBillsIncluded(billsIncluded: BillsIncluded): String =

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/landlordRegistration/stepConfig/LandlordRegistrationCyaStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/landlordRegistration/stepConfig/LandlordRegistrationCyaStepConfig.kt
@@ -10,6 +10,7 @@ import uk.gov.communities.prsdb.webapp.constants.enums.CharityRegulator
 import uk.gov.communities.prsdb.webapp.constants.enums.GoverningBodyMemberType
 import uk.gov.communities.prsdb.webapp.constants.enums.OrgType
 import uk.gov.communities.prsdb.webapp.exceptions.NotNullFormModelValueIsNullException.Companion.notNullValue
+import uk.gov.communities.prsdb.webapp.helpers.converters.MessageKeyConverter
 import uk.gov.communities.prsdb.webapp.helpers.extensions.MessageSourceExtensions.Companion.getMessageForKey
 import uk.gov.communities.prsdb.webapp.journeys.Destination
 import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.states.LandlordRegistrationState
@@ -379,10 +380,9 @@ class LandlordRegistrationCyaStepConfig(
             add(
                 SummaryListRowViewModel.forCheckYourAnswersPage(
                     "registerAsALandlord.orgCheckAnswers.landlordDetails.organisationType",
-                    org.orgTypeStep.formModel.orgTypes
-                        .filterNotNull()
-                        .filter { it.isNotBlank() }
-                        .joinToString(", ") { messageSource.getMessageForKey(orgTypeMessageKey(it)) },
+                    org.orgTypeStep.formModel
+                        .getSelectedOrgTypes()
+                        .joinToString(", ") { messageSource.getMessageForKey(MessageKeyConverter.convert(it)) },
                     Destination.VisitableStep(org.orgTypeStep, state.getCyaJourneyId(org.orgTypeStep)),
                 ),
             )
@@ -415,7 +415,7 @@ class LandlordRegistrationCyaStepConfig(
                 add(
                     SummaryListRowViewModel.forCheckYourAnswersPage(
                         "registerAsALandlord.orgCheckAnswers.landlordDetails.charityCommission",
-                        regulatorMessageKey(charityRegulator),
+                        charityRegulator,
                         Destination.VisitableStep(
                             org.charityTask.orgCharityRegisteredWithStep,
                             state.getCyaJourneyId(org.charityTask.orgCharityRegisteredWithStep),
@@ -663,22 +663,6 @@ class LandlordRegistrationCyaStepConfig(
             CharityRegulator.NONE, null -> null
         }
     }
-
-    private fun orgTypeMessageKey(orgTypeName: String) =
-        when (orgTypeName) {
-            OrgType.COMPANY.name -> "registerAsALandlord.orgType.checkbox.company"
-            OrgType.CHARITY.name -> "registerAsALandlord.orgType.checkbox.charity"
-            OrgType.TRUST.name -> "registerAsALandlord.orgType.checkbox.trust"
-            else -> "commonText.other"
-        }
-
-    private fun regulatorMessageKey(regulator: CharityRegulator) =
-        when (regulator) {
-            CharityRegulator.ENGLAND_AND_WALES -> "forms.orgCharityRegisteredWith.radios.option.englandAndWales"
-            CharityRegulator.NORTHERN_IRELAND -> "forms.orgCharityRegisteredWith.radios.option.northernIreland"
-            CharityRegulator.SCOTLAND -> "forms.orgCharityRegisteredWith.radios.option.scotland"
-            CharityRegulator.NONE -> "commonText.other"
-        }
 }
 
 @JourneyFrameworkComponent

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/summaryModels/OrgLandlordViewModel.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/summaryModels/OrgLandlordViewModel.kt
@@ -1,38 +1,120 @@
 package uk.gov.communities.prsdb.webapp.models.viewModels.summaryModels
 
+import kotlinx.datetime.toKotlinInstant
+import uk.gov.communities.prsdb.webapp.constants.enums.CharityRegulator
+import uk.gov.communities.prsdb.webapp.constants.enums.OrgType
+import uk.gov.communities.prsdb.webapp.controllers.UpdateOrganisationLandlordNameController.Companion.UPDATE_ORG_NAME_ROUTE
 import uk.gov.communities.prsdb.webapp.database.entity.OrganisationalLandlord
+import uk.gov.communities.prsdb.webapp.helpers.DateTimeHelper
+import uk.gov.communities.prsdb.webapp.helpers.converters.MessageKeyConverter
+import uk.gov.communities.prsdb.webapp.helpers.extensions.addRow
+import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.OrgNameStep
+import uk.gov.communities.prsdb.webapp.models.dataModels.RegistrationNumberDataModel
 
-// TODO: PDJB-1474 (details tab) & PDJB-1475 (contacts tab): Replace this skeleton view model with summary list rows
 class OrgLandlordViewModel(
-    orgLandlord: OrganisationalLandlord,
+    landlord: OrganisationalLandlord,
 ) {
-    val name: String = orgLandlord.name
+    val name: String = landlord.name
 
-    val singleLineAddress: String = orgLandlord.address.singleLineAddress
+    val organisationDetails: List<SummaryListRowViewModel> =
+        mutableListOf<SummaryListRowViewModel>()
+            .apply {
+                addRow(
+                    "landlordDetails.org.registrationDate",
+                    DateTimeHelper.getDateInUK(landlord.createdDate.toKotlinInstant()),
+                )
+                addRow(
+                    "landlordDetails.org.lrn",
+                    RegistrationNumberDataModel.fromRegistrationNumber(landlord.registrationNumber),
+                )
+                addRow(
+                    "landlordDetails.org.landlordType",
+                    "landlordDetails.org.landlordTypeValue",
+                )
+                addRow(
+                    "landlordDetails.org.name",
+                    landlord.name,
+                    CHANGE_LINK_MESSAGE_KEY,
+                    UPDATE_ORG_NAME_URL,
+                )
+                // TODO: PDJB-1444: Add update journey
+                addRow(
+                    "landlordDetails.org.address",
+                    landlord.address.toMultiLineAddress().split("\n"),
+                    CHANGE_LINK_MESSAGE_KEY,
+                    PLACEHOLDER_CHANGE_URL,
+                )
+                // TODO: PDJB-1235: Add update journey
+                addRow(
+                    "landlordDetails.org.email",
+                    landlord.wholeOrgEmail,
+                    CHANGE_LINK_MESSAGE_KEY,
+                    PLACEHOLDER_CHANGE_URL,
+                )
+                // TODO: PDJB-1236: Add update journey
+                addRow(
+                    "landlordDetails.org.phone",
+                    landlord.phoneNumber,
+                    CHANGE_LINK_MESSAGE_KEY,
+                    PLACEHOLDER_CHANGE_URL,
+                )
+                // TODO: PDJB-1237: Add update journey
+                addRow(
+                    "landlordDetails.org.organisationType",
+                    landlord.organisationTypes.map { orgTypeMessageKey(it) },
+                    CHANGE_LINK_MESSAGE_KEY,
+                    PLACEHOLDER_CHANGE_URL,
+                )
+                // TODO: PDJB-1239: Add update journey
+                addRow(
+                    "landlordDetails.org.registeredCharity",
+                    MessageKeyConverter.convert(landlord.isRegisteredCharity),
+                    CHANGE_LINK_MESSAGE_KEY,
+                    PLACEHOLDER_CHANGE_URL,
+                )
+                if (landlord.isRegisteredCharity) {
+                    addRow(
+                        "landlordDetails.org.charityCommission",
+                        regulatorMessageKey(landlord.charityRegisteredWith!!),
+                    )
+                }
+                if (landlord.charityNumber != null) {
+                    addRow("landlordDetails.org.charityNumber", landlord.charityNumber)
+                }
+                // TODO: PDJB-1238: Add update journey
+                addRow(
+                    "landlordDetails.org.registeredWithCompaniesHouse",
+                    MessageKeyConverter.convert(landlord.isRegisteredCompany),
+                    CHANGE_LINK_MESSAGE_KEY,
+                    PLACEHOLDER_CHANGE_URL,
+                )
+                if (landlord.isRegisteredCompany) {
+                    addRow("landlordDetails.org.companyNumber", landlord.companyNumber)
+                }
+            }.toList()
 
-    val email: String = orgLandlord.wholeOrgEmail
+    private fun orgTypeMessageKey(orgType: OrgType) =
+        when (orgType) {
+            OrgType.COMPANY -> "registerAsALandlord.orgType.checkbox.company"
+            OrgType.CHARITY -> "registerAsALandlord.orgType.checkbox.charity"
+            OrgType.TRUST -> "registerAsALandlord.orgType.checkbox.trust"
+            OrgType.NONE -> "commonText.other"
+        }
 
-    val phoneNumber: String = orgLandlord.phoneNumber
+    private fun regulatorMessageKey(regulator: CharityRegulator) =
+        when (regulator) {
+            CharityRegulator.ENGLAND_AND_WALES -> "forms.orgCharityRegisteredWith.radios.option.englandAndWales"
+            CharityRegulator.NORTHERN_IRELAND -> "forms.orgCharityRegisteredWith.radios.option.northernIreland"
+            CharityRegulator.SCOTLAND -> "forms.orgCharityRegisteredWith.radios.option.scotland"
+            CharityRegulator.NONE -> "commonText.other"
+        }
 
-    val isCompany: Boolean = orgLandlord.isCompany
+    companion object {
+        private const val CHANGE_LINK_MESSAGE_KEY = "forms.links.change"
 
-    val isCharity: Boolean = orgLandlord.isCharity
+        private const val UPDATE_ORG_NAME_URL = "$UPDATE_ORG_NAME_ROUTE/${OrgNameStep.ROUTE_SEGMENT}"
 
-    val isTrust: Boolean = orgLandlord.isTrust
-
-    val companyNumber: String? = orgLandlord.companyNumber
-
-    val charityNumber: String? = orgLandlord.charityNumber
-
-    val mainContactName: String = orgLandlord.mainContactName
-
-    val mainContactEmail: String = orgLandlord.mainContactEmail
-
-    val mainContactPhone: String = orgLandlord.mainContactPhone
-
-    val leadTrusteeName: String? = orgLandlord.leadTrusteeName
-
-    val leadTrusteeEmail: String? = orgLandlord.leadTrusteeEmail
-
-    val leadTrusteePhone: String? = orgLandlord.leadTrusteePhone
+        // Non-functional Change link placeholder until the remaining organisation update journeys exist.
+        private const val PLACEHOLDER_CHANGE_URL = "#"
+    }
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/summaryModels/OrgLandlordViewModel.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/summaryModels/OrgLandlordViewModel.kt
@@ -2,11 +2,13 @@ package uk.gov.communities.prsdb.webapp.models.viewModels.summaryModels
 
 import kotlinx.datetime.toKotlinInstant
 import uk.gov.communities.prsdb.webapp.controllers.UpdateOrganisationLandlordNameController.Companion.UPDATE_ORG_NAME_ROUTE
+import uk.gov.communities.prsdb.webapp.controllers.UpdateOrganisationTypeController.Companion.UPDATE_ORG_TYPE_ROUTE
 import uk.gov.communities.prsdb.webapp.database.entity.OrganisationalLandlord
 import uk.gov.communities.prsdb.webapp.helpers.DateTimeHelper
 import uk.gov.communities.prsdb.webapp.helpers.converters.MessageKeyConverter
 import uk.gov.communities.prsdb.webapp.helpers.extensions.addRow
 import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.OrgNameStep
+import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.OrgTypeStep
 import uk.gov.communities.prsdb.webapp.models.dataModels.RegistrationNumberDataModel
 
 class OrgLandlordViewModel(
@@ -60,8 +62,7 @@ class OrgLandlordViewModel(
                     "landlordDetails.org.organisationType",
                     landlord.organisationTypes,
                     CHANGE_LINK_MESSAGE_KEY,
-                    // TODO: PDJB-1237: Add update journey
-                    null,
+                    UPDATE_ORG_TYPE_URL,
                 )
                 addRow(
                     "landlordDetails.org.registeredCharity",
@@ -92,5 +93,7 @@ class OrgLandlordViewModel(
         private const val CHANGE_LINK_MESSAGE_KEY = "forms.links.change"
 
         private const val UPDATE_ORG_NAME_URL = "$UPDATE_ORG_NAME_ROUTE/${OrgNameStep.ROUTE_SEGMENT}"
+
+        private const val UPDATE_ORG_TYPE_URL = "$UPDATE_ORG_TYPE_ROUTE/${OrgTypeStep.ROUTE_SEGMENT}"
     }
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/summaryModels/OrgLandlordViewModel.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/summaryModels/OrgLandlordViewModel.kt
@@ -70,10 +70,10 @@ class OrgLandlordViewModel(
                     // TODO: PDJB-1239: Add update journey
                     null,
                 )
-                landlord.charityRegisteredWith?.let { charityRegulator ->
-                    addRow("landlordDetails.org.charityCommission", charityRegulator)
+                if (landlord.isRegisteredCharity) {
+                    addRow("landlordDetails.org.charityCommission", landlord.charityRegisteredWith)
                 }
-                if (landlord.charityNumber != null) {
+                if (landlord.hasCharityNumber) {
                     addRow("landlordDetails.org.charityNumber", landlord.charityNumber)
                 }
                 addRow(

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/summaryModels/OrgLandlordViewModel.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/summaryModels/OrgLandlordViewModel.kt
@@ -1,8 +1,6 @@
 package uk.gov.communities.prsdb.webapp.models.viewModels.summaryModels
 
 import kotlinx.datetime.toKotlinInstant
-import uk.gov.communities.prsdb.webapp.constants.enums.CharityRegulator
-import uk.gov.communities.prsdb.webapp.constants.enums.OrgType
 import uk.gov.communities.prsdb.webapp.controllers.UpdateOrganisationLandlordNameController.Companion.UPDATE_ORG_NAME_ROUTE
 import uk.gov.communities.prsdb.webapp.database.entity.OrganisationalLandlord
 import uk.gov.communities.prsdb.webapp.helpers.DateTimeHelper
@@ -37,84 +35,62 @@ class OrgLandlordViewModel(
                     CHANGE_LINK_MESSAGE_KEY,
                     UPDATE_ORG_NAME_URL,
                 )
-                // TODO: PDJB-1444: Add update journey
                 addRow(
                     "landlordDetails.org.address",
                     landlord.address.toMultiLineAddress().split("\n"),
                     CHANGE_LINK_MESSAGE_KEY,
-                    PLACEHOLDER_CHANGE_URL,
+                    // TODO: PDJB-1444: Add update journey
+                    null,
                 )
-                // TODO: PDJB-1235: Add update journey
                 addRow(
                     "landlordDetails.org.email",
                     landlord.wholeOrgEmail,
                     CHANGE_LINK_MESSAGE_KEY,
-                    PLACEHOLDER_CHANGE_URL,
+                    // TODO: PDJB-1235: Add update journey
+                    null,
                 )
-                // TODO: PDJB-1236: Add update journey
                 addRow(
                     "landlordDetails.org.phone",
                     landlord.phoneNumber,
                     CHANGE_LINK_MESSAGE_KEY,
-                    PLACEHOLDER_CHANGE_URL,
+                    // TODO: PDJB-1236: Add update journey
+                    null,
                 )
-                // TODO: PDJB-1237: Add update journey
                 addRow(
                     "landlordDetails.org.organisationType",
-                    landlord.organisationTypes.map { orgTypeMessageKey(it) },
+                    landlord.organisationTypes,
                     CHANGE_LINK_MESSAGE_KEY,
-                    PLACEHOLDER_CHANGE_URL,
+                    // TODO: PDJB-1237: Add update journey
+                    null,
                 )
-                // TODO: PDJB-1239: Add update journey
                 addRow(
                     "landlordDetails.org.registeredCharity",
                     MessageKeyConverter.convert(landlord.isRegisteredCharity),
                     CHANGE_LINK_MESSAGE_KEY,
-                    PLACEHOLDER_CHANGE_URL,
+                    // TODO: PDJB-1239: Add update journey
+                    null,
                 )
-                if (landlord.isRegisteredCharity) {
-                    addRow(
-                        "landlordDetails.org.charityCommission",
-                        regulatorMessageKey(landlord.charityRegisteredWith!!),
-                    )
+                landlord.charityRegisteredWith?.let { charityRegulator ->
+                    addRow("landlordDetails.org.charityCommission", charityRegulator)
                 }
                 if (landlord.charityNumber != null) {
                     addRow("landlordDetails.org.charityNumber", landlord.charityNumber)
                 }
-                // TODO: PDJB-1238: Add update journey
                 addRow(
                     "landlordDetails.org.registeredWithCompaniesHouse",
                     MessageKeyConverter.convert(landlord.isRegisteredCompany),
                     CHANGE_LINK_MESSAGE_KEY,
-                    PLACEHOLDER_CHANGE_URL,
+                    // TODO: PDJB-1238: Add update journey
+                    null,
                 )
                 if (landlord.isRegisteredCompany) {
                     addRow("landlordDetails.org.companyNumber", landlord.companyNumber)
                 }
             }.toList()
 
-    private fun orgTypeMessageKey(orgType: OrgType) =
-        when (orgType) {
-            OrgType.COMPANY -> "registerAsALandlord.orgType.checkbox.company"
-            OrgType.CHARITY -> "registerAsALandlord.orgType.checkbox.charity"
-            OrgType.TRUST -> "registerAsALandlord.orgType.checkbox.trust"
-            OrgType.NONE -> "commonText.other"
-        }
-
-    private fun regulatorMessageKey(regulator: CharityRegulator) =
-        when (regulator) {
-            CharityRegulator.ENGLAND_AND_WALES -> "forms.orgCharityRegisteredWith.radios.option.englandAndWales"
-            CharityRegulator.NORTHERN_IRELAND -> "forms.orgCharityRegisteredWith.radios.option.northernIreland"
-            CharityRegulator.SCOTLAND -> "forms.orgCharityRegisteredWith.radios.option.scotland"
-            CharityRegulator.NONE -> "commonText.other"
-        }
-
     companion object {
         private const val CHANGE_LINK_MESSAGE_KEY = "forms.links.change"
 
         private const val UPDATE_ORG_NAME_URL = "$UPDATE_ORG_NAME_ROUTE/${OrgNameStep.ROUTE_SEGMENT}"
-
-        // Non-functional Change link placeholder until the remaining organisation update journeys exist.
-        private const val PLACEHOLDER_CHANGE_URL = "#"
     }
 }

--- a/src/main/resources/messages/landlordDetails.yml
+++ b/src/main/resources/messages/landlordDetails.yml
@@ -39,16 +39,20 @@ org:
   tabs:
     organisationDetails: Organisation details
     organisationContacts: Organisation contacts
+  registrationDate: Registration date
+  lrn: Landlord Registration Number
+  landlordType: Landlord type
+  landlordTypeValue: Organisation
   name: Organisation name
   address: Organisation address
   email: Organisation email
   phone: Organisation phone number
   organisationType: Organisation type
-  isCompany: Company
   companyNumber: Companies House number
-  isCharity: Charity
-  isTrust: Trust
+  registeredCharity: Registered charity
+  charityCommission: Charity commission
   charityNumber: Charity number
+  registeredWithCompaniesHouse: Registered with Companies House
   mainContactHeading: Main contact
   mainContactName: Name
   mainContactEmail: Email

--- a/src/main/resources/messages/landlordDetails.yml
+++ b/src/main/resources/messages/landlordDetails.yml
@@ -46,7 +46,7 @@ org:
   name: Organisation name
   address: Organisation address
   email: Organisation email
-  phone: Organisation phone number
+  phone: Organisation phone
   organisationType: Organisation type
   companyNumber: Companies House number
   registeredCharity: Registered charity

--- a/src/main/resources/templates/orgLandlordDetailsView.html
+++ b/src/main/resources/templates/orgLandlordDetailsView.html
@@ -20,61 +20,7 @@
             </ul>
 
             <div id="organisation-details-panel" th:replace="~{fragments/tabs/tabsPanel :: tabsPanel('organisation-details', ~{::#organisation-details-panel/content()})}">
-                <h2 class="govuk-heading-m" th:text="#{landlordDetails.org.tabs.organisationDetails}">landlordDetails.org.tabs.organisationDetails</h2>
-
-                <p class="govuk-body">
-                    <strong th:text="#{landlordDetails.org.name}">landlordDetails.org.name</strong><br/>
-                    <span th:text="${orgLandlord.name}">orgLandlord.name</span><br/>
-                    <a class="govuk-link" th:href="@{'/landlord/landlord-details/update-organisation-name/organisation-name'}">Change</a>
-                </p> <!-- TODO: PDJB-1474: Update links instead of using hrefs -->
-
-                <p class="govuk-body">
-                    <strong th:text="#{landlordDetails.org.address}">landlordDetails.org.address</strong><br/>
-                    <span th:text="${orgLandlord.singleLineAddress}">orgLandlord.singleLineAddress</span><br/>
-                    <a class="govuk-link" href="#" th:text="#{forms.links.change}">forms.links.change</a> <!-- TODO: PDJB-1444: Add update journey -->
-                </p>
-
-                <p class="govuk-body">
-                    <strong th:text="#{landlordDetails.org.email}">landlordDetails.org.email</strong><br/>
-                    <span th:text="${orgLandlord.email}">orgLandlord.email</span><br/>
-                    <a class="govuk-link" href="#" th:text="#{forms.links.change}">forms.links.change</a> <!-- TODO: PDJB-1235: Add update journey -->
-                </p>
-
-                <p class="govuk-body">
-                    <strong th:text="#{landlordDetails.org.phone}">landlordDetails.org.phone</strong><br/>
-                    <span th:text="${orgLandlord.phoneNumber}">orgLandlord.phoneNumber</span><br/>
-                    <a class="govuk-link" href="#" th:text="#{forms.links.change}">forms.links.change</a> <!-- TODO: PDJB-1236: Add update journey -->
-                </p>
-
-                <h2 class="govuk-heading-m" th:text="#{landlordDetails.org.organisationType}">landlordDetails.org.organisationType</h2>
-
-                <p class="govuk-body">
-                    <strong th:text="#{landlordDetails.org.organisationType}">landlordDetails.org.organisationType</strong><br/>
-                    <span th:if="${orgLandlord.isCompany}" th:text="#{landlordDetails.org.isCompany}">landlordDetails.org.isCompany</span>
-                    <span th:if="${orgLandlord.isCharity}" th:text="#{landlordDetails.org.isCharity}">landlordDetails.org.isCharity</span>
-                    <span th:if="${orgLandlord.isTrust}" th:text="#{landlordDetails.org.isTrust}">landlordDetails.org.isTrust</span><br/>
-                    <a class="govuk-link" th:href="@{/landlord/landlord-details/update-organisation-type/organisation-type}" th:text="#{forms.links.change}">forms.links.change</a>
-                </p>
-
-                <p class="govuk-body">
-                    <strong th:text="#{landlordDetails.org.isCompany}">landlordDetails.org.isCompany</strong><br/>
-                    <span th:text="${orgLandlord.isCompany}">orgLandlord.isCompany</span><br/>
-                    <th:block th:if="${orgLandlord.companyNumber != null}">
-                        <strong th:text="#{landlordDetails.org.companyNumber}">landlordDetails.org.companyNumber</strong><br/>
-                        <span th:text="${orgLandlord.companyNumber}">orgLandlord.companyNumber</span><br/>
-                    </th:block>
-                    <a class="govuk-link" href="#" th:text="#{forms.links.change}">forms.links.change</a> <!-- TODO: PDJB-1238: Add update journey -->
-                </p>
-
-                <p class="govuk-body">
-                    <strong th:text="#{landlordDetails.org.isCharity}">landlordDetails.org.isCharity</strong><br/>
-                    <span th:text="${orgLandlord.isCharity}">orgLandlord.isCharity</span><br/>
-                    <th:block th:if="${orgLandlord.charityNumber != null}">
-                        <strong th:text="#{landlordDetails.org.charityNumber}">landlordDetails.org.charityNumber</strong><br/>
-                        <span th:text="${orgLandlord.charityNumber}">orgLandlord.charityNumber</span><br/>
-                    </th:block>
-                    <a class="govuk-link" href="#" th:text="#{forms.links.change}">forms.links.change</a> <!-- TODO: PDJB-1239: Add update journey -->
-                </p>
+                <dl th:replace="~{fragments/summaryList :: summaryList(${orgLandlord.organisationDetails})}"></dl>
             </div>
 
             <div id="organisation-contacts-panel" th:replace="~{fragments/tabs/tabsPanel :: tabsPanel('organisation-contacts', ~{::#organisation-contacts-panel/content()})}">

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/helpers/converters/MessageKeyConverterTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/helpers/converters/MessageKeyConverterTests.kt
@@ -7,6 +7,7 @@ import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.EnumSource
 import uk.gov.communities.prsdb.webapp.config.YamlMessageSource
 import uk.gov.communities.prsdb.webapp.constants.enums.BillsIncluded
+import uk.gov.communities.prsdb.webapp.constants.enums.CharityRegulator
 import uk.gov.communities.prsdb.webapp.constants.enums.ComplianceCertStatus
 import uk.gov.communities.prsdb.webapp.constants.enums.EpcExemptionReason
 import uk.gov.communities.prsdb.webapp.constants.enums.FileUploadStatus
@@ -14,6 +15,7 @@ import uk.gov.communities.prsdb.webapp.constants.enums.FurnishedStatus
 import uk.gov.communities.prsdb.webapp.constants.enums.GoverningBodyMemberType
 import uk.gov.communities.prsdb.webapp.constants.enums.LicensingType
 import uk.gov.communities.prsdb.webapp.constants.enums.MeesExemptionReason
+import uk.gov.communities.prsdb.webapp.constants.enums.OrgType
 import uk.gov.communities.prsdb.webapp.constants.enums.OwnershipType
 import uk.gov.communities.prsdb.webapp.constants.enums.PropertyType
 import uk.gov.communities.prsdb.webapp.constants.enums.RentFrequency
@@ -120,6 +122,18 @@ class MessageKeyConverterTests {
     @ParameterizedTest
     @EnumSource(GoverningBodyMemberType::class)
     fun `convert returns a resolvable message key for every GoverningBodyMemberType`(value: GoverningBodyMemberType) {
+        assertMessageKeyResolves(MessageKeyConverter.convert(value))
+    }
+
+    @ParameterizedTest
+    @EnumSource(OrgType::class)
+    fun `convert returns a resolvable message key for every OrgType`(value: OrgType) {
+        assertMessageKeyResolves(MessageKeyConverter.convert(value))
+    }
+
+    @ParameterizedTest
+    @EnumSource(CharityRegulator::class)
+    fun `convert returns a resolvable message key for every CharityRegulator`(value: CharityRegulator) {
         assertMessageKeyResolves(MessageKeyConverter.convert(value))
     }
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/OrgLandlordDetailTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/OrgLandlordDetailTests.kt
@@ -19,14 +19,6 @@ class OrgLandlordDetailTests : IntegrationTestWithImmutableData("data-local.sql"
     }
 
     @Test
-    fun `the organisation details tab shows the organisation's details`(page: Page) {
-        val detailsPage = navigator.goToOrgLandlordDetails()
-
-        assertThat(detailsPage.organisationDetailsPanel).containsText("Organisation type")
-        assertThat(detailsPage.organisationDetailsPanel).containsText("Companies House number")
-    }
-
-    @Test
     fun `the organisation contacts tab shows the main contact's details`(page: Page) {
         val detailsPage = navigator.goToOrgLandlordDetails()
 
@@ -59,5 +51,22 @@ class OrgLandlordDetailTests : IntegrationTestWithImmutableData("data-local.sql"
 
         detailsPage.tabs.goToOrganisationDetails()
         assertEquals("organisation-details", detailsPage.tabs.activeTabPanelId)
+    }
+
+    @Test
+    fun `the organisation details tab shows the organisation's registration and organisation type details`(page: Page) {
+        val detailsPage = navigator.goToOrgLandlordDetails()
+        val summaryList = detailsPage.organisationDetailsSummaryList
+
+        assertThat(summaryList.lrnRow.value).containsText("L-")
+        assertThat(summaryList.landlordTypeRow.value).containsText("Organisation")
+        assertThat(summaryList.nameRow.value).containsText("Local Organisation Landlord")
+        assertThat(summaryList.addressRow.value).containsText("FA1 1AE")
+        assertThat(summaryList.emailRow.value).containsText("local-org-landlord@example.com")
+        assertThat(summaryList.phoneRow.value).containsText("07111111111")
+        assertThat(summaryList.organisationTypeRow.value).containsText("Company")
+        assertThat(summaryList.registeredCharityRow.value).containsText("No")
+        assertThat(summaryList.registeredWithCompaniesHouseRow.value).containsText("Yes")
+        assertThat(summaryList.companyNumberRow.value).containsText("12345678")
     }
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/OrganisationLandlordRegistrationSinglePageTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/OrganisationLandlordRegistrationSinglePageTests.kt
@@ -953,7 +953,7 @@ class OrganisationLandlordRegistrationSinglePageTests : IntegrationTestWithImmut
                 )
 
             assertThat(checkAnswersPage.landlordDetails.registeredCharityRow.value).containsText("Yes")
-            assertThat(checkAnswersPage.landlordDetails.charityCommissionRow.value).containsText("Other")
+            assertThat(checkAnswersPage.landlordDetails.charityCommissionRow.value).containsText("None of these")
             assertThat(checkAnswersPage.landlordDetails.charityNumberRow.value).hasCount(0)
         }
 

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/OrgLandlordDetailsPage.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/OrgLandlordDetailsPage.kt
@@ -33,6 +33,7 @@ class OrgLandlordDetailsPage(
     val leadTrusteeCard = LeadTrusteeSummaryCard(page)
     val registrationContactCard = RegistrationContactSummaryCard(page)
     val governingBodyMembersLink = Link.byText(page, "Add, change or remove members of your governing body")
+    val organisationDetailsSummaryList = OrganisationDetailsSummaryList(page)
 
     fun governingBodyMemberCard(title: String) = GoverningBodyMemberSummaryCard(page, title)
 
@@ -113,5 +114,21 @@ class OrgLandlordDetailsPage(
         fun goToOrganisationDetails() = goToTab("Organisation details")
 
         fun goToOrganisationContacts() = goToTab("Organisation contacts")
+    }
+
+    class OrganisationDetailsSummaryList(
+        page: Page,
+    ) : SummaryList(page) {
+        val registrationDateRow = getRow("Registration date")
+        val lrnRow = getRow("Landlord Registration Number")
+        val landlordTypeRow = getRow("Landlord type")
+        val nameRow = getRow("Organisation name")
+        val addressRow = getRow("Organisation address")
+        val emailRow = getRow("Organisation email")
+        val phoneRow = getRow("Organisation phone number")
+        val organisationTypeRow = getRow("Organisation type")
+        val registeredCharityRow = getRow("Registered charity")
+        val registeredWithCompaniesHouseRow = getRow("Registered with Companies House")
+        val companyNumberRow = getRow("Companies House number")
     }
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/OrgLandlordDetailsPage.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/OrgLandlordDetailsPage.kt
@@ -125,7 +125,7 @@ class OrgLandlordDetailsPage(
         val nameRow = getRow("Organisation name")
         val addressRow = getRow("Organisation address")
         val emailRow = getRow("Organisation email")
-        val phoneRow = getRow("Organisation phone number")
+        val phoneRow = getRow("Organisation phone")
         val organisationTypeRow = getRow("Organisation type")
         val registeredCharityRow = getRow("Registered charity")
         val registeredWithCompaniesHouseRow = getRow("Registered with Companies House")

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/summaryModels/OrgLandlordViewModelTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/summaryModels/OrgLandlordViewModelTests.kt
@@ -164,7 +164,7 @@ class OrgLandlordViewModelTests {
                 charityRegisteredWith = CharityRegulator.ENGLAND_AND_WALES,
                 charityNumber = "0123456",
             )
-        val changeableHeadings = listOf("landlordDetails.org.name")
+        val changeableHeadings = listOf("landlordDetails.org.name", "landlordDetails.org.organisationType")
 
         val viewModel = OrgLandlordViewModel(landlord)
 

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/summaryModels/OrgLandlordViewModelTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/summaryModels/OrgLandlordViewModelTests.kt
@@ -83,7 +83,9 @@ class OrgLandlordViewModelTests {
         )
         assertEquals(
             "commonText.other",
-            viewModel.organisationDetails.single { it.fieldHeading == "landlordDetails.org.charityCommission" }.fieldValue,
+            viewModel.organisationDetails
+                .single { it.fieldHeading == "landlordDetails.org.charityCommission" }
+                .getConvertedFieldValue(),
         )
     }
 
@@ -131,7 +133,9 @@ class OrgLandlordViewModelTests {
                 "registerAsALandlord.orgType.checkbox.charity",
                 "registerAsALandlord.orgType.checkbox.trust",
             ),
-            viewModel.organisationDetails.single { it.fieldHeading == "landlordDetails.org.organisationType" }.fieldValue as List<*>,
+            viewModel.organisationDetails
+                .single { it.fieldHeading == "landlordDetails.org.organisationType" }
+                .getConvertedFieldValue() as List<*>,
         )
     }
 
@@ -144,7 +148,9 @@ class OrgLandlordViewModelTests {
 
         assertIterableEquals(
             listOf("commonText.other"),
-            viewModel.organisationDetails.single { it.fieldHeading == "landlordDetails.org.organisationType" }.fieldValue as List<*>,
+            viewModel.organisationDetails
+                .single { it.fieldHeading == "landlordDetails.org.organisationType" }
+                .getConvertedFieldValue() as List<*>,
         )
     }
 
@@ -158,16 +164,7 @@ class OrgLandlordViewModelTests {
                 charityRegisteredWith = CharityRegulator.ENGLAND_AND_WALES,
                 charityNumber = "0123456",
             )
-        val changeableHeadings =
-            listOf(
-                "landlordDetails.org.name",
-                "landlordDetails.org.address",
-                "landlordDetails.org.email",
-                "landlordDetails.org.phone",
-                "landlordDetails.org.organisationType",
-                "landlordDetails.org.registeredCharity",
-                "landlordDetails.org.registeredWithCompaniesHouse",
-            )
+        val changeableHeadings = listOf("landlordDetails.org.name")
 
         val viewModel = OrgLandlordViewModel(landlord)
 

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/summaryModels/OrgLandlordViewModelTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/summaryModels/OrgLandlordViewModelTests.kt
@@ -82,7 +82,7 @@ class OrgLandlordViewModelTests {
             viewModel.organisationDetails.single { it.fieldHeading == "landlordDetails.org.registeredCharity" }.fieldValue,
         )
         assertEquals(
-            "commonText.other",
+            "forms.orgCharityRegisteredWith.radios.option.none",
             viewModel.organisationDetails
                 .single { it.fieldHeading == "landlordDetails.org.charityCommission" }
                 .getConvertedFieldValue(),
@@ -140,14 +140,14 @@ class OrgLandlordViewModelTests {
     }
 
     @Test
-    fun `an organisation with no selected organisation types shows other`() {
+    fun `an organisation with no selected organisation types shows none of these`() {
         val landlord =
             MockLandlordData.createOrgLandlord(isCompany = false, isCharity = false, isTrust = false)
 
         val viewModel = OrgLandlordViewModel(landlord)
 
         assertIterableEquals(
-            listOf("commonText.other"),
+            listOf("registerAsALandlord.orgType.checkbox.none"),
             viewModel.organisationDetails
                 .single { it.fieldHeading == "landlordDetails.org.organisationType" }
                 .getConvertedFieldValue() as List<*>,

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/summaryModels/OrgLandlordViewModelTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/summaryModels/OrgLandlordViewModelTests.kt
@@ -1,45 +1,182 @@
 package uk.gov.communities.prsdb.webapp.models.viewModels.summaryModels
 
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertIterableEquals
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
+import uk.gov.communities.prsdb.webapp.constants.enums.CharityRegulator
+import uk.gov.communities.prsdb.webapp.database.entity.Address
+import uk.gov.communities.prsdb.webapp.models.dataModels.AddressDataModel
 import uk.gov.communities.prsdb.webapp.testHelpers.mockObjects.MockLandlordData
 
 class OrgLandlordViewModelTests {
     @Test
-    fun `the view model exposes the organisation landlord's details`() {
-        val testLandlord = MockLandlordData.createOrgLandlord()
+    fun `a registered charity and registered company shows all organisation detail rows in order`() {
+        val landlord =
+            MockLandlordData.createOrgLandlord(
+                isCompany = true,
+                isCharity = true,
+                isTrust = false,
+                companyNumber = "01234567",
+                charityRegisteredWith = CharityRegulator.ENGLAND_AND_WALES,
+                charityNumber = "0123456",
+            )
 
-        val viewModel = OrgLandlordViewModel(testLandlord)
+        val viewModel = OrgLandlordViewModel(landlord)
 
-        assertEquals(testLandlord.name, viewModel.name)
-        assertEquals(testLandlord.address.singleLineAddress, viewModel.singleLineAddress)
-        assertEquals(testLandlord.wholeOrgEmail, viewModel.email)
-        assertEquals(testLandlord.phoneNumber, viewModel.phoneNumber)
-        assertEquals(testLandlord.isCompany, viewModel.isCompany)
-        assertEquals(testLandlord.isCharity, viewModel.isCharity)
-        assertEquals(testLandlord.isTrust, viewModel.isTrust)
-        assertEquals(testLandlord.companyNumber, viewModel.companyNumber)
-        assertEquals(testLandlord.charityNumber, viewModel.charityNumber)
-        assertEquals(testLandlord.mainContactName, viewModel.mainContactName)
-        assertEquals(testLandlord.mainContactEmail, viewModel.mainContactEmail)
-        assertEquals(testLandlord.mainContactPhone, viewModel.mainContactPhone)
+        assertIterableEquals(
+            listOf(
+                "landlordDetails.org.registrationDate",
+                "landlordDetails.org.lrn",
+                "landlordDetails.org.landlordType",
+                "landlordDetails.org.name",
+                "landlordDetails.org.address",
+                "landlordDetails.org.email",
+                "landlordDetails.org.phone",
+                "landlordDetails.org.organisationType",
+                "landlordDetails.org.registeredCharity",
+                "landlordDetails.org.charityCommission",
+                "landlordDetails.org.charityNumber",
+                "landlordDetails.org.registeredWithCompaniesHouse",
+                "landlordDetails.org.companyNumber",
+            ),
+            viewModel.organisationDetails.map { it.fieldHeading },
+        )
     }
 
     @Test
-    fun `the view model exposes lead trustee details for a trust`() {
-        val testLandlord =
+    fun `an organisation that is not a registered charity omits the charity commission and charity number rows`() {
+        val landlord =
             MockLandlordData.createOrgLandlord(
-                isCompany = false,
-                isTrust = true,
-                leadTrusteeName = "Lead trustee",
-                leadTrusteeEmail = "lead.trustee@example.com",
-                leadTrusteePhoneNumber = "07123456782",
+                isCharity = false,
+                charityRegisteredWith = null,
+                charityNumber = null,
             )
 
-        val viewModel = OrgLandlordViewModel(testLandlord)
+        val viewModel = OrgLandlordViewModel(landlord)
 
-        assertEquals("Lead trustee", viewModel.leadTrusteeName)
-        assertEquals("lead.trustee@example.com", viewModel.leadTrusteeEmail)
-        assertEquals("07123456782", viewModel.leadTrusteePhone)
+        val headings = viewModel.organisationDetails.map { it.fieldHeading }
+        assertTrue("landlordDetails.org.charityCommission" !in headings)
+        assertTrue("landlordDetails.org.charityNumber" !in headings)
+        assertEquals(
+            "commonText.no",
+            viewModel.organisationDetails.single { it.fieldHeading == "landlordDetails.org.registeredCharity" }.fieldValue,
+        )
+    }
+
+    @Test
+    fun `a registered charity with regulator NONE shows the charity commission row but omits the charity number row`() {
+        val landlord =
+            MockLandlordData.createOrgLandlord(
+                isCharity = true,
+                charityRegisteredWith = CharityRegulator.NONE,
+                charityNumber = null,
+            )
+
+        val viewModel = OrgLandlordViewModel(landlord)
+
+        val headings = viewModel.organisationDetails.map { it.fieldHeading }
+        assertTrue("landlordDetails.org.charityNumber" !in headings)
+        assertEquals(
+            "commonText.yes",
+            viewModel.organisationDetails.single { it.fieldHeading == "landlordDetails.org.registeredCharity" }.fieldValue,
+        )
+        assertEquals(
+            "commonText.other",
+            viewModel.organisationDetails.single { it.fieldHeading == "landlordDetails.org.charityCommission" }.fieldValue,
+        )
+    }
+
+    @Test
+    fun `an organisation without a company number omits the companies house number row`() {
+        val landlord = MockLandlordData.createOrgLandlord(isCompany = false, companyNumber = null)
+
+        val viewModel = OrgLandlordViewModel(landlord)
+
+        val headings = viewModel.organisationDetails.map { it.fieldHeading }
+        assertTrue("landlordDetails.org.companyNumber" !in headings)
+        assertEquals(
+            "commonText.no",
+            viewModel.organisationDetails
+                .single { it.fieldHeading == "landlordDetails.org.registeredWithCompaniesHouse" }
+                .fieldValue,
+        )
+    }
+
+    @Test
+    fun `the organisation address is split into multiple lines`() {
+        val landlord =
+            MockLandlordData.createOrgLandlord(
+                address = Address(AddressDataModel("3rd Floor, 88 Kingsway Square, London, ZX1 4QP")),
+            )
+
+        val viewModel = OrgLandlordViewModel(landlord)
+
+        assertIterableEquals(
+            listOf("3rd Floor", "88 Kingsway Square", "London", "ZX1 4QP"),
+            viewModel.organisationDetails.single { it.fieldHeading == "landlordDetails.org.address" }.fieldValue as List<*>,
+        )
+    }
+
+    @Test
+    fun `the organisation type row maps each selected organisation type to its message key`() {
+        val landlord =
+            MockLandlordData.createOrgLandlord(isCompany = true, isCharity = true, isTrust = true)
+
+        val viewModel = OrgLandlordViewModel(landlord)
+
+        assertIterableEquals(
+            listOf(
+                "registerAsALandlord.orgType.checkbox.company",
+                "registerAsALandlord.orgType.checkbox.charity",
+                "registerAsALandlord.orgType.checkbox.trust",
+            ),
+            viewModel.organisationDetails.single { it.fieldHeading == "landlordDetails.org.organisationType" }.fieldValue as List<*>,
+        )
+    }
+
+    @Test
+    fun `an organisation with no selected organisation types shows other`() {
+        val landlord =
+            MockLandlordData.createOrgLandlord(isCompany = false, isCharity = false, isTrust = false)
+
+        val viewModel = OrgLandlordViewModel(landlord)
+
+        assertIterableEquals(
+            listOf("commonText.other"),
+            viewModel.organisationDetails.single { it.fieldHeading == "landlordDetails.org.organisationType" }.fieldValue as List<*>,
+        )
+    }
+
+    @Test
+    fun `only the changeable rows have action links`() {
+        val landlord =
+            MockLandlordData.createOrgLandlord(
+                isCompany = true,
+                isCharity = true,
+                companyNumber = "01234567",
+                charityRegisteredWith = CharityRegulator.ENGLAND_AND_WALES,
+                charityNumber = "0123456",
+            )
+        val changeableHeadings =
+            listOf(
+                "landlordDetails.org.name",
+                "landlordDetails.org.address",
+                "landlordDetails.org.email",
+                "landlordDetails.org.phone",
+                "landlordDetails.org.organisationType",
+                "landlordDetails.org.registeredCharity",
+                "landlordDetails.org.registeredWithCompaniesHouse",
+            )
+
+        val viewModel = OrgLandlordViewModel(landlord)
+
+        viewModel.organisationDetails.forEach { row ->
+            if (row.fieldHeading in changeableHeadings) {
+                assertTrue(row.actions.isNotEmpty(), "${row.fieldHeading} should have an action link")
+            } else {
+                assertTrue(row.actions.isEmpty(), "${row.fieldHeading} should not have an action link")
+            }
+        }
     }
 }


### PR DESCRIPTION
## Ticket number

PDJB-1474

## Goal of change

Fill in the Organisation details tab of the org landlord record page so org landlords can see their registration and organisation details.

## Description of main change(s)

- Adds `OrgLandlordViewModel`, mapping an `OrganisationLandlord` onto the tab's summary list. The charity commission, charity number and Companies House number rows only appear when the organisation holds that data.
- Replaces the skeleton `<p>` markup in the panel with the shared `summaryList` fragment.
- Fixes `OrganisationLandlord.isRegisteredCharity`, which was derived from `charityNumber` and so reported `false` for a registered charity whose regulator is "None of these". Also adds `hasCharityNumber`, so the charity commission, charity number and Companies House number rows are each guarded by an entity accessor rather than three different inline null checks.
- Adds `OrgType` and `CharityRegulator` to `MessageKeyConverter`, removing a verbatim copy of both mappings from `LandlordRegistrationCyaStepConfig`.

## Screenshots

| Seeded landlord (company) | With charity rows |
| --- | --- |
| ![Organisation details tab](https://github.com/user-attachments/assets/71d84db2-6034-41b4-8df7-aa6ef66267d5) | ![With charity rows](https://github.com/user-attachments/assets/a7d2030f-66a3-4cae-86d5-9ba1a118c6c5) |

## Anything you'd like to highlight to the reviewer?

- Only the Organisation name row has a Change link. Rows whose update journeys don't exist yet pass `null` as the action link so nothing is rendered, matching `LandlordViewModel`'s `PRSD-688` rows. Each carries a `TODO` naming its ticket.
- CYA output is unchanged by the `MessageKeyConverter` refactor — the org type row now uses the existing `OrgTypeFormModel.getSelectedOrgTypes()`, which filters identically.
- One design question I'd like a steer on, left as-is here: the address renders multi-line (the individual landlord page uses `singleLineAddress`).
- Charity rows aren't covered by the integration test — the fixture is company-only — but are covered by `OrgLandlordViewModelTests`.
- Post-review: the organisation phone row label is now "Organisation phone" (was "Organisation phone number"), so the screenshots above show the old label for that row. `OrgType.NONE` and `CharityRegulator.NONE` now render as "None of these" (was "Other"), reusing each question's existing `none` option key. The registration CYA copy in `registerAsALandlord.yml` is deliberately unchanged — that's PDJB-1168 scope and has already been through QA.

## Checklist

- [x] Screenshots of any UI changes have been added
- [x] Unit tests for new logic (e.g. new service methods) have been added
- [x] Controller tests for any new endpoints, including testing the relevant permissions
- [x] Test suite has been run in full locally and is passing
- [x] Branch has been rebased onto main and run locally, with everything working as expected (both for your new feature
  and any related functionality)
- [x] TODO comments referencing this JIRA ticket have been searched for and removed - if a future PR will address them,
  mention that here
- [x] QA instructions have been added to the ticket (particularly if this is the last PR required to complete the ticket)
- [x] This feature is behind a feature flag. I've checked that there will be no change in function if the feature flag is disabled

Full suite not run locally — leaving to CI. The affected suites pass (`OrgLandlordViewModelTests`, `MessageKeyConverterTests`, `OrgLandlordDetailTests`, `OrganisationLandlordRegistrationSinglePageTests`) plus `ktlintCheck`.
