### PR TITLE
PDJB-1478: Ensure org LL do not appear in LC search

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/database/repository/LandlordSearchRepository.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/database/repository/LandlordSearchRepository.kt
@@ -43,6 +43,7 @@ class LandlordSearchRepositoryImpl(
                 FROM landlord l
                 JOIN registration_number r ON l.registration_number_id = r.id
                 WHERE r.number = :searchTerm
+                $INDIVIDUAL_LANDLORD_FILTER
                 ${if (restrictToLocalCouncil) LOCAL_COUNCIL_FILTER else "" }
             )
             $SELECT_FROM_RESULTING_LANDLORDS;
@@ -67,6 +68,7 @@ class LandlordSearchRepositoryImpl(
                   FROM landlord l
                   ${if (restrictToLocalCouncil) LOCAL_COUNCIL_FILTER_JOIN else "" }
                   WHERE gin_landlord_details(l.individual_phone_number, l.individual_email, l.individual_name) %> :searchTerm
+                  $INDIVIDUAL_LANDLORD_FILTER
                   ${if (restrictToLocalCouncil) LOCAL_COUNCIL_FILTER_GROUP_BY else "" }
                   LIMIT $MAX_ENTRIES_IN_LANDLORDS_SEARCH
                  ) subquery;
@@ -86,6 +88,7 @@ class LandlordSearchRepositoryImpl(
                 FROM landlord l
                 ${if (restrictToLocalCouncil) LOCAL_COUNCIL_FILTER_JOIN else "" }
                 WHERE gist_landlord_details(l.individual_phone_number, l.individual_email, l.individual_name) %> :searchTerm
+                $INDIVIDUAL_LANDLORD_FILTER
                 ${if (restrictToLocalCouncil) LOCAL_COUNCIL_FILTER_GROUP_BY else "" }
                 ORDER BY gist_landlord_details(l.individual_phone_number, l.individual_email, l.individual_name) <->> :searchTerm
                 LIMIT :limit OFFSET :offset
@@ -104,6 +107,11 @@ class LandlordSearchRepositoryImpl(
     }
 
     companion object {
+        // TODO PDJB-1280: Add org LL to LC search
+        // Note that this filter is only a final preventative measure. Removing it will still likely not show org LLs as they don't have
+        // the correct database cols set.
+        private const val INDIVIDUAL_LANDLORD_FILTER = "AND l.landlord_type = 0"
+
         // Filters results to only landlords who have active property ownerships in LC user's LC
         private const val LOCAL_COUNCIL_FILTER =
             """

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/SearchRegisterTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/SearchRegisterTests.kt
@@ -229,6 +229,22 @@ class SearchRegisterTests : IntegrationTestWithImmutableData("data-search.sql") 
             assertPageIs(page, SearchLandlordRegisterPage::class)
             assertThat(resultTable.getCell(0, LANDLORD_COL_INDEX)).containsText("Alexander Smith\nL-CKSQ-3SX9")
         }
+
+        @Test
+        fun `searching by an organisation landlord LRN returns no results`() {
+            val searchLandlordRegisterPage = navigator.goToLandlordSearchPage()
+            searchLandlordRegisterPage.searchBar.search("L-DGHK-QSQT")
+
+            assertTrue(searchLandlordRegisterPage.noResultErrorMessage.isVisible)
+        }
+
+        @Test
+        fun `organisation landlords do not appear in fuzzy search results`() {
+            val searchLandlordRegisterPage = navigator.goToLandlordSearchPage()
+            searchLandlordRegisterPage.searchBar.search("Test Org Landlord Corp")
+
+            assertTrue(searchLandlordRegisterPage.noResultErrorMessage.isVisible)
+        }
     }
 
     @Nested

--- a/src/test/resources/data-search.sql
+++ b/src/test/resources/data-search.sql
@@ -340,3 +340,44 @@ VALUES
        (31, 31, null, null),
        (32, 32, null, null),
        (33, 33, null, null);
+
+-- Organisation landlord: landlord_type = 1, with a property in LC 1
+INSERT INTO prsdb_user (id, created_date)
+VALUES ('urn:fdc:gov.uk:2022:OrgLandlordUser', '01/15/25');
+
+INSERT INTO registration_number (id, created_date, number, type)
+VALUES (66, '01/15/25', 9009009009, 1);
+
+INSERT INTO address (id, created_date, last_modified_date, uprn, single_line_address, local_council_id, postcode)
+VALUES (39, '01/15/25', '01/15/25', 1039, '99 Org Street, EG1 9ZZ', 1, 'EG1 9ZZ'),
+       (40, '01/15/25', '01/15/25', 1040, '100 Org Property Road, EG1 9ZY', 1, 'EG1 9ZY');
+
+INSERT INTO landlord (id, created_date, last_modified_date, registration_number_id, landlord_type,
+                      organisation_landlord_name, organisation_address_id, organisation_email,
+                      organisation_phone_number, organisation_registrant_name, organisation_registrant_date_of_birth,
+                      organisation_registrant_email, organisation_registrant_phone_number,
+                      organisation_is_company, organisation_is_charity, organisation_is_trust,
+                      organisation_main_contact_name, organisation_main_contact_email, organisation_main_contact_phone)
+VALUES (34, '01/15/25', '01/15/25', 66, 1,
+        'Test Org Landlord Corp', 39, 'org@example.com',
+        '07999999999', 'Org Registrant', '01/01/1980',
+        'registrant@example.com', '07888888888',
+        false, false, false,
+        'Main Contact', 'contact@example.com', '07777777777');
+
+INSERT INTO organisational_landlord_user (id, organisation_landlord_id, subject_identifier, created_date, name, email)
+VALUES (1, 34, 'urn:fdc:gov.uk:2022:OrgLandlordUser', '01/15/25', 'Org User', 'orguser@example.com');
+
+INSERT INTO registration_number (id, created_date, number, type)
+VALUES (67, '01/15/25', 0006001034, 0);
+
+INSERT INTO property_ownership (id, is_active, ownership_type, current_num_households, current_num_tenants, registration_number_id, address_id, created_date, last_modified_date, license_id, property_build_type,
+                                num_bedrooms, bills_included_list, custom_bills_included, furnished_status, rent_frequency, custom_rent_frequency, rent_amount, is_occupied)
+VALUES (34, true, 1, 0, 0, 67, 40, '01/15/25', '01/15/25', null, 1,
+        null, null, null, null, null, null, null, false);
+
+INSERT INTO ownership_link (landlord_id, landlordship_id, created_date)
+VALUES (34, 34, '2025-01-15');
+
+INSERT INTO property_compliance (id, property_ownership_id, has_gas_supply, epc_exemption_reason)
+VALUES (34, 34, null, null);


### PR DESCRIPTION
## Ticket number

[PDJB-1478](https://mhclgdigital.atlassian.net/browse/PDJB-1478)

## Goal of change

validate specifically that org LLs will never appear in LC search

## Description of main change(s)

adds a little bit of code to ensure that an org LL never appears in LC search

I don't think this is possible when testing but would rather something in that specifically prevents it

## Anything you'd like to highlight to the reviewer?

we could also do nothing here

## Checklist

- [x] Single page integration tests have been added for any unhappy-flow UI features, e.g. validation errors
- [x] Test suite has been run in full locally and is passing
- [x] Branch has been rebased onto main and run locally, with everything working as expected (both for your new feature
  and any related functionality)
- [x] TODO comments referencing this JIRA ticket have been searched for and removed - if a future PR will address them,
  mention that here
- [x] QA instructions have been added to the ticket (particularly if this is the last PR required to complete the ticket)
- [x] This feature is not behind a feature flag. I've checked that this is appropriate and we're happy with this code becoming live as soon as we release
