### PR TITLE
PDJB-1279: Update Joint Landlords to work for Org Landlords

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/acceptOrRejectJointLandlordInvitation/steps/ConfirmYouAreALandlordForThisPropertyStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/acceptOrRejectJointLandlordInvitation/steps/ConfirmYouAreALandlordForThisPropertyStepConfig.kt
@@ -83,7 +83,7 @@ class ConfirmYouAreALandlordForThisPropertyStepConfig(
         val propertyRegistrationNumber =
             RegistrationNumberDataModel.fromRegistrationNumber(propertyOwnership.registrationNumber).toString()
 
-        // TODO: PDJB-1274: Update emails to account for org landlord
+        // TODO: PDJB-1274: Update emails to account for org landlord (check which org email address to use, currently registrant)
         acceptedEmailSender.sendEmail(
             acceptingLandlord.email,
             JointLandlordInvitationAcceptedEmail(
@@ -98,6 +98,7 @@ class ConfirmYouAreALandlordForThisPropertyStepConfig(
             .filter { it.id != acceptingLandlord.id }
             // TODO: PDJB-1274: Update emails to account for org landlord
             .forEach { landlord ->
+                // TODO: PDJB-1274: Check which org landlord email address should be used here (currently the registrant email)
                 otherLandlordEmailSender.sendEmail(
                     landlord.email,
                     JointLandlordInvitationAcceptedOtherLandlordEmail(

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/JointLandlordInvitationService.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/JointLandlordInvitationService.kt
@@ -11,7 +11,6 @@ import uk.gov.communities.prsdb.webapp.constants.JOINT_LANDLORD_INVITATION_EMAIL
 import uk.gov.communities.prsdb.webapp.constants.JOINT_LANDLORD_INVITATION_REJECTION_PROPERTY_ADDRESS
 import uk.gov.communities.prsdb.webapp.constants.JOINT_LANDLORD_INVITATION_TOKEN_WITH_ACCEPTANCE_JOURNEY_IDS
 import uk.gov.communities.prsdb.webapp.constants.enums.JointLandlordInvitationStatus
-import uk.gov.communities.prsdb.webapp.database.entity.IndividualLandlord
 import uk.gov.communities.prsdb.webapp.database.entity.JointLandlordInvitation
 import uk.gov.communities.prsdb.webapp.database.entity.Landlord
 import uk.gov.communities.prsdb.webapp.database.entity.PropertyOwnership
@@ -69,7 +68,6 @@ class JointLandlordInvitationService(
         // Re-check against the current state of the database when finishing the journey. The form-level checks happen
         // when an email is submitted, so without this a concurrent journey could invite the same email twice.
         val alreadyInvitedEmails = getExistingInvitedEmails(propertyOwnership.id)
-        // TODO: PDJB-1279: Update joint landlord flow to account for org landlords
         val existingLandlordEmails = propertyOwnership.landlords.map { it.email }
         val emailsToInvite =
             jointLandlordEmails.filter { candidateEmail ->
@@ -103,6 +101,7 @@ class JointLandlordInvitationService(
 
         if (emailsToInvite.isNotEmpty()) {
             val propertyRecordUrl = absoluteUrlProvider.buildPropertyDetailsUri(propertyOwnership.id).toString()
+            // TODO: PDJB-1274: Check which org landlord email address should be used here (currently the registrant email)
             confirmationEmailSender.sendEmail(
                 invitingLandlord.email,
                 JointLandlordInvitationConfirmationEmail(
@@ -115,6 +114,7 @@ class JointLandlordInvitationService(
 
             val existingJointLandlords = propertyOwnership.landlords.filter { it.id != invitingLandlord.id }
             existingJointLandlords.forEach { landlord ->
+                // TODO: PDJB-1274: Check which org landlord email address should be used here (currently the registrant email)
                 notifyExistingEmailSender.sendEmail(
                     landlord.email,
                     JointLandlordInvitationNotifyExistingEmail(
@@ -134,8 +134,6 @@ class JointLandlordInvitationService(
         propertyOwnership: PropertyOwnership,
         invitingLandlord: Landlord,
     ): String {
-        // TODO: PDJB-1279: Update joint landlord flow to account for org landlords
-        check(invitingLandlord is IndividualLandlord)
         val invitation =
             invitationRepository
                 .findById(invitationId)

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/LeavePropertyService.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/LeavePropertyService.kt
@@ -42,6 +42,7 @@ class LeavePropertyService(
     ) {
         propertyOwnershipService.removeLandlord(propertyOwnership, landlord)
 
+        // TODO: PDJB-1274: Check which org landlord email address should be used here (currently the registrant email)
         TransactionHelper.runAfterTransactionCommits {
             confirmationEmailSender.sendEmail(
                 landlord.email,

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/LeavePropertyService.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/LeavePropertyService.kt
@@ -5,7 +5,6 @@ import org.springframework.http.HttpStatus
 import org.springframework.web.server.ResponseStatusException
 import uk.gov.communities.prsdb.webapp.annotations.webAnnotations.PrsdbWebService
 import uk.gov.communities.prsdb.webapp.constants.PROPERTIES_LEFT_THIS_SESSION
-import uk.gov.communities.prsdb.webapp.database.entity.IndividualLandlord
 import uk.gov.communities.prsdb.webapp.database.entity.Landlord
 import uk.gov.communities.prsdb.webapp.database.entity.PropertyOwnership
 import uk.gov.communities.prsdb.webapp.helpers.TransactionHelper
@@ -41,7 +40,6 @@ class LeavePropertyService(
         landlord: Landlord,
         propertyOwnership: PropertyOwnership,
     ) {
-        check(landlord is IndividualLandlord)
         propertyOwnershipService.removeLandlord(propertyOwnership, landlord)
 
         TransactionHelper.runAfterTransactionCommits {

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/PropertyRegistrationService.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/PropertyRegistrationService.kt
@@ -185,7 +185,7 @@ class PropertyRegistrationService(
         addressModel: AddressDataModel,
         jointLandlordEmails: List<String>?,
     ) {
-        // TODO: PDJB-1274: Update emails to account for org landlord
+        // TODO: PDJB-1274: Update emails to account for org landlord (check which org email address to use, currently registrant)
         confirmationEmailSender.sendEmail(
             landlord.email,
             PropertyRegistrationConfirmationEmail(

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/JointLandlordInvitationServiceTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/JointLandlordInvitationServiceTests.kt
@@ -579,6 +579,70 @@ class JointLandlordInvitationServiceTests {
             verify(mockInvitationEmailSender, times(0)).sendEmail(any(), any())
             verify(mockConfirmationEmailSender, times(0)).sendEmail(any(), any())
         }
+
+        @Test
+        fun `sendInvitationEmails sends confirmation email to an organisation inviting landlord`() {
+            val orgLandlord =
+                MockLandlordData.createOrgLandlord(name = "Org Landlord", registrantEmail = "org.user@example.com")
+            ReflectionTestUtils.setField(orgLandlord, "id", 1L)
+            val propertyOwnership =
+                MockLandlordData.createPropertyOwnership(id = 123L, landlords = mutableSetOf(orgLandlord))
+            val jointLandlordEmails = listOf("new@example.com")
+
+            whenever(mockAbsoluteUrlProvider.buildJointLandlordInvitationUri(any()))
+                .thenReturn(URI("https://example.com/invite/test-token"))
+
+            invitationService.sendInvitationEmails(jointLandlordEmails, propertyOwnership, orgLandlord)
+
+            val emailModelCaptor = argumentCaptor<JointLandlordInvitationConfirmationEmail>()
+            verify(mockConfirmationEmailSender).sendEmail(eq("org.user@example.com"), emailModelCaptor.capture())
+            assertEquals("Org Landlord", emailModelCaptor.firstValue.senderName)
+        }
+
+        @Test
+        fun `sendInvitationEmails skips emails already an organisation landlord on the property`() {
+            val existingOrgLandlord =
+                MockLandlordData.createOrgLandlord(registrantEmail = "existing@example.com")
+            val propertyOwnership =
+                MockLandlordData.createPropertyOwnership(
+                    id = 123L,
+                    landlords = mutableSetOf(MockLandlordData.createIndividualLandlord(), existingOrgLandlord),
+                )
+            val jointLandlordEmails = listOf("existing@example.com", "new@example.com")
+
+            whenever(mockAbsoluteUrlProvider.buildJointLandlordInvitationUri(any()))
+                .thenReturn(URI("https://example.com/invite/test-token"))
+
+            invitationService.sendInvitationEmails(jointLandlordEmails, propertyOwnership, invitingLandlord)
+
+            val emailCaptor = argumentCaptor<String>()
+            verify(mockInvitationEmailSender, times(1)).sendEmail(emailCaptor.capture(), any())
+            assertEquals(listOf("new@example.com"), emailCaptor.allValues)
+        }
+
+        @Test
+        fun `sendInvitationEmails sends notify-existing email to an existing organisation landlord`() {
+            val jointLandlordEmails = listOf("new@example.com")
+            val existingOrgLandlord =
+                MockLandlordData.createOrgLandlord(name = "Existing Org", registrantEmail = "existing@example.com")
+            ReflectionTestUtils.setField(existingOrgLandlord, "id", 2L)
+            ReflectionTestUtils.setField(invitingLandlord, "id", 1L)
+            val propertyOwnership =
+                MockLandlordData.createPropertyOwnership(
+                    id = 123L,
+                    landlords = mutableSetOf(invitingLandlord, existingOrgLandlord),
+                )
+
+            whenever(mockAbsoluteUrlProvider.buildJointLandlordInvitationUri(any()))
+                .thenReturn(URI("https://example.com/invite/test-token"))
+
+            invitationService.sendInvitationEmails(jointLandlordEmails, propertyOwnership, invitingLandlord)
+
+            val emailModelCaptor = argumentCaptor<JointLandlordInvitationNotifyExistingEmail>()
+            verify(mockNotifyExistingEmailSender).sendEmail(eq("existing@example.com"), emailModelCaptor.capture())
+            assertEquals("Existing Org", emailModelCaptor.firstValue.recipientName)
+            assertEquals(listOf("new@example.com"), emailModelCaptor.firstValue.jointLandlordEmails)
+        }
     }
 
     @Nested
@@ -1009,6 +1073,30 @@ class JointLandlordInvitationServiceTests {
                     invitationService.resendInvitation(oldInvitation.id, propertyOwnership, invitingLandlord)
                 }
             assertEquals(HttpStatus.NOT_FOUND, exception.statusCode)
+        }
+
+        @Test
+        fun `resendInvitation succeeds for an organisation inviting landlord`() {
+            val orgLandlord = MockLandlordData.createOrgLandlord(name = "Org Landlord")
+            val propertyOwnership = MockLandlordData.createPropertyOwnership(id = 1L)
+            val oldInvitation =
+                MockJointLandlordData.createJointLandlordInvitation(
+                    email = "joint@example.com",
+                    propertyOwnership = propertyOwnership,
+                    invitingLandlordName = orgLandlord.name,
+                )
+            val mockUri = URI("https://example.com/invite/new-token")
+
+            whenever(mockJointLandlordInvitationRepository.findById(oldInvitation.id))
+                .thenReturn(Optional.of(oldInvitation))
+            whenever(mockAbsoluteUrlProvider.buildJointLandlordInvitationUri(any()))
+                .thenReturn(mockUri)
+
+            val result = invitationService.resendInvitation(oldInvitation.id, propertyOwnership, orgLandlord)
+
+            assertEquals("joint@example.com", result)
+            verify(mockJointLandlordInvitationRepository).save(argThat { token == oldInvitation.token })
+            verify(mockInvitationEmailSender).sendEmail(eq("joint@example.com"), any())
         }
     }
 

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/JointLandlordInvitationServiceTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/JointLandlordInvitationServiceTests.kt
@@ -582,6 +582,7 @@ class JointLandlordInvitationServiceTests {
 
         @Test
         fun `sendInvitationEmails sends confirmation email to an organisation inviting landlord`() {
+            // Arrange
             val orgLandlord =
                 MockLandlordData.createOrgLandlord(name = "Org Landlord", registrantEmail = "org.user@example.com")
             ReflectionTestUtils.setField(orgLandlord, "id", 1L)
@@ -592,8 +593,10 @@ class JointLandlordInvitationServiceTests {
             whenever(mockAbsoluteUrlProvider.buildJointLandlordInvitationUri(any()))
                 .thenReturn(URI("https://example.com/invite/test-token"))
 
+            // Act
             invitationService.sendInvitationEmails(jointLandlordEmails, propertyOwnership, orgLandlord)
 
+            // Assert
             val emailModelCaptor = argumentCaptor<JointLandlordInvitationConfirmationEmail>()
             verify(mockConfirmationEmailSender).sendEmail(eq("org.user@example.com"), emailModelCaptor.capture())
             assertEquals("Org Landlord", emailModelCaptor.firstValue.senderName)
@@ -601,6 +604,7 @@ class JointLandlordInvitationServiceTests {
 
         @Test
         fun `sendInvitationEmails skips emails already an organisation landlord on the property`() {
+            // Arrange
             val existingOrgLandlord =
                 MockLandlordData.createOrgLandlord(registrantEmail = "existing@example.com")
             val propertyOwnership =
@@ -613,8 +617,10 @@ class JointLandlordInvitationServiceTests {
             whenever(mockAbsoluteUrlProvider.buildJointLandlordInvitationUri(any()))
                 .thenReturn(URI("https://example.com/invite/test-token"))
 
+            // Act
             invitationService.sendInvitationEmails(jointLandlordEmails, propertyOwnership, invitingLandlord)
 
+            // Assert
             val emailCaptor = argumentCaptor<String>()
             verify(mockInvitationEmailSender, times(1)).sendEmail(emailCaptor.capture(), any())
             assertEquals(listOf("new@example.com"), emailCaptor.allValues)
@@ -622,6 +628,7 @@ class JointLandlordInvitationServiceTests {
 
         @Test
         fun `sendInvitationEmails sends notify-existing email to an existing organisation landlord`() {
+            // Arrange
             val jointLandlordEmails = listOf("new@example.com")
             val existingOrgLandlord =
                 MockLandlordData.createOrgLandlord(name = "Existing Org", registrantEmail = "existing@example.com")
@@ -636,8 +643,10 @@ class JointLandlordInvitationServiceTests {
             whenever(mockAbsoluteUrlProvider.buildJointLandlordInvitationUri(any()))
                 .thenReturn(URI("https://example.com/invite/test-token"))
 
+            // Act
             invitationService.sendInvitationEmails(jointLandlordEmails, propertyOwnership, invitingLandlord)
 
+            // Assert
             val emailModelCaptor = argumentCaptor<JointLandlordInvitationNotifyExistingEmail>()
             verify(mockNotifyExistingEmailSender).sendEmail(eq("existing@example.com"), emailModelCaptor.capture())
             assertEquals("Existing Org", emailModelCaptor.firstValue.recipientName)
@@ -1077,6 +1086,7 @@ class JointLandlordInvitationServiceTests {
 
         @Test
         fun `resendInvitation succeeds for an organisation inviting landlord`() {
+            // Arrange
             val orgLandlord = MockLandlordData.createOrgLandlord(name = "Org Landlord")
             val propertyOwnership = MockLandlordData.createPropertyOwnership(id = 1L)
             val oldInvitation =
@@ -1092,8 +1102,10 @@ class JointLandlordInvitationServiceTests {
             whenever(mockAbsoluteUrlProvider.buildJointLandlordInvitationUri(any()))
                 .thenReturn(mockUri)
 
+            // Act
             val result = invitationService.resendInvitation(oldInvitation.id, propertyOwnership, orgLandlord)
 
+            // Assert
             assertEquals("joint@example.com", result)
             verify(mockJointLandlordInvitationRepository).save(argThat { token == oldInvitation.token })
             verify(mockInvitationEmailSender).sendEmail(eq("joint@example.com"), any())

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/LeavePropertyServiceTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/LeavePropertyServiceTests.kt
@@ -114,6 +114,27 @@ class LeavePropertyServiceTests {
     }
 
     @Test
+    fun `leavePropertyOwnership removes an organisation landlord and sends them a confirmation email`() {
+        val address = MockLandlordData.createAddress(singleLineAddress = "10 High Street, London, SW1A 1AA")
+        val orgLandlord = MockLandlordData.createOrgLandlord(name = "Org Landlord", registrantEmail = "org.user@example.com")
+        val propertyOwnership =
+            MockLandlordData.createPropertyOwnership(
+                landlords = mutableSetOf(orgLandlord, MockLandlordData.createIndividualLandlord(name = "Bob")),
+                address = address,
+            )
+
+        leavePropertyService.leavePropertyOwnership(orgLandlord, propertyOwnership)
+
+        verify(mockPropertyOwnershipService).removeLandlord(propertyOwnership, orgLandlord)
+
+        val emailCaptor = argumentCaptor<JointLandlordYouLeftConfirmation>()
+        verify(emailSender).sendEmail(eq("org.user@example.com"), emailCaptor.capture())
+        val sentEmail = emailCaptor.firstValue
+        assertEquals("Org Landlord", sentEmail.recipientName)
+        assertEquals(address.toMultiLineAddress(), sentEmail.propertyAddress)
+    }
+
+    @Test
     fun `leavePropertyOwnership sends swap to individual nudge email`() {
         val landlord = MockLandlordData.createIndividualLandlord(name = "Alice", email = "alice@example.com")
         val propertyOwnership =

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/LeavePropertyServiceTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/LeavePropertyServiceTests.kt
@@ -115,6 +115,7 @@ class LeavePropertyServiceTests {
 
     @Test
     fun `leavePropertyOwnership removes an organisation landlord and sends them a confirmation email`() {
+        // Arrange
         val address = MockLandlordData.createAddress(singleLineAddress = "10 High Street, London, SW1A 1AA")
         val orgLandlord = MockLandlordData.createOrgLandlord(name = "Org Landlord", registrantEmail = "org.user@example.com")
         val propertyOwnership =
@@ -123,8 +124,10 @@ class LeavePropertyServiceTests {
                 address = address,
             )
 
+        // Act
         leavePropertyService.leavePropertyOwnership(orgLandlord, propertyOwnership)
 
+        // Assert
         verify(mockPropertyOwnershipService).removeLandlord(propertyOwnership, orgLandlord)
 
         val emailCaptor = argumentCaptor<JointLandlordYouLeftConfirmation>()


### PR DESCRIPTION
## Ticket number

PDJB-1279

## Goal of change

Allow organisation landlords (not just individuals) to send and resend joint landlord invitations.

## Description of main change(s)

- Removes the `check(invitingLandlord is IndividualLandlord)` guard in `JointLandlordInvitationService.resendInvitation`, so an org landlord can resend a pending invitation (Just Works)
- Removes the `check(landlord is IndividualLandlord)` guard in `LeavePropertyService.leavePropertyOwnership`, so an org landlord can leave a jointly-owned property  (Just Works)

TODO - want to make sure there are integration tests covering joint landlord actions as an org landlord. Although maybe these should be in another PR

## Anything you'd like to highlight to the reviewer?

- For org landlords, all outbound joint-landlord email currently goes to the **registrant** email (the org user's email); the organisation email is display-only and the main contact email is unused. This is unchanged and consistent with the rest of the app. The team has agreed to keep the registrant email for now, and I've added `PDJB-1274` TODOs at the registrant-send sites to revisit which org address should be used (`JointLandlordInvitationService`, `ConfirmYouAreALandlordForThisPropertyStepConfig`, `PropertyRegistrationService`).


## Checklist

Delete any that are not applicable, and add explanation below for any that are applicable but haven't been done

- [x] Unit tests for new logic (e.g. new service methods) have been added
-  New journey steps have been added to the appropriate journey integration test(s) - I'll add a separate PR for integration tests
- [x] Test suite has been run in full locally and is passing
- [x] Branch has been rebased onto main and run locally, with everything working as expected (both for your new feature
  and any related functionality)
- [x] QA instructions have been added to the ticket (particularly if this is the last PR required to complete the ticket)
- [x] This feature is behind a feature flag. I've checked that there will be no change in function if the feature flag is disabled (not a new feature flag)