### PR TITLE
PDJB-1392: Complete org landlord registration

### DIFF
--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/LandlordRegistrationJourneyTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/LandlordRegistrationJourneyTests.kt
@@ -355,9 +355,13 @@ class LandlordRegistrationJourneyTests : IntegrationTestWithMutableData("data-mo
             ),
         )
 
-        // TODO: PDJB-1392: assert the confirmation page renders here. It currently errors for org landlords because
-        //  RegisterLandlordController.getConfirmation looks the landlord up via retrieveLandlordByBaseUserId, which
-        //  only finds IndividualLandlords.
+        val confirmationPage = assertPageIs(page, ConfirmationPageLandlordRegistration::class)
+        assertEquals(createdOrgLandlordRegNum.toString(), confirmationPage.confirmationBanner.registrationNumberText)
+        assertThat(confirmationPage.surveyLink).isVisible()
+        confirmationPage.goToDashboardLink.clickAndWait()
+        assertPageIs(page, LandlordDashboardPage::class)
+
+        // TODO: PDJB-1278: Check that clicking the go to dashboard button goes to the dashboard
     }
 
     @Test
@@ -506,7 +510,10 @@ class LandlordRegistrationJourneyTests : IntegrationTestWithMutableData("data-mo
         featureFlagManager.enable(ORGANISATION_LANDLORD_REGISTRATION)
 
         val checkAnswersPage = navigator.skipToLandlordRegistrationOrgCheckAnswersPage()
-        checkAnswersPage.leadTrusteeCard.getAction("Change").link.clickAndWait()
+        checkAnswersPage.leadTrusteeCard
+            .getAction("Change")
+            .link
+            .clickAndWait()
 
         val leadTrusteeNamePage = assertPageIs(page, LeadTrusteeNameFormPageLandlordRegistration::class)
         leadTrusteeNamePage.submitName("Updated Lead Trustee Name")
@@ -581,7 +588,10 @@ class LandlordRegistrationJourneyTests : IntegrationTestWithMutableData("data-mo
         featureFlagManager.enable(ORGANISATION_LANDLORD_REGISTRATION)
 
         val checkAnswersPage = navigator.skipToLandlordRegistrationOrgCheckAnswersPage()
-        checkAnswersPage.governingBodyMemberCard.getAction("Change").link.clickAndWait()
+        checkAnswersPage.governingBodyMemberCard
+            .getAction("Change")
+            .link
+            .clickAndWait()
 
         val memberListPage = assertPageIs(page, OrgGovBodyMemberListFormPageLandlordRegistration::class)
         memberListPage.form.submit()
@@ -594,7 +604,10 @@ class LandlordRegistrationJourneyTests : IntegrationTestWithMutableData("data-mo
         featureFlagManager.enable(ORGANISATION_LANDLORD_REGISTRATION)
 
         val checkAnswersPage = navigator.skipToLandlordRegistrationOrgCheckAnswersPage()
-        checkAnswersPage.mainContactCard.getAction("Change").link.clickAndWait()
+        checkAnswersPage.mainContactCard
+            .getAction("Change")
+            .link
+            .clickAndWait()
 
         val orgMainContactPage = assertPageIs(page, OrgMainContactFormPageLandlordRegistration::class)
         orgMainContactPage.submit("Updated Contact Name", "updated.contact@example.com", "07888888888")


### PR DESCRIPTION
## Ticket number

[PDJB-1392](https://mhclgdigital.atlassian.net/browse/PDJB-1392)

## Goal of change

ensure the confirmation page shows
<img alt="landlord reg confirmation page" src="https://github.com/user-attachments/assets/bc5587c9-9340-4787-a256-6549c2dfc0a3" />

## Description of main change(s)

this just works as-is since the only bespoke text on that page is the landlord reg number

checked and the current registration confirmation page is reused for org LL so no changes needed there

adds a TODO that we should check the dashboard page renders in the integration test - this means we can be sure the database commit was successful

## Checklist

- [x] Screenshots of any UI changes have been added
- [x] New journey steps have been added to the appropriate journey integration test(s)
- [x] Test suite has been run in full locally and is passing
- [x] Branch has been rebased onto main and run locally, with everything working as expected (both for your new feature
  and any related functionality)
- [x] TODO comments referencing this JIRA ticket have been searched for and removed - if a future PR will address them,
  mention that here
- [x] QA instructions have been added to the ticket (particularly if this is the last PR required to complete the ticket)
- [x] This feature is behind a feature flag. I've checked that there will be no change in function if the feature flag is disabled
