### PR TITLE
PDJB-1392: Remove survey link on org landlord registration

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/RegisterLandlordController.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/RegisterLandlordController.kt
@@ -15,6 +15,7 @@ import uk.gov.communities.prsdb.webapp.constants.REGISTER_LANDLORD_JOURNEY_URL
 import uk.gov.communities.prsdb.webapp.constants.START_PAGE_PATH_SEGMENT
 import uk.gov.communities.prsdb.webapp.controllers.LandlordController.Companion.LANDLORD_DASHBOARD_URL
 import uk.gov.communities.prsdb.webapp.controllers.RegisterLandlordController.Companion.LANDLORD_REGISTRATION_ROUTE
+import uk.gov.communities.prsdb.webapp.database.entity.IndividualLandlord
 import uk.gov.communities.prsdb.webapp.journeys.FormData
 import uk.gov.communities.prsdb.webapp.journeys.JourneyStepDispatcher
 import uk.gov.communities.prsdb.webapp.journeys.StepLifecycleOrchestrator
@@ -70,6 +71,7 @@ class RegisterLandlordController(
             RegistrationNumberDataModel.fromRegistrationNumber(landlord.registrationNumber).toString(),
         )
         model.addAttribute("landlordDashboardUrl", LANDLORD_DASHBOARD_URL)
+        model.addAttribute("showSurveyLink", landlord is IndividualLandlord)
         model.addAttribute("landlordRegistrationSurveyUrl", LANDLORD_REGISTRATION_SURVEY_URL)
 
         return "registerAsALandlordConfirmation"

--- a/src/main/resources/templates/registerAsALandlordConfirmation.html
+++ b/src/main/resources/templates/registerAsALandlordConfirmation.html
@@ -34,11 +34,13 @@
                 registerAsALandlord.confirmation.whatYouNeedToDo.bullet.two
             </li>
         </ul>
-        <div th:replace="~{fragments/content/feedbackSurveyPanel :: feedbackSurveyPanel(
-            #{common.confirmationPage.feedback.heading},
-            #{registerAsALandlord.confirmation.feedback.body},
-            ${landlordRegistrationSurveyUrl})}">
-        </div>
+        <th:block th:if="${showSurveyLink}">
+            <div th:replace="~{fragments/content/feedbackSurveyPanel :: feedbackSurveyPanel(
+                #{common.confirmationPage.feedback.heading},
+                #{registerAsALandlord.confirmation.feedback.body},
+                ${landlordRegistrationSurveyUrl})}">
+            </div>
+        </th:block>
         <p class="govuk-body">
             <a class="govuk-link"
                th:href="@{${landlordDashboardUrl}}"

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/controllers/RegisterLandlordControllerTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/controllers/RegisterLandlordControllerTests.kt
@@ -133,6 +133,23 @@ class RegisterLandlordControllerTests(
                         "landlordRegistrationSurveyUrl",
                         LANDLORD_REGISTRATION_SURVEY_URL,
                     )
+                    attribute("showSurveyLink", true)
+                }
+            }
+    }
+
+    @Test
+    @WithMockUser
+    fun `getConfirmation hides survey link for org landlords`() {
+        val landlord = MockLandlordData.createOrgLandlord()
+        whenever(userToLandlordService.getCurrentLandlordForUser()).thenReturn(landlord)
+
+        mvc
+            .get(LANDLORD_REGISTRATION_CONFIRMATION_ROUTE)
+            .andExpect {
+                status { isOk() }
+                model {
+                    attribute("showSurveyLink", false)
                 }
             }
     }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/LandlordRegistrationJourneyTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/LandlordRegistrationJourneyTests.kt
@@ -357,7 +357,7 @@ class LandlordRegistrationJourneyTests : IntegrationTestWithMutableData("data-mo
 
         val confirmationPage = assertPageIs(page, ConfirmationPageLandlordRegistration::class)
         assertEquals(createdOrgLandlordRegNum.toString(), confirmationPage.confirmationBanner.registrationNumberText)
-        assertThat(confirmationPage.surveyLink).isVisible()
+        assertThat(confirmationPage.surveyLink).not().isVisible()
         confirmationPage.goToDashboardLink.clickAndWait()
 
         val dashboardPage = assertPageIs(page, LandlordDashboardPage::class)


### PR DESCRIPTION
## Ticket number

[PDJB-1392](https://mhclgdigital.atlassian.net/browse/PDJB-1392)

## Goal of change

<img alt="reg confirmation no survey link" src="https://github.com/user-attachments/assets/9f272982-08c9-4d47-9f86-827392a398c0" />

^ no survey link

## Description of main change(s)

adds a content parameter for this

## Anything you'd like to highlight to the reviewer?

as per this comment https://mhclgdigital.atlassian.net/browse/PDJB-1392?focusedCommentId=870950

## Checklist

- [x] Screenshots of any UI changes have been added
- [x] Controller tests for any new endpoints, including testing the relevant permissions
- [x] Single page integration tests have been added for any unhappy-flow UI features, e.g. validation errors
- [x] Test suite has been run in full locally and is passing
- [x] Branch has been rebased onto main and run locally, with everything working as expected (both for your new feature
  and any related functionality)
- [ ] QA instructions have been added to the ticket (particularly if this is the last PR required to complete the ticket)
- [x] This feature is behind a feature flag. I've checked that there will be no change in function if the feature flag is disabled
