### PR TITLE
PDJB-NONE: Share one database and cache container across test contexts

### DIFF
--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/SharedContainers.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/SharedContainers.kt
@@ -1,0 +1,39 @@
+package uk.gov.communities.prsdb.webapp
+
+import org.testcontainers.containers.GenericContainer
+import org.testcontainers.containers.PostgreSQLContainer
+import org.testcontainers.utility.DockerImageName
+
+// The containers are shared by every Spring test context in the JVM, so they must outlive any one context.
+// Spring closes container beans when a context is destroyed, which would take the containers away from every
+// other cached context, so closing is suppressed here. Testcontainers' own reaper stops them when the JVM exits.
+class SharedPostgresContainer(
+    image: DockerImageName,
+) : PostgreSQLContainer<SharedPostgresContainer>(image) {
+    override fun stop() = Unit
+
+    override fun close() = Unit
+}
+
+class SharedRedisContainer(
+    image: DockerImageName,
+) : GenericContainer<SharedRedisContainer>(image) {
+    override fun stop() = Unit
+
+    override fun close() = Unit
+}
+
+object SharedContainers {
+    val postgres: SharedPostgresContainer =
+        SharedPostgresContainer(DockerImageName.parse("postgres:latest")).apply {
+            // One Postgres now serves every context, so it needs headroom for all their connection pools.
+            setCommand("postgres", "-c", "max_connections=400")
+            start()
+        }
+
+    val redis: SharedRedisContainer =
+        SharedRedisContainer(DockerImageName.parse("redis:latest")).apply {
+            addExposedPort(6379)
+            start()
+        }
+}

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/TestcontainersConfiguration.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/TestcontainersConfiguration.kt
@@ -3,17 +3,14 @@ package uk.gov.communities.prsdb.webapp
 import org.springframework.boot.test.context.TestConfiguration
 import org.springframework.boot.testcontainers.service.connection.ServiceConnection
 import org.springframework.context.annotation.Bean
-import org.testcontainers.containers.GenericContainer
-import org.testcontainers.containers.PostgreSQLContainer
-import org.testcontainers.utility.DockerImageName
 
 @TestConfiguration(proxyBeanMethods = false)
 class TestcontainersConfiguration {
     @Bean
     @ServiceConnection
-    fun postgresContainer(): PostgreSQLContainer<*> = PostgreSQLContainer(DockerImageName.parse("postgres:latest"))
+    fun postgresContainer(): SharedPostgresContainer = SharedContainers.postgres
 
     @Bean
     @ServiceConnection(name = "redis")
-    fun redisContainer(): GenericContainer<*> = GenericContainer(DockerImageName.parse("redis:latest")).withExposedPorts(6379)
+    fun redisContainer(): SharedRedisContainer = SharedContainers.redis
 }


### PR DESCRIPTION
## Ticket number

PDJB-NONE

## Goal of change

Stops the test suite starting a Postgres and Redis container for every Spring test context

## Description of main change(s)

- Holds one Postgres and one Redis container per JVM as shared instances, rather than creating a pair per Spring test context
- Raises `max_connections` on Postgres, as one database now serves every context's connection pool

A serial run previously started around 16 container pairs, and running the shards in parallel started enough to destabilise Docker Desktop.

Verified on a full local run: 800 suites, 3,943 tests, 0 failures.

## Anything you'd like to highlight to the reviewer?

**Expect the speed up to vary by platform.** Most of the gain comes from removing container pressure, so it is largest when running the shards in parallel on Docker Desktop for Windows. Serially it is roughly time neutral, and on macOS or CI it is likely to be closer to neutral than to the Windows result.

**The shared containers deliberately ignore `stop()` and `close()`.** Spring closes container beans when a test context is destroyed, which would take the containers away from every other cached context. Testcontainers' reaper still stops them when the JVM exits.

Spring does have a supported way to skip that shutdown, but it only applies when the container is marked for reuse *and* the environment supports reuse, which requires `testcontainers.reuse.enable=true` in each developer's `~/.testcontainers.properties`. That would work on some machines and silently not on others, so it is not relied on here.

## Checklist

Delete any that are not applicable, and add explanation below for any that are applicable but haven't been done

- [x] Test suite has been run in full locally and is passing
- [X] Branch has been rebased onto main and run locally, with everything working as expected (both for your new feature
  and any related functionality)