### PR TITLE
PDJB-NONE: Report deploy pipeline status when an earlier job fails

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -150,10 +150,10 @@ jobs:
 
   report-pipeline-status:
     runs-on: ubuntu-latest
-    needs: update-ecs-service
+    needs: [build-and-deploy, update-task-definition, migrate-database, update-ecs-service]
+    if: always()
     steps:
       - name: Report pipeline status
-        if: always()
         id: slack
         uses: slackapi/slack-github-action@v1.26.0
         with:
@@ -161,7 +161,7 @@ jobs:
             {
               "environment": "${{ (inputs.environment == 'integration') && 'Integration' || (inputs.environment == 'production') && 'Production' || (inputs.environment == 'test') && 'Test' || inputs.environment }}",
               "commit": ${{ toJson(github.event.head_commit.message) }},
-              "result": "${{ (needs.update-ecs-service.result == 'success' || needs.update-ecs-service.result == 'skipped') && 'Success :tick:' || 'Failure :no-cross:' }}",
+              "result": "${{ (!contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') && !contains(needs.*.result, 'skipped')) && 'Success :tick:' || 'Failure :no-cross:' }}",
               "url": "${{ format('https://github.com/communitiesuk/prsdb-webapp/actions/runs/{0}', github.run_id) }}"
             }
         env:


### PR DESCRIPTION
## Ticket number

PDJB-NONE

## Goal of change

The Slack pipeline status report does not fire when a deploy fails, which is exactly when it is needed.

## Description of main change(s)

- Moves `always()` from the reporting step up to the `report-pipeline-status` job. At job level GitHub applies an implicit `if: success()`, so a failure anywhere upstream skipped the whole job before its step condition was ever evaluated.
- Makes the job depend on every upstream job rather than just `update-ecs-service`, so failures in the build, task definition update, or database migration are visible to the report.
- Treats `skipped` as a failure rather than a success. No job in this workflow is conditional, so a skip only ever means an upstream job failed.

## Anything you'd like to highlight to the reviewer?

Seen on [run 31175018530](https://github.com/communitiesuk/prsdb-webapp/actions/runs/31175018530), where an amended migration failed `Run database migration`, `Update ECS service` was skipped, and no Slack message was sent.

Fixing only the `always()` placement would have made things worse: the old expression scored `skipped` as success, so that run would have reported a green deploy. Both changes are needed together.

## Checklist

- [x] Branch has been rebased onto main and run locally, with everything working as expected (both for your new feature
  and any related functionality)
