### PR TITLE
PDJB-1048: add missing section divider to local council view

### DIFF
--- a/src/main/resources/templates/propertyDetailsView.html
+++ b/src/main/resources/templates/propertyDetailsView.html
@@ -69,12 +69,14 @@
                             <dl th:replace="~{fragments/summaryList :: summaryList(${propertyDetails.licensingSection})}"></dl>
                         </th:block>
                         <p th:if="${propertyDetails.licensingProvideLaterParagraph != null}" class="govuk-body" th:utext="${propertyDetails.licensingProvideLaterParagraph}"></p>
+                        <hr th:if="${propertyDetails.licensingProvideLaterParagraph != null}" class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
                         <th:block th:if="${propertyDetails.showTenancySection}">
                             <h3 class="govuk-heading-s" th:text="#{${propertyDetails.tenancyHeadingKey}}">propertyDetails.propertyRecord.tenancy.heading</h3>
                             <th:block th:if="${not #lists.isEmpty(propertyDetails.tenancySection)}">
                                 <dl th:replace="~{fragments/summaryList :: summaryList(${propertyDetails.tenancySection})}"></dl>
                             </th:block>
                             <p th:if="${propertyDetails.tenancyProvideLaterParagraph != null}" class="govuk-body" th:utext="${propertyDetails.tenancyProvideLaterParagraph}"></p>
+                            <hr th:if="${propertyDetails.tenancyProvideLaterParagraph != null}" class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
                         </th:block>
                     <p th:if="${isLandlordView}" class="govuk-body prsd-deregister-link" >
                         <a class="govuk-link" th:href="${deregisterPropertyLink}" th:text="#{propertyDetails.deregisterPropertyLink.text}">


### PR DESCRIPTION
## Ticket number

PDJB-1048

## Goal of change

Add missing section divider to local council view or property details

## Description of main change(s)

This was missing when the "provide this later" paragraph was displayed.

Now added
<img width="637" height="173" alt="image" src="https://github.com/user-attachments/assets/6a74564e-c66f-45cf-84f9-bdc7bb0eaf6d" />
<img width="617" height="165" alt="image" src="https://github.com/user-attachments/assets/9dcb1267-c138-412a-8c41-89215dd25351" />


## Anything you'd like to highlight to the reviewer?


## Checklist

Delete any that are not applicable, and add explanation below for any that are applicable but haven't been done

- [x] Screenshots of any UI changes have been added
- [ ] Test suite has been run in full locally and is passing
- [x] Branch has been rebased onto main and run locally, with everything working as expected (both for your new feature
  and any related functionality)
- [ ] QA instructions have been added to the ticket (particularly if this is the last PR required to complete the ticket)
