### PR TITLE
PDJB-1277: Show organisation landlords on local council property Landlords tab

### DIFF
--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/summaryModels/PropertyDetailsLandlordViewModelBuilder.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/summaryModels/PropertyDetailsLandlordViewModelBuilder.kt
@@ -91,6 +91,15 @@ class PropertyDetailsLandlordViewModelBuilder {
                             SummaryCardViewModel(
                                 title = landlord.name,
                                 summaryList = buildLocalCouncilOrgCardRows(landlord),
+                                actions =
+                                    listOf(
+                                        // TODO: PDJB-1432: Link this to the landlord record for an org landlord
+                                        SummaryCardActionViewModel(
+                                            text = "propertyDetails.landlordDetails.registeredLandlords.viewLandlordRecord",
+                                            url = landlordDetailsUrlProvider(landlord),
+                                            opensInNewTab = true,
+                                        ),
+                                    ),
                             )
 
                         else -> throw IllegalArgumentException("Unknown landlord type")

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/summaryModels/PropertyDetailsLandlordViewModelBuilder.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/summaryModels/PropertyDetailsLandlordViewModelBuilder.kt
@@ -70,25 +70,44 @@ class PropertyDetailsLandlordViewModelBuilder {
             landlordDetailsUrlProvider: (Landlord) -> String,
         ): List<SummaryCardViewModel> =
             landlords
-                // TODO: PDJB-1277: Update landlord tab local authority view for org landlords
+                .sortedBy { it.name }
                 .map { landlord ->
-                    check(landlord is IndividualLandlord)
-                    landlord
-                }.sortedBy { it.name }
-                .map { landlord ->
-                    SummaryCardViewModel(
-                        title = landlord.name,
-                        summaryList = buildLocalCouncilCardRows(landlord),
-                        actions =
-                            listOf(
-                                SummaryCardActionViewModel(
-                                    text = "propertyDetails.landlordDetails.registeredLandlords.viewLandlordRecord",
-                                    url = landlordDetailsUrlProvider(landlord),
-                                    opensInNewTab = true,
-                                ),
-                            ),
-                    )
+                    when (landlord) {
+                        is IndividualLandlord ->
+                            SummaryCardViewModel(
+                                title = landlord.name,
+                                summaryList = buildLocalCouncilCardRows(landlord),
+                                actions =
+                                    listOf(
+                                        SummaryCardActionViewModel(
+                                            text = "propertyDetails.landlordDetails.registeredLandlords.viewLandlordRecord",
+                                            url = landlordDetailsUrlProvider(landlord),
+                                            opensInNewTab = true,
+                                        ),
+                                    ),
+                            )
+
+                        is OrganisationalLandlord ->
+                            SummaryCardViewModel(
+                                title = landlord.name,
+                                summaryList = buildLocalCouncilOrgCardRows(landlord),
+                            )
+
+                        else -> throw IllegalArgumentException("Unknown landlord type")
+                    }
                 }
+
+        private fun buildLocalCouncilOrgCardRows(landlord: OrganisationalLandlord): List<SummaryListRowViewModel> =
+            listOf(
+                SummaryListRowViewModel(
+                    fieldHeading = "landlordDetails.personalDetails.lrn",
+                    fieldValue = RegistrationNumberDataModel.fromRegistrationNumber(landlord.registrationNumber),
+                ),
+                SummaryListRowViewModel(
+                    fieldHeading = "landlordDetails.personalDetails.emailAddress",
+                    fieldValue = landlord.wholeOrgEmail,
+                ),
+            )
 
         private fun buildLocalCouncilCardRows(landlord: IndividualLandlord): List<SummaryListRowViewModel> =
             listOf(

--- a/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/summaryModels/PropertyDetailsLandlordViewModelBuilder.kt
+++ b/src/main/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/summaryModels/PropertyDetailsLandlordViewModelBuilder.kt
@@ -76,7 +76,7 @@ class PropertyDetailsLandlordViewModelBuilder {
                         is IndividualLandlord ->
                             SummaryCardViewModel(
                                 title = landlord.name,
-                                summaryList = buildLocalCouncilCardRows(landlord),
+                                summaryList = buildLocalCouncilIndividualCardRows(landlord),
                                 actions =
                                     listOf(
                                         SummaryCardActionViewModel(
@@ -118,7 +118,7 @@ class PropertyDetailsLandlordViewModelBuilder {
                 ),
             )
 
-        private fun buildLocalCouncilCardRows(landlord: IndividualLandlord): List<SummaryListRowViewModel> =
+        private fun buildLocalCouncilIndividualCardRows(landlord: IndividualLandlord): List<SummaryListRowViewModel> =
             listOf(
                 SummaryListRowViewModel(
                     fieldHeading = "landlordDetails.personalDetails.lrn",

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/PropertyDetailsTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/PropertyDetailsTests.kt
@@ -333,7 +333,7 @@ class PropertyDetailsTests : IntegrationTestWithImmutableData("data-local.sql") 
             }
 
             @Test
-            fun `an org landlord is shown as a card with name, LRN and email and no view landlord record link`(page: Page) {
+            fun `an org landlord is shown as a card with name, LRN, email and a view landlord record link`(page: Page) {
                 val detailsPage = navigator.goToPropertyDetailsLocalCouncilView(48)
                 detailsPage.tabs.goToLandlordDetails()
 
@@ -341,7 +341,7 @@ class PropertyDetailsTests : IntegrationTestWithImmutableData("data-local.sql") 
                     detailsPage.landlordSummaryCards.single { it.title.getText() == "Local Organisation Landlord" }
                 assertThat(orgCard.summaryList.registrationNumberRow.value).not().isEmpty()
                 assertThat(orgCard.summaryList.emailAddressRow.value).containsText("local-org-landlord@example.com")
-                assertThat(orgCard.getAction("View landlord record").link).not().isVisible()
+                assertThat(orgCard.getAction("View landlord record").link).isVisible()
             }
         }
 

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/PropertyDetailsTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/integration/PropertyDetailsTests.kt
@@ -331,6 +331,18 @@ class PropertyDetailsTests : IntegrationTestWithImmutableData("data-local.sql") 
                 assertThat(actionLink).hasAttribute("target", "_blank")
                 assertThat(actionLink).hasAttribute("rel", "noreferrer noopener")
             }
+
+            @Test
+            fun `an org landlord is shown as a card with name, LRN and email and no view landlord record link`(page: Page) {
+                val detailsPage = navigator.goToPropertyDetailsLocalCouncilView(48)
+                detailsPage.tabs.goToLandlordDetails()
+
+                val orgCard =
+                    detailsPage.landlordSummaryCards.single { it.title.getText() == "Local Organisation Landlord" }
+                assertThat(orgCard.summaryList.registrationNumberRow.value).not().isEmpty()
+                assertThat(orgCard.summaryList.emailAddressRow.value).containsText("local-org-landlord@example.com")
+                assertThat(orgCard.getAction("View landlord record").link).not().isVisible()
+            }
         }
 
         // Test properties used for notification banner tests:

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/summaryModels/PropertyDetailsLandlordViewModelBuilderTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/summaryModels/PropertyDetailsLandlordViewModelBuilderTests.kt
@@ -2,6 +2,7 @@ package uk.gov.communities.prsdb.webapp.models.viewModels.summaryModels
 
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotEquals
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import uk.gov.communities.prsdb.webapp.constants.enums.RegistrationNumberType
@@ -172,6 +173,68 @@ class PropertyDetailsLandlordViewModelBuilderTests {
             )
             assertEquals("/local-council/landlord-details/${landlord.id}", card.actions!![0].url)
             assertEquals(true, card.actions!![0].opensInNewTab)
+        }
+
+        @Test
+        fun `org landlord card has title of org name and two rows LRN and whole-org email`() {
+            val orgLandlord =
+                MockLandlordData.createOrgLandlord(
+                    name = "ACME Properties Ltd",
+                    email = "info@acme.com",
+                    registrationNumber = RegistrationNumber(RegistrationNumberType.LANDLORD, 9012L),
+                )
+
+            val cards =
+                PropertyDetailsLandlordViewModelBuilder.buildLocalCouncilSummaryCards(
+                    setOf(orgLandlord),
+                    landlordDetailsUrlProvider = { "/local-council/landlord-details/${it.id}" },
+                )
+
+            val card = cards.single()
+            assertEquals("ACME Properties Ltd", card.title)
+            assertEquals(2, card.summaryList.size)
+            assertEquals("landlordDetails.personalDetails.lrn", card.summaryList[0].fieldHeading)
+            assertEquals(9012L, (card.summaryList[0].fieldValue as RegistrationNumberDataModel).number)
+            assertEquals("landlordDetails.personalDetails.emailAddress", card.summaryList[1].fieldHeading)
+            assertEquals("info@acme.com", card.summaryList[1].fieldValue)
+        }
+
+        @Test
+        fun `org landlord card has no action link`() {
+            val orgLandlord = MockLandlordData.createOrgLandlord(name = "ACME Properties Ltd", email = "info@acme.com")
+
+            val cards =
+                PropertyDetailsLandlordViewModelBuilder.buildLocalCouncilSummaryCards(
+                    setOf(orgLandlord),
+                    landlordDetailsUrlProvider = { "/local-council/landlord-details/${it.id}" },
+                )
+
+            assertTrue(cards.single().actions.isNullOrEmpty())
+        }
+
+        @Test
+        fun `mixed individual and org landlords are sorted by name, individuals keep four rows and link, org gets two rows and no link`() {
+            val individual =
+                MockLandlordData.createIndividualLandlord(
+                    name = "Zoe Adams",
+                    email = "zoe@example.com",
+                    phoneNumber = "07700000000",
+                )
+            val org = MockLandlordData.createOrgLandlord(name = "Acme Ltd", email = "info@acme.com")
+
+            val cards =
+                PropertyDetailsLandlordViewModelBuilder.buildLocalCouncilSummaryCards(
+                    setOf(individual, org),
+                    landlordDetailsUrlProvider = { "/local-council/landlord-details/${it.id}" },
+                )
+
+            assertEquals(2, cards.size)
+            assertEquals("Acme Ltd", cards[0].title)
+            assertEquals(2, cards[0].summaryList.size)
+            assertTrue(cards[0].actions.isNullOrEmpty())
+            assertEquals("Zoe Adams", cards[1].title)
+            assertEquals(4, cards[1].summaryList.size)
+            assertEquals(1, cards[1].actions!!.size)
         }
     }
 }

--- a/src/test/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/summaryModels/PropertyDetailsLandlordViewModelBuilderTests.kt
+++ b/src/test/kotlin/uk/gov/communities/prsdb/webapp/models/viewModels/summaryModels/PropertyDetailsLandlordViewModelBuilderTests.kt
@@ -2,7 +2,6 @@ package uk.gov.communities.prsdb.webapp.models.viewModels.summaryModels
 
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotEquals
-import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import uk.gov.communities.prsdb.webapp.constants.enums.RegistrationNumberType
@@ -200,7 +199,7 @@ class PropertyDetailsLandlordViewModelBuilderTests {
         }
 
         @Test
-        fun `org landlord card has no action link`() {
+        fun `org landlord card has a view landlord record action that opens in new tab`() {
             val orgLandlord = MockLandlordData.createOrgLandlord(name = "ACME Properties Ltd", email = "info@acme.com")
 
             val cards =
@@ -209,11 +208,18 @@ class PropertyDetailsLandlordViewModelBuilderTests {
                     landlordDetailsUrlProvider = { "/local-council/landlord-details/${it.id}" },
                 )
 
-            assertTrue(cards.single().actions.isNullOrEmpty())
+            val card = cards.single()
+            assertEquals(1, card.actions!!.size)
+            assertEquals(
+                "propertyDetails.landlordDetails.registeredLandlords.viewLandlordRecord",
+                card.actions!![0].text,
+            )
+            assertEquals("/local-council/landlord-details/${orgLandlord.id}", card.actions!![0].url)
+            assertEquals(true, card.actions!![0].opensInNewTab)
         }
 
         @Test
-        fun `mixed individual and org landlords are sorted by name, individuals keep four rows and link, org gets two rows and no link`() {
+        fun `mixed individual and org landlords are sorted by name and both keep the view record link`() {
             val individual =
                 MockLandlordData.createIndividualLandlord(
                     name = "Zoe Adams",
@@ -231,7 +237,7 @@ class PropertyDetailsLandlordViewModelBuilderTests {
             assertEquals(2, cards.size)
             assertEquals("Acme Ltd", cards[0].title)
             assertEquals(2, cards[0].summaryList.size)
-            assertTrue(cards[0].actions.isNullOrEmpty())
+            assertEquals(1, cards[0].actions!!.size)
             assertEquals("Zoe Adams", cards[1].title)
             assertEquals(4, cards[1].summaryList.size)
             assertEquals(1, cards[1].actions!!.size)


### PR DESCRIPTION
## Ticket number

PDJB-1277

## Goal of change

Stop the local council view of a property record's Landlords tab from crashing when a landlord is an organisation, and show them in a card.

## Description of main change(s)

- `PropertyDetailsLandlordViewModelBuilder.buildLocalCouncilSummaryCards` now branches by landlord type instead of asserting every landlord is an individual.
- Organisation landlords render a card mirroring the landlord-facing org card: org name as the title, with Landlord Registration Number and (whole-org) email address.
- Org cards get a "View landlord record" link like individual cards. It currently points at the shared local council landlord-record path; a `TODO PDJB-1432` marks pointing it at the org landlord record once that page supports organisations.
- Individual landlord cards are unchanged (LRN, email, phone, contact address + "View landlord record" link).

## Anything you'd like to highlight to the reviewer?

- The org "View landlord record" link currently targets the shared local council landlord-record page, which does not yet render organisations (it casts to `IndividualLandlord`). Linking it correctly is deferred to PDJB-1432 (TODO in `PropertyDetailsLandlordViewModelBuilder.kt`).
- No screenshot attached — the new single-page integration test drives the exact local council page and asserts the org card rendering, so behaviour is verified end-to-end.

## Checklist

- [x] Unit tests for new logic (e.g. new service methods) have been added
- [x] Single page integration test added covering an org landlord on the local council Landlords tab (uses existing seed property 48)
- [x] Branch has been rebased onto main and run locally, with everything working as expected
- [x] TODO comments referencing this JIRA ticket have been searched for and removed (`PropertyDetailsLandlordViewModelBuilder.kt`)
- [x] This feature is not behind a feature flag. This mirrors the landlord-facing card, which already renders org co-landlords unconditionally; org landlords only exist where the existing org-registration flag is/was enabled, and the change removes a crash rather than introducing new user-facing behaviour where none should be.
