### PR TITLE
PDJB-1237: User update org type

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/LandlordDetailsController.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/LandlordDetailsController.kt
@@ -153,6 +153,7 @@ class LandlordDetailsController(
     companion object {
         const val LANDLORD_DETAILS_FOR_LANDLORD_ROUTE = "/$LANDLORD_PATH_SEGMENT/$LANDLORD_DETAILS_PATH_SEGMENT"
         const val LANDLORD_DETAILS_FOR_LOCAL_COUNCIL_USER_ROUTE = "/$LOCAL_COUNCIL_PATH_SEGMENT/$LANDLORD_DETAILS_PATH_SEGMENT/{id}"
+        const val ORGANISATION_CONTACTS_FRAGMENT = "organisation-contacts"
         const val UPDATE_ROUTE = "$LANDLORD_DETAILS_FOR_LANDLORD_ROUTE/$UPDATE_PATH_SEGMENT"
 
         fun getLandlordDetailsForLocalCouncilUserPath(landlordId: Long? = null): String =

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/UpdateOrganisationTypeController.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/controllers/UpdateOrganisationTypeController.kt
@@ -1,0 +1,77 @@
+package uk.gov.communities.prsdb.webapp.controllers
+
+import org.springframework.http.HttpStatus
+import org.springframework.security.access.prepost.PreAuthorize
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.server.ResponseStatusException
+import org.springframework.web.servlet.ModelAndView
+import uk.gov.communities.prsdb.webapp.annotations.webAnnotations.AvailableWhenFeatureEnabled
+import uk.gov.communities.prsdb.webapp.annotations.webAnnotations.PrsdbController
+import uk.gov.communities.prsdb.webapp.constants.LANDLORD_DETAILS_PATH_SEGMENT
+import uk.gov.communities.prsdb.webapp.constants.LANDLORD_PATH_SEGMENT
+import uk.gov.communities.prsdb.webapp.constants.ORGANISATION_LANDLORD_REGISTRATION
+import uk.gov.communities.prsdb.webapp.controllers.UpdateOrganisationTypeController.Companion.UPDATE_ORG_TYPE_ROUTE
+import uk.gov.communities.prsdb.webapp.database.entity.OrganisationalLandlord
+import uk.gov.communities.prsdb.webapp.journeys.FormData
+import uk.gov.communities.prsdb.webapp.journeys.JourneyStepDispatcher
+import uk.gov.communities.prsdb.webapp.journeys.StepLifecycleOrchestrator
+import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.update.organisationType.UpdateOrganisationTypeJourneyFactory
+import uk.gov.communities.prsdb.webapp.services.UserToLandlordService
+import java.security.Principal
+
+@PrsdbController
+@RequestMapping(UPDATE_ORG_TYPE_ROUTE)
+@PreAuthorize("hasRole('LANDLORD')")
+class UpdateOrganisationTypeController(
+    private val journeyFactory: UpdateOrganisationTypeJourneyFactory,
+    private val userToLandlordService: UserToLandlordService,
+) {
+    @AvailableWhenFeatureEnabled(ORGANISATION_LANDLORD_REGISTRATION)
+    @GetMapping("/{*stepPath}")
+    fun getUpdateStep(
+        principal: Principal,
+        @PathVariable stepPath: String,
+    ): ModelAndView {
+        checkUserIsOrganisationLandlord()
+        return dispatchJourneyStep(stepPath, principal) { getStepModelAndView() }
+    }
+
+    @AvailableWhenFeatureEnabled(ORGANISATION_LANDLORD_REGISTRATION)
+    @PostMapping("/{*stepPath}")
+    fun postUpdateStep(
+        principal: Principal,
+        @PathVariable stepPath: String,
+        @RequestParam formData: FormData,
+    ): ModelAndView {
+        checkUserIsOrganisationLandlord()
+        return dispatchJourneyStep(stepPath, principal) { postStepModelAndView(formData) }
+    }
+
+    private fun checkUserIsOrganisationLandlord() {
+        val landlord = userToLandlordService.getCurrentLandlordForUser()
+        if (landlord !is OrganisationalLandlord) {
+            throw ResponseStatusException(HttpStatus.FORBIDDEN, "Only organisation landlords can update their organisation type")
+        }
+    }
+
+    private fun dispatchJourneyStep(
+        stepPath: String,
+        principal: Principal,
+        dispatch: StepLifecycleOrchestrator.() -> ModelAndView,
+    ): ModelAndView =
+        JourneyStepDispatcher.handleInitialisableRequest(
+            rawStepPath = stepPath,
+            createRoutingMap = { journeyFactory.createJourneySteps() },
+            initialiseJourney = { journeyFactory.initializeJourneyState(principal) },
+            dispatch = dispatch,
+        )
+
+    companion object {
+        const val UPDATE_ORG_TYPE_PATH_SEGMENT = "update-organisation-type"
+        const val UPDATE_ORG_TYPE_ROUTE = "/$LANDLORD_PATH_SEGMENT/$LANDLORD_DETAILS_PATH_SEGMENT/$UPDATE_ORG_TYPE_PATH_SEGMENT"
+    }
+}

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/landlordRegistration/states/LandlordRegistrationOrgLandlordState.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/landlordRegistration/states/LandlordRegistrationOrgLandlordState.kt
@@ -25,6 +25,6 @@ interface LandlordRegistrationOrgLandlordState : JourneyState {
     val leadTrusteeTask: LeadTrusteeTask
     val orgMainContactStep: OrgMainContactStep
 
-    // TODO PDJB-1237 PDJB-1238: remove this placeholder once the org type and companies house update journeys exist.
+    // TODO PDJB-1238: remove this placeholder once the companies house update journey exists.
     val updateDetailsTodoStep: UpdateDetailsTodoStep
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/landlordRegistration/states/LandlordRegistrationState.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/landlordRegistration/states/LandlordRegistrationState.kt
@@ -9,11 +9,15 @@ import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.
 import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.tasks.IdentityTask
 import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.tasks.IndividualLandlordLocationTask
 import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.tasks.OrgLandlordRegistrationTask
+import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.update.organisationType.OrgTypeTrustInterruptionStep
+import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.update.organisationType.OrgTypeUpdateRoutingStep
+import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.update.organisationType.OrgTypeUpdateState
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.FinishCyaJourneyStep
 import uk.gov.communities.prsdb.webapp.journeys.shared.states.CheckYourAnswersJourneyState
 
 interface LandlordRegistrationState :
-    CheckYourAnswersJourneyState {
+    CheckYourAnswersJourneyState,
+    OrgTypeUpdateState {
     val emailStep: EmailStep
     val phoneNumberStep: PhoneNumberStep
     val individualLandlordLocationTask: IndividualLandlordLocationTask
@@ -24,4 +28,6 @@ interface LandlordRegistrationState :
     val identityTask: IdentityTask
     override val finishCyaStep: FinishCyaJourneyStep
     override val cyaStep: LandlordRegistrationCyaStep
+    val orgTypeUpdateRoutingStep: OrgTypeUpdateRoutingStep
+    val orgTypeTrustInterruptionStep: OrgTypeTrustInterruptionStep
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/landlordRegistration/stepConfig/UpdateDetailsTodoStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/landlordRegistration/stepConfig/UpdateDetailsTodoStepConfig.kt
@@ -7,9 +7,9 @@ import uk.gov.communities.prsdb.webapp.journeys.JourneyStep.RequestableStep
 import uk.gov.communities.prsdb.webapp.journeys.shared.Complete
 import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.NoInputFormModel
 
-// TODO PDJB-1237 PDJB-1238: remove this placeholder step once the organisation type and companies house update
-//  journeys exist. It renders a dead-end TODO page (no continue button) so the corresponding check-your-answers change
-//  links don't 404. The todoComment shown is supplied per branch where the step is wired into the journey map.
+// TODO PDJB-1238: remove this placeholder step once the companies house update journey exists. It renders a dead-end
+//  TODO page (no continue button) so the corresponding check-your-answers change links don't 404. The todoComment
+//  shown is supplied per branch where the step is wired into the journey map.
 @JourneyFrameworkComponent
 class UpdateDetailsTodoStepConfig : AbstractRequestableStepConfig<Complete, NoInputFormModel, JourneyState>() {
     override val formModelClass = NoInputFormModel::class

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/landlordRegistration/tasks/LandlordRegistrationTask.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/landlordRegistration/tasks/LandlordRegistrationTask.kt
@@ -5,10 +5,12 @@ import org.springframework.beans.factory.ObjectFactory
 import uk.gov.communities.prsdb.webapp.annotations.webAnnotations.JourneyFrameworkComponent
 import uk.gov.communities.prsdb.webapp.config.managers.FeatureFlagManager
 import uk.gov.communities.prsdb.webapp.constants.ORGANISATION_LANDLORD_REGISTRATION
+import uk.gov.communities.prsdb.webapp.constants.enums.OrgType
 import uk.gov.communities.prsdb.webapp.journeys.AndParents
 import uk.gov.communities.prsdb.webapp.journeys.Destination
 import uk.gov.communities.prsdb.webapp.journeys.JourneyStateService
 import uk.gov.communities.prsdb.webapp.journeys.OrParents
+import uk.gov.communities.prsdb.webapp.journeys.StepInitialisationStage
 import uk.gov.communities.prsdb.webapp.journeys.StepLifecycleOrchestrator
 import uk.gov.communities.prsdb.webapp.journeys.TaskWithoutDependencies
 import uk.gov.communities.prsdb.webapp.journeys.builders.JourneyBuilder.Companion.journey
@@ -37,10 +39,15 @@ import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.
 import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.OrgMainContactStep
 import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.OrgNameStep
 import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.OrgPhoneNumberStep
+import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.OrgTypeMode
 import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.OrgTypeStep
 import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.PhoneNumberStep
 import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.PrivacyNoticeStep
+import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.update.organisationType.OrgTypeTrustInterruptionStep
+import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.update.organisationType.OrgTypeUpdateRouteMode
+import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.update.organisationType.OrgTypeUpdateRoutingStep
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.FinishCyaJourneyStep
+import uk.gov.communities.prsdb.webapp.journeys.shared.states.CheckYourAnswersJourneyState
 import uk.gov.communities.prsdb.webapp.journeys.shared.states.CheckYourAnswersJourneyState.Companion.checkAnswerStep
 import uk.gov.communities.prsdb.webapp.journeys.shared.states.CheckYourAnswersJourneyState.Companion.checkAnswerTask
 import uk.gov.communities.prsdb.webapp.journeys.shared.stepConfig.AbstractCheckYourAnswersStep
@@ -61,6 +68,8 @@ class LandlordRegistrationTask(
     override val privacyNoticeStep: PrivacyNoticeStep,
     override val cyaStep: LandlordRegistrationCyaStep,
     override val finishCyaStep: FinishCyaJourneyStep,
+    override val orgTypeUpdateRoutingStep: OrgTypeUpdateRoutingStep,
+    override val orgTypeTrustInterruptionStep: OrgTypeTrustInterruptionStep,
     journeyStateService: JourneyStateService,
     override val stateFactory: ObjectFactory<LandlordRegistrationTask>,
 ) : TaskWithoutDependencies<LandlordRegistrationState>(journeyStateService),
@@ -69,6 +78,10 @@ class LandlordRegistrationTask(
     override var cyaJourneys: Map<String, String> = mapOf()
     override var checkingAnswersFor: String? by delegateProvider.nullableDelegate("checkingAnswersFor")
     override var cyaUrlPath: String? by delegateProvider.nullableDelegate("cyaRouteSegment")
+    override var previousOrgTypeMode: OrgTypeMode by delegateProvider.requiredDelegate("previous-org-type")
+
+    override val orgTypeStep: OrgTypeStep
+        get() = orgLandlordRegistrationTask.orgTypeStep
 
     override val taskState get() = this
 
@@ -173,6 +186,26 @@ class LandlordRegistrationTask(
             }
         }
 
+    override fun createChildJourneyState(childJourneyId: String): CheckYourAnswersJourneyState {
+        // TODO: PDJB-585: Remove this cast
+        val newJourney = super.createChildJourneyState(childJourneyId) as LandlordRegistrationTask
+
+        val orgTypeStep = orgLandlordRegistrationTask.orgTypeStep
+        // only wire this in if the CYA journey is on an org landlord journey & has orgTypeStep set up
+        if (orgTypeStep.initialisationStage == StepInitialisationStage.FULLY_INITIALISED) {
+            orgTypeStep.formModelOrNull?.let { orgTypeFormModel ->
+                newJourney.previousOrgTypeMode =
+                    if (OrgType.TRUST in orgTypeFormModel.getSelectedOrgTypes()) {
+                        OrgTypeMode.INCLUDES_TRUST
+                    } else {
+                        OrgTypeMode.EXCLUDES_TRUST
+                    }
+            }
+        }
+
+        return newJourney
+    }
+
     companion object {
         fun <T : LandlordRegistrationState> checkYourAnswersJourneyMap(
             state: T,
@@ -224,11 +257,17 @@ class LandlordRegistrationTask(
                             }
                             nextDestination { destination ->
                                 when (destination) {
-                                    LandlordTypeChangeDestination.CHECK_ANSWERS -> Destination(journey.finishCyaStep)
-                                    LandlordTypeChangeDestination.INDIVIDUAL_TASK ->
+                                    LandlordTypeChangeDestination.CHECK_ANSWERS -> {
+                                        Destination(journey.finishCyaStep)
+                                    }
+
+                                    LandlordTypeChangeDestination.INDIVIDUAL_TASK -> {
                                         Destination(journey.individualLandlordLocationTask.firstStep)
-                                    LandlordTypeChangeDestination.ORGANISATION_TASK ->
+                                    }
+
+                                    LandlordTypeChangeDestination.ORGANISATION_TASK -> {
                                         Destination(journey.orgLandlordRegistrationTask.firstStep)
+                                    }
                                 }
                             }
                         }
@@ -262,9 +301,45 @@ class LandlordRegistrationTask(
                     }
 
                     OrgTypeStep.ROUTE_SEGMENT -> {
-                        // TODO PDJB-1237 : replace this placeholder with the org type update journey
-                        checkAnswerStep(journey.orgLandlordRegistrationTask.updateDetailsTodoStep, OrgTypeStep.ROUTE_SEGMENT) {
-                            withAdditionalContentProperty { "todoComment" to "TODO PDJB-1237: Organisation type update journey" }
+                        step(journey.orgLandlordRegistrationTask.orgTypeStep) {
+                            initialStep()
+                            routeSegment(OrgTypeStep.ROUTE_SEGMENT)
+                            nextStep { journey.orgTypeUpdateRoutingStep }
+                        }
+                        step(journey.orgTypeUpdateRoutingStep) {
+                            parents { journey.orgLandlordRegistrationTask.orgTypeStep.isComplete() }
+                            nextDestination { mode ->
+                                when (mode) {
+                                    OrgTypeUpdateRouteMode.TRUST_UNCHANGED -> Destination(journey.finishCyaStep)
+                                    OrgTypeUpdateRouteMode.ADDING_TRUST -> Destination(journey.orgTypeTrustInterruptionStep)
+                                    OrgTypeUpdateRouteMode.REMOVING_TRUST -> Destination(journey.orgTypeTrustInterruptionStep)
+                                }
+                            }
+                        }
+                        step(journey.orgTypeTrustInterruptionStep) {
+                            routeSegment(OrgTypeTrustInterruptionStep.ROUTE_SEGMENT)
+                            parents {
+                                OrParents(
+                                    journey.orgTypeUpdateRoutingStep.hasOutcome(OrgTypeUpdateRouteMode.ADDING_TRUST),
+                                    journey.orgTypeUpdateRoutingStep.hasOutcome(OrgTypeUpdateRouteMode.REMOVING_TRUST),
+                                )
+                            }
+                            nextStep {
+                                if (journey.orgTypeUpdateRoutingStep.outcome == OrgTypeUpdateRouteMode.ADDING_TRUST) {
+                                    journey.orgLandlordRegistrationTask.leadTrusteeTask.firstStep
+                                } else {
+                                    journey.finishCyaStep
+                                }
+                            }
+                        }
+                        task(journey.orgLandlordRegistrationTask.leadTrusteeTask) {
+                            parents {
+                                AndParents(
+                                    journey.orgTypeTrustInterruptionStep.isComplete(),
+                                    journey.orgTypeUpdateRoutingStep.hasOutcome(OrgTypeUpdateRouteMode.ADDING_TRUST),
+                                )
+                            }
+                            nextStep { journey.finishCyaStep }
                         }
                     }
 

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/landlordRegistration/tasks/LandlordRegistrationTask.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/landlordRegistration/tasks/LandlordRegistrationTask.kt
@@ -5,12 +5,10 @@ import org.springframework.beans.factory.ObjectFactory
 import uk.gov.communities.prsdb.webapp.annotations.webAnnotations.JourneyFrameworkComponent
 import uk.gov.communities.prsdb.webapp.config.managers.FeatureFlagManager
 import uk.gov.communities.prsdb.webapp.constants.ORGANISATION_LANDLORD_REGISTRATION
-import uk.gov.communities.prsdb.webapp.constants.enums.OrgType
 import uk.gov.communities.prsdb.webapp.journeys.AndParents
 import uk.gov.communities.prsdb.webapp.journeys.Destination
 import uk.gov.communities.prsdb.webapp.journeys.JourneyStateService
 import uk.gov.communities.prsdb.webapp.journeys.OrParents
-import uk.gov.communities.prsdb.webapp.journeys.StepInitialisationStage
 import uk.gov.communities.prsdb.webapp.journeys.StepLifecycleOrchestrator
 import uk.gov.communities.prsdb.webapp.journeys.TaskWithoutDependencies
 import uk.gov.communities.prsdb.webapp.journeys.builders.JourneyBuilder.Companion.journey
@@ -39,15 +37,14 @@ import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.
 import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.OrgMainContactStep
 import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.OrgNameStep
 import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.OrgPhoneNumberStep
-import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.OrgTypeMode
 import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.OrgTypeStep
 import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.PhoneNumberStep
 import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.PrivacyNoticeStep
 import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.update.organisationType.OrgTypeTrustInterruptionStep
 import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.update.organisationType.OrgTypeUpdateRouteMode
 import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.update.organisationType.OrgTypeUpdateRoutingStep
+import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.update.organisationType.OrgTypeUpdateRoutingStepConfig
 import uk.gov.communities.prsdb.webapp.journeys.propertyRegistration.steps.FinishCyaJourneyStep
-import uk.gov.communities.prsdb.webapp.journeys.shared.states.CheckYourAnswersJourneyState
 import uk.gov.communities.prsdb.webapp.journeys.shared.states.CheckYourAnswersJourneyState.Companion.checkAnswerStep
 import uk.gov.communities.prsdb.webapp.journeys.shared.states.CheckYourAnswersJourneyState.Companion.checkAnswerTask
 import uk.gov.communities.prsdb.webapp.journeys.shared.stepConfig.AbstractCheckYourAnswersStep
@@ -78,7 +75,6 @@ class LandlordRegistrationTask(
     override var cyaJourneys: Map<String, String> = mapOf()
     override var checkingAnswersFor: String? by delegateProvider.nullableDelegate("checkingAnswersFor")
     override var cyaUrlPath: String? by delegateProvider.nullableDelegate("cyaRouteSegment")
-    override var previousOrgTypeMode: OrgTypeMode by delegateProvider.requiredDelegate("previous-org-type")
 
     override val orgTypeStep: OrgTypeStep
         get() = orgLandlordRegistrationTask.orgTypeStep
@@ -186,26 +182,6 @@ class LandlordRegistrationTask(
             }
         }
 
-    override fun createChildJourneyState(childJourneyId: String): CheckYourAnswersJourneyState {
-        // TODO: PDJB-585: Remove this cast
-        val newJourney = super.createChildJourneyState(childJourneyId) as LandlordRegistrationTask
-
-        val orgTypeStep = orgLandlordRegistrationTask.orgTypeStep
-        // only wire this in if the CYA journey is on an org landlord journey & has orgTypeStep set up
-        if (orgTypeStep.initialisationStage == StepInitialisationStage.FULLY_INITIALISED) {
-            orgTypeStep.formModelOrNull?.let { orgTypeFormModel ->
-                newJourney.previousOrgTypeMode =
-                    if (OrgType.TRUST in orgTypeFormModel.getSelectedOrgTypes()) {
-                        OrgTypeMode.INCLUDES_TRUST
-                    } else {
-                        OrgTypeMode.EXCLUDES_TRUST
-                    }
-            }
-        }
-
-        return newJourney
-    }
-
     companion object {
         fun <T : LandlordRegistrationState> checkYourAnswersJourneyMap(
             state: T,
@@ -306,7 +282,15 @@ class LandlordRegistrationTask(
                             routeSegment(OrgTypeStep.ROUTE_SEGMENT)
                             nextStep { journey.orgTypeUpdateRoutingStep }
                         }
-                        step(journey.orgTypeUpdateRoutingStep) {
+                        step<OrgTypeUpdateRouteMode, OrgTypeUpdateRoutingStepConfig>(journey.orgTypeUpdateRoutingStep) {
+                            stepSpecificInitialisation {
+                                usingPreviousIsTrust {
+                                    getPreviousIsTrustFromBaseJourney(
+                                        journey,
+                                        journey.orgLandlordRegistrationTask.orgTypeStep,
+                                    )
+                                }
+                            }
                             parents { journey.orgLandlordRegistrationTask.orgTypeStep.isComplete() }
                             nextDestination { mode ->
                                 when (mode) {

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/landlordRegistration/tasks/OrgLandlordRegistrationTask.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/landlordRegistration/tasks/OrgLandlordRegistrationTask.kt
@@ -32,7 +32,7 @@ class OrgLandlordRegistrationTask(
     override val companiesHouseTask: OrgCompaniesHouseTask,
     override val orgGovBodyTask: OrgGovBodyTask,
     override val orgMainContactStep: OrgMainContactStep,
-    // TODO PDJB-1237 PDJB-1238: remove this placeholder once the org type and companies house update journeys exist.
+    // TODO PDJB-1238: remove this placeholder once the companies house update journey exists.
     override val updateDetailsTodoStep: UpdateDetailsTodoStep,
 ) : TaskWithoutDependencies<LandlordRegistrationOrgLandlordState>(journeyStateService),
     LandlordRegistrationOrgLandlordState {

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/landlordRegistration/update/organisationType/CompleteOrganisationTypeUpdateStep.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/landlordRegistration/update/organisationType/CompleteOrganisationTypeUpdateStep.kt
@@ -1,0 +1,78 @@
+package uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.update.organisationType
+
+import uk.gov.communities.prsdb.webapp.annotations.webAnnotations.JourneyFrameworkComponent
+import uk.gov.communities.prsdb.webapp.constants.enums.OrgType
+import uk.gov.communities.prsdb.webapp.exceptions.NotNullFormModelValueIsNullException.Companion.notNullValue
+import uk.gov.communities.prsdb.webapp.journeys.AbstractInternalStepConfig
+import uk.gov.communities.prsdb.webapp.journeys.Destination
+import uk.gov.communities.prsdb.webapp.journeys.JourneyStep.InternalStep
+import uk.gov.communities.prsdb.webapp.journeys.shared.Complete
+import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.LeadTrusteeEmailFormModel
+import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.LeadTrusteeNameFormModel
+import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.LeadTrusteePhoneFormModel
+import uk.gov.communities.prsdb.webapp.services.LandlordService
+
+@JourneyFrameworkComponent
+class CompleteOrganisationTypeUpdateStepConfig(
+    private val landlordService: LandlordService,
+) : AbstractInternalStepConfig<Complete, UpdateOrganisationTypeJourneyState>() {
+    override fun mode(state: UpdateOrganisationTypeJourneyState): Complete = Complete.COMPLETE
+
+    override fun afterStepIsReached(state: UpdateOrganisationTypeJourneyState) {
+        val selectedOrgTypes = state.orgTypeStep.formModel.getSelectedOrgTypes()
+        val addingTrust = state.orgTypeUpdateRoutingStep.outcome == OrgTypeUpdateRouteMode.ADDING_TRUST
+
+        landlordService.updateOrganisationLandlordType(
+            isCompany = OrgType.COMPANY in selectedOrgTypes,
+            isCharity = OrgType.CHARITY in selectedOrgTypes,
+            isTrust = OrgType.TRUST in selectedOrgTypes,
+            leadTrusteeName =
+                if (addingTrust) {
+                    state.leadTrusteeTask.leadTrusteeNameStep.formModel
+                        .notNullValue(LeadTrusteeNameFormModel::name)
+                } else {
+                    null
+                },
+            leadTrusteeDateOfBirth =
+                if (addingTrust) {
+                    state.leadTrusteeTask.leadTrusteeDobStep.formModel
+                        .toLocalDateOrNull()
+                } else {
+                    null
+                },
+            leadTrusteeEmail =
+                if (addingTrust) {
+                    state.leadTrusteeTask.leadTrusteeEmailStep.formModel
+                        .notNullValue(LeadTrusteeEmailFormModel::emailAddress)
+                } else {
+                    null
+                },
+            leadTrusteePhone =
+                if (addingTrust) {
+                    state.leadTrusteeTask.leadTrusteePhoneStep.formModel
+                        .notNullValue(LeadTrusteePhoneFormModel::phoneNumber)
+                } else {
+                    null
+                },
+            leadTrusteeAddress =
+                if (addingTrust) {
+                    state.leadTrusteeTask.trusteeAddressTask.getAddress()
+                } else {
+                    null
+                },
+        )
+    }
+
+    override fun resolveNextDestination(
+        state: UpdateOrganisationTypeJourneyState,
+        defaultDestination: Destination,
+    ): Destination {
+        state.deleteJourney()
+        return defaultDestination
+    }
+}
+
+@JourneyFrameworkComponent
+class CompleteOrganisationTypeUpdateStep(
+    stepConfig: CompleteOrganisationTypeUpdateStepConfig,
+) : InternalStep<Complete, UpdateOrganisationTypeJourneyState>(stepConfig)

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/landlordRegistration/update/organisationType/OrgTypeCyaStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/landlordRegistration/update/organisationType/OrgTypeCyaStepConfig.kt
@@ -1,0 +1,29 @@
+package uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.update.organisationType
+
+import uk.gov.communities.prsdb.webapp.annotations.webAnnotations.JourneyFrameworkComponent
+import uk.gov.communities.prsdb.webapp.journeys.AbstractRequestableStepConfig
+import uk.gov.communities.prsdb.webapp.journeys.JourneyState
+import uk.gov.communities.prsdb.webapp.journeys.JourneyStep.RequestableStep
+import uk.gov.communities.prsdb.webapp.journeys.shared.Complete
+import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.NoInputFormModel
+
+@JourneyFrameworkComponent
+class OrgTypeCyaStepConfig : AbstractRequestableStepConfig<Complete, NoInputFormModel, JourneyState>() {
+    override val formModelClass = NoInputFormModel::class
+
+    override fun getStepSpecificContent(state: JourneyState) =
+        mapOf("todoComment" to "TODO PDJB-1445: Organisation type check your answers page")
+
+    override fun chooseTemplate(state: JourneyState) = "forms/todo"
+
+    override fun mode(state: JourneyState) = getFormModelFromStateOrNull(state)?.let { Complete.COMPLETE }
+}
+
+@JourneyFrameworkComponent
+final class OrgTypeCyaStep(
+    stepConfig: OrgTypeCyaStepConfig,
+) : RequestableStep<Complete, NoInputFormModel, JourneyState>(stepConfig) {
+    companion object {
+        const val ROUTE_SEGMENT = "organisation-type-check-your-answers"
+    }
+}

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/landlordRegistration/update/organisationType/OrgTypeTrustInterruptionStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/landlordRegistration/update/organisationType/OrgTypeTrustInterruptionStepConfig.kt
@@ -1,0 +1,28 @@
+package uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.update.organisationType
+
+import uk.gov.communities.prsdb.webapp.annotations.webAnnotations.JourneyFrameworkComponent
+import uk.gov.communities.prsdb.webapp.journeys.AbstractRequestableStepConfig
+import uk.gov.communities.prsdb.webapp.journeys.JourneyStep.RequestableStep
+import uk.gov.communities.prsdb.webapp.journeys.shared.Complete
+import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.NoInputFormModel
+
+@JourneyFrameworkComponent
+class OrgTypeTrustInterruptionStepConfig : AbstractRequestableStepConfig<Complete, NoInputFormModel, OrgTypeUpdateState>() {
+    override val formModelClass = NoInputFormModel::class
+
+    override fun getStepSpecificContent(state: OrgTypeUpdateState) =
+        mapOf("todoComment" to "TODO PDJB-1466: Organisation type trust interruption page")
+
+    override fun chooseTemplate(state: OrgTypeUpdateState) = "forms/todo"
+
+    override fun mode(state: OrgTypeUpdateState) = getFormModelFromStateOrNull(state)?.let { Complete.COMPLETE }
+}
+
+@JourneyFrameworkComponent
+final class OrgTypeTrustInterruptionStep(
+    stepConfig: OrgTypeTrustInterruptionStepConfig,
+) : RequestableStep<Complete, NoInputFormModel, OrgTypeUpdateState>(stepConfig) {
+    companion object {
+        const val ROUTE_SEGMENT = "organisation-type-trust-interruption"
+    }
+}

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/landlordRegistration/update/organisationType/OrgTypeUpdateRoutingStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/landlordRegistration/update/organisationType/OrgTypeUpdateRoutingStepConfig.kt
@@ -1,0 +1,31 @@
+package uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.update.organisationType
+
+import uk.gov.communities.prsdb.webapp.annotations.webAnnotations.JourneyFrameworkComponent
+import uk.gov.communities.prsdb.webapp.journeys.AbstractInternalStepConfig
+import uk.gov.communities.prsdb.webapp.journeys.JourneyStep.InternalStep
+import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.OrgTypeMode
+
+enum class OrgTypeUpdateRouteMode {
+    TRUST_UNCHANGED,
+    ADDING_TRUST,
+    REMOVING_TRUST,
+}
+
+@JourneyFrameworkComponent
+class OrgTypeUpdateRoutingStepConfig : AbstractInternalStepConfig<OrgTypeUpdateRouteMode, OrgTypeUpdateState>() {
+    override fun mode(state: OrgTypeUpdateState): OrgTypeUpdateRouteMode? {
+        val previousIsTrust = state.previousOrgTypeMode == OrgTypeMode.INCLUDES_TRUST
+        val newOrgTypeMode = state.orgTypeStep.outcome ?: return null
+        val newIsTrust = newOrgTypeMode == OrgTypeMode.INCLUDES_TRUST
+        return when {
+            previousIsTrust == newIsTrust -> OrgTypeUpdateRouteMode.TRUST_UNCHANGED
+            newIsTrust -> OrgTypeUpdateRouteMode.ADDING_TRUST
+            else -> OrgTypeUpdateRouteMode.REMOVING_TRUST
+        }
+    }
+}
+
+@JourneyFrameworkComponent
+class OrgTypeUpdateRoutingStep(
+    stepConfig: OrgTypeUpdateRoutingStepConfig,
+) : InternalStep<OrgTypeUpdateRouteMode, OrgTypeUpdateState>(stepConfig)

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/landlordRegistration/update/organisationType/OrgTypeUpdateRoutingStepConfig.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/landlordRegistration/update/organisationType/OrgTypeUpdateRoutingStepConfig.kt
@@ -1,9 +1,13 @@
 package uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.update.organisationType
 
 import uk.gov.communities.prsdb.webapp.annotations.webAnnotations.JourneyFrameworkComponent
+import uk.gov.communities.prsdb.webapp.constants.enums.OrgType
 import uk.gov.communities.prsdb.webapp.journeys.AbstractInternalStepConfig
 import uk.gov.communities.prsdb.webapp.journeys.JourneyStep.InternalStep
 import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.OrgTypeMode
+import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.OrgTypeStep
+import uk.gov.communities.prsdb.webapp.journeys.shared.states.CheckYourAnswersJourneyState
+import uk.gov.communities.prsdb.webapp.services.UserToLandlordService
 
 enum class OrgTypeUpdateRouteMode {
     TRUST_UNCHANGED,
@@ -13,12 +17,31 @@ enum class OrgTypeUpdateRouteMode {
 
 @JourneyFrameworkComponent
 class OrgTypeUpdateRoutingStepConfig : AbstractInternalStepConfig<OrgTypeUpdateRouteMode, OrgTypeUpdateState>() {
+    private lateinit var previousIsTrust: () -> Boolean
+
+    fun usingPreviousIsTrust(previousIsTrust: () -> Boolean): OrgTypeUpdateRoutingStepConfig {
+        this.previousIsTrust = previousIsTrust
+        return this
+    }
+
+    fun getPreviousIsTrustFromDatabase(userToLandlordService: UserToLandlordService): Boolean =
+        userToLandlordService.getCurrentOrganisationLandlordForUser().isTrust
+
+    fun getPreviousIsTrustFromBaseJourney(
+        state: CheckYourAnswersJourneyState,
+        orgTypeStep: OrgTypeStep,
+    ): Boolean =
+        OrgType.TRUST in
+            orgTypeStep.stepConfig
+                .getFormModelFromState(state.getBaseJourneyState())
+                .getSelectedOrgTypes()
+
+    override fun isSubClassInitialised() = ::previousIsTrust.isInitialized
+
     override fun mode(state: OrgTypeUpdateState): OrgTypeUpdateRouteMode? {
-        val previousIsTrust = state.previousOrgTypeMode == OrgTypeMode.INCLUDES_TRUST
-        val newOrgTypeMode = state.orgTypeStep.outcome ?: return null
-        val newIsTrust = newOrgTypeMode == OrgTypeMode.INCLUDES_TRUST
+        val newIsTrust = state.orgTypeStep.outcome?.let { it == OrgTypeMode.INCLUDES_TRUST } ?: return null
         return when {
-            previousIsTrust == newIsTrust -> OrgTypeUpdateRouteMode.TRUST_UNCHANGED
+            previousIsTrust() == newIsTrust -> OrgTypeUpdateRouteMode.TRUST_UNCHANGED
             newIsTrust -> OrgTypeUpdateRouteMode.ADDING_TRUST
             else -> OrgTypeUpdateRouteMode.REMOVING_TRUST
         }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/landlordRegistration/update/organisationType/OrgTypeUpdateState.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/landlordRegistration/update/organisationType/OrgTypeUpdateState.kt
@@ -1,10 +1,8 @@
 package uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.update.organisationType
 
 import uk.gov.communities.prsdb.webapp.journeys.JourneyState
-import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.OrgTypeMode
 import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.OrgTypeStep
 
 interface OrgTypeUpdateState : JourneyState {
-    val previousOrgTypeMode: OrgTypeMode
     val orgTypeStep: OrgTypeStep
 }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/landlordRegistration/update/organisationType/OrgTypeUpdateState.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/landlordRegistration/update/organisationType/OrgTypeUpdateState.kt
@@ -1,0 +1,10 @@
+package uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.update.organisationType
+
+import uk.gov.communities.prsdb.webapp.journeys.JourneyState
+import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.OrgTypeMode
+import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.OrgTypeStep
+
+interface OrgTypeUpdateState : JourneyState {
+    val previousOrgTypeMode: OrgTypeMode
+    val orgTypeStep: OrgTypeStep
+}

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/landlordRegistration/update/organisationType/UpdateOrganisationTypeJourneyFactory.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/landlordRegistration/update/organisationType/UpdateOrganisationTypeJourneyFactory.kt
@@ -15,7 +15,6 @@ import uk.gov.communities.prsdb.webapp.journeys.StepLifecycleOrchestrator
 import uk.gov.communities.prsdb.webapp.journeys.builders.JourneyBuilder.Companion.journey
 import uk.gov.communities.prsdb.webapp.journeys.hasOutcome
 import uk.gov.communities.prsdb.webapp.journeys.isComplete
-import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.OrgTypeMode
 import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.OrgTypeStep
 import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.tasks.LeadTrusteeTask
 import uk.gov.communities.prsdb.webapp.services.UserToLandlordService
@@ -28,16 +27,6 @@ class UpdateOrganisationTypeJourneyFactory(
 ) {
     fun createJourneySteps(): Map<String, StepLifecycleOrchestrator> {
         val state = stateFactory.getObject()
-
-        if (!state.isStateInitialized) {
-            state.previousOrgTypeMode =
-                if (userToLandlordService.getCurrentOrganisationLandlordForUser().isTrust) {
-                    OrgTypeMode.INCLUDES_TRUST
-                } else {
-                    OrgTypeMode.EXCLUDES_TRUST
-                }
-            state.isStateInitialized = true
-        }
 
         return journey(state) {
             unreachableStepUrl { LANDLORD_DETAILS_FOR_LANDLORD_ROUTE }
@@ -55,7 +44,10 @@ class UpdateOrganisationTypeJourneyFactory(
                     )
                 }
             }
-            step(journey.orgTypeUpdateRoutingStep) {
+            step<OrgTypeUpdateRouteMode, OrgTypeUpdateRoutingStepConfig>(journey.orgTypeUpdateRoutingStep) {
+                stepSpecificInitialisation {
+                    usingPreviousIsTrust { getPreviousIsTrustFromDatabase(userToLandlordService) }
+                }
                 parents { journey.orgTypeStep.isComplete() }
                 nextDestination { mode ->
                     when (mode) {
@@ -132,7 +124,6 @@ interface UpdateOrganisationTypeJourneyState :
     val leadTrusteeTask: LeadTrusteeTask
     val orgTypeCyaStep: OrgTypeCyaStep
     val completeOrganisationTypeUpdateStep: CompleteOrganisationTypeUpdateStep
-    var isStateInitialized: Boolean
 }
 
 @JourneyFrameworkComponent
@@ -147,9 +138,6 @@ class UpdateOrganisationTypeJourney(
     private val journeyName: String = "organisation-type",
 ) : AbstractJourneyState(journeyStateService),
     UpdateOrganisationTypeJourneyState {
-    override var previousOrgTypeMode: OrgTypeMode by delegateProvider.requiredDelegate("previous-org-type")
-    override var isStateInitialized: Boolean by delegateProvider.requiredDelegate("isStateInitialized", false)
-
     override fun generateJourneyId(seed: Any?): String {
         val user: Principal? = seed as? Principal
         return super<AbstractJourneyState>.generateJourneyId(

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/landlordRegistration/update/organisationType/UpdateOrganisationTypeJourneyFactory.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/landlordRegistration/update/organisationType/UpdateOrganisationTypeJourneyFactory.kt
@@ -4,6 +4,7 @@ import org.springframework.beans.factory.ObjectFactory
 import uk.gov.communities.prsdb.webapp.annotations.webAnnotations.JourneyFrameworkComponent
 import uk.gov.communities.prsdb.webapp.annotations.webAnnotations.PrsdbWebService
 import uk.gov.communities.prsdb.webapp.controllers.LandlordDetailsController.Companion.LANDLORD_DETAILS_FOR_LANDLORD_ROUTE
+import uk.gov.communities.prsdb.webapp.controllers.LandlordDetailsController.Companion.ORGANISATION_CONTACTS_FRAGMENT
 import uk.gov.communities.prsdb.webapp.journeys.AbstractJourneyState
 import uk.gov.communities.prsdb.webapp.journeys.AndParents
 import uk.gov.communities.prsdb.webapp.journeys.Destination
@@ -108,7 +109,13 @@ class UpdateOrganisationTypeJourneyFactory(
             }
             step(journey.completeOrganisationTypeUpdateStep) {
                 parents { journey.orgTypeCyaStep.isComplete() }
-                nextUrl { LANDLORD_DETAILS_FOR_LANDLORD_ROUTE }
+                nextUrl {
+                    if (journey.orgTypeUpdateRoutingStep.outcome == OrgTypeUpdateRouteMode.REMOVING_TRUST) {
+                        "$LANDLORD_DETAILS_FOR_LANDLORD_ROUTE#$ORGANISATION_CONTACTS_FRAGMENT"
+                    } else {
+                        LANDLORD_DETAILS_FOR_LANDLORD_ROUTE
+                    }
+                }
             }
         }
     }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/landlordRegistration/update/organisationType/UpdateOrganisationTypeJourneyFactory.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/journeys/landlordRegistration/update/organisationType/UpdateOrganisationTypeJourneyFactory.kt
@@ -1,0 +1,152 @@
+package uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.update.organisationType
+
+import org.springframework.beans.factory.ObjectFactory
+import uk.gov.communities.prsdb.webapp.annotations.webAnnotations.JourneyFrameworkComponent
+import uk.gov.communities.prsdb.webapp.annotations.webAnnotations.PrsdbWebService
+import uk.gov.communities.prsdb.webapp.controllers.LandlordDetailsController.Companion.LANDLORD_DETAILS_FOR_LANDLORD_ROUTE
+import uk.gov.communities.prsdb.webapp.journeys.AbstractJourneyState
+import uk.gov.communities.prsdb.webapp.journeys.AndParents
+import uk.gov.communities.prsdb.webapp.journeys.Destination
+import uk.gov.communities.prsdb.webapp.journeys.JourneyState
+import uk.gov.communities.prsdb.webapp.journeys.JourneyStateService
+import uk.gov.communities.prsdb.webapp.journeys.OrParents
+import uk.gov.communities.prsdb.webapp.journeys.StepLifecycleOrchestrator
+import uk.gov.communities.prsdb.webapp.journeys.builders.JourneyBuilder.Companion.journey
+import uk.gov.communities.prsdb.webapp.journeys.hasOutcome
+import uk.gov.communities.prsdb.webapp.journeys.isComplete
+import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.OrgTypeMode
+import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.OrgTypeStep
+import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.tasks.LeadTrusteeTask
+import uk.gov.communities.prsdb.webapp.services.UserToLandlordService
+import java.security.Principal
+
+@PrsdbWebService
+class UpdateOrganisationTypeJourneyFactory(
+    private val stateFactory: ObjectFactory<UpdateOrganisationTypeJourney>,
+    private val userToLandlordService: UserToLandlordService,
+) {
+    fun createJourneySteps(): Map<String, StepLifecycleOrchestrator> {
+        val state = stateFactory.getObject()
+
+        if (!state.isStateInitialized) {
+            state.previousOrgTypeMode =
+                if (userToLandlordService.getCurrentOrganisationLandlordForUser().isTrust) {
+                    OrgTypeMode.INCLUDES_TRUST
+                } else {
+                    OrgTypeMode.EXCLUDES_TRUST
+                }
+            state.isStateInitialized = true
+        }
+
+        return journey(state) {
+            unreachableStepUrl { LANDLORD_DETAILS_FOR_LANDLORD_ROUTE }
+            configure {
+                withAdditionalContentProperty { "title" to "landlordDetails.update.title" }
+            }
+            step(journey.orgTypeStep) {
+                routeSegment(OrgTypeStep.ROUTE_SEGMENT)
+                initialStep()
+                backUrl { LANDLORD_DETAILS_FOR_LANDLORD_ROUTE }
+                nextStep { journey.orgTypeUpdateRoutingStep }
+                withAdditionalContentProperties {
+                    mapOf(
+                        "submitButtonText" to "forms.buttons.continue",
+                    )
+                }
+            }
+            step(journey.orgTypeUpdateRoutingStep) {
+                parents { journey.orgTypeStep.isComplete() }
+                nextDestination { mode ->
+                    when (mode) {
+                        OrgTypeUpdateRouteMode.TRUST_UNCHANGED -> Destination(journey.orgTypeCyaStep)
+                        OrgTypeUpdateRouteMode.ADDING_TRUST -> Destination(journey.orgTypeTrustInterruptionStep)
+                        OrgTypeUpdateRouteMode.REMOVING_TRUST -> Destination(journey.orgTypeTrustInterruptionStep)
+                    }
+                }
+            }
+            step(journey.orgTypeTrustInterruptionStep) {
+                routeSegment(OrgTypeTrustInterruptionStep.ROUTE_SEGMENT)
+                parents {
+                    OrParents(
+                        journey.orgTypeUpdateRoutingStep.hasOutcome(OrgTypeUpdateRouteMode.ADDING_TRUST),
+                        journey.orgTypeUpdateRoutingStep.hasOutcome(OrgTypeUpdateRouteMode.REMOVING_TRUST),
+                    )
+                }
+                nextStep {
+                    if (journey.orgTypeUpdateRoutingStep.outcome == OrgTypeUpdateRouteMode.ADDING_TRUST) {
+                        journey.leadTrusteeTask.firstStep
+                    } else {
+                        journey.orgTypeCyaStep
+                    }
+                }
+            }
+            task(journey.leadTrusteeTask) {
+                parents {
+                    AndParents(
+                        journey.orgTypeTrustInterruptionStep.isComplete(),
+                        journey.orgTypeUpdateRoutingStep.hasOutcome(OrgTypeUpdateRouteMode.ADDING_TRUST),
+                    )
+                }
+                nextStep { journey.orgTypeCyaStep }
+            }
+            step(journey.orgTypeCyaStep) {
+                routeSegment(OrgTypeCyaStep.ROUTE_SEGMENT)
+                parents {
+                    OrParents(
+                        journey.orgTypeUpdateRoutingStep.hasOutcome(OrgTypeUpdateRouteMode.TRUST_UNCHANGED),
+                        journey.leadTrusteeTask.isComplete(),
+                        AndParents(
+                            journey.orgTypeTrustInterruptionStep.isComplete(),
+                            journey.orgTypeUpdateRoutingStep.hasOutcome(OrgTypeUpdateRouteMode.REMOVING_TRUST),
+                        ),
+                    )
+                }
+                nextStep { journey.completeOrganisationTypeUpdateStep }
+                withAdditionalContentProperties {
+                    mapOf("submitButtonText" to "forms.buttons.confirmAndSubmitUpdate")
+                }
+            }
+            step(journey.completeOrganisationTypeUpdateStep) {
+                parents { journey.orgTypeCyaStep.isComplete() }
+                nextUrl { LANDLORD_DETAILS_FOR_LANDLORD_ROUTE }
+            }
+        }
+    }
+
+    fun initializeJourneyState(user: Principal): String = stateFactory.getObject().initializeOrRestoreState(user)
+}
+
+interface UpdateOrganisationTypeJourneyState :
+    JourneyState,
+    OrgTypeUpdateState {
+    override val orgTypeStep: OrgTypeStep
+    val orgTypeUpdateRoutingStep: OrgTypeUpdateRoutingStep
+    val orgTypeTrustInterruptionStep: OrgTypeTrustInterruptionStep
+    val leadTrusteeTask: LeadTrusteeTask
+    val orgTypeCyaStep: OrgTypeCyaStep
+    val completeOrganisationTypeUpdateStep: CompleteOrganisationTypeUpdateStep
+    var isStateInitialized: Boolean
+}
+
+@JourneyFrameworkComponent
+class UpdateOrganisationTypeJourney(
+    override val orgTypeStep: OrgTypeStep,
+    override val orgTypeUpdateRoutingStep: OrgTypeUpdateRoutingStep,
+    override val orgTypeTrustInterruptionStep: OrgTypeTrustInterruptionStep,
+    override val leadTrusteeTask: LeadTrusteeTask,
+    override val orgTypeCyaStep: OrgTypeCyaStep,
+    override val completeOrganisationTypeUpdateStep: CompleteOrganisationTypeUpdateStep,
+    journeyStateService: JourneyStateService,
+    private val journeyName: String = "organisation-type",
+) : AbstractJourneyState(journeyStateService),
+    UpdateOrganisationTypeJourneyState {
+    override var previousOrgTypeMode: OrgTypeMode by delegateProvider.requiredDelegate("previous-org-type")
+    override var isStateInitialized: Boolean by delegateProvider.requiredDelegate("isStateInitialized", false)
+
+    override fun generateJourneyId(seed: Any?): String {
+        val user: Principal? = seed as? Principal
+        return super<AbstractJourneyState>.generateJourneyId(
+            user?.let { "Update $journeyName for landlord ${it.name}" },
+        )
+    }
+}

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/dataModels/updateModels/OrganisationLandlordUpdateModel.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/dataModels/updateModels/OrganisationLandlordUpdateModel.kt
@@ -1,5 +1,16 @@
 package uk.gov.communities.prsdb.webapp.models.dataModels.updateModels
 
+import uk.gov.communities.prsdb.webapp.models.dataModels.AddressDataModel
+import java.time.LocalDate
+
 data class OrganisationLandlordUpdateModel(
     val name: String? = null,
+    val isCompany: Boolean? = null,
+    val isCharity: Boolean? = null,
+    val isTrust: Boolean? = null,
+    val leadTrusteeName: String? = null,
+    val leadTrusteeDateOfBirth: LocalDate? = null,
+    val leadTrusteeEmail: String? = null,
+    val leadTrusteePhone: String? = null,
+    val leadTrusteeAddress: AddressDataModel? = null,
 )

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/LandlordService.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/LandlordService.kt
@@ -250,16 +250,29 @@ class LandlordService(
         leadTrusteePhone: String? = null,
         leadTrusteeAddress: AddressDataModel? = null,
     ) {
-        updateOrganisationLandlordForUser(
-            OrganisationLandlordUpdateModel(
-                isCompany = isCompany,
-                isCharity = isCharity,
-                isTrust = isTrust,
-                leadTrusteeName = leadTrusteeName,
-                leadTrusteeDateOfBirth = leadTrusteeDateOfBirth,
-                leadTrusteeEmail = leadTrusteeEmail,
-                leadTrusteePhone = leadTrusteePhone,
-                leadTrusteeAddress = leadTrusteeAddress,
+        val landlord =
+            updateOrganisationLandlordForUser(
+                OrganisationLandlordUpdateModel(
+                    isCompany = isCompany,
+                    isCharity = isCharity,
+                    isTrust = isTrust,
+                    leadTrusteeName = leadTrusteeName,
+                    leadTrusteeDateOfBirth = leadTrusteeDateOfBirth,
+                    leadTrusteeEmail = leadTrusteeEmail,
+                    leadTrusteePhone = leadTrusteePhone,
+                    leadTrusteeAddress = leadTrusteeAddress,
+                ),
+            )
+
+        updateConfirmationSender.sendEmail(
+            landlord.email,
+            LandlordUpdateConfirmation(
+                registrationNumber =
+                    RegistrationNumberDataModel
+                        .fromRegistrationNumber(landlord.registrationNumber)
+                        .toString(),
+                dashboardUrl = absoluteUrlProvider.buildLandlordDashboardUri(),
+                updatedDetail = "organisation type and lead trustee details",
             ),
         )
     }

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/LandlordService.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/services/LandlordService.kt
@@ -208,6 +208,26 @@ class LandlordService(
         val landlordEntity = userToLandlordService.getCurrentOrganisationLandlordForUser()
 
         orgLandlordUpdate.name?.let { landlordEntity.name = it }
+        orgLandlordUpdate.isCompany?.let { landlordEntity.isCompany = it }
+        orgLandlordUpdate.isCharity?.let { landlordEntity.isCharity = it }
+        orgLandlordUpdate.isTrust?.let { isTrust ->
+            landlordEntity.isTrust = isTrust
+            if (!isTrust) {
+                landlordEntity.leadTrusteeName = null
+                landlordEntity.leadTrusteeDateOfBirth = null
+                landlordEntity.leadTrusteeEmail = null
+                landlordEntity.leadTrusteePhone = null
+                landlordEntity.leadTrusteeAddress = null
+            }
+        }
+
+        orgLandlordUpdate.leadTrusteeName?.let { landlordEntity.leadTrusteeName = it }
+        orgLandlordUpdate.leadTrusteeDateOfBirth?.let { landlordEntity.leadTrusteeDateOfBirth = it }
+        orgLandlordUpdate.leadTrusteeEmail?.let { landlordEntity.leadTrusteeEmail = it }
+        orgLandlordUpdate.leadTrusteePhone?.let { landlordEntity.leadTrusteePhone = it }
+        orgLandlordUpdate.leadTrusteeAddress?.let {
+            landlordEntity.leadTrusteeAddress = addressService.findOrCreateAddress(it)
+        }
 
         return landlordEntity
     }
@@ -216,6 +236,31 @@ class LandlordService(
     fun updateOrganisationLandlordName(orgName: String) {
         updateOrganisationLandlordForUser(
             OrganisationLandlordUpdateModel(name = orgName),
+        )
+    }
+
+    @Transactional
+    fun updateOrganisationLandlordType(
+        isCompany: Boolean,
+        isCharity: Boolean,
+        isTrust: Boolean,
+        leadTrusteeName: String? = null,
+        leadTrusteeDateOfBirth: LocalDate? = null,
+        leadTrusteeEmail: String? = null,
+        leadTrusteePhone: String? = null,
+        leadTrusteeAddress: AddressDataModel? = null,
+    ) {
+        updateOrganisationLandlordForUser(
+            OrganisationLandlordUpdateModel(
+                isCompany = isCompany,
+                isCharity = isCharity,
+                isTrust = isTrust,
+                leadTrusteeName = leadTrusteeName,
+                leadTrusteeDateOfBirth = leadTrusteeDateOfBirth,
+                leadTrusteeEmail = leadTrusteeEmail,
+                leadTrusteePhone = leadTrusteePhone,
+                leadTrusteeAddress = leadTrusteeAddress,
+            ),
         )
     }
 

--- a/src/main/resources/templates/orgLandlordDetailsView.html
+++ b/src/main/resources/templates/orgLandlordDetailsView.html
@@ -53,7 +53,7 @@
                     <span th:if="${orgLandlord.isCompany}" th:text="#{landlordDetails.org.isCompany}">landlordDetails.org.isCompany</span>
                     <span th:if="${orgLandlord.isCharity}" th:text="#{landlordDetails.org.isCharity}">landlordDetails.org.isCharity</span>
                     <span th:if="${orgLandlord.isTrust}" th:text="#{landlordDetails.org.isTrust}">landlordDetails.org.isTrust</span><br/>
-                    <a class="govuk-link" href="#" th:text="#{forms.links.change}">forms.links.change</a> <!-- TODO: PDJB-1237: Add update journey -->
+                    <a class="govuk-link" th:href="@{/landlord/landlord-details/update-organisation-type/organisation-type}" th:text="#{forms.links.change}">forms.links.change</a>
                 </p>
 
                 <p class="govuk-body">

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/controllers/UpdateOrganisationTypeControllerTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/controllers/UpdateOrganisationTypeControllerTests.kt
@@ -1,0 +1,142 @@
+package uk.gov.communities.prsdb.webapp.controllers
+
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.whenever
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.security.test.context.support.WithMockUser
+import org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf
+import org.springframework.test.context.bean.override.mockito.MockitoBean
+import org.springframework.test.web.servlet.get
+import org.springframework.test.web.servlet.post
+import org.springframework.web.context.WebApplicationContext
+import org.springframework.web.servlet.ModelAndView
+import uk.gov.communities.prsdb.webapp.database.entity.OrganisationalLandlord
+import uk.gov.communities.prsdb.webapp.journeys.StepLifecycleOrchestrator
+import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.OrgTypeStep
+import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.update.organisationType.UpdateOrganisationTypeJourneyFactory
+import uk.gov.communities.prsdb.webapp.services.UserToLandlordService
+import uk.gov.communities.prsdb.webapp.testHelpers.mockObjects.MockLandlordData.Companion.createIndividualLandlord
+
+@WebMvcTest(UpdateOrganisationTypeController::class)
+class UpdateOrganisationTypeControllerTests(
+    @Autowired val webContext: WebApplicationContext,
+) : ControllerTest(webContext) {
+    @MockitoBean
+    private lateinit var mockJourneyFactory: UpdateOrganisationTypeJourneyFactory
+
+    @MockitoBean
+    private lateinit var mockStepLifecycleOrchestrator: StepLifecycleOrchestrator.VisitableStepLifecycleOrchestrator
+
+    @MockitoBean
+    private lateinit var mockUserToLandlordService: UserToLandlordService
+
+    val updateOrgTypeRoute =
+        UpdateOrganisationTypeController.UPDATE_ORG_TYPE_ROUTE +
+            "/${OrgTypeStep.ROUTE_SEGMENT}"
+
+    @Test
+    fun `getUpdateStep returns a redirect for unauthenticated user`() {
+        mvc.get(updateOrgTypeRoute).andExpect {
+            status { is3xxRedirection() }
+        }
+    }
+
+    @Test
+    @WithMockUser
+    fun `getUpdateStep returns 403 for an unauthorised user`() {
+        mvc
+            .get(updateOrgTypeRoute)
+            .andExpect {
+                status { isForbidden() }
+            }
+    }
+
+    @Test
+    @WithMockUser(roles = ["LANDLORD"], value = "user")
+    fun `getUpdateStep returns 403 for a non-organisation landlord`() {
+        whenever(mockUserToLandlordService.getCurrentLandlordForUser()).thenReturn(createIndividualLandlord())
+
+        mvc
+            .get(updateOrgTypeRoute)
+            .andExpect {
+                status { isForbidden() }
+            }
+    }
+
+    @Test
+    @WithMockUser(roles = ["LANDLORD"], value = "user")
+    fun `getUpdateStep returns 200 for an organisation landlord`() {
+        whenever(mockUserToLandlordService.getCurrentLandlordForUser()).thenReturn(OrganisationalLandlord())
+        whenever(
+            mockJourneyFactory.createJourneySteps(),
+        ).thenReturn(mapOf(OrgTypeStep.ROUTE_SEGMENT to mockStepLifecycleOrchestrator))
+        whenever(
+            mockStepLifecycleOrchestrator.getStepModelAndView(),
+        ).thenReturn(ModelAndView("placeholder", mapOf("title" to "placeholder")))
+
+        mvc
+            .get(updateOrgTypeRoute)
+            .andExpect {
+                status { isOk() }
+            }
+    }
+
+    @Test
+    fun `postUpdateStep returns a redirect for unauthenticated user`() {
+        mvc
+            .post(updateOrgTypeRoute) {
+                param("formData", "")
+                with(csrf())
+            }.andExpect {
+                status { is3xxRedirection() }
+            }
+    }
+
+    @Test
+    @WithMockUser
+    fun `postUpdateStep returns 403 for an unauthorised user`() {
+        mvc
+            .post(updateOrgTypeRoute) {
+                param("formData", "")
+                with(csrf())
+            }.andExpect {
+                status { isForbidden() }
+            }
+    }
+
+    @Test
+    @WithMockUser(roles = ["LANDLORD"], value = "user")
+    fun `postUpdateStep returns 403 for a non-organisation landlord`() {
+        whenever(mockUserToLandlordService.getCurrentLandlordForUser()).thenReturn(createIndividualLandlord())
+
+        mvc
+            .post(updateOrgTypeRoute) {
+                param("formData", "")
+                with(csrf())
+            }.andExpect {
+                status { isForbidden() }
+            }
+    }
+
+    @Test
+    @WithMockUser(roles = ["LANDLORD"], value = "user")
+    fun `postUpdateStep returns 200 for an organisation landlord`() {
+        whenever(mockUserToLandlordService.getCurrentLandlordForUser()).thenReturn(OrganisationalLandlord())
+        whenever(
+            mockJourneyFactory.createJourneySteps(),
+        ).thenReturn(mapOf(OrgTypeStep.ROUTE_SEGMENT to mockStepLifecycleOrchestrator))
+        whenever(
+            mockStepLifecycleOrchestrator.postStepModelAndView(any()),
+        ).thenReturn(ModelAndView("placeholder", mapOf("title" to "placeholder")))
+
+        mvc
+            .post(updateOrgTypeRoute) {
+                param("formData", "")
+                with(csrf())
+            }.andExpect {
+                status { isOk() }
+            }
+    }
+}

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/LandlordRegistrationJourneyTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/LandlordRegistrationJourneyTests.kt
@@ -58,6 +58,7 @@ import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.landlordReg
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.landlordRegistrationJourneyPages.OrgPhoneNumberFormPageLandlordRegistration
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.landlordRegistrationJourneyPages.OrgSelectAddressFormPageLandlordRegistration
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.landlordRegistrationJourneyPages.OrgTypeFormPageLandlordRegistration
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.landlordRegistrationJourneyPages.OrgTypeTrustInterruptionPageLandlordRegistration
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.landlordRegistrationJourneyPages.PhoneNumberFormPageLandlordRegistration
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.landlordRegistrationJourneyPages.PrivacyNoticePageLandlordRegistration
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.landlordRegistrationJourneyPages.SelectAddressFormPageLandlordRegistration
@@ -644,8 +645,77 @@ class LandlordRegistrationJourneyTests : IntegrationTestWithMutableData("data-mo
         assertPageIs(page, OrgNameFormPageLandlordRegistration::class)
     }
 
-    // TODO PDJB-1237: add a test for the organisation type change link once the org type update journey is wired into
-    //  LandlordRegistrationTask.checkYourAnswersJourneyMap (the OrgTypeStep.ROUTE_SEGMENT branch is currently empty).
+    @Test
+    fun `The organisation type change link returns to the org check answers page with the updated value`(page: Page) {
+        featureFlagManager.enable(ORGANISATION_LANDLORD_REGISTRATION)
+
+        val checkAnswersPage = navigator.skipToLandlordRegistrationOrgCheckAnswersPage()
+        checkAnswersPage.landlordDetails.organisationTypeRow.clickNamedActionLinkAndWait("Change")
+
+        val orgTypePage = assertPageIs(page, OrgTypeFormPageLandlordRegistration::class)
+        orgTypePage.selectCharity()
+        orgTypePage.selectTrust()
+        orgTypePage.form.submit()
+
+        val updatedCheckAnswersPage = assertPageIs(page, OrgCheckAnswersPageLandlordRegistration::class)
+        assertThat(updatedCheckAnswersPage.landlordDetails.organisationTypeRow).containsText("Charity")
+        assertThat(updatedCheckAnswersPage.landlordDetails.organisationTypeRow).containsText("Trust")
+    }
+
+    @Test
+    fun `The organisation type change link shows interruption pages when trust status changes`(page: Page) {
+        featureFlagManager.enable(ORGANISATION_LANDLORD_REGISTRATION)
+
+        var checkAnswersPage = navigator.skipToLandlordRegistrationOrgCheckAnswersPage()
+        checkAnswersPage.landlordDetails.organisationTypeRow.clickNamedActionLinkAndWait("Change")
+
+        var orgTypePage = assertPageIs(page, OrgTypeFormPageLandlordRegistration::class)
+        orgTypePage.selectCharity()
+        orgTypePage.form.submit()
+
+        var interruptionPage = assertPageIs(page, OrgTypeTrustInterruptionPageLandlordRegistration::class)
+        interruptionPage.submit()
+
+        checkAnswersPage = assertPageIs(page, OrgCheckAnswersPageLandlordRegistration::class)
+        assertThat(checkAnswersPage.landlordDetails.organisationTypeRow).containsText("Charity")
+        assertThat(checkAnswersPage.landlordDetails.organisationTypeRow).not().containsText("Trust")
+        assertThat(checkAnswersPage.leadTrusteeCard).hasCount(0)
+
+        checkAnswersPage.landlordDetails.organisationTypeRow.clickNamedActionLinkAndWait("Change")
+
+        orgTypePage = assertPageIs(page, OrgTypeFormPageLandlordRegistration::class)
+        orgTypePage.selectCharity()
+        orgTypePage.selectTrust()
+        orgTypePage.form.submit()
+
+        interruptionPage = assertPageIs(page, OrgTypeTrustInterruptionPageLandlordRegistration::class)
+        interruptionPage.submit()
+
+        val leadTrusteeNamePage = assertPageIs(page, LeadTrusteeNameFormPageLandlordRegistration::class)
+        leadTrusteeNamePage.submitName("Reassigned Lead Trustee")
+
+        val leadTrusteeDobPage = assertPageIs(page, LeadTrusteeDobFormPageLandlordRegistration::class)
+        leadTrusteeDobPage.submitDate("15", "6", "1980")
+
+        val leadTrusteeEmailPage = assertPageIs(page, LeadTrusteeEmailFormPageLandlordRegistration::class)
+        leadTrusteeEmailPage.submitEmail("reassigned.trustee@test.com")
+
+        val leadTrusteePhonePage = assertPageIs(page, LeadTrusteePhoneFormPageLandlordRegistration::class)
+        leadTrusteePhonePage.submitPhoneNumber("07123456789")
+
+        val leadTrusteeLookupAddressPage = assertPageIs(page, LeadTrusteeAddressFormPageLandlordRegistration::class)
+        leadTrusteeLookupAddressPage.submitPostcodeAndBuildingNameOrNumber("EG1 2AA", "1")
+
+        val leadTrusteeSelectAddressPage =
+            assertPageIs(page, LeadTrusteeSelectAddressFormPageLandlordRegistration::class)
+        leadTrusteeSelectAddressPage.selectAddressAndSubmit("1 PRSDB Square, EG1 2AA")
+
+        checkAnswersPage = assertPageIs(page, OrgCheckAnswersPageLandlordRegistration::class)
+        assertThat(checkAnswersPage.landlordDetails.organisationTypeRow).containsText("Charity")
+        assertThat(checkAnswersPage.landlordDetails.organisationTypeRow).containsText("Trust")
+        assertThat(checkAnswersPage.leadTrusteeCard).containsText("Reassigned Lead Trustee")
+        assertThat(checkAnswersPage.leadTrusteeCard).containsText("reassigned.trustee@test.com")
+    }
 
     // TODO PDJB-1238: add tests for the Companies House and company number change links once the companies update
     //  journey is wired into LandlordRegistrationTask.checkYourAnswersJourneyMap (the OrgIsRegisteredCompanyStep /

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/OrganisationLandlordUpdateJourneyTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/OrganisationLandlordUpdateJourneyTests.kt
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import uk.gov.communities.prsdb.webapp.constants.ORGANISATION_LANDLORD_REGISTRATION
+import uk.gov.communities.prsdb.webapp.controllers.LandlordDetailsController.Companion.ORGANISATION_CONTACTS_FRAGMENT
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.OrgLandlordDetailsPage
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages.BasePage.Companion.assertPageIs
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.updateLandlordDetailsPages.OrgNameFormPageUpdateLandlordDetails
@@ -18,6 +19,7 @@ import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.updateOrgan
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.updateOrganisationTypeJourneyPages.OrgTypeCyaPageUpdateOrganisationType
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.updateOrganisationTypeJourneyPages.OrgTypeFormPageUpdateOrganisationType
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.updateOrganisationTypeJourneyPages.OrgTypeTrustInterruptionPageUpdateOrganisationType
+import kotlin.test.assertEquals
 
 @WithOrgLandlordProfile
 class OrganisationLandlordUpdateJourneyTests : IntegrationTestWithMutableData("data-local.sql") {
@@ -139,6 +141,7 @@ class OrganisationLandlordUpdateJourneyTests : IntegrationTestWithMutableData("d
             cyaPage.submit()
 
             orgLandlordDetailsPage = assertPageIs(page, OrgLandlordDetailsPage::class)
+            assertEquals(ORGANISATION_CONTACTS_FRAGMENT, orgLandlordDetailsPage.tabs.activeTabPanelId)
             assertThat(orgLandlordDetailsPage.mainContent).containsText("Company")
             assertThat(orgLandlordDetailsPage.mainContent).not().containsText("Trust")
             assertThat(orgLandlordDetailsPage.mainContent).not().containsText("Existing Lead Trustee")

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/OrganisationLandlordUpdateJourneyTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/OrganisationLandlordUpdateJourneyTests.kt
@@ -3,11 +3,21 @@ package uk.gov.communities.prsdb.webapp.integration
 import com.microsoft.playwright.Page
 import com.microsoft.playwright.assertions.PlaywrightAssertions.assertThat
 import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import uk.gov.communities.prsdb.webapp.constants.ORGANISATION_LANDLORD_REGISTRATION
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.OrgLandlordDetailsPage
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages.BasePage.Companion.assertPageIs
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.updateLandlordDetailsPages.OrgNameFormPageUpdateLandlordDetails
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.updateOrganisationTypeJourneyPages.LeadTrusteeAddressFormPageUpdateOrganisationType
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.updateOrganisationTypeJourneyPages.LeadTrusteeDobFormPageUpdateOrganisationType
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.updateOrganisationTypeJourneyPages.LeadTrusteeEmailFormPageUpdateOrganisationType
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.updateOrganisationTypeJourneyPages.LeadTrusteeNameFormPageUpdateOrganisationType
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.updateOrganisationTypeJourneyPages.LeadTrusteePhoneFormPageUpdateOrganisationType
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.updateOrganisationTypeJourneyPages.LeadTrusteeSelectAddressFormPageUpdateOrganisationType
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.updateOrganisationTypeJourneyPages.OrgTypeCyaPageUpdateOrganisationType
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.updateOrganisationTypeJourneyPages.OrgTypeFormPageUpdateOrganisationType
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.updateOrganisationTypeJourneyPages.OrgTypeTrustInterruptionPageUpdateOrganisationType
 
 @WithOrgLandlordProfile
 class OrganisationLandlordUpdateJourneyTests : IntegrationTestWithMutableData("data-local.sql") {
@@ -44,5 +54,101 @@ class OrganisationLandlordUpdateJourneyTests : IntegrationTestWithMutableData("d
         val updateOrgNamePage = assertPageIs(page, OrgNameFormPageUpdateLandlordDetails::class)
         updateOrgNamePage.submitName("")
         assertThat(updateOrgNamePage.form.getErrorMessage()).containsText("Enter an organisation name")
+    }
+
+    @Test
+    fun `An organisation landlord can update organisation type when trust status is unchanged`(page: Page) {
+        var orgLandlordDetailsPage = navigator.goToOrgLandlordDetails()
+        orgLandlordDetailsPage.clickOrganisationTypeChangeLinkAndWait()
+
+        val orgTypePage = assertPageIs(page, OrgTypeFormPageUpdateOrganisationType::class)
+        orgTypePage.selectCharity()
+        orgTypePage.form.submit()
+
+        val cyaPage = assertPageIs(page, OrgTypeCyaPageUpdateOrganisationType::class)
+        cyaPage.submit()
+
+        orgLandlordDetailsPage = assertPageIs(page, OrgLandlordDetailsPage::class)
+        assertThat(orgLandlordDetailsPage.mainContent).containsText("Charity")
+        assertThat(orgLandlordDetailsPage.mainContent).not().containsText("Trust")
+    }
+
+    @Test
+    fun `An organisation landlord can add trust to their organisation type and provide lead trustee details`(page: Page) {
+        var orgLandlordDetailsPage = navigator.goToOrgLandlordDetails()
+        orgLandlordDetailsPage.clickOrganisationTypeChangeLinkAndWait()
+
+        val orgTypePage = assertPageIs(page, OrgTypeFormPageUpdateOrganisationType::class)
+        orgTypePage.selectCompany()
+        orgTypePage.selectTrust()
+        orgTypePage.form.submit()
+
+        val interruptionPage = assertPageIs(page, OrgTypeTrustInterruptionPageUpdateOrganisationType::class)
+        interruptionPage.submit()
+
+        val leadTrusteeNamePage = assertPageIs(page, LeadTrusteeNameFormPageUpdateOrganisationType::class)
+        leadTrusteeNamePage.submitName(LEAD_TRUSTEE_NAME)
+
+        val leadTrusteeDobPage = assertPageIs(page, LeadTrusteeDobFormPageUpdateOrganisationType::class)
+        leadTrusteeDobPage.submitDate("15", "6", "1980")
+
+        val leadTrusteeEmailPage = assertPageIs(page, LeadTrusteeEmailFormPageUpdateOrganisationType::class)
+        leadTrusteeEmailPage.submitEmail(LEAD_TRUSTEE_EMAIL)
+
+        val leadTrusteePhonePage = assertPageIs(page, LeadTrusteePhoneFormPageUpdateOrganisationType::class)
+        leadTrusteePhonePage.submitPhoneNumber(LEAD_TRUSTEE_PHONE)
+
+        val leadTrusteeLookupAddressPage = assertPageIs(page, LeadTrusteeAddressFormPageUpdateOrganisationType::class)
+        leadTrusteeLookupAddressPage.submitPostcodeAndBuildingNameOrNumber("EG1 2AA", "1")
+
+        val leadTrusteeSelectAddressPage = assertPageIs(page, LeadTrusteeSelectAddressFormPageUpdateOrganisationType::class)
+        leadTrusteeSelectAddressPage.selectAddressAndSubmit("1 PRSDB Square, EG1 2AA")
+
+        val cyaPage = assertPageIs(page, OrgTypeCyaPageUpdateOrganisationType::class)
+        cyaPage.submit()
+
+        orgLandlordDetailsPage = assertPageIs(page, OrgLandlordDetailsPage::class)
+        assertThat(orgLandlordDetailsPage.mainContent).containsText("Company")
+        assertThat(orgLandlordDetailsPage.mainContent).containsText("Trust")
+        assertThat(orgLandlordDetailsPage.mainContent).containsText(LEAD_TRUSTEE_NAME)
+        assertThat(orgLandlordDetailsPage.mainContent).containsText(LEAD_TRUSTEE_EMAIL)
+        assertThat(orgLandlordDetailsPage.mainContent).containsText(LEAD_TRUSTEE_PHONE)
+    }
+
+    @Nested
+    inner class RemovingTrustUpdates : NestedIntegrationTestWithMutableData("data-org-landlord-trust.sql") {
+        @BeforeEach
+        fun setup() {
+            featureFlagManager.enable(ORGANISATION_LANDLORD_REGISTRATION)
+        }
+
+        @Test
+        fun `An organisation landlord can remove trust from their organisation type without re-walking trustee details`(page: Page) {
+            var orgLandlordDetailsPage = navigator.goToOrgLandlordDetails()
+            orgLandlordDetailsPage.clickOrganisationTypeChangeLinkAndWait()
+
+            val orgTypePage = assertPageIs(page, OrgTypeFormPageUpdateOrganisationType::class)
+            orgTypePage.deselectTrust()
+            orgTypePage.selectCompany()
+            orgTypePage.form.submit()
+
+            val interruptionPage = assertPageIs(page, OrgTypeTrustInterruptionPageUpdateOrganisationType::class)
+            interruptionPage.submit()
+
+            val cyaPage = assertPageIs(page, OrgTypeCyaPageUpdateOrganisationType::class)
+            cyaPage.submit()
+
+            orgLandlordDetailsPage = assertPageIs(page, OrgLandlordDetailsPage::class)
+            assertThat(orgLandlordDetailsPage.mainContent).containsText("Company")
+            assertThat(orgLandlordDetailsPage.mainContent).not().containsText("Trust")
+            assertThat(orgLandlordDetailsPage.mainContent).not().containsText("Existing Lead Trustee")
+            assertThat(orgLandlordDetailsPage.mainContent).not().containsText("Lead trustee")
+        }
+    }
+
+    companion object {
+        private const val LEAD_TRUSTEE_NAME = "Test Lead Trustee Name"
+        private const val LEAD_TRUSTEE_EMAIL = "trustee@test.com"
+        private const val LEAD_TRUSTEE_PHONE = "07123456789"
     }
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/OrgLandlordDetailsPage.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/OrgLandlordDetailsPage.kt
@@ -4,11 +4,13 @@ import com.microsoft.playwright.Locator
 import com.microsoft.playwright.Page
 import uk.gov.communities.prsdb.webapp.controllers.LandlordDetailsController
 import uk.gov.communities.prsdb.webapp.controllers.UpdateOrganisationLandlordNameController.Companion.UPDATE_ORG_NAME_ROUTE
+import uk.gov.communities.prsdb.webapp.controllers.UpdateOrganisationTypeController.Companion.UPDATE_ORG_TYPE_ROUTE
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.Link
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.SummaryCard
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.SummaryList
 import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages.LandlordDetailsBasePage
 import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.OrgNameStep
+import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.OrgTypeStep
 
 class OrgLandlordDetailsPage(
     page: Page,
@@ -18,9 +20,14 @@ class OrgLandlordDetailsPage(
     val organisationDetailsPanel: Locator = page.locator("#organisation-details")
     val organisationContactsPanel: Locator = page.locator("#organisation-contacts")
     val mainContent: Locator = page.locator("main")
-    private val organisationNameChangeLink = Link(page.locator("a[href='$UPDATE_ORG_NAME_ROUTE/${OrgNameStep.ROUTE_SEGMENT}']"))
+    private val organisationNameChangeLink =
+        Link(page.locator("a[href='$UPDATE_ORG_NAME_ROUTE/${OrgNameStep.ROUTE_SEGMENT}']"))
+    private val organisationTypeChangeLink =
+        Link(page.locator("a[href='$UPDATE_ORG_TYPE_ROUTE/${OrgTypeStep.ROUTE_SEGMENT}']"))
 
     fun clickOrganisationNameChangeLinkAndWait() = organisationNameChangeLink.clickAndWait()
+
+    fun clickOrganisationTypeChangeLinkAndWait() = organisationTypeChangeLink.clickAndWait()
 
     val mainContactCard = MainContactSummaryCard(page)
     val leadTrusteeCard = LeadTrusteeSummaryCard(page)

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/basePages/InterruptionPage.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/basePages/InterruptionPage.kt
@@ -1,0 +1,13 @@
+package uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages
+
+import com.microsoft.playwright.Page
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.PostForm
+
+abstract class InterruptionPage(
+    page: Page,
+    urlSegment: String,
+) : BasePage(page, urlSegment) {
+    val form = PostForm(page)
+
+    fun submit() = form.submit()
+}

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/basePages/OrgTypeFormPage.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/basePages/OrgTypeFormPage.kt
@@ -1,0 +1,29 @@
+package uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages
+
+import com.microsoft.playwright.Page
+import uk.gov.communities.prsdb.webapp.constants.enums.OrgType
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.Checkboxes
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.FormWithSectionHeader
+
+abstract class OrgTypeFormPage(
+    page: Page,
+    urlSegment: String,
+) : BasePage(page, urlSegment) {
+    val form = OrgTypeForm(page)
+
+    fun selectCompany() = form.orgTypeCheckboxes.checkCheckbox(OrgType.COMPANY.toString())
+
+    fun selectCharity() = form.orgTypeCheckboxes.checkCheckbox(OrgType.CHARITY.toString())
+
+    fun selectTrust() = form.orgTypeCheckboxes.checkCheckbox(OrgType.TRUST.toString())
+
+    fun deselectTrust() = form.orgTypeCheckboxes.getCheckbox(OrgType.TRUST.toString()).uncheck()
+
+    fun selectNoneOfThese() = form.orgTypeCheckboxes.checkCheckbox(OrgType.NONE.toString())
+
+    class OrgTypeForm(
+        page: Page,
+    ) : FormWithSectionHeader(page) {
+        val orgTypeCheckboxes = Checkboxes(locator)
+    }
+}

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/landlordRegistrationJourneyPages/LeadTrusteeNameFormPageLandlordRegistration.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/landlordRegistrationJourneyPages/LeadTrusteeNameFormPageLandlordRegistration.kt
@@ -2,24 +2,9 @@ package uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.landlordRe
 
 import com.microsoft.playwright.Page
 import uk.gov.communities.prsdb.webapp.controllers.RegisterLandlordController.Companion.LANDLORD_REGISTRATION_ROUTE
-import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.PostForm
-import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.TextInput
-import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages.BasePage
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages.TextFormPage
 import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.LeadTrusteeNameStep
 
 class LeadTrusteeNameFormPageLandlordRegistration(
     page: Page,
-) : BasePage(page, "$LANDLORD_REGISTRATION_ROUTE/${LeadTrusteeNameStep.ROUTE_SEGMENT}") {
-    val form = LeadTrusteeNameForm(page)
-
-    fun submitName(name: String) {
-        form.trusteeNameInput.fill(name)
-        form.submit()
-    }
-
-    class LeadTrusteeNameForm(
-        page: Page,
-    ) : PostForm(page) {
-        val trusteeNameInput = TextInput.textByFieldName(locator, "name")
-    }
-}
+) : TextFormPage(page, "$LANDLORD_REGISTRATION_ROUTE/${LeadTrusteeNameStep.ROUTE_SEGMENT}")

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/landlordRegistrationJourneyPages/OrgTypeFormPageLandlordRegistration.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/landlordRegistrationJourneyPages/OrgTypeFormPageLandlordRegistration.kt
@@ -1,27 +1,10 @@
 package uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.landlordRegistrationJourneyPages
 
 import com.microsoft.playwright.Page
-import uk.gov.communities.prsdb.webapp.constants.enums.OrgType
 import uk.gov.communities.prsdb.webapp.controllers.RegisterLandlordController.Companion.LANDLORD_REGISTRATION_ROUTE
-import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.Checkboxes
-import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.FormWithSectionHeader
-import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages.BasePage
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages.OrgTypeFormPage
 import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.OrgTypeStep
 
 class OrgTypeFormPageLandlordRegistration(
     page: Page,
-) : BasePage(page, "$LANDLORD_REGISTRATION_ROUTE/${OrgTypeStep.ROUTE_SEGMENT}") {
-    val form = OrgTypeForm(page)
-
-    fun selectCompany() = form.orgTypeCheckboxes.checkCheckbox(OrgType.COMPANY.toString())
-
-    fun selectTrust() = form.orgTypeCheckboxes.checkCheckbox(OrgType.TRUST.toString())
-
-    fun selectNoneOfThese() = form.orgTypeCheckboxes.checkCheckbox(OrgType.NONE.toString())
-
-    class OrgTypeForm(
-        page: Page,
-    ) : FormWithSectionHeader(page) {
-        val orgTypeCheckboxes = Checkboxes(locator)
-    }
-}
+) : OrgTypeFormPage(page, "$LANDLORD_REGISTRATION_ROUTE/${OrgTypeStep.ROUTE_SEGMENT}")

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/landlordRegistrationJourneyPages/OrgTypeTrustInterruptionPageLandlordRegistration.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/landlordRegistrationJourneyPages/OrgTypeTrustInterruptionPageLandlordRegistration.kt
@@ -1,0 +1,10 @@
+package uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.landlordRegistrationJourneyPages
+
+import com.microsoft.playwright.Page
+import uk.gov.communities.prsdb.webapp.controllers.RegisterLandlordController.Companion.LANDLORD_REGISTRATION_ROUTE
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages.InterruptionPage
+import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.update.organisationType.OrgTypeTrustInterruptionStep
+
+class OrgTypeTrustInterruptionPageLandlordRegistration(
+    page: Page,
+) : InterruptionPage(page, "$LANDLORD_REGISTRATION_ROUTE/${OrgTypeTrustInterruptionStep.ROUTE_SEGMENT}")

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/updateOrganisationTypeJourneyPages/LeadTrusteeAddressFormPageUpdateOrganisationType.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/updateOrganisationTypeJourneyPages/LeadTrusteeAddressFormPageUpdateOrganisationType.kt
@@ -1,0 +1,14 @@
+package uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.updateOrganisationTypeJourneyPages
+
+import com.microsoft.playwright.Page
+import uk.gov.communities.prsdb.webapp.controllers.UpdateOrganisationTypeController.Companion.UPDATE_ORG_TYPE_ROUTE
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages.LookupAddressFormPage
+import uk.gov.communities.prsdb.webapp.journeys.shared.stepConfig.LookupAddressStep
+import uk.gov.communities.prsdb.webapp.journeys.shared.tasks.TrusteeAddressTask
+
+class LeadTrusteeAddressFormPageUpdateOrganisationType(
+    page: Page,
+) : LookupAddressFormPage(
+        page,
+        "$UPDATE_ORG_TYPE_ROUTE/${TrusteeAddressTask.ROUTE_SEGMENT}/${LookupAddressStep.ROUTE_SEGMENT}",
+    )

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/updateOrganisationTypeJourneyPages/LeadTrusteeDobFormPageUpdateOrganisationType.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/updateOrganisationTypeJourneyPages/LeadTrusteeDobFormPageUpdateOrganisationType.kt
@@ -1,0 +1,10 @@
+package uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.updateOrganisationTypeJourneyPages
+
+import com.microsoft.playwright.Page
+import uk.gov.communities.prsdb.webapp.controllers.UpdateOrganisationTypeController.Companion.UPDATE_ORG_TYPE_ROUTE
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages.DateFormPage
+import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.LeadTrusteeDobStep
+
+class LeadTrusteeDobFormPageUpdateOrganisationType(
+    page: Page,
+) : DateFormPage(page, "$UPDATE_ORG_TYPE_ROUTE/${LeadTrusteeDobStep.ROUTE_SEGMENT}")

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/updateOrganisationTypeJourneyPages/LeadTrusteeEmailFormPageUpdateOrganisationType.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/updateOrganisationTypeJourneyPages/LeadTrusteeEmailFormPageUpdateOrganisationType.kt
@@ -1,0 +1,10 @@
+package uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.updateOrganisationTypeJourneyPages
+
+import com.microsoft.playwright.Page
+import uk.gov.communities.prsdb.webapp.controllers.UpdateOrganisationTypeController.Companion.UPDATE_ORG_TYPE_ROUTE
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages.EmailFormPage
+import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.LeadTrusteeEmailStep
+
+class LeadTrusteeEmailFormPageUpdateOrganisationType(
+    page: Page,
+) : EmailFormPage(page, "$UPDATE_ORG_TYPE_ROUTE/${LeadTrusteeEmailStep.ROUTE_SEGMENT}")

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/updateOrganisationTypeJourneyPages/LeadTrusteeNameFormPageUpdateOrganisationType.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/updateOrganisationTypeJourneyPages/LeadTrusteeNameFormPageUpdateOrganisationType.kt
@@ -1,0 +1,10 @@
+package uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.updateOrganisationTypeJourneyPages
+
+import com.microsoft.playwright.Page
+import uk.gov.communities.prsdb.webapp.controllers.UpdateOrganisationTypeController.Companion.UPDATE_ORG_TYPE_ROUTE
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages.TextFormPage
+import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.LeadTrusteeNameStep
+
+class LeadTrusteeNameFormPageUpdateOrganisationType(
+    page: Page,
+) : TextFormPage(page, "$UPDATE_ORG_TYPE_ROUTE/${LeadTrusteeNameStep.ROUTE_SEGMENT}")

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/updateOrganisationTypeJourneyPages/LeadTrusteePhoneFormPageUpdateOrganisationType.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/updateOrganisationTypeJourneyPages/LeadTrusteePhoneFormPageUpdateOrganisationType.kt
@@ -1,0 +1,10 @@
+package uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.updateOrganisationTypeJourneyPages
+
+import com.microsoft.playwright.Page
+import uk.gov.communities.prsdb.webapp.controllers.UpdateOrganisationTypeController.Companion.UPDATE_ORG_TYPE_ROUTE
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages.PhoneNumberFormPage
+import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.LeadTrusteePhoneStep
+
+class LeadTrusteePhoneFormPageUpdateOrganisationType(
+    page: Page,
+) : PhoneNumberFormPage(page, "$UPDATE_ORG_TYPE_ROUTE/${LeadTrusteePhoneStep.ROUTE_SEGMENT}")

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/updateOrganisationTypeJourneyPages/LeadTrusteeSelectAddressFormPageUpdateOrganisationType.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/updateOrganisationTypeJourneyPages/LeadTrusteeSelectAddressFormPageUpdateOrganisationType.kt
@@ -1,0 +1,14 @@
+package uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.updateOrganisationTypeJourneyPages
+
+import com.microsoft.playwright.Page
+import uk.gov.communities.prsdb.webapp.controllers.UpdateOrganisationTypeController.Companion.UPDATE_ORG_TYPE_ROUTE
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages.SelectAddressFormPage
+import uk.gov.communities.prsdb.webapp.journeys.shared.stepConfig.SelectAddressStep
+import uk.gov.communities.prsdb.webapp.journeys.shared.tasks.TrusteeAddressTask
+
+class LeadTrusteeSelectAddressFormPageUpdateOrganisationType(
+    page: Page,
+) : SelectAddressFormPage(
+        page,
+        "$UPDATE_ORG_TYPE_ROUTE/${TrusteeAddressTask.ROUTE_SEGMENT}/${SelectAddressStep.ROUTE_SEGMENT}",
+    )

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/updateOrganisationTypeJourneyPages/OrgTypeCyaPageUpdateOrganisationType.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/updateOrganisationTypeJourneyPages/OrgTypeCyaPageUpdateOrganisationType.kt
@@ -1,0 +1,15 @@
+package uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.updateOrganisationTypeJourneyPages
+
+import com.microsoft.playwright.Page
+import uk.gov.communities.prsdb.webapp.controllers.UpdateOrganisationTypeController.Companion.UPDATE_ORG_TYPE_ROUTE
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.PostForm
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages.BasePage
+import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.update.organisationType.OrgTypeCyaStep
+
+class OrgTypeCyaPageUpdateOrganisationType(
+    page: Page,
+) : BasePage(page, "$UPDATE_ORG_TYPE_ROUTE/${OrgTypeCyaStep.ROUTE_SEGMENT}") {
+    val form = PostForm(page)
+
+    fun submit() = form.submit()
+}

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/updateOrganisationTypeJourneyPages/OrgTypeFormPageUpdateOrganisationType.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/updateOrganisationTypeJourneyPages/OrgTypeFormPageUpdateOrganisationType.kt
@@ -1,0 +1,10 @@
+package uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.updateOrganisationTypeJourneyPages
+
+import com.microsoft.playwright.Page
+import uk.gov.communities.prsdb.webapp.controllers.UpdateOrganisationTypeController.Companion.UPDATE_ORG_TYPE_ROUTE
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages.OrgTypeFormPage
+import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.OrgTypeStep
+
+class OrgTypeFormPageUpdateOrganisationType(
+    page: Page,
+) : OrgTypeFormPage(page, "$UPDATE_ORG_TYPE_ROUTE/${OrgTypeStep.ROUTE_SEGMENT}")

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/updateOrganisationTypeJourneyPages/OrgTypeTrustInterruptionPageUpdateOrganisationType.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/updateOrganisationTypeJourneyPages/OrgTypeTrustInterruptionPageUpdateOrganisationType.kt
@@ -2,14 +2,9 @@ package uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.updateOrga
 
 import com.microsoft.playwright.Page
 import uk.gov.communities.prsdb.webapp.controllers.UpdateOrganisationTypeController.Companion.UPDATE_ORG_TYPE_ROUTE
-import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.PostForm
-import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages.BasePage
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages.InterruptionPage
 import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.update.organisationType.OrgTypeTrustInterruptionStep
 
 class OrgTypeTrustInterruptionPageUpdateOrganisationType(
     page: Page,
-) : BasePage(page, "$UPDATE_ORG_TYPE_ROUTE/${OrgTypeTrustInterruptionStep.ROUTE_SEGMENT}") {
-    val form = PostForm(page)
-
-    fun submit() = form.submit()
-}
+) : InterruptionPage(page, "$UPDATE_ORG_TYPE_ROUTE/${OrgTypeTrustInterruptionStep.ROUTE_SEGMENT}")

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/updateOrganisationTypeJourneyPages/OrgTypeTrustInterruptionPageUpdateOrganisationType.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/pageObjects/pages/updateOrganisationTypeJourneyPages/OrgTypeTrustInterruptionPageUpdateOrganisationType.kt
@@ -1,0 +1,15 @@
+package uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.updateOrganisationTypeJourneyPages
+
+import com.microsoft.playwright.Page
+import uk.gov.communities.prsdb.webapp.controllers.UpdateOrganisationTypeController.Companion.UPDATE_ORG_TYPE_ROUTE
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.components.PostForm
+import uk.gov.communities.prsdb.webapp.integration.pageObjects.pages.basePages.BasePage
+import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.update.organisationType.OrgTypeTrustInterruptionStep
+
+class OrgTypeTrustInterruptionPageUpdateOrganisationType(
+    page: Page,
+) : BasePage(page, "$UPDATE_ORG_TYPE_ROUTE/${OrgTypeTrustInterruptionStep.ROUTE_SEGMENT}") {
+    val form = PostForm(page)
+
+    fun submit() = form.submit()
+}

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/landlordRegistration/update/organisationType/OrgTypeUpdateRoutingStepConfigTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/landlordRegistration/update/organisationType/OrgTypeUpdateRoutingStepConfigTests.kt
@@ -1,0 +1,76 @@
+package uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.update.organisationType
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.OrgTypeMode
+import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.OrgTypeStep
+
+class OrgTypeUpdateRoutingStepConfigTests {
+    @Nested
+    inner class ModeTests {
+        @Test
+        fun `mode returns TRUST_UNCHANGED when previous is trust and new includes trust`() {
+            val result =
+                OrgTypeUpdateRoutingStepConfig().mode(
+                    stateWith(previousOrgTypeMode = OrgTypeMode.INCLUDES_TRUST, newOrgTypeMode = OrgTypeMode.INCLUDES_TRUST),
+                )
+
+            assertEquals(OrgTypeUpdateRouteMode.TRUST_UNCHANGED, result)
+        }
+
+        @Test
+        fun `mode returns TRUST_UNCHANGED when previous is not trust and new excludes trust`() {
+            val result =
+                OrgTypeUpdateRoutingStepConfig().mode(
+                    stateWith(previousOrgTypeMode = OrgTypeMode.EXCLUDES_TRUST, newOrgTypeMode = OrgTypeMode.EXCLUDES_TRUST),
+                )
+
+            assertEquals(OrgTypeUpdateRouteMode.TRUST_UNCHANGED, result)
+        }
+
+        @Test
+        fun `mode returns ADDING_TRUST when previous is not trust and new includes trust`() {
+            val result =
+                OrgTypeUpdateRoutingStepConfig().mode(
+                    stateWith(previousOrgTypeMode = OrgTypeMode.EXCLUDES_TRUST, newOrgTypeMode = OrgTypeMode.INCLUDES_TRUST),
+                )
+
+            assertEquals(OrgTypeUpdateRouteMode.ADDING_TRUST, result)
+        }
+
+        @Test
+        fun `mode returns REMOVING_TRUST when previous is trust and new excludes trust`() {
+            val result =
+                OrgTypeUpdateRoutingStepConfig().mode(
+                    stateWith(previousOrgTypeMode = OrgTypeMode.INCLUDES_TRUST, newOrgTypeMode = OrgTypeMode.EXCLUDES_TRUST),
+                )
+
+            assertEquals(OrgTypeUpdateRouteMode.REMOVING_TRUST, result)
+        }
+
+        @Test
+        fun `mode returns null when new org type mode is null`() {
+            val result =
+                OrgTypeUpdateRoutingStepConfig().mode(
+                    stateWith(previousOrgTypeMode = OrgTypeMode.INCLUDES_TRUST, newOrgTypeMode = null),
+                )
+
+            assertNull(result)
+        }
+    }
+
+    private fun stateWith(
+        previousOrgTypeMode: OrgTypeMode,
+        newOrgTypeMode: OrgTypeMode?,
+    ): OrgTypeUpdateState {
+        val mockOrgTypeStep = mock<OrgTypeStep> { on { outcome } doReturn newOrgTypeMode }
+        return mock<OrgTypeUpdateState> {
+            on { this.previousOrgTypeMode } doReturn previousOrgTypeMode
+            on { orgTypeStep } doReturn mockOrgTypeStep
+        }
+    }
+}

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/landlordRegistration/update/organisationType/OrgTypeUpdateRoutingStepConfigTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/journeys/landlordRegistration/update/organisationType/OrgTypeUpdateRoutingStepConfigTests.kt
@@ -1,76 +1,105 @@
 package uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.update.organisationType
 
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
+import uk.gov.communities.prsdb.webapp.constants.enums.OrgType
 import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.OrgTypeMode
 import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.OrgTypeStep
+import uk.gov.communities.prsdb.webapp.journeys.landlordRegistration.stepConfig.OrgTypeStepConfig
+import uk.gov.communities.prsdb.webapp.journeys.shared.states.CheckYourAnswersJourneyState
+import uk.gov.communities.prsdb.webapp.models.requestModels.formModels.OrgTypeFormModel
 
 class OrgTypeUpdateRoutingStepConfigTests {
     @Nested
     inner class ModeTests {
         @Test
         fun `mode returns TRUST_UNCHANGED when previous is trust and new includes trust`() {
-            val result =
-                OrgTypeUpdateRoutingStepConfig().mode(
-                    stateWith(previousOrgTypeMode = OrgTypeMode.INCLUDES_TRUST, newOrgTypeMode = OrgTypeMode.INCLUDES_TRUST),
-                )
+            val result = configuredConfig(true).mode(stateWith(OrgTypeMode.INCLUDES_TRUST))
 
             assertEquals(OrgTypeUpdateRouteMode.TRUST_UNCHANGED, result)
         }
 
         @Test
         fun `mode returns TRUST_UNCHANGED when previous is not trust and new excludes trust`() {
-            val result =
-                OrgTypeUpdateRoutingStepConfig().mode(
-                    stateWith(previousOrgTypeMode = OrgTypeMode.EXCLUDES_TRUST, newOrgTypeMode = OrgTypeMode.EXCLUDES_TRUST),
-                )
+            val result = configuredConfig(false).mode(stateWith(OrgTypeMode.EXCLUDES_TRUST))
 
             assertEquals(OrgTypeUpdateRouteMode.TRUST_UNCHANGED, result)
         }
 
         @Test
         fun `mode returns ADDING_TRUST when previous is not trust and new includes trust`() {
-            val result =
-                OrgTypeUpdateRoutingStepConfig().mode(
-                    stateWith(previousOrgTypeMode = OrgTypeMode.EXCLUDES_TRUST, newOrgTypeMode = OrgTypeMode.INCLUDES_TRUST),
-                )
+            val result = configuredConfig(false).mode(stateWith(OrgTypeMode.INCLUDES_TRUST))
 
             assertEquals(OrgTypeUpdateRouteMode.ADDING_TRUST, result)
         }
 
         @Test
         fun `mode returns REMOVING_TRUST when previous is trust and new excludes trust`() {
-            val result =
-                OrgTypeUpdateRoutingStepConfig().mode(
-                    stateWith(previousOrgTypeMode = OrgTypeMode.INCLUDES_TRUST, newOrgTypeMode = OrgTypeMode.EXCLUDES_TRUST),
-                )
+            val result = configuredConfig(true).mode(stateWith(OrgTypeMode.EXCLUDES_TRUST))
 
             assertEquals(OrgTypeUpdateRouteMode.REMOVING_TRUST, result)
         }
 
         @Test
-        fun `mode returns null when new org type mode is null`() {
-            val result =
-                OrgTypeUpdateRoutingStepConfig().mode(
-                    stateWith(previousOrgTypeMode = OrgTypeMode.INCLUDES_TRUST, newOrgTypeMode = null),
-                )
+        fun `mode returns null without reading previous trust status when new org type mode is null`() {
+            var previousIsTrustWasRead = false
+            val config =
+                OrgTypeUpdateRoutingStepConfig().apply {
+                    usingPreviousIsTrust {
+                        previousIsTrustWasRead = true
+                        true
+                    }
+                }
+
+            val result = config.mode(stateWith(null))
 
             assertNull(result)
+            assertFalse(previousIsTrustWasRead)
         }
     }
 
-    private fun stateWith(
-        previousOrgTypeMode: OrgTypeMode,
-        newOrgTypeMode: OrgTypeMode?,
-    ): OrgTypeUpdateState {
-        val mockOrgTypeStep = mock<OrgTypeStep> { on { outcome } doReturn newOrgTypeMode }
-        return mock<OrgTypeUpdateState> {
-            on { this.previousOrgTypeMode } doReturn previousOrgTypeMode
-            on { orgTypeStep } doReturn mockOrgTypeStep
+    @Nested
+    inner class PreviousTrustStatusTests {
+        @Test
+        fun `base journey lookup returns true when original organisation type includes trust`() {
+            val result = getPreviousIsTrustFromBaseJourney(listOf(OrgType.COMPANY, OrgType.TRUST))
+
+            assertTrue(result)
         }
+
+        @Test
+        fun `base journey lookup returns false when original organisation type excludes trust`() {
+            val result = getPreviousIsTrustFromBaseJourney(listOf(OrgType.CHARITY))
+
+            assertFalse(result)
+        }
+    }
+
+    private fun configuredConfig(previousIsTrust: Boolean) =
+        OrgTypeUpdateRoutingStepConfig().apply {
+            usingPreviousIsTrust { previousIsTrust }
+        }
+
+    private fun stateWith(newOrgTypeMode: OrgTypeMode?): OrgTypeUpdateState {
+        val orgTypeStep = mock<OrgTypeStep> { on { outcome } doReturn newOrgTypeMode }
+        return mock<OrgTypeUpdateState> { on { this.orgTypeStep } doReturn orgTypeStep }
+    }
+
+    private fun getPreviousIsTrustFromBaseJourney(selectedOrgTypes: List<OrgType>): Boolean {
+        val baseState = mock<CheckYourAnswersJourneyState>()
+        val childState = mock<CheckYourAnswersJourneyState> { on { getBaseJourneyState() } doReturn baseState }
+        val formModel = mock<OrgTypeFormModel> { on { getSelectedOrgTypes() } doReturn selectedOrgTypes }
+        val stepConfig = mock<OrgTypeStepConfig> { on { getFormModelFromState(baseState) } doReturn formModel }
+
+        return OrgTypeUpdateRoutingStepConfig().getPreviousIsTrustFromBaseJourney(
+            childState,
+            OrgTypeStep(stepConfig),
+        )
     }
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/LandlordServiceTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/services/LandlordServiceTests.kt
@@ -46,6 +46,7 @@ import uk.gov.communities.prsdb.webapp.models.viewModels.searchResultModels.Land
 import uk.gov.communities.prsdb.webapp.testHelpers.mockObjects.MockLandlordData.Companion.createAddress
 import uk.gov.communities.prsdb.webapp.testHelpers.mockObjects.MockLandlordData.Companion.createIndividualLandlord
 import uk.gov.communities.prsdb.webapp.testHelpers.mockObjects.MockLandlordData.Companion.createLandlordSearchResultDataModel
+import uk.gov.communities.prsdb.webapp.testHelpers.mockObjects.MockLandlordData.Companion.createOrgLandlord
 import java.net.URI
 import java.time.LocalDate
 import java.util.Optional
@@ -707,6 +708,29 @@ class LandlordServiceTests {
     @Test
     fun `updateOrganisationLandlordName is annotated with @Transactional`() {
         assertTrue(landlordService::updateOrganisationLandlordName.hasAnnotation<Transactional>())
+    }
+
+    @Test
+    fun `updateOrganisationLandlordType sends a confirmation email`() {
+        val orgLandlord = createOrgLandlord()
+        whenever(mockUserToLandlordService.getCurrentOrganisationLandlordForUser()).thenReturn(orgLandlord)
+        val dashboardUrl = URI("example.com/landlord-dashboard")
+        whenever(absoluteUrlProvider.buildLandlordDashboardUri()).thenReturn(dashboardUrl)
+
+        landlordService.updateOrganisationLandlordType(isCompany = false, isCharity = false, isTrust = false)
+
+        val expectedEmailModel =
+            LandlordUpdateConfirmation(
+                RegistrationNumberDataModel.fromRegistrationNumber(orgLandlord.registrationNumber).toString(),
+                dashboardUrl,
+                "organisation type and lead trustee details",
+            )
+        verify(updateConfirmationSender).sendEmail(eq(orgLandlord.email), eq(expectedEmailModel))
+    }
+
+    @Test
+    fun `updateOrganisationLandlordType is annotated with @Transactional`() {
+        assertTrue(landlordService::updateOrganisationLandlordType.hasAnnotation<Transactional>())
     }
 
     companion object {

--- a/src/test/resources/data-org-landlord-trust.sql
+++ b/src/test/resources/data-org-landlord-trust.sql
@@ -1,0 +1,34 @@
+INSERT INTO prsdb_user (id, created_date)
+VALUES ('urn:fdc:gov.uk:2022:ORG01', '2026-07-23');
+
+INSERT INTO registration_number (id, created_date, number, type)
+VALUES (1, '2026-07-23', 2001001999, 1);
+
+SELECT setval(pg_get_serial_sequence('registration_number', 'id'), (SELECT MAX(id) FROM registration_number));
+
+INSERT INTO address (id, created_date, last_modified_date, uprn, single_line_address, local_council_id, postcode)
+VALUES (1, '2026-07-23', '2026-07-23', 1, '1 PRSDB Square, EG1 2AA', 2, 'EG1 2AA'),
+       (2, '2026-07-23', '2026-07-23', 2, '2 PRSDB Square, EG1 2AA', 2, 'EG1 2AA');
+
+SELECT setval(pg_get_serial_sequence('address', 'id'), (SELECT MAX(id) FROM address));
+
+INSERT INTO landlord (id, created_date, last_modified_date, registration_number_id, landlord_type,
+                      organisation_landlord_name, organisation_address_id, organisation_email,
+                      organisation_phone_number, organisation_registrant_name,
+                      organisation_registrant_date_of_birth, organisation_registrant_email,
+                      organisation_registrant_phone_number, organisation_is_company,
+                      organisation_is_charity, organisation_is_trust, organisation_company_number,
+                      organisation_lead_trustee_name, organisation_lead_trustee_date_of_birth,
+                      organisation_lead_trustee_email, organisation_lead_trustee_phone,
+                      organisation_lead_trustee_address_id, organisation_main_contact_name,
+                      organisation_main_contact_email, organisation_main_contact_phone)
+VALUES (1, '2026-07-23', '2026-07-23', 1, 1, 'Local Organisation Landlord', 1,
+        'local-trust-org-landlord@example.com', '07111111111', 'Local Registrant', '1990-01-01',
+        'local-registrant@example.com', '07111111112', false, false, true, null,
+        'Existing Lead Trustee', '1980-06-15', 'existing-trustee@example.com', '07123456789', 2,
+        'Local Main Contact', 'local-main-contact@example.com', '07111111113');
+
+SELECT setval(pg_get_serial_sequence('landlord', 'id'), (SELECT MAX(id) FROM landlord));
+
+INSERT INTO organisational_landlord_user (organisation_landlord_id, subject_identifier, name, email, created_date)
+VALUES (1, 'urn:fdc:gov.uk:2022:ORG01', 'Local Registrant', 'local-registrant@example.com', '2026-07-23');


### PR DESCRIPTION
## Ticket number

PDJB-1237

## Goal of change

allow for org type & if needed, lead trustee to be updated

## Description of main change(s)

adds a new controller & journey

updates the TODO in the existing CYA page for org type update

adds a shared state interface to allow for some sharing of common state between these two objects

uses step initialisation to allow for the steps to know whether this answer is a changed from the previous or not

adds tests

adds some common base page test files for pages reused between the landlord reg & update journeys

## Anything you'd like to highlight to the reviewer?

are we happy with the way the two journeys are set up?

## Checklist

Delete any that are not applicable, and add explanation below for any that are applicable but haven't been done

- [x] Unit tests for new logic (e.g. new service methods) have been added
- [x] Controller tests for any new endpoints, including testing the relevant permissions
- [x] A new journey integration test has been added for any new journeys
- [x] Test suite has been run in full locally and is passing
- [x] Branch has been rebased onto main and run locally, with everything working as expected (both for your new feature
  and any related functionality)
- [x] TODO comments referencing this JIRA ticket have been searched for and removed - if a future PR will address them,
  mention that here
- [x] QA instructions have been added to the ticket (particularly if this is the last PR required to complete the ticket)
- [x] This feature is behind a feature flag. I've checked that there will be no change in function if the feature flag is disabled
